### PR TITLE
Replace ace calls to standard functions

### DIFF
--- a/src/cppcache/src/CacheImpl.cpp
+++ b/src/cppcache/src/CacheImpl.cpp
@@ -34,7 +34,6 @@
 #include "ClientProxyMembershipID.hpp"
 #include "AutoDelete.hpp"
 #include <string>
-#include "ace/OS.h"
 #include <gfcpp/PoolManager.hpp>
 #include <gfcpp/RegionAttributes.hpp>
 #include "ThinClientPoolHADM.hpp"
@@ -484,7 +483,7 @@ void CacheImpl::createRegion(const char* name,
     RegionPtr tmp;
     if (0 == m_regions->find(namestr, tmp)) {
       char buffer[256];
-      ACE_OS::snprintf(
+      std::snprintf(
           buffer, 256,
           "Cache::createRegion: \"%s\" region exists in local cache",
           namestr.c_str());
@@ -506,14 +505,14 @@ void CacheImpl::createRegion(const char* name,
       throw;
     } catch (std::exception& ex) {
       char buffer[512];
-      ACE_OS::snprintf(buffer, 512,
+      std::snprintf(buffer, 512,
                        "Cache::createRegion: Failed to create Region \"%s\" "
                        "due to unknown exception: %s",
                        namestr.c_str(), ex.what());
       throw UnknownException(buffer);
     } catch (...) {
       char buffer[256];
-      ACE_OS::snprintf(buffer, 256,
+      std::snprintf(buffer, 256,
                        "Cache::createRegion: Failed to create Region \"%s\" "
                        "due to unknown exception.",
                        namestr.c_str());
@@ -521,7 +520,7 @@ void CacheImpl::createRegion(const char* name,
     }
     if (rpImpl == NULL) {
       char buffer[256];
-      ACE_OS::snprintf(buffer, 256,
+      std::snprintf(buffer, 256,
                        "Cache::createRegion: Failed to create Region \"%s\"",
                        namestr.c_str());
       throw RegionCreationFailedException(buffer);

--- a/src/cppcache/src/CacheXmlParser.cpp
+++ b/src/cppcache/src/CacheXmlParser.cpp
@@ -20,6 +20,7 @@
 #include <gfcpp/PoolFactory.hpp>
 #include "AutoDelete.hpp"
 #include "CacheImpl.hpp"
+#include <cstring>
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -82,47 +83,67 @@ extern "C" void startElementSAX2Function(void* ctx, const xmlChar* name,
       (!parser->isIllegalStateException()) &&
       (!parser->isAnyOtherException())) {
     try {
-      if (strcmp((char*)name, parser->CACHE) == 0) {
+      if (strcmp(reinterpret_cast<const char*>(name), parser->CACHE) == 0) {
         parser->startCache(ctx, atts);
-      } else if (strcmp((char*)name, parser->CLIENT_CACHE) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->CLIENT_CACHE) == 0) {
         parser->startCache(ctx, atts);
-      } else if (strcmp((char*)name, parser->PDX) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->PDX) == 0) {
         parser->startPdx(atts);
-      } else if (strcmp((char*)name, parser->REGION) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->REGION) == 0) {
         parser->incNesting();
         parser->startRegion(atts, parser->isRootLevel());
-      } else if (strcmp((char*)name, parser->ROOT_REGION) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->ROOT_REGION) == 0) {
         parser->incNesting();
         parser->startRegion(atts, parser->isRootLevel());
-      } else if (strcmp((char*)name, parser->REGION_ATTRIBUTES) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->REGION_ATTRIBUTES) == 0) {
         parser->startRegionAttributes(atts);
-      } else if (strcmp((char*)name, parser->REGION_TIME_TO_LIVE) == 0) {
-      } else if (strcmp((char*)name, parser->REGION_IDLE_TIME) == 0) {
-      } else if (strcmp((char*)name, parser->ENTRY_TIME_TO_LIVE) == 0) {
-      } else if (strcmp((char*)name, parser->ENTRY_IDLE_TIME) == 0) {
-      } else if (strcmp((char*)name, parser->EXPIRATION_ATTRIBUTES) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->REGION_TIME_TO_LIVE) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->REGION_IDLE_TIME) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->ENTRY_TIME_TO_LIVE) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->ENTRY_IDLE_TIME) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->EXPIRATION_ATTRIBUTES) == 0) {
         parser->startExpirationAttributes(atts);
-      } else if (strcmp((char*)name, parser->CACHE_LOADER) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->CACHE_LOADER) == 0) {
         parser->startCacheLoader(atts);
-      } else if (strcmp((char*)name, parser->CACHE_WRITER) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->CACHE_WRITER) == 0) {
         parser->startCacheWriter(atts);
-      } else if (strcmp((char*)name, parser->CACHE_LISTENER) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->CACHE_LISTENER) == 0) {
         parser->startCacheListener(atts);
-      } else if (strcmp((char*)name, parser->PARTITION_RESOLVER) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->PARTITION_RESOLVER) == 0) {
         parser->startPartitionResolver(atts);
-      } else if (strcmp((char*)name, parser->PERSISTENCE_MANAGER) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->PERSISTENCE_MANAGER) == 0) {
         parser->startPersistenceManager(atts);
-      } else if (strcmp((char*)name, parser->PROPERTIES) == 0) {
-      } else if (strcmp((char*)name, parser->PROPERTY) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->PROPERTIES) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->PROPERTY) == 0) {
         parser->startPersistenceProperties(atts);
-      } else if (strcmp((char*)name, parser->POOL) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->POOL) == 0) {
         parser->startPool(atts);
-      } else if (strcmp((char*)name, parser->LOCATOR) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->LOCATOR) == 0) {
         parser->startLocator(atts);
-      } else if (strcmp((char*)name, parser->SERVER) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->SERVER) == 0) {
         parser->startServer(atts);
       } else {
-        std::string temp((char*)name);
+        std::string temp(reinterpret_cast<const char*>(name));
         std::string s = "XML:Unknown XML element \"" + temp + "\"";
         throw CacheXmlException(s.c_str());
       }
@@ -155,45 +176,65 @@ extern "C" void endElementSAX2Function(void* ctx, const xmlChar* name) {
       (!parser->isIllegalStateException()) &&
       (!parser->isAnyOtherException())) {
     try {
-      if (strcmp((char*)name, parser->CACHE) == 0) {
+      if (strcmp(reinterpret_cast<const char*>(name), parser->CACHE) == 0) {
         parser->endCache();
-      } else if (strcmp((char*)name, parser->CLIENT_CACHE) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->CLIENT_CACHE) == 0) {
         parser->endCache();
-      } else if (strcmp((char*)name, parser->PDX) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->PDX) == 0) {
         parser->endPdx();
-      } else if (strcmp((char*)name, parser->REGION) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->REGION) == 0) {
         parser->endRegion(parser->isRootLevel());
         parser->decNesting();
-      } else if (strcmp((char*)name, parser->ROOT_REGION) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->ROOT_REGION) == 0) {
         parser->endRegion(parser->isRootLevel());
         parser->decNesting();
-      } else if (strcmp((char*)name, parser->REGION_ATTRIBUTES) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->REGION_ATTRIBUTES) == 0) {
         parser->endRegionAttributes();
-      } else if (strcmp((char*)name, parser->REGION_TIME_TO_LIVE) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->REGION_TIME_TO_LIVE) == 0) {
         parser->endRegionTimeToLive();
-      } else if (strcmp((char*)name, parser->REGION_IDLE_TIME) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->REGION_IDLE_TIME) == 0) {
         parser->endRegionIdleTime();
-      } else if (strcmp((char*)name, parser->ENTRY_TIME_TO_LIVE) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->ENTRY_TIME_TO_LIVE) == 0) {
         parser->endEntryTimeToLive();
-      } else if (strcmp((char*)name, parser->ENTRY_IDLE_TIME) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->ENTRY_IDLE_TIME) == 0) {
         parser->endEntryIdleTime();
-      } else if (strcmp((char*)name, parser->EXPIRATION_ATTRIBUTES) == 0) {
-      } else if (strcmp((char*)name, parser->CACHE_LOADER) == 0) {
-      } else if (strcmp((char*)name, parser->CACHE_WRITER) == 0) {
-      } else if (strcmp((char*)name, parser->CACHE_LISTENER) == 0) {
-      } else if (strcmp((char*)name, parser->PARTITION_RESOLVER) == 0) {
-      } else if (strcmp((char*)name, parser->PERSISTENCE_MANAGER) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->EXPIRATION_ATTRIBUTES) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->CACHE_LOADER) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->CACHE_WRITER) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->CACHE_LISTENER) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->PARTITION_RESOLVER) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->PERSISTENCE_MANAGER) == 0) {
         parser->endPersistenceManager();
-      } else if (strcmp((char*)name, parser->PROPERTIES) == 0) {
-      } else if (strcmp((char*)name, parser->PROPERTY) == 0) {
-      } else if (strcmp((char*)name, parser->POOL) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->PROPERTIES) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->PROPERTY) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->POOL) == 0) {
         parser->endPool();
-      } else if (strcmp((char*)name, parser->LOCATOR) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->LOCATOR) == 0) {
         // parser->endLocator();
-      } else if (strcmp((char*)name, parser->SERVER) == 0) {
+      } else if (strcmp(reinterpret_cast<const char*>(name),
+                        parser->SERVER) == 0) {
         // parser->endServer();
       } else {
-        std::string temp((char*)name);
+        std::string temp(reinterpret_cast<const char*>(name));
         std::string s = "XML:Unknown XML element \"" + temp + "\"";
         throw CacheXmlException(s.c_str());
       }
@@ -342,7 +383,7 @@ void CacheXmlParser::handleParserErrors(int res) {
   if (res != 0)  // xml file is not well-formed
   {
     char buf[256];
-    ACE_OS::snprintf(buf, 256, "Error code returned by xml parser is : %d ",
+    std::snprintf(buf, 256, "Error code returned by xml parser is : %d ",
                      res);
     Log::error(buf);
 
@@ -438,10 +479,10 @@ void CacheXmlParser::create(Cache* cache) {
 void CacheXmlParser::startCache(void* ctx, const xmlChar** attrs) {
   int attrsCount = 0;
   if (attrs != NULL) {
-    char* attrName;
-    char* attrValue;
-    while ((attrName = (char*)attrs[attrsCount++]) != NULL) {
-      attrValue = (char*)attrs[attrsCount++];
+    const char* attrName;
+    const char* attrValue;
+    while ((attrName = reinterpret_cast<const char*>(attrs[attrsCount++])) != NULL) {
+      attrValue = reinterpret_cast<const char*>(attrs[attrsCount++]);
       if (attrValue == NULL) {
         std::string exStr = "XML: No value provided for attribute: ";
         exStr += attrName;
@@ -719,11 +760,11 @@ void CacheXmlParser::startRegion(const xmlChar** atts, bool isRoot) {
   }
 
   char* regionName = NULL;
-  char* refid = NULL;
+  const char* refid = NULL;
 
   for (int i = 0; (atts[i] != NULL); i++) {
     if (atts[i] != NULL) {
-      char* name = (char*)atts[i];
+      const char* name = (char*)atts[i];
       i++;
       if (atts[i] != NULL) {
         char* value = (char*)atts[i];
@@ -799,7 +840,7 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
       throw CacheXmlException(s.c_str());
     }
 
-    char* refid = NULL;
+    const char* refid = NULL;
 
     for (int i = 0; (atts[i] != NULL); i++) {
       i++;
@@ -815,12 +856,14 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
           throw CacheXmlException(s.c_str());
         }
 
-        if (strcmp((char*)atts[i - 1], ID) == 0) {
+        if (strcmp(reinterpret_cast<const char*>(atts[i - 1]), ID) == 0) {
           RegionXmlCreation* region =
               reinterpret_cast<RegionXmlCreation*>(_stack.top());
-          region->setAttrId(std::string((char*)atts[i]));
-        } else if (strcmp((char*)atts[i - 1], REFID) == 0) {
-          refid = (char*)atts[i];
+          region->setAttrId(
+              std::string(reinterpret_cast<const char*>(atts[i])));
+        } else if (strcmp(reinterpret_cast<const char*>(atts[i - 1]),
+                          REFID) == 0) {
+          refid = reinterpret_cast<const char*>(atts[i]);
         }
       }
     }
@@ -849,13 +892,15 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
     _stack.push(attrsFactory);
 
     for (int i = 0; (atts[i] != NULL); i++) {
-      if (strcmp(ID, (char*)atts[i]) == 0 ||
-          strcmp(REFID, (char*)atts[i]) == 0) {
+      if (strcmp(ID, reinterpret_cast<const char*>(atts[i])) == 0 ||
+          strcmp(REFID, reinterpret_cast<const char*>(atts[i])) == 0) {
         i++;
         continue;
-      } else if (strcmp(CLIENT_NOTIFICATION_ENABLED, (char*)atts[i]) == 0) {
+      } else if (strcmp(CLIENT_NOTIFICATION_ENABLED,
+                        reinterpret_cast<const char*>(atts[i])) == 0) {
         i++;
-        char* client_notification_enabled = (char*)atts[i];
+        const char* client_notification_enabled =
+            reinterpret_cast<const char*>(atts[i]);
         if (strcmp("false", client_notification_enabled) == 0 ||
             strcmp("FALSE", client_notification_enabled) == 0) {
           if (m_poolFactory) {
@@ -867,30 +912,34 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
             m_poolFactory->setSubscriptionEnabled(true);
           }
         } else {
-          char* name = (char*)atts[i];
+          const char* name = reinterpret_cast<const char*>(atts[i]);
           std::string temp(name);
           std::string s =
               "XML: " + temp +
               " is not a valid value for the attribute <client-notification>\n";
           throw CacheXmlException(s.c_str());
         }
-      } else if (strcmp(INITIAL_CAPACITY, (char*)atts[i]) == 0) {
+      } else if (strcmp(INITIAL_CAPACITY,
+                        reinterpret_cast<const char*>(atts[i])) == 0) {
         i++;
-        char* initialCapacity = (char*)atts[i];
+        const char* initialCapacity = reinterpret_cast<const char*>(atts[i]);
         attrsFactory->setInitialCapacity(atoi(initialCapacity));
-      } else if (strcmp(CONCURRENCY_LEVEL, (char*)atts[i]) == 0) {
+      } else if (strcmp(CONCURRENCY_LEVEL,
+                        reinterpret_cast<const char*>(atts[i])) == 0) {
         i++;
-        char* concurrencyLevel = (char*)atts[i];
+        const char* concurrencyLevel = reinterpret_cast<const char*>(atts[i]);
         attrsFactory->setConcurrencyLevel(atoi(concurrencyLevel));
-      } else if (strcmp(LOAD_FACTOR, (char*)atts[i]) == 0) {
+      } else if (strcmp(LOAD_FACTOR,
+                        reinterpret_cast<const char*>(atts[i])) == 0) {
         i++;
-        char* loadFactor = (char*)atts[i];
+        const char* loadFactor = reinterpret_cast<const char*>(atts[i]);
         attrsFactory->setLoadFactor(
             static_cast<float>(atof(loadFactor)));  // check whether this works
-      } else if (strcmp(CACHING_ENABLED, (char*)atts[i]) == 0) {
+      } else if (strcmp(CACHING_ENABLED,
+                        reinterpret_cast<const char*>(atts[i])) == 0) {
         bool flag = false;
         i++;
-        char* cachingEnabled = (char*)atts[i];
+        const char* cachingEnabled = reinterpret_cast<const char*>(atts[i]);
         if (strcmp("true", cachingEnabled) == 0 ||
             strcmp("TRUE", cachingEnabled) == 0) {
           flag = true;
@@ -898,7 +947,7 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
                    strcmp("FALSE", cachingEnabled) == 0) {
           flag = false;
         } else {
-          char* name = (char*)atts[i];
+          const char* name = reinterpret_cast<const char*>(atts[i]);
           std::string temp(name);
           std::string s =
               "XML: " + temp +
@@ -906,15 +955,17 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
           throw CacheXmlException(s.c_str());
         }
         attrsFactory->setCachingEnabled(flag);  // check whether this works
-      } else if (strcmp(LRU_ENTRIES_LIMIT, (char*)atts[i]) == 0) {
+      } else if (strcmp(LRU_ENTRIES_LIMIT,
+                        reinterpret_cast<const char*>(atts[i])) == 0) {
         i++;
-        char* lruentriesLimit = (char*)atts[i];
+        const char* lruentriesLimit = reinterpret_cast<const char*>(atts[i]);
         int lruentriesLimitInt = atoi(lruentriesLimit);
         uint32_t temp = static_cast<uint32_t>(lruentriesLimitInt);
         attrsFactory->setLruEntriesLimit(temp);
-      } else if (strcmp(DISK_POLICY, (char*)atts[i]) == 0) {
+      } else if (strcmp(DISK_POLICY,
+                        reinterpret_cast<const char*>(atts[i])) == 0) {
         i++;
-        char* diskPolicy = (char*)atts[i];
+        const char* diskPolicy = reinterpret_cast<const char*>(atts[i]);
         if (strcmp(OVERFLOWS, diskPolicy) == 0) {
           attrsFactory->setDiskPolicy(
               apache::geode::client::DiskPolicyType::OVERFLOWS);
@@ -924,18 +975,19 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
           attrsFactory->setDiskPolicy(
               apache::geode::client::DiskPolicyType::NONE);
         } else {
-          char* name = (char*)atts[i];
+          const char* name = reinterpret_cast<const char*>(atts[i]);
           std::string temp(name);
           std::string s =
               "XML: " + temp +
               " is not a valid value for the attribute <disk-policy>";
           throw CacheXmlException(s.c_str());
         }
-      } else if (strcmp(ENDPOINTS, (char*)atts[i]) == 0) {
+      } else if (strcmp(ENDPOINTS,
+                        reinterpret_cast<const char*>(atts[i])) == 0) {
         i++;
         if (m_poolFactory) {
           std::vector<std::pair<std::string, int>> endPoints(
-              parseEndPoints((char*)atts[i]));
+              parseEndPoints(reinterpret_cast<const char*>(atts[i])));
           std::vector<std::pair<std::string, int>>::iterator endPoint;
           for (endPoint = endPoints.begin(); endPoint != endPoints.end();
                endPoint++) {
@@ -943,15 +995,17 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
           }
         }
         isTCR = true;
-      } else if (strcmp(POOL_NAME, (char*)atts[i]) == 0) {
+      } else if (strcmp(POOL_NAME,
+                        reinterpret_cast<const char*>(atts[i])) == 0) {
         i++;
-        char* poolName = (char*)atts[i];
+        const char* poolName = reinterpret_cast<const char*>(atts[i]);
         attrsFactory->setPoolName(poolName);
         isTCR = true;
-      } else if (strcmp(CLONING_ENABLED, (char*)atts[i]) == 0) {
+      } else if (strcmp(CLONING_ENABLED,
+                        reinterpret_cast<const char*>(atts[i])) == 0) {
         i++;
         bool flag = false;
-        char* isClonable = (char*)atts[i];
+        const char* isClonable = reinterpret_cast<const char*>(atts[i]);
 
         if (strcmp("true", isClonable) == 0 ||
             strcmp("TRUE", isClonable) == 0) {
@@ -960,7 +1014,7 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
                    strcmp("FALSE", isClonable) == 0) {
           flag = false;
         } else {
-          char* name = (char*)atts[i];
+          const char* name = reinterpret_cast<const char*>(atts[i]);
           std::string temp(name);
           std::string s =
               "XML: " + temp +
@@ -970,10 +1024,12 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
 
         attrsFactory->setCloningEnabled(flag);
         isTCR = true;
-      } else if (strcmp(CONCURRENCY_CHECKS_ENABLED, (char*)atts[i]) == 0) {
+      } else if (strcmp(CONCURRENCY_CHECKS_ENABLED,
+                        reinterpret_cast<const char*>(atts[i])) == 0) {
         bool flag = false;
         i++;
-        char* concurrencyChecksEnabled = (char*)atts[i];
+        const char* concurrencyChecksEnabled =
+            reinterpret_cast<const char*>(atts[i]);
         if (strcmp("true", concurrencyChecksEnabled) == 0 ||
             strcmp("TRUE", concurrencyChecksEnabled) == 0) {
           flag = true;
@@ -981,7 +1037,7 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
                    strcmp("FALSE", concurrencyChecksEnabled) == 0) {
           flag = false;
         } else {
-          char* name = (char*)atts[i];
+          const char* name = reinterpret_cast<const char*>(atts[i]);
           std::string temp(name);
           std::string s = "XML: " + temp +
                           " is not a valid value for the attribute "
@@ -1051,22 +1107,22 @@ void CacheXmlParser::startExpirationAttributes(const xmlChar** atts) {
         "<expirartion-attributes>";
     throw CacheXmlException(s.c_str());
   }
-  char* timeOut = NULL;
+  const char* timeOut = NULL;
   int timeOutInt = 0;
   ExpirationAction::Action expire = ExpirationAction::INVALID_ACTION;
   for (int i = 0; (atts[i] != NULL); i++) {
-    if (strcmp(TIMEOUT, (char*)atts[i]) == 0) {
+    if (strcmp(TIMEOUT, reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      timeOut = (char*)atts[i];
+      timeOut = reinterpret_cast<const char*>(atts[i]);
       if (strcmp(timeOut, "") == 0) {
         std::string s =
             "XML:Value for attribute <timeout> needs to be specified";
         throw CacheXmlException(s.c_str());
       }
       timeOutInt = atoi(timeOut);
-    } else if (strcmp(ACTION, (char*)atts[i]) == 0) {
+    } else if (strcmp(ACTION, reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      char* action = (char*)atts[i];
+      const char* action = reinterpret_cast<const char*>(atts[i]);
       if (strcmp(action, "") == 0)
 
       {
@@ -1085,14 +1141,14 @@ void CacheXmlParser::startExpirationAttributes(const xmlChar** atts) {
       } else if (strcmp(LOCAL_DESTROY, action) == 0) {
         expire = ExpirationAction::LOCAL_DESTROY;
       } else {
-        char* name = (char*)atts[i];
+        const char* name = reinterpret_cast<const char*>(atts[i]);
         std::string temp(name);
         std::string s =
             "XML: " + temp + " is not a valid value for the attribute <action>";
         throw CacheXmlException(s.c_str());
       }
     } else {
-      char* name = (char*)atts[i];
+      const char* name = reinterpret_cast<const char*>(atts[i]);
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in "
@@ -1132,9 +1188,9 @@ void CacheXmlParser::startPersistenceManager(const xmlChar** atts) {
   char* libraryName = NULL;
   char* libraryFunctionName = NULL;
   for (int i = 0; (atts[i] != NULL); i++) {
-    if (strcmp(LIBRARY_NAME, (char*)atts[i]) == 0) {
+    if (strcmp(LIBRARY_NAME, reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      size_t len = strlen((char*)atts[i]) + 1;
+      size_t len = strlen(reinterpret_cast<const char*>(atts[i])) + 1;
       libraryName = new char[len];
       /* adongre
        * CID 28824: Dereference before null check (REVERSE_INULL)
@@ -1143,7 +1199,7 @@ void CacheXmlParser::startPersistenceManager(const xmlChar** atts) {
         std::string s = "Memory allocation fails";
         throw CacheXmlException(s.c_str());
       }
-      ACE_OS::strncpy(libraryName, (char*)atts[i], len);
+      std::strncpy(libraryName, reinterpret_cast<const char*>(atts[i]), len);
 
       if (libraryName == NULL) {
         std::string s =
@@ -1153,9 +1209,10 @@ void CacheXmlParser::startPersistenceManager(const xmlChar** atts) {
             "will be set";
         throw CacheXmlException(s.c_str());
       }
-    } else if (strcmp(LIBRARY_FUNCTION_NAME, (char*)atts[i]) == 0) {
+    } else if (strcmp(LIBRARY_FUNCTION_NAME,
+                      reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      size_t len = strlen((char*)atts[i]) + 1;
+      size_t len = strlen(reinterpret_cast<const char*>(atts[i])) + 1;
       libraryFunctionName = new char[len];
       /* adongre
        * CID 28823: Dereference before null check (REVERSE_INULL)
@@ -1165,7 +1222,8 @@ void CacheXmlParser::startPersistenceManager(const xmlChar** atts) {
         throw CacheXmlException(s.c_str());
       }
 
-      ACE_OS::strncpy(libraryFunctionName, (char*)atts[i], len);
+      std::strncpy(libraryFunctionName,
+                   reinterpret_cast<const char*>(atts[i]), len);
       if (libraryFunctionName == NULL) {
         std::string s =
             "XML:Value for the <library-function-name> needs to be provided";
@@ -1173,7 +1231,7 @@ void CacheXmlParser::startPersistenceManager(const xmlChar** atts) {
         throw CacheXmlException(s.c_str());
       }
     } else {
-      char* name = (char*)atts[i];
+      const char* name = reinterpret_cast<const char*>(atts[i]);
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in <persistence-manager>: " +
@@ -1219,21 +1277,21 @@ void CacheXmlParser::startPersistenceProperties(const xmlChar** atts) {
       m_config = Properties::create();
     }
   }
-  char* propName = NULL;
-  char* propValue = NULL;
+  const char* propName = NULL;
+  const char* propValue = NULL;
   for (int i = 0; (atts[i] != NULL); i++) {
-    if (strcmp("name", (char*)atts[i]) == 0) {
+    if (strcmp("name", reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      propName = (char*)atts[i];
+      propName = reinterpret_cast<const char*>(atts[i]);
       if (propName == NULL || strcmp(propName, "") == 0) {
         std::string s =
             "XML:Value for attribute <name> needs to be specified in the "
             "<property>";
         throw CacheXmlException(s.c_str());
       }
-    } else if (strcmp("value", (char*)atts[i]) == 0) {
+    } else if (strcmp("value", reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      propValue = (char*)atts[i];
+      propValue = reinterpret_cast<const char*>(atts[i]);
       if (propValue == NULL || strcmp(propValue, "") == 0) {
         std::string s =
             "XML:Value for attribute <value> needs to be "
@@ -1241,7 +1299,7 @@ void CacheXmlParser::startPersistenceProperties(const xmlChar** atts) {
         throw CacheXmlException(s.c_str());
       }
     } else {
-      char* name = (char*)atts[i];
+      const char* name = reinterpret_cast<const char*>(atts[i]);
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in <property>: " + temp;
@@ -1262,8 +1320,8 @@ void CacheXmlParser::startPersistenceProperties(const xmlChar** atts) {
 }
 
 void CacheXmlParser::startCacheLoader(const xmlChar** atts) {
-  char* libraryName = NULL;
-  char* libraryFunctionName = NULL;
+  const char* libraryName = NULL;
+  const char* libraryFunctionName = NULL;
   int attrsCount = 0;
   if (!atts) {
     std::string s = "XML:No attributes provided for <cache-loader>";
@@ -1277,9 +1335,9 @@ void CacheXmlParser::startCacheLoader(const xmlChar** atts) {
   }
 
   for (int i = 0; (atts[i] != NULL); i++) {
-    if (strcmp(LIBRARY_NAME, (char*)atts[i]) == 0) {
+    if (strcmp(LIBRARY_NAME, reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      libraryName = (char*)atts[i];
+      libraryName = reinterpret_cast<const char*>(atts[i]);
       if (libraryName == NULL || strcmp(libraryName, "") == 0) {
         std::string s =
             "XML:The attribute <library-name> of <cache-loader> cannot be set "
@@ -1288,16 +1346,17 @@ void CacheXmlParser::startCacheLoader(const xmlChar** atts) {
             "will be set";
         throw CacheXmlException(s.c_str());
       }
-    } else if (strcmp(LIBRARY_FUNCTION_NAME, (char*)atts[i]) == 0) {
+    } else if (strcmp(LIBRARY_FUNCTION_NAME,
+                      reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      libraryFunctionName = (char*)atts[i];
+      libraryFunctionName = reinterpret_cast<const char*>(atts[i]);
       if (libraryFunctionName == NULL || strcmp(libraryFunctionName, "") == 0) {
         std::string s =
             "XML:Value for the <library-function-name> needs to be provided";
         throw CacheXmlException(s.c_str());
       }
     } else {
-      char* name = (char*)atts[i];
+      const char* name = reinterpret_cast<const char*>(atts[i]);
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in <cache-loader> : " + temp;
@@ -1328,8 +1387,8 @@ void CacheXmlParser::startCacheLoader(const xmlChar** atts) {
 }
 
 void CacheXmlParser::startCacheListener(const xmlChar** atts) {
-  char* libraryName = NULL;
-  char* libraryFunctionName = NULL;
+  const char* libraryName = NULL;
+  const char* libraryFunctionName = NULL;
   int attrsCount = 0;
   if (!atts) {
     std::string s = "XML:No attributes provided for <cache-listener> ";
@@ -1343,9 +1402,9 @@ void CacheXmlParser::startCacheListener(const xmlChar** atts) {
   }
 
   for (int i = 0; (atts[i] != NULL); i++) {
-    if (strcmp(LIBRARY_NAME, (char*)atts[i]) == 0) {
+    if (strcmp(LIBRARY_NAME, reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      libraryName = (char*)atts[i];
+      libraryName = reinterpret_cast<const char*>(atts[i]);
       if (libraryName == NULL || strcmp(libraryName, "") == 0) {
         std::string s =
             "XML:The attribute <library-name> of the <cache-listener> tag "
@@ -1354,16 +1413,17 @@ void CacheXmlParser::startCacheListener(const xmlChar** atts) {
             "default value will be set";
         throw CacheXmlException(s.c_str());
       }
-    } else if (strcmp(LIBRARY_FUNCTION_NAME, (char*)atts[i]) == 0) {
+    } else if (strcmp(LIBRARY_FUNCTION_NAME,
+                      reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      libraryFunctionName = (char*)atts[i];
+      libraryFunctionName = reinterpret_cast<const char*>(atts[i]);
       if (libraryFunctionName == NULL || strcmp(libraryFunctionName, "") == 0) {
         std::string s =
             "XML:Value for <library-function-name> needs to be provided";
         throw CacheXmlException(s.c_str());
       }
     } else {
-      char* name = (char*)atts[i];
+      const char* name = reinterpret_cast<const char*>(atts[i]);
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in <cache-listener> : " +
@@ -1395,8 +1455,8 @@ void CacheXmlParser::startCacheListener(const xmlChar** atts) {
 }
 
 void CacheXmlParser::startPartitionResolver(const xmlChar** atts) {
-  char* libraryName = NULL;
-  char* libraryFunctionName = NULL;
+  const char* libraryName = NULL;
+  const char* libraryFunctionName = NULL;
   int attrsCount = 0;
   if (!atts) {
     std::string s = "XML:No attributes provided for <partition-resolver> ";
@@ -1410,9 +1470,9 @@ void CacheXmlParser::startPartitionResolver(const xmlChar** atts) {
   }
 
   for (int i = 0; (atts[i] != NULL); i++) {
-    if (strcmp(LIBRARY_NAME, (char*)atts[i]) == 0) {
+    if (strcmp(LIBRARY_NAME, reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      libraryName = (char*)atts[i];
+      libraryName = reinterpret_cast<const char*>(atts[i]);
       if (libraryName == NULL || strcmp(libraryName, "") == 0) {
         std::string s =
             "XML:The attribute <library-name> of the <partition-resolver> tag "
@@ -1421,16 +1481,17 @@ void CacheXmlParser::startPartitionResolver(const xmlChar** atts) {
             "default value will be set";
         throw CacheXmlException(s.c_str());
       }
-    } else if (strcmp(LIBRARY_FUNCTION_NAME, (char*)atts[i]) == 0) {
+    } else if (strcmp(LIBRARY_FUNCTION_NAME,
+                      reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      libraryFunctionName = (char*)atts[i];
+      libraryFunctionName = reinterpret_cast<const char*>(atts[i]);
       if (libraryFunctionName == NULL || strcmp(libraryFunctionName, "") == 0) {
         std::string s =
             "XML:Value for <library-function-name> needs to be provided";
         throw CacheXmlException(s.c_str());
       }
     } else {
-      char* name = (char*)atts[i];
+      const char* name = reinterpret_cast<const char*>(atts[i]);
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in <partition-resolver> : " +
@@ -1462,8 +1523,8 @@ void CacheXmlParser::startPartitionResolver(const xmlChar** atts) {
 }
 
 void CacheXmlParser::startCacheWriter(const xmlChar** atts) {
-  char* libraryName = NULL;
-  char* libraryFunctionName = NULL;
+  const char* libraryName = NULL;
+  const char* libraryFunctionName = NULL;
   int attrsCount = 0;
   if (!atts) {
     std::string s = "XML:No attributes provided for <cache-writer>";
@@ -1477,9 +1538,9 @@ void CacheXmlParser::startCacheWriter(const xmlChar** atts) {
   }
 
   for (int i = 0; (atts[i] != NULL); i++) {
-    if (strcmp(LIBRARY_NAME, (char*)atts[i]) == 0) {
+    if (strcmp(LIBRARY_NAME, reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      libraryName = (char*)atts[i];
+      libraryName = reinterpret_cast<const char*>(atts[i]);
       if (libraryName == NULL || strcmp(libraryName, "") == 0) {
         std::string s =
             "XML:The attribute <library-name> of <cache-writer> cannot be set "
@@ -1488,16 +1549,17 @@ void CacheXmlParser::startCacheWriter(const xmlChar** atts) {
             "will be set";
         throw CacheXmlException(s.c_str());
       }
-    } else if (strcmp(LIBRARY_FUNCTION_NAME, (char*)atts[i]) == 0) {
+    } else if (strcmp(LIBRARY_FUNCTION_NAME,
+                      reinterpret_cast<const char*>(atts[i])) == 0) {
       i++;
-      libraryFunctionName = (char*)atts[i];
+      libraryFunctionName = reinterpret_cast<const char*>(atts[i]);
       if (libraryFunctionName == NULL || strcmp(libraryFunctionName, "") == 0) {
         std::string s =
             "XML:Value for the <library-function-name> needs to be provided";
         throw CacheXmlException(s.c_str());
       }
     } else {
-      char* name = (char*)atts[i];
+      const char* name = reinterpret_cast<const char*>(atts[i]);
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in <cache-writer>: " + temp;

--- a/src/cppcache/src/CacheableDate.cpp
+++ b/src/cppcache/src/CacheableDate.cpp
@@ -23,6 +23,7 @@
 #include <gfcpp/ExceptionTypes.hpp>
 #include <gfcpp/GeodeTypeIds.hpp>
 
+#include <cstdio>
 #include <cwchar>
 #include <ace/OS.h>
 
@@ -113,9 +114,9 @@ CacheableStringPtr CacheableDate::toString() const {
   struct tm date = {0};
   time_t sec = m_timevalue / 1000;
   ACE_OS::localtime_r(&sec, &date);
-  ACE_OS::snprintf(buffer, 24, "%d/%d/%d %d:%d:%d", date.tm_mon + 1,
-                   date.tm_mday, date.tm_year + 1900, date.tm_hour, date.tm_min,
-                   date.tm_sec);
+  std::snprintf(buffer, 24, "%d/%d/%d %d:%d:%d", date.tm_mon + 1,
+                date.tm_mday, date.tm_year + 1900, date.tm_hour, date.tm_min,
+                date.tm_sec);
   return CacheableString::create(buffer);
 }
 
@@ -123,9 +124,9 @@ int32_t CacheableDate::logString(char* buffer, int32_t maxLength) const {
   struct tm date = {0};
   time_t sec = m_timevalue / 1000;
   ACE_OS::localtime_r(&sec, &date);
-  return ACE_OS::snprintf(buffer, maxLength,
-                          "CacheableDate (mm/dd/yyyy) ( %d/%d/%d )",
-                          date.tm_mon + 1, date.tm_mday, date.tm_year + 1900);
+  return std::snprintf(buffer, maxLength,
+                       "CacheableDate (mm/dd/yyyy) ( %d/%d/%d )",
+                       date.tm_mon + 1, date.tm_mday, date.tm_year + 1900);
 }
 
 }  // namespace client

--- a/src/cppcache/src/CacheableKey.cpp
+++ b/src/cppcache/src/CacheableKey.cpp
@@ -19,7 +19,7 @@
 
 #include <gfcpp/CacheableKey.hpp>
 
-#include <ace/OS.h>
+#include <cstdio>
 #include <typeinfo>
 
 namespace apache {
@@ -27,8 +27,8 @@ namespace geode {
 namespace client {
 
 int32_t CacheableKey::logString(char* buffer, int32_t maxLength) const {
-  return ACE_OS::snprintf(buffer, maxLength, "%s( @0x%08lX )",
-                          typeid(*this).name(), (unsigned long)this);
+  return std::snprintf(buffer, maxLength, "%s( @0x%08lX )",
+                       typeid(*this).name(), (unsigned long)this);
 }
 }  // namespace client
 }  // namespace geode

--- a/src/cppcache/src/CacheableString.cpp
+++ b/src/cppcache/src/CacheableString.cpp
@@ -23,8 +23,6 @@
 
 #include <cwchar>
 #include <cstdlib>
-#include <ace/ACE.h>
-#include <ace/OS.h>
 
 using namespace apache::geode::client;
 
@@ -299,12 +297,12 @@ CacheableString::~CacheableString() {
 
 int32_t CacheableString::logString(char* buffer, int32_t maxLength) const {
   if (isCString()) {
-    return ACE_OS::snprintf(
+    return std::snprintf(
         buffer, maxLength, "%s( %s )", className(),
         (m_str != NULL ? reinterpret_cast<const char*>(m_str) : "null"));
   } else {
     GF_DEV_ASSERT(isWideString());
-    int32_t numChars = ACE_OS::snprintf(buffer, maxLength, "%s( ", className());
+    int32_t numChars = std::snprintf(buffer, maxLength, "%s( ", className());
     if (numChars >= (int)maxLength || numChars <= 0) {
       return numChars;
     }
@@ -318,7 +316,7 @@ int32_t CacheableString::logString(char* buffer, int32_t maxLength) const {
     }
     buffer += numChars;
     maxLength -= numChars;
-    numChars = ACE_OS::snprintf(buffer, maxLength, " )");
+    numChars = std::snprintf(buffer, maxLength, " )");
     return numChars + static_cast<int32_t>(buffer - bufStart);
   }
 }

--- a/src/cppcache/src/ClientProxyMembershipID.cpp
+++ b/src/cppcache/src/ClientProxyMembershipID.cpp
@@ -89,7 +89,7 @@ void ClientProxyMembershipID::init(const std::string& dsName) {
       randString[RAND_STRING_LEN] = '\0';
     }
     char ps[15] = {0};
-    ACE_OS::snprintf(ps, 15, "%d", pid);
+    std::snprintf(ps, 15, "%d", pid);
     g_randString = "GFNative_";
     g_randString.append(randString).append(ps);
     LOGINFO("Using %s as random data for ClientProxyMembershipID",
@@ -217,13 +217,12 @@ void ClientProxyMembershipID::initObjectVars(
    * callers must be careful not to overflow the actual space of the
    * destination.
    * Use snprintf() instead, or correct precision specifiers.
-   * Fix : using ACE_OS::snprintf
    */
   char PID[15] = {0};
   char Synch_Counter[15] = {0};
-  // ACE_OS::snprintf(PID, 15, "%d",vPID);
+  // std::snprintf(PID, 15, "%d",vPID);
   ACE_OS::itoa(vPID, PID, 10);
-  // ACE_OS::snprintf(Synch_Counter, 15, "%d",synch_counter);
+  // std::snprintf(Synch_Counter, 15, "%d",synch_counter);
   ACE_OS::itoa(synch_counter, Synch_Counter, 10);
   clientID.append(hostname);
   clientID.append("(");
@@ -239,7 +238,7 @@ void ClientProxyMembershipID::initObjectVars(
   // int offset = 0;
   for (uint32_t i = 0; i < getHostAddrLen(); i++) {
     char hostInfo[16] = {0};
-    // offset += ACE_OS::snprintf(hostInfo + offset , 255 - offset, ":%x",
+    // offset += std::snprintf(hostInfo + offset , 255 - offset, ":%x",
     // m_hostAddr[i]);
     ACE_OS::itoa(m_hostAddr[i], hostInfo, 16);
     m_hashKey.append(":");
@@ -248,7 +247,7 @@ void ClientProxyMembershipID::initObjectVars(
   m_hashKey.append(":");
   char hostInfoPort[16] = {0};
   ACE_OS::itoa(getHostPort(), hostInfoPort, 10);
-  //  offset += ACE_OS::snprintf(hostInfo + offset, 255 - offset , ":%d",
+  //  offset += std::snprintf(hostInfo + offset, 255 - offset , ":%d",
   //  getHostPort());
   m_hashKey.append(hostInfoPort);
   m_hashKey.append(":");
@@ -260,7 +259,7 @@ void ClientProxyMembershipID::initObjectVars(
     m_hashKey.append(":");
     char viewid[16] = {0};
     ACE_OS::itoa(m_vmViewId, viewid, 10);
-    // offset += ACE_OS::snprintf(hostInfo + offset , 255 - offset , ":%d",
+    // offset += std::snprintf(hostInfo + offset , 255 - offset , ":%d",
     // m_vmViewId);
     m_hashKey.append(viewid);
   }
@@ -318,7 +317,7 @@ void ClientProxyMembershipID::getClientProxyMembershipID() {
   // DSMemberId = DSMemberId.append(host);
   // DSMemberId= DSMemberId.append("(");
   m_dsmemID.write(static_cast<int8_t>('('));
-  int lenPid = ACE_OS::snprintf(buf, 50, "%d", pid);
+  int lenPid = std::snprintf(buf, 50, "%d", pid);
   // DSMemberId.append(buf);
   // m_dsmemID.writeInt((int32_t)pid);
   m_dsmemID.writeBytesOnly(reinterpret_cast<int8_t*>(buf), lenPid);
@@ -336,7 +335,7 @@ void ClientProxyMembershipID::getClientProxyMembershipID() {
   m_dsmemID.writeBytesOnly(reinterpret_cast<int8_t*>(hexBuf), 8);
   m_dsmemID.write(static_cast<int8_t>(':'));
   // DSMemberId = DSMemberId.append(":");
-  ACE_OS::snprintf(dsName, 50, "%s", dsPtr->getName());
+  std::snprintf(dsName, 50, "%s", dsPtr->getName());
   // DSMemberId.append(dsName);
   uint32_t dsLen = static_cast<uint32_t>(strlen(dsName));
   m_dsmemID.writeBytesOnly(reinterpret_cast<int8_t*>(dsName), dsLen);

--- a/src/cppcache/src/ClientProxyMembershipID.hpp
+++ b/src/cppcache/src/ClientProxyMembershipID.hpp
@@ -25,7 +25,6 @@
 #include <gfcpp/DataOutput.hpp>
 #include "GeodeTypeIdsImpl.hpp"
 #include "DSMemberForVersionStamp.hpp"
-#include <ace/OS.h>
 #include <string>
 
 namespace apache {
@@ -92,8 +91,8 @@ class ClientProxyMembershipID : public DSMemberForVersionStamp {
     char hostInfo[255] = {0};
     uint32_t offset = 0;
     for (uint32_t i = 0; i < getHostAddrLen(); i++) {
-      offset += ACE_OS::snprintf(hostInfo + offset, 255 - offset, ":%x",
-                                 m_hostAddr[i]);
+      offset += std::snprintf(hostInfo + offset, 255 - offset, ":%x",
+                              m_hostAddr[i]);
     }
     CacheableStringPtr tempHashCode = CacheableString::create(hostInfo, offset);
     result = result + tempHashCode->hashcode();

--- a/src/cppcache/src/CqEventImpl.cpp
+++ b/src/cppcache/src/CqEventImpl.cpp
@@ -90,7 +90,7 @@ bool CqEventImpl::getError() { return m_error; }
 
 std::string CqEventImpl::toString() {
   char buffer[1024];
-  ACE_OS::snprintf(
+  std::snprintf(
       buffer, 1024,
       "CqEvent CqName=%s; base operation=%d; cq operation= %d;key=%s;value=%s",
       m_cQuery->getName(), m_baseOp, m_queryOp, m_key->toString()->asChar(),

--- a/src/cppcache/src/DiffieHellman.cpp
+++ b/src/cppcache/src/DiffieHellman.cpp
@@ -44,8 +44,8 @@ void* DiffieHellman::getOpenSSLFuncPtr(const char* function_name) {
   void* func = m_dll.symbol(function_name);
   if (func == NULL) {
     char msg[1000];
-    ACE_OS::snprintf(msg, 1000, "cannot find function %s in library %s",
-                     function_name, "cryptoImpl");
+    std::snprintf(msg, 1000, "cannot find function %s in library %s",
+                  function_name, "cryptoImpl");
     LOGERROR(msg);
     throw IllegalStateException(msg);
   }
@@ -61,7 +61,7 @@ void DiffieHellman::initOpenSSLFuncPtrs() {
 
   if (m_dll.open(libName, ACE_DEFAULT_SHLIB_MODE, 0) == -1) {
     char msg[1000];
-    ACE_OS::snprintf(msg, 1000, "cannot open library: %s", libName);
+    std::snprintf(msg, 1000, "cannot open library: %s", libName);
     LOGERROR(msg);
     throw FileNotFoundException(msg);
   }
@@ -99,13 +99,13 @@ void DiffieHellman::initDhKeys(const PropertiesPtr& props) {
 
   if (error == DH_ERR_UNSUPPORTED_ALGO) {  // Unsupported Algorithm
     char msg[64] = {'\0'};
-    ACE_OS::snprintf(msg, 64, "Algorithm %s is not supported.",
-                     dhAlgo->asChar());
+    std::snprintf(msg, 64, "Algorithm %s is not supported.",
+                  dhAlgo->asChar());
     throw IllegalArgumentException(msg);
   } else if (error == DH_ERR_ILLEGAL_KEYSIZE) {  // Illegal Key size
     char msg[64] = {'\0'};
-    ACE_OS::snprintf(msg, 64, "Illegal key size for algorithm %s.",
-                     dhAlgo->asChar());
+    std::snprintf(msg, 64, "Illegal key size for algorithm %s.",
+                  dhAlgo->asChar());
     throw IllegalArgumentException(msg);
   } else if (m_dhCtx == NULL) {
     throw IllegalStateException(

--- a/src/cppcache/src/DiskStoreId.cpp
+++ b/src/cppcache/src/DiskStoreId.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "DiskStoreId.hpp"
-#include <ace/OS.h>
 
 namespace apache {
 namespace geode {
@@ -32,10 +31,9 @@ std::string DiskStoreId::getHashKey() {
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(hashCode, 128, "%" PRIx64 "_%" PRIx64, m_mostSig,
-                     m_leastSig);
+    std::snprintf(hashCode, 128, "%" PRIx64 "_%" PRIx64, m_mostSig,
+                  m_leastSig);
     m_hashCode.append(hashCode);
   }
   return m_hashCode;

--- a/src/cppcache/src/EventId.cpp
+++ b/src/cppcache/src/EventId.cpp
@@ -19,9 +19,7 @@
 #include "GeodeTypeIdsImpl.hpp"
 #include "ClientProxyMembershipID.hpp"
 #include <ace/TSS_T.h>
-
-#include <ace/OS.h>
-#include <ace/INET_Addr.h>
+#include <cstring>
 
 namespace apache {
 namespace geode {
@@ -134,7 +132,7 @@ int8_t EventId::typeId() const { return GeodeTypeIdsImpl::EventId; }
 
 EventId::EventId(char* memId, uint32_t memIdLen, int64_t thr, int64_t seq) {
   // TODO: statics being assigned; not thread-safe??
-  ACE_OS::memcpy(m_eidMem, memId, memIdLen);
+  std::memcpy(m_eidMem, memId, memIdLen);
   m_eidMemLen = memIdLen;
   m_eidThr = thr;
   m_eidSeq = seq;
@@ -180,10 +178,10 @@ EventId::~EventId() {}
 
 /** used to render as a string for logging. */
 size_t EventId::logString(char* buffer, size_t maxLength) const {
-  return ACE_OS::snprintf(buffer, maxLength,
-                          "EventId( memID=[binary], thr=%" PRIi64
-                          ", seq=%" PRIi64 " )",
-                          m_eidThr, m_eidSeq);
+  return std::snprintf(buffer, maxLength,
+                       "EventId( memID=[binary], thr=%" PRIi64
+                       ", seq=%" PRIi64 " )",
+                       m_eidThr, m_eidSeq);
 }
 }  // namespace client
 }  // namespace geode

--- a/src/cppcache/src/Exception.cpp
+++ b/src/cppcache/src/Exception.cpp
@@ -19,13 +19,13 @@ extern "C" {
 #include <string.h>
 #include <stdlib.h>
 }
-#include <ace/OS.h>
 
 #include <gfcpp/Exception.hpp>
 #include <gfcpp/CacheableString.hpp>
 #include <StackTrace.hpp>
 #include <ace/TSS_T.h>
 
+#include <cstring>
 #include <string>
 
 namespace apache {
@@ -54,10 +54,10 @@ Exception::Exception(const char* msg1, const char* msg2, bool forceTrace,
   char* msg;
   GF_NEW(msg, char[len + 1]);
   if (msg1) {
-    ACE_OS::memcpy(msg, msg1, len1);
+    std::memcpy(msg, msg1, len1);
   }
   if (msg2) {
-    ACE_OS::memcpy(msg + len1, msg2, len2);
+    std::memcpy(msg + len1, msg2, len2);
   }
   msg[len] = '\0';
 
@@ -107,7 +107,7 @@ size_t Exception::getStackTrace(char* buffer, size_t maxLength) const {
       traceString += "Cause by exception: ";
       m_cause->m_stack->getString(traceString);
     }
-    len = ACE_OS::snprintf(buffer, maxLength, "%s", traceString.c_str());
+    len = std::snprintf(buffer, maxLength, "%s", traceString.c_str());
   }
   return len;
 }

--- a/src/cppcache/src/ExceptionTypes.cpp
+++ b/src/cppcache/src/ExceptionTypes.cpp
@@ -329,7 +329,7 @@ void GfErrTypeThrowException(const char* str, GfErrType err) {
       char buf[64];
       LOGINFO("error code: %d", err);
       if (exMsg == NULL) {
-        ACE_OS::snprintf(buf, 64, "Unknown error code[0x%X]", err);
+        std::snprintf(buf, 64, "Unknown error code[0x%X]", err);
         exMsg = buf;
       }
       UnknownException ex(str, exMsg);

--- a/src/cppcache/src/Log.cpp
+++ b/src/cppcache/src/Log.cpp
@@ -18,6 +18,9 @@
 #include <gfcpp/gfcpp_globals.hpp>
 
 #include <cctype>
+#include <cstdlib>
+#include <ctime>
+#include <cstring>
 #include <string>
 #include <utility>
 #include <vector>
@@ -110,7 +113,7 @@ static int selector(const dirent* d) {
     size_t fileHyphenPos = tempname.find_last_of('-');
     if (fileHyphenPos != std::string::npos) {
       std::string buff1 = tempname.substr(0, fileHyphenPos);
-      if (ACE_OS::strstr(filebasename.c_str(), buff1.c_str()) == 0) {
+      if (std::strstr(filebasename.c_str(), buff1.c_str()) == 0) {
         return 0;
       }
       if (fileHyphenPos != actualHyphenPos) return 0;
@@ -138,7 +141,7 @@ static int comparator(const dirent** d1, const dirent** d2) {
     return 1;
   }
 
-  int diff = ACE_OS::strcmp((*d1)->d_name, (*d2)->d_name);
+  int diff = std::strcmp((*d1)->d_name, (*d2)->d_name);
   if (diff < 0) {
     return -1;
   } else if (diff > 0) {
@@ -186,7 +189,7 @@ const char* Log::logFileName() {
       throw IllegalStateException(
           ("Log file name is too long: " + *g_logFile).c_str());
     }
-    ACE_OS::strncpy(g_logFileNameBuffer, g_logFile->c_str(),
+    std::strncpy(g_logFileNameBuffer, g_logFile->c_str(),
                     sizeof(g_logFileNameBuffer));
   }
 
@@ -230,7 +233,7 @@ void Log::init(LogLevel level, const char* logFileName, int32 logFileLimit,
     // replace all '\' with '/' to make everything easier..
     size_t length = g_logFile->length() + 1;
     char* slashtmp = new char[length];
-    ACE_OS::strncpy(slashtmp, g_logFile->c_str(), length);
+    std::strncpy(slashtmp, g_logFile->c_str(), length);
     for (size_t i = 0; i < g_logFile->length(); i++) {
       if (slashtmp[i] == '/') {
         slashtmp[i] = '\\';
@@ -319,7 +322,7 @@ void Log::init(LogLevel level, const char* logFileName, int32 logFileLimit,
           if (fileHyphenPos != std::string::npos) {
             std::string buff =
                 tempname.substr(fileHyphenPos + 1, tempname.length());
-            g_rollIndex = ACE_OS::atoi(buff.c_str()) + 1;
+            g_rollIndex = std::atoi(buff.c_str()) + 1;
           }
         }  // if loop
       }    // for loop
@@ -354,7 +357,6 @@ void Log::init(LogLevel level, const char* logFileName, int32 logFileLimit,
        * callers must be careful not to overflow the actual space of the
        * destination.
        * Use snprintf() instead, or correct precision specifiers.
-       * Fix : using ACE_OS::snprintf
        */
       char rollFile[1024] = {0};
       std::string logsdirname;
@@ -382,18 +384,18 @@ void Log::init(LogLevel level, const char* logFileName, int32 logFileLimit,
         fnameBeforeExt = logsbasename.substr(0, posOfExt);
         extName = logsbasename.substr(posOfExt + 1, baselen);
       }
-      ACE_OS::snprintf(rollFile, 1024, "%s%c%s-%d.%s", logsdirname.c_str(),
-                       ACE_DIRECTORY_SEPARATOR_CHAR, fnameBeforeExt.c_str(),
-                       g_rollIndex++, extName.c_str());
+      std::snprintf(rollFile, 1024, "%s%c%s-%d.%s", logsdirname.c_str(),
+                    ACE_DIRECTORY_SEPARATOR_CHAR, fnameBeforeExt.c_str(),
+                    g_rollIndex++, extName.c_str());
       bool rollFileNameGot = false;
       while (!rollFileNameGot) {
         FILE* checkFile = fopen(rollFile, "r");
         if (checkFile != NULL) {
           fclose(checkFile);
           checkFile = NULL;
-          ACE_OS::snprintf(rollFile, 1024, "%s%c%s-%d.%s", logsdirname.c_str(),
-                           ACE_DIRECTORY_SEPARATOR_CHAR, fnameBeforeExt.c_str(),
-                           g_rollIndex++, extName.c_str());
+          std::snprintf(rollFile, 1024, "%s%c%s-%d.%s", logsdirname.c_str(),
+                        ACE_DIRECTORY_SEPARATOR_CHAR, fnameBeforeExt.c_str(),
+                        g_rollIndex++, extName.c_str());
         } else {
           rollFileNameGot = true;
         }
@@ -562,7 +564,7 @@ const char* Log::levelToChars(Log::LogLevel level) {
 
     default: {
       char buf[64] = {0};
-      ACE_OS::snprintf(buf, 64, "Unexpected log level: %d", level);
+      std::snprintf(buf, 64, "Unexpected log level: %d", level);
       throw IllegalArgumentException(buf);
     }
   }
@@ -614,14 +616,14 @@ char* Log::formatLogLine(char* buf, Log::LogLevel level) {
   time_t secs = clock.sec();
   struct tm* tm_val = ACE_OS::localtime(&secs);
   char* pbuf = buf;
-  pbuf += ACE_OS::snprintf(pbuf, 15, "[%s ", Log::levelToChars(level));
-  pbuf += ACE_OS::strftime(pbuf, MINBUFSIZE, "%Y/%m/%d %H:%M:%S", tm_val);
+  pbuf += std::snprintf(pbuf, 15, "[%s ", Log::levelToChars(level));
+  pbuf += std::strftime(pbuf, MINBUFSIZE, "%Y/%m/%d %H:%M:%S", tm_val);
   pbuf +=
-      ACE_OS::snprintf(pbuf, 15, ".%06ld ", static_cast<long>(clock.usec()));
-  pbuf += ACE_OS::strftime(pbuf, MINBUFSIZE, "%Z ", tm_val);
+      std::snprintf(pbuf, 15, ".%06ld ", static_cast<long>(clock.usec()));
+  pbuf += std::strftime(pbuf, MINBUFSIZE, "%Z ", tm_val);
 
-  ACE_OS::snprintf(pbuf, 300, "%s:%d %lu] ", g_uname.nodename, g_pid,
-                   (unsigned long)ACE_OS::thr_self());
+  std::snprintf(pbuf, 300, "%s:%d %lu] ", g_uname.nodename, g_pid,
+                (unsigned long)ACE_OS::thr_self());
 
   return buf;
 }
@@ -660,7 +662,7 @@ void Log::put(LogLevel level, const char* msg) {
 
     formatLogLine(buf, level);
     size_t numChars =
-        static_cast<int>(ACE_OS::strlen(buf) + ACE_OS::strlen(msg));
+        static_cast<int>(std::strlen(buf) + std::strlen(msg));
     g_bytesWritten +=
         numChars + 2;  // bcoz we have to count trailing new line (\n)
 
@@ -691,17 +693,17 @@ void Log::put(LogLevel level, const char* msg) {
         fnameBeforeExt = logsbasename.substr(0, posOfExt);
         extName = logsbasename.substr(posOfExt + 1, baselen);
       }
-      ACE_OS::snprintf(rollFile, 1024, "%s%c%s-%d.%s", logsdirname.c_str(),
-                       ACE_DIRECTORY_SEPARATOR_CHAR, fnameBeforeExt.c_str(),
-                       g_rollIndex++, extName.c_str());
+      std::snprintf(rollFile, 1024, "%s%c%s-%d.%s", logsdirname.c_str(),
+                    ACE_DIRECTORY_SEPARATOR_CHAR, fnameBeforeExt.c_str(),
+                    g_rollIndex++, extName.c_str());
       bool rollFileNameGot = false;
       while (!rollFileNameGot) {
         FILE* fp1 = fopen(rollFile, "r");
         if (fp1 != NULL) {
           fclose(fp1);
-          ACE_OS::snprintf(rollFile, 1024, "%s%c%s-%d.%s", logsdirname.c_str(),
-                           ACE_DIRECTORY_SEPARATOR_CHAR, fnameBeforeExt.c_str(),
-                           g_rollIndex++, extName.c_str());
+          std::snprintf(rollFile, 1024, "%s%c%s-%d.%s", logsdirname.c_str(),
+                        ACE_DIRECTORY_SEPARATOR_CHAR, fnameBeforeExt.c_str(),
+                        g_rollIndex++, extName.c_str());
         } else {
           rollFileNameGot = true;
         }
@@ -736,7 +738,7 @@ void Log::put(LogLevel level, const char* msg) {
       g_spaceUsed = 0;
       ACE_stat statBuf = {0};
       /*for(int i = 1; i < entries_count; i++) {
-        ACE_OS::snprintf(fullpath , 512 ,
+        std::snprintf(fullpath , 512 ,
     "%s%c%s",dirname.c_str(),ACE_DIRECTORY_SEPARATOR_CHAR,resultArray[i]->d_name);
         ACE_OS::stat(fullpath,&statBuf);
         g_fileInfoPair = std::make_pair(fullpath,statBuf.st_size);
@@ -756,8 +758,8 @@ void Log::put(LogLevel level, const char* msg) {
       int status = sds.open(dirname.c_str(), selector, comparator);
       if (status != -1) {
         for (int index = 1; index < sds.length(); ++index) {
-          ACE_OS::snprintf(fullpath, 512, "%s%c%s", dirname.c_str(),
-                           ACE_DIRECTORY_SEPARATOR_CHAR, sds[index]->d_name);
+          std::snprintf(fullpath, 512, "%s%c%s", dirname.c_str(),
+                        ACE_DIRECTORY_SEPARATOR_CHAR, sds[index]->d_name);
           ACE_OS::stat(fullpath, &statBuf);
           g_fileInfoPair = std::make_pair(fullpath, statBuf.st_size);
           fileInfo.push_back(g_fileInfoPair);
@@ -774,8 +776,8 @@ void Log::put(LogLevel level, const char* msg) {
           g_spaceUsed -= fileSize;
         } else {
           char printmsg[256];
-          ACE_OS::snprintf(printmsg, 256, "%s\t%s\n", "Could not delete",
-                           fileInfo[fileIndex].first.c_str());
+          std::snprintf(printmsg, 256, "%s\t%s\n", "Could not delete",
+                        fileInfo[fileIndex].first.c_str());
           int numChars =
               fprintf(g_log, "%s%s\n", formatLogLine(buf, level), printmsg);
           g_bytesWritten +=
@@ -808,13 +810,13 @@ void Log::put(LogLevel level, const char* msg) {
 
 void Log::putThrow(LogLevel level, const char* msg, const Exception& ex) {
   char buf[128] = {0};
-  ACE_OS::snprintf(buf, 128, "Geode exception %s thrown: ", ex.getName());
+  std::snprintf(buf, 128, "Geode exception %s thrown: ", ex.getName());
   put(level, (std::string(buf) + ex.getMessage() + "\n" + msg).c_str());
 }
 
 void Log::putCatch(LogLevel level, const char* msg, const Exception& ex) {
   char buf[128] = {0};
-  ACE_OS::snprintf(buf, 128, "Geode exception %s caught: ", ex.getName());
+  std::snprintf(buf, 128, "Geode exception %s caught: ", ex.getName());
   put(level, (std::string(buf) + ex.getMessage() + "\n" + msg).c_str());
 }
 
@@ -825,7 +827,7 @@ void Log::enterFn(LogLevel level, const char* functionName) {
     fn = fn.substr(fn.size() - MAX_NAME_LENGTH, MAX_NAME_LENGTH);
   }
   char buf[MAX_NAME_LENGTH + 512] = {0};
-  ACE_OS::snprintf(buf, 1536, "{{{===>>> Entering function %s", fn.c_str());
+  std::snprintf(buf, 1536, "{{{===>>> Entering function %s", fn.c_str());
   put(level, buf);
 }
 
@@ -836,7 +838,7 @@ void Log::exitFn(LogLevel level, const char* functionName) {
     fn = fn.substr(fn.size() - MAX_NAME_LENGTH, MAX_NAME_LENGTH);
   }
   char buf[MAX_NAME_LENGTH + 512] = {0};
-  ACE_OS::snprintf(buf, 1536, "<<<===}}} Exiting function %s", fn.c_str());
+  std::snprintf(buf, 1536, "<<<===}}} Exiting function %s", fn.c_str());
   put(level, buf);
 }
 

--- a/src/cppcache/src/PdxFieldType.cpp
+++ b/src/cppcache/src/PdxFieldType.cpp
@@ -27,8 +27,6 @@
 #include <gfcpp/PdxFieldTypes.hpp>
 //#include <malloc.h>
 
-#include "ace/OS.h"
-
 namespace apache {
 namespace geode {
 namespace client {
@@ -155,9 +153,8 @@ CacheableStringPtr PdxFieldType::toString() const {
    * callers must be careful not to overflow the actual space of the
    * destination.
    * Use snprintf() instead, or correct precision specifiers.
-   * Fix : using ACE_OS::snprintf
    */
-  ACE_OS::snprintf(
+  std::snprintf(
       stringBuf, 1024,
       " PdxFieldName=%s TypeId=%d VarLenFieldIdx=%d sequenceid=%d\n",
       this->m_fieldName.c_str(), this->m_typeId, this->m_varLenFieldIdx,

--- a/src/cppcache/src/PdxInstanceFactoryImpl.cpp
+++ b/src/cppcache/src/PdxInstanceFactoryImpl.cpp
@@ -18,7 +18,6 @@
 #include "PdxType.hpp"
 #include "PdxTypes.hpp"
 #include "PdxInstanceImpl.hpp"
-#include <ace/OS_NS_stdio.h>
 
 namespace apache {
 namespace geode {
@@ -394,12 +393,11 @@ void PdxInstanceFactoryImpl::isFieldAdded(const char* fieldName) {
      * callers must be careful not to overflow the actual space of the
      * destination.
      * Use snprintf() instead, or correct precision specifiers.
-     * Fix : using ACE_OS::snprintf
      */
-    ACE_OS::snprintf(excpStr, 256,
-                     "Field: %s is either already added into "
-                     "PdxInstanceFactory or it is null ",
-                     fieldName);
+    std::snprintf(excpStr, 256,
+                  "Field: %s is either already added into "
+                  "PdxInstanceFactory or it is null ",
+                  fieldName);
     throw IllegalStateException(excpStr);
   }
 }

--- a/src/cppcache/src/PdxInstanceImpl.cpp
+++ b/src/cppcache/src/PdxInstanceImpl.cpp
@@ -26,6 +26,7 @@
 #include "CacheImpl.hpp"
 #include "Utils.hpp"
 #include <algorithm>
+#include <cstring>
 
 /* adongre  - Coverity II
 * CID 29255: Calling risky function (SECURE_CODING)[VERY RISKY]. Using "sprintf"
@@ -34,13 +35,12 @@
 * arbitrarily long string,
 * callers must be careful not to overflow the actual space of the destination.
 * Use snprintf() instead, or correct precision specifiers.
-* Fix : using ACE_OS::snprintf
 */
 
 #define VERIFY_PDX_INSTANCE_FIELD_THROW                                 \
   if (pft == NULLPTR) {                                                 \
     char excpStr[256] = {0};                                            \
-    ACE_OS::snprintf(excpStr, 256, "PdxInstance doesn't has field %s ", \
+    std::snprintf(excpStr, 256, "PdxInstance doesn't has field %s ", \
                      fieldname);                                        \
     throw IllegalStateException(excpStr);                               \
   }
@@ -68,7 +68,7 @@ PdxFieldTypePtr PdxInstanceImpl::m_DefaultPdxFieldType(
                      -1 /*field index*/, false, 1, -1 /*var len field idx*/));
 
 bool sortFunc(PdxFieldTypePtr field1, PdxFieldTypePtr field2) {
-  int diff = ACE_OS::strcmp(field1->getFieldName(), field2->getFieldName());
+  int diff = std::strcmp(field1->getFieldName(), field2->getFieldName());
   if (diff < 0) {
     return true;
   } else {
@@ -570,9 +570,8 @@ bool PdxInstanceImpl::deepArrayEquals(CacheablePtr obj, CacheablePtr otherObj) {
       * callers must be careful not to overflow the actual space of the
       * destination.
       * Use snprintf() instead, or correct precision specifiers.
-      * Fix : using ACE_OS::snprintf
       */
-      ACE_OS::snprintf(excpStr, 256,
+      std::snprintf(excpStr, 256,
                        "PdxInstance cannot calculate equals of the field %s "
                        "since equals is only supported for CacheableKey "
                        "derived types ",
@@ -727,9 +726,8 @@ int PdxInstanceImpl::deepArrayHashCode(CacheablePtr obj) {
       * callers must be careful not to overflow the actual space of the
       * destination.
       * Use snprintf() instead, or correct precision specifiers.
-      * Fix : using ACE_OS::snprintf
       */
-      ACE_OS::snprintf(excpStr, 256,
+      std::snprintf(excpStr, 256,
                        "PdxInstance cannot calculate hashcode of the field %s "
                        "since hashcode is only supported for CacheableKey "
                        "derived types ",
@@ -806,9 +804,8 @@ uint32_t PdxInstanceImpl::hashcode() const {
         * callers must be careful not to overflow the actual space of the
         * destination.
         * Use snprintf() instead, or correct precision specifiers.
-        * Fix : using ACE_OS::snprintf
         */
-        ACE_OS::snprintf(excpStr, 256, "PdxInstance not found typeid %d ",
+        std::snprintf(excpStr, 256, "PdxInstance not found typeid %d ",
                          pField->getTypeId());
         throw IllegalStateException(excpStr);
       }
@@ -1211,15 +1208,14 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
   * arbitrarily long string,
   * callers must be careful not to overflow the actual space of the destination.
   * Use snprintf() instead, or correct precision specifiers.
-  * Fix : using ACE_OS::snprintf
   */
   PdxTypePtr pt = getPdxType();
   std::string toString = "PDX[";
   char buf[2048];
-  ACE_OS::snprintf(buf, 2048, "%d", pt->getTypeId());
+  std::snprintf(buf, 2048, "%d", pt->getTypeId());
   toString += buf;
   toString += ",";
-  ACE_OS::snprintf(buf, 2048, "%s", pt->getPdxClassName());
+  std::snprintf(buf, 2048, "%s", pt->getPdxClassName());
   toString += buf;
   toString += "]{";
   bool firstElement = true;
@@ -1230,7 +1226,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
     } else {
       toString += ",";
     }
-    ACE_OS::snprintf(buf, 2048, "%s", identityFields.at(i)->getFieldName());
+    std::snprintf(buf, 2048, "%s", identityFields.at(i)->getFieldName());
     toString += buf;
     toString += "=";
 
@@ -1238,63 +1234,63 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
       case PdxFieldTypes::BOOLEAN: {
         bool value = false;
         getField(identityFields.at(i)->getFieldName(), value);
-        ACE_OS::snprintf(buf, 2048, "%s", value ? "true" : "false");
+        std::snprintf(buf, 2048, "%s", value ? "true" : "false");
         toString += buf;
         break;
       }
       case PdxFieldTypes::BYTE: {
         signed char value = 0;
         getField(identityFields.at(i)->getFieldName(), value);
-        ACE_OS::snprintf(buf, 2048, "%d", value);
+        std::snprintf(buf, 2048, "%d", value);
         toString += buf;
         break;
       }
       case PdxFieldTypes::SHORT: {
         int16_t value = 0;
         getField(identityFields.at(i)->getFieldName(), value);
-        ACE_OS::snprintf(buf, 2048, "%d", value);
+        std::snprintf(buf, 2048, "%d", value);
         toString += buf;
         break;
       }
       case PdxFieldTypes::INT: {
         int32_t value = 0;
         getField(identityFields.at(i)->getFieldName(), value);
-        ACE_OS::snprintf(buf, 2048, "%d", value);
+        std::snprintf(buf, 2048, "%d", value);
         toString += buf;
         break;
       }
       case PdxFieldTypes::LONG: {
         int64_t value = 0;
         getField(identityFields.at(i)->getFieldName(), value);
-        ACE_OS::snprintf(buf, 2048, "%lld", value);
+        std::snprintf(buf, 2048, "%lld", value);
         toString += buf;
         break;
       }
       case PdxFieldTypes::FLOAT: {
         float value = 0;
         getField(identityFields.at(i)->getFieldName(), value);
-        ACE_OS::snprintf(buf, 2048, "%f", value);
+        std::snprintf(buf, 2048, "%f", value);
         toString += buf;
         break;
       }
       case PdxFieldTypes::DOUBLE: {
         double value = 0;
         getField(identityFields.at(i)->getFieldName(), value);
-        ACE_OS::snprintf(buf, 2048, "%f", value);
+        std::snprintf(buf, 2048, "%f", value);
         toString += buf;
         break;
       }
       case PdxFieldTypes::CHAR: {
         wchar_t value = 0;
         getField(identityFields.at(i)->getFieldName(), value);
-        ACE_OS::snprintf(buf, 2048, "%c", value);
+        std::snprintf(buf, 2048, "%c", value);
         toString += buf;
         break;
       }
       case PdxFieldTypes::STRING: {
         wchar_t* value = 0;
         getField(identityFields.at(i)->getFieldName(), &value);
-        ACE_OS::snprintf(buf, 2048, "%ls", value);
+        std::snprintf(buf, 2048, "%ls", value);
         toString += buf;
         break;
       }
@@ -1304,7 +1300,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
         getField(identityFields.at(i)->getFieldName(), &value, length);
         if (length > 0) {
           for (int i = 0; i < length; i++) {
-            ACE_OS::snprintf(buf, 2048, "%c\t", value[i]);
+            std::snprintf(buf, 2048, "%c\t", value[i]);
             toString += buf;
           }
           GF_SAFE_DELETE_ARRAY(value);
@@ -1317,7 +1313,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
         getField(identityFields.at(i)->getFieldName(), &value, length);
         if (length > 0) {
           for (int i = 0; i < length; i++) {
-            ACE_OS::snprintf(buf, 2048, "%ls\t", value[i]);
+            std::snprintf(buf, 2048, "%ls\t", value[i]);
             toString += buf;
           }
         }
@@ -1329,7 +1325,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
         getField(identityFields.at(i)->getFieldName(), &value, length);
         if (length > 0) {
           for (int i = 0; i < length; i++) {
-            ACE_OS::snprintf(buf, 2048, "%d\t", value[i]);
+            std::snprintf(buf, 2048, "%d\t", value[i]);
             toString += buf;
           }
           GF_SAFE_DELETE_ARRAY(value);
@@ -1342,7 +1338,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
         getField(identityFields.at(i)->getFieldName(), &value, length);
         if (length > 0) {
           for (int i = 0; i < length; i++) {
-            ACE_OS::snprintf(buf, 2048, "%d\t", value[i]);
+            std::snprintf(buf, 2048, "%d\t", value[i]);
             toString += buf;
           }
           GF_SAFE_DELETE_ARRAY(value);
@@ -1355,7 +1351,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
         getField(identityFields.at(i)->getFieldName(), &value, length);
         if (length > 0) {
           for (int i = 0; i < length; i++) {
-            ACE_OS::snprintf(buf, 2048, "%d\t", value[i]);
+            std::snprintf(buf, 2048, "%d\t", value[i]);
             toString += buf;
           }
           GF_SAFE_DELETE_ARRAY(value);
@@ -1368,7 +1364,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
         getField(identityFields.at(i)->getFieldName(), &value, length);
         if (length > 0) {
           for (int i = 0; i < length; i++) {
-            ACE_OS::snprintf(buf, 2048, "%lld\t", value[i]);
+            std::snprintf(buf, 2048, "%lld\t", value[i]);
             toString += buf;
           }
         }
@@ -1380,7 +1376,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
         getField(identityFields.at(i)->getFieldName(), &value, length);
         if (length > 0) {
           for (int i = 0; i < length; i++) {
-            ACE_OS::snprintf(buf, 2048, "%f\t", value[i]);
+            std::snprintf(buf, 2048, "%f\t", value[i]);
             toString += buf;
           }
           GF_SAFE_DELETE_ARRAY(value);
@@ -1393,7 +1389,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
         getField(identityFields.at(i)->getFieldName(), &value, length);
         if (length > 0) {
           for (int i = 0; i < length; i++) {
-            ACE_OS::snprintf(buf, 2048, "%f\t", value[i]);
+            std::snprintf(buf, 2048, "%f\t", value[i]);
             toString += buf;
           }
         }
@@ -1403,7 +1399,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
         CacheableDatePtr value = NULLPTR;
         getField(identityFields.at(i)->getFieldName(), value);
         if (value != NULLPTR) {
-          ACE_OS::snprintf(buf, 2048, "%s", value->toString()->asChar());
+          std::snprintf(buf, 2048, "%s", value->toString()->asChar());
           toString += buf;
         }
         break;
@@ -1414,7 +1410,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
         getField(identityFields.at(i)->getFieldName(), &value, length);
         if (length > 0) {
           for (int i = 0; i < length; i++) {
-            ACE_OS::snprintf(buf, 2048, "%s\t", value[i] ? "true" : "false");
+            std::snprintf(buf, 2048, "%s\t", value[i] ? "true" : "false");
             toString += buf;
           }
           GF_SAFE_DELETE_ARRAY(value);
@@ -1430,7 +1426,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
         if (arrayLength > 0) {
           for (int j = 0; j < arrayLength; j++) {
             for (int k = 0; k < elementLength[j]; k++) {
-              ACE_OS::snprintf(buf, 2048, "%d\t", value[j][k]);
+              std::snprintf(buf, 2048, "%d\t", value[j][k]);
               toString += buf;
             }
           }
@@ -1441,7 +1437,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
         CacheableObjectArrayPtr value;
         getField(identityFields.at(i)->getFieldName(), value);
         if (value != NULLPTR) {
-          ACE_OS::snprintf(buf, 2048, "%s\t", value->toString()->asChar());
+          std::snprintf(buf, 2048, "%s\t", value->toString()->asChar());
           toString += buf;
         }
         break;
@@ -1450,7 +1446,7 @@ CacheableStringPtr PdxInstanceImpl::toString() const {
         CacheablePtr value;
         getField(identityFields.at(i)->getFieldName(), value);
         if (value != NULLPTR) {
-          ACE_OS::snprintf(buf, 2048, "%s\t", value->toString()->asChar());
+          std::snprintf(buf, 2048, "%s\t", value->toString()->asChar());
           toString += buf;
         }
       }
@@ -1534,7 +1530,7 @@ bool PdxInstanceImpl::operator==(const CacheableKey& other) const {
   char* myPdxClassName = myPdxType->getPdxClassName();
   char* otherPdxClassName = otherPdxType->getPdxClassName();
 
-  if (ACE_OS::strcmp(otherPdxClassName, myPdxClassName) != 0) {
+  if (std::strcmp(otherPdxClassName, myPdxClassName) != 0) {
     return false;
   }
 
@@ -1645,9 +1641,8 @@ bool PdxInstanceImpl::operator==(const CacheableKey& other) const {
         * callers must be careful not to overflow the actual space of the
         * destination.
         * Use snprintf() instead, or correct precision specifiers.
-        * Fix : using ACE_OS::snprintf
         */
-        ACE_OS::snprintf(excpStr, 256, "PdxInstance not found typeid  %d ",
+        std::snprintf(excpStr, 256, "PdxInstance not found typeid  %d ",
                          myPFT->getTypeId());
         throw IllegalStateException(excpStr);
       }
@@ -1808,7 +1803,7 @@ const char* PdxInstanceImpl::getClassName() const {
     PdxTypePtr pdxtype = PdxTypeRegistry::getPdxType(m_typeId);
     if (pdxtype == NULLPTR) {
       char excpStr[256] = {0};
-      ACE_OS::snprintf(excpStr, 256,
+      std::snprintf(excpStr, 256,
                        "PdxType is not defined for PdxInstance: %d ", m_typeId);
       throw IllegalStateException(excpStr);
     }
@@ -2039,9 +2034,8 @@ void PdxInstanceImpl::setField(const char* fieldName, bool value) {
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2065,9 +2059,8 @@ void PdxInstanceImpl::setField(const char* fieldName, signed char value) {
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2091,9 +2084,8 @@ void PdxInstanceImpl::setField(const char* fieldName, unsigned char value) {
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2109,7 +2101,7 @@ void PdxInstanceImpl::setField(const char* fieldName, int16_t value) {
 
   if (pft != NULLPTR && pft->getTypeId() != PdxFieldTypes::SHORT) {
     char excpStr[256] = {0};
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2133,9 +2125,8 @@ void PdxInstanceImpl::setField(const char* fieldName, int32_t value) {
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2159,9 +2150,8 @@ void PdxInstanceImpl::setField(const char* fieldName, int64_t value) {
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2185,9 +2175,8 @@ void PdxInstanceImpl::setField(const char* fieldName, float value) {
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2211,9 +2200,8 @@ void PdxInstanceImpl::setField(const char* fieldName, double value) {
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2237,9 +2225,8 @@ void PdxInstanceImpl::setField(const char* fieldName, wchar_t value) {
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2263,9 +2250,8 @@ void PdxInstanceImpl::setField(const char* fieldName, char value) {
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2282,7 +2268,7 @@ void PdxInstanceImpl::setField(const char* fieldName, CacheableDatePtr value) {
 
   if (pft != NULLPTR && pft->getTypeId() != PdxFieldTypes::DATE) {
     char excpStr[256] = {0};
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2306,9 +2292,8 @@ void PdxInstanceImpl::setField(const char* fieldName, CacheablePtr value) {
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2324,7 +2309,7 @@ void PdxInstanceImpl::setField(const char* fieldName,
 
   if (pft != NULLPTR && pft->getTypeId() != PdxFieldTypes::OBJECT_ARRAY) {
     char excpStr[256] = {0};
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2348,9 +2333,8 @@ void PdxInstanceImpl::setField(const char* fieldName, bool* value,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2375,9 +2359,8 @@ void PdxInstanceImpl::setField(const char* fieldName, signed char* value,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2403,9 +2386,8 @@ void PdxInstanceImpl::setField(const char* fieldName, unsigned char* value,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2431,9 +2413,8 @@ void PdxInstanceImpl::setField(const char* fieldName, int16_t* value,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2458,9 +2439,8 @@ void PdxInstanceImpl::setField(const char* fieldName, int32_t* value,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2485,9 +2465,8 @@ void PdxInstanceImpl::setField(const char* fieldName, int64_t* value,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2512,9 +2491,8 @@ void PdxInstanceImpl::setField(const char* fieldName, float* value,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2539,9 +2517,8 @@ void PdxInstanceImpl::setField(const char* fieldName, double* value,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2566,9 +2543,8 @@ void PdxInstanceImpl::setField(const char* fieldName, wchar_t* value,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2593,9 +2569,8 @@ void PdxInstanceImpl::setField(const char* fieldName, char* value,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2623,9 +2598,8 @@ void PdxInstanceImpl::setField(const char* fieldName, const wchar_t* value) {
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2649,9 +2623,8 @@ void PdxInstanceImpl::setField(const char* fieldName, const char* value) {
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2677,9 +2650,8 @@ void PdxInstanceImpl::setField(const char* fieldName, int8_t** value,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2709,9 +2681,8 @@ void PdxInstanceImpl::setField(const char* fieldName, wchar_t** value,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));
@@ -2752,9 +2723,8 @@ void PdxInstanceImpl::setField(const char* fieldName, char** value,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "PdxInstance doesn't has field %s or type of field not matched %s ",
         fieldName, (pft != NULLPTR ? pft->toString()->asChar() : ""));

--- a/src/cppcache/src/PdxReaderWithTypeCollector.cpp
+++ b/src/cppcache/src/PdxReaderWithTypeCollector.cpp
@@ -24,7 +24,6 @@
 #include "PdxReaderWithTypeCollector.hpp"
 #include "PdxTypes.hpp"
 #include <gfcpp/PdxFieldTypes.hpp>
-#include <ace/OS_NS_stdio.h>
 
 namespace apache {
 namespace geode {
@@ -52,7 +51,7 @@ void PdxReaderWithTypeCollector::checkType(const char* fieldName, int8_t typeId,
   if (pft != NULLPTR) {
     if (typeId != pft->getTypeId()) {
       char excpStr[128] = {0};
-      ACE_OS::snprintf(
+      std::snprintf(
           excpStr, 128,
           "Expected %s fieldType field but found field of type %s ", fieldType,
           pft->toString()->asChar());

--- a/src/cppcache/src/PdxType.cpp
+++ b/src/cppcache/src/PdxType.cpp
@@ -28,7 +28,8 @@
 #include "Utils.hpp"
 #include "PdxTypeRegistry.hpp"
 #include "PdxHelper.hpp"
-#include <ace/OS.h>
+
+#include <cstring>
 
 namespace apache {
 namespace geode {
@@ -182,9 +183,8 @@ void PdxType::addFixedLengthTypeField(const char* fieldName,
     * callers must be careful not to overflow the actual space of the
     * destination.
     * Use snprintf() instead, or correct precision specifiers.
-    * Fix : using ACE_OS::snprintf
     */
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "Field: %s is either already added into PdxWriter or it is null ",
         fieldName);
@@ -204,7 +204,7 @@ void PdxType::addVariableLengthTypeField(const char* fieldName,
           m_fieldNameVsPdxType
               .end()) {  // COVERITY ---> 30289 Same on both sides
     char excpStr[256] = {0};
-    ACE_OS::snprintf(
+    std::snprintf(
         excpStr, 256,
         "Field: %s is either already added into PdxWriter or it is null ",
         fieldName);
@@ -625,7 +625,7 @@ bool PdxType::Equals(PdxTypePtr otherObj) {
 }
 
 bool PdxType::operator<(const PdxType& other) const {
-  return ACE_OS::strcmp(this->m_className, other.m_className) < 0;
+  return std::strcmp(this->m_className, other.m_className) < 0;
 }
 }  // namespace client
 }  // namespace geode

--- a/src/cppcache/src/PoolAttributes.cpp
+++ b/src/cppcache/src/PoolAttributes.cpp
@@ -134,7 +134,7 @@ void PoolAttributes::addLocator(const char* host, int port) {
         "Cannot add both locators and servers to a pool");
   }
   char buff[128] = {'\0'};
-  ACE_OS::snprintf(buff, 128, "%s:%d", host, port);
+  std::snprintf(buff, 128, "%s:%d", host, port);
   m_initLocList.push_back(buff);
 }
 
@@ -144,6 +144,6 @@ void PoolAttributes::addServer(const char* host, int port) {
         "Cannot add both locators and servers to a pool");
   }
   char buff[128] = {'\0'};
-  ACE_OS::snprintf(buff, 128, "%s:%d", host, port);
+  std::snprintf(buff, 128, "%s:%d", host, port);
   m_initServList.push_back(buff);
 }

--- a/src/cppcache/src/PoolFactory.cpp
+++ b/src/cppcache/src/PoolFactory.cpp
@@ -186,13 +186,13 @@ PoolPtr PoolFactory::create(const char* name) {
 void PoolFactory::addCheck(const char* host, int port) {
   if (port <= 0) {
     char buff[100];
-    ACE_OS::snprintf(buff, 100, "port must be greater than 0 but was %d", port);
+    std::snprintf(buff, 100, "port must be greater than 0 but was %d", port);
     throw IllegalArgumentException(buff);
   }
   ACE_INET_Addr addr(port, host);
   if (!(addr.get_ip_address())) {
     char buff[100];
-    ACE_OS::snprintf(buff, 100, "Unknown host %s", host);
+    std::snprintf(buff, 100, "Unknown host %s", host);
     throw IllegalArgumentException(buff);
   }
 }

--- a/src/cppcache/src/Properties.cpp
+++ b/src/cppcache/src/Properties.cpp
@@ -131,7 +131,7 @@ void Properties::insert(const char* key, const int value) {
     throw NullPointerException("Properties::insert: Null key given.");
   }
   char temp[64];
-  ACE_OS::snprintf(temp, 64, "%d", value);
+  std::snprintf(temp, 64, "%d", value);
   CacheableStringPtr keyptr = CacheableString::create(key);
   CacheableStringPtr valptr = CacheableString::create(temp);
   MAP->rebind(keyptr, valptr);

--- a/src/cppcache/src/ProxyRegion.cpp
+++ b/src/cppcache/src/ProxyRegion.cpp
@@ -21,7 +21,7 @@
 
 void ProxyRegion::unSupportedOperation(const char* operationName) const {
   char msg[256] = {'\0'};
-  ACE_OS::snprintf(
+  std::snprintf(
       msg, 256,
       "%s operation is not supported when Region instance is logical.",
       operationName);

--- a/src/cppcache/src/ProxyRemoteQueryService.cpp
+++ b/src/cppcache/src/ProxyRemoteQueryService.cpp
@@ -43,10 +43,10 @@ QueryPtr ProxyRemoteQueryService::newQuery(const char* querystring) {
 
 void ProxyRemoteQueryService::unSupportedException(const char* operationName) {
   char msg[256] = {'\0'};
-  ACE_OS::snprintf(msg, 256,
-                   "%s operation is not supported when pool is in multiuser "
-                   "authentication mode.",
-                   operationName);
+  std::snprintf(msg, 256,
+                "%s operation is not supported when pool is in multiuser "
+                "authentication mode.",
+                operationName);
   throw UnsupportedOperationException(msg);
 }
 

--- a/src/cppcache/src/PutAllPartialResult.hpp
+++ b/src/cppcache/src/PutAllPartialResult.hpp
@@ -81,8 +81,8 @@ class PutAllPartialResult : public Serializable {
   virtual CacheableStringPtr toString() const {
     char msgStr1[1024];
     if (m_firstFailedKey != NULLPTR) {
-      ACE_OS::snprintf(msgStr1, 1024, "[ Key =%s ]",
-                       m_firstFailedKey->toString()->asChar());
+      std::snprintf(msgStr1, 1024, "[ Key =%s ]",
+                    m_firstFailedKey->toString()->asChar());
     }
 
     char msgStr2[1024];
@@ -90,12 +90,12 @@ class PutAllPartialResult : public Serializable {
       // TODO:: impl. CacheableObjectPartList.size();
       int failedKeyNum = m_totalMapSize - m_succeededKeys->size();
       if (failedKeyNum > 0) {
-        ACE_OS::snprintf(
+        std::snprintf(
             msgStr2, 1024,
             "The putAll operation failed to put %d out of %d entries ",
             failedKeyNum, m_totalMapSize);
       } else {
-        ACE_OS::snprintf(
+        std::snprintf(
             msgStr2, 1024,
             "The putAll operation successfully put %d out of %d entries ",
             m_succeededKeys->size(), m_totalMapSize);
@@ -103,8 +103,8 @@ class PutAllPartialResult : public Serializable {
     }
 
     char stringBuf[7000];
-    ACE_OS::snprintf(stringBuf, 7000, "PutAllPartialResult: %s%s", msgStr1,
-                     msgStr2);
+    std::snprintf(stringBuf, 7000, "PutAllPartialResult: %s%s", msgStr1,
+                  msgStr2);
     return CacheableString::create(stringBuf);
   }
 

--- a/src/cppcache/src/RegionAttributes.cpp
+++ b/src/cppcache/src/RegionAttributes.cpp
@@ -18,12 +18,12 @@
 #include <gfcpp/Cache.hpp>
 #include <Utils.hpp>
 #include <gfcpp/DataOutput.hpp>
+#include <cstring>
 #include <string.h>
 #include <stdlib.h>
 #include <gfcpp/GeodeTypeIds.hpp>
 #include <CacheXmlParser.hpp>
 #include <ace/DLL.h>
-#include <ace/OS.h>
 #include <gfcpp/DataInput.hpp>
 #include <gfcpp/Properties.hpp>
 
@@ -100,28 +100,28 @@ RegionAttributes::RegionAttributes(const RegionAttributes& rhs)
   if (rhs.m_cacheLoaderLibrary != NULL) {
     size_t len = strlen(rhs.m_cacheLoaderLibrary) + 1;
     m_cacheLoaderLibrary = new char[len];
-    ACE_OS::strncpy(m_cacheLoaderLibrary, rhs.m_cacheLoaderLibrary, len);
+    std::strncpy(m_cacheLoaderLibrary, rhs.m_cacheLoaderLibrary, len);
   } else {
     m_cacheLoaderLibrary = NULL;
   }
   if (rhs.m_cacheWriterLibrary != NULL) {
     size_t len = strlen(rhs.m_cacheWriterLibrary) + 1;
     m_cacheWriterLibrary = new char[len];
-    ACE_OS::strncpy(m_cacheWriterLibrary, rhs.m_cacheWriterLibrary, len);
+    std::strncpy(m_cacheWriterLibrary, rhs.m_cacheWriterLibrary, len);
   } else {
     m_cacheWriterLibrary = NULL;
   }
   if (rhs.m_cacheListenerLibrary != NULL) {
     size_t len = strlen(rhs.m_cacheListenerLibrary) + 1;
     m_cacheListenerLibrary = new char[len];
-    ACE_OS::strncpy(m_cacheListenerLibrary, rhs.m_cacheListenerLibrary, len);
+    std::strncpy(m_cacheListenerLibrary, rhs.m_cacheListenerLibrary, len);
   } else {
     m_cacheListenerLibrary = NULL;
   }
   if (rhs.m_partitionResolverLibrary != NULL) {
     size_t len = strlen(rhs.m_partitionResolverLibrary) + 1;
     m_partitionResolverLibrary = new char[len];
-    ACE_OS::strncpy(m_partitionResolverLibrary, rhs.m_partitionResolverLibrary,
+    std::strncpy(m_partitionResolverLibrary, rhs.m_partitionResolverLibrary,
                     len);
   } else {
     m_partitionResolverLibrary = NULL;
@@ -129,28 +129,28 @@ RegionAttributes::RegionAttributes(const RegionAttributes& rhs)
   if (rhs.m_cacheLoaderFactory != NULL) {
     size_t len = strlen(rhs.m_cacheLoaderFactory) + 1;
     m_cacheLoaderFactory = new char[len];
-    ACE_OS::strncpy(m_cacheLoaderFactory, rhs.m_cacheLoaderFactory, len);
+    std::strncpy(m_cacheLoaderFactory, rhs.m_cacheLoaderFactory, len);
   } else {
     m_cacheLoaderFactory = NULL;
   }
   if (rhs.m_cacheWriterFactory != NULL) {
     size_t len = strlen(rhs.m_cacheWriterFactory) + 1;
     m_cacheWriterFactory = new char[len];
-    ACE_OS::strncpy(m_cacheWriterFactory, rhs.m_cacheWriterFactory, len);
+    std::strncpy(m_cacheWriterFactory, rhs.m_cacheWriterFactory, len);
   } else {
     m_cacheWriterFactory = NULL;
   }
   if (rhs.m_cacheListenerFactory != NULL) {
     size_t len = strlen(rhs.m_cacheListenerFactory) + 1;
     m_cacheListenerFactory = new char[len];
-    ACE_OS::strncpy(m_cacheListenerFactory, rhs.m_cacheListenerFactory, len);
+    std::strncpy(m_cacheListenerFactory, rhs.m_cacheListenerFactory, len);
   } else {
     m_cacheListenerFactory = NULL;
   }
   if (rhs.m_partitionResolverFactory != NULL) {
     size_t len = strlen(rhs.m_partitionResolverFactory) + 1;
     m_partitionResolverFactory = new char[len];
-    ACE_OS::strncpy(m_partitionResolverFactory, rhs.m_partitionResolverFactory,
+    std::strncpy(m_partitionResolverFactory, rhs.m_partitionResolverFactory,
                     len);
   } else {
     m_partitionResolverFactory = NULL;
@@ -158,28 +158,28 @@ RegionAttributes::RegionAttributes(const RegionAttributes& rhs)
   if (rhs.m_endpoints != NULL) {
     size_t len = strlen(rhs.m_endpoints) + 1;
     m_endpoints = new char[len];
-    ACE_OS::strncpy(m_endpoints, rhs.m_endpoints, len);
+    std::strncpy(m_endpoints, rhs.m_endpoints, len);
   } else {
     m_endpoints = NULL;
   }
   if (rhs.m_poolName != NULL) {
     size_t len = strlen(rhs.m_poolName) + 1;
     m_poolName = new char[len];
-    ACE_OS::strncpy(m_poolName, rhs.m_poolName, len);
+    std::strncpy(m_poolName, rhs.m_poolName, len);
   } else {
     m_poolName = NULL;
   }
   if (rhs.m_persistenceLibrary != NULL) {
     size_t len = strlen(rhs.m_persistenceLibrary) + 1;
     m_persistenceLibrary = new char[len];
-    ACE_OS::strncpy(m_persistenceLibrary, rhs.m_persistenceLibrary, len);
+    std::strncpy(m_persistenceLibrary, rhs.m_persistenceLibrary, len);
   } else {
     m_persistenceLibrary = NULL;
   }
   if (rhs.m_persistenceFactory != NULL) {
     size_t len = strlen(rhs.m_persistenceFactory) + 1;
     m_persistenceFactory = new char[len];
-    ACE_OS::strncpy(m_persistenceFactory, rhs.m_persistenceFactory, len);
+    std::strncpy(m_persistenceFactory, rhs.m_persistenceFactory, len);
   } else {
     m_persistenceFactory = NULL;
   }
@@ -222,13 +222,13 @@ void* getFactoryFunc(const char* lib, const char* funcName) {
   if (dll.open(lib, ACE_DEFAULT_SHLIB_MODE, 0) == -1) {
     // error...
     char msg[1000];
-    ACE_OS::snprintf(msg, 1000, "cannot open library: %s", lib);
+    std::snprintf(msg, 1000, "cannot open library: %s", lib);
     throw IllegalArgumentException(msg);
   }
   void* func = dll.symbol(funcName);
   if (func == NULL) {
     char msg[1000];
-    ACE_OS::snprintf(msg, 1000, "cannot find factory function %s in library %s",
+    std::snprintf(msg, 1000, "cannot find factory function %s in library %s",
                      funcName, lib);
     throw IllegalArgumentException(msg);
   }

--- a/src/cppcache/src/RegionFactory.cpp
+++ b/src/cppcache/src/RegionFactory.cpp
@@ -163,7 +163,7 @@ RegionFactoryPtr RegionFactory::setRegionTimeToLive(
 RegionFactoryPtr RegionFactory::setInitialCapacity(int initialCapacity) {
   char excpStr[256] = {0};
   if (initialCapacity < 0) {
-    ACE_OS::snprintf(excpStr, 256, "initialCapacity must be >= 0 ");
+    std::snprintf(excpStr, 256, "initialCapacity must be >= 0 ");
     throw IllegalArgumentException(excpStr);
   }
   m_attributeFactory->setInitialCapacity(initialCapacity);

--- a/src/cppcache/src/RemoteQuery.cpp
+++ b/src/cppcache/src/RemoteQuery.cpp
@@ -59,10 +59,10 @@ SelectResultsPtr RemoteQuery::execute(uint32_t timeout, const char* func,
                                       CacheableVectorPtr paramList) {
   if ((timeout * 1000) >= 0x7fffffff) {
     char exMsg[1024];
-    ACE_OS::snprintf(exMsg, 1023,
-                     "%s: timeout parameter "
-                     "greater than maximum allowed (2^31/1000 i.e 2147483)",
-                     func);
+    std::snprintf(exMsg, 1023,
+                  "%s: timeout parameter "
+                  "greater than maximum allowed (2^31/1000 i.e 2147483)",
+                  func);
     throw IllegalArgumentException(exMsg);
   }
   ThinClientPoolDM* pool = dynamic_cast<ThinClientPoolDM*>(tcdm);
@@ -92,10 +92,10 @@ SelectResultsPtr RemoteQuery::execute(uint32_t timeout, const char* func,
   } else {
     if (values->size() % fieldNameVec.size() != 0) {
       char exMsg[1024];
-      ACE_OS::snprintf(exMsg, 1023,
-                       "%s: Number of values coming from "
-                       "server has to be exactly divisible by field count",
-                       func);
+      std::snprintf(exMsg, 1023,
+                    "%s: Number of values coming from "
+                    "server has to be exactly divisible by field count",
+                    func);
       throw MessageException(exMsg);
     } else {
       LOGFINEST("%s: creating StructSet for query: %s", func,

--- a/src/cppcache/src/ServerLocation.cpp
+++ b/src/cppcache/src/ServerLocation.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "ServerLocation.hpp"
-#include <ace/OS_NS_stdio.h>
 
 namespace apache {
 namespace geode {
@@ -24,7 +23,7 @@ namespace client {
 void ServerLocation::makeEpString() {
   if (m_serverName != NULLPTR) {
     char epstring[1024] = {0};
-    ACE_OS::snprintf(epstring, 1024, "%s:%d", m_serverName->asChar(), m_port);
+    std::snprintf(epstring, 1024, "%s:%d", m_serverName->asChar(), m_port);
     m_epString = epstring;
   }
 }

--- a/src/cppcache/src/SslSockStream.cpp
+++ b/src/cppcache/src/SslSockStream.cpp
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cstdio>
 #include "SslSockStream.hpp"
 #include <gfcpp/ExceptionTypes.hpp>
 #include <ace/OS_NS_stdio.h>
@@ -28,8 +29,8 @@ void *SslSockStream::getACESSLFuncPtr(const char *function_name) {
   void *func = m_dll.symbol(function_name);
   if (func == NULL) {
     char msg[1000];
-    ACE_OS::snprintf(msg, 1000, "cannot find function %s in library %s",
-                     function_name, "cryptoImpl");
+    std::snprintf(msg, 1000, "cannot find function %s in library %s",
+                  function_name, "cryptoImpl");
     LOGERROR(msg);
     throw IllegalStateException(msg);
   }
@@ -43,7 +44,7 @@ void SslSockStream::initACESSLFuncPtrs() {
     LOGERROR("Failed to open cryptoImpl . Errno: %d : %s", lastError,
              ACE_OS::strerror(lastError));
     char msg[1000] = {0};
-    ACE_OS::snprintf(msg, 1000, "cannot open library: %s", libName);
+    std::snprintf(msg, 1000, "cannot open library: %s", libName);
     LOGERROR(msg);
     throw FileNotFoundException(msg);
   }

--- a/src/cppcache/src/StackFrame.cpp
+++ b/src/cppcache/src/StackFrame.cpp
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <ace/OS.h>
+#include <cstdio>
 #include <gfcpp/gfcpp_globals.hpp>
 #include "StackFrame.hpp"
 #include <gfcpp/gf_base.hpp>
@@ -33,8 +33,8 @@ char* StackFrame::asString() {
       }
       modlen--;
     }
-    ACE_OS::snprintf(m_string, 1024, "%s at %s in %s", m_symbol, m_offset,
-                     tmp_module + modlen);
+    std::snprintf(m_string, 1024, "%s at %s in %s", m_symbol, m_offset,
+                  tmp_module + modlen);
   }
   return m_string;
 }

--- a/src/cppcache/src/SystemProperties.cpp
+++ b/src/cppcache/src/SystemProperties.cpp
@@ -17,6 +17,7 @@
 
 #include <gfcpp/gfcpp_globals.hpp>
 
+#include <cstring>
 #include <string>
 #include <stdlib.h>
 #include <string.h>
@@ -519,7 +520,7 @@ void SystemProperties::processProperty(const char* property,
     }
     size_t len = strlen(value) + 1;
     m_statisticsArchiveFile = new char[len];
-    ACE_OS::strncpy(m_statisticsArchiveFile, value, len);
+    std::strncpy(m_statisticsArchiveFile, value, len);
 
   } else if (prop == LogFilename) {
     if (m_logFilename != NULL) {
@@ -528,7 +529,7 @@ void SystemProperties::processProperty(const char* property,
     if (value != NULL) {
       size_t len = strlen(value) + 1;
       m_logFilename = new char[len];
-      ACE_OS::strncpy(m_logFilename, value, len);
+      std::strncpy(m_logFilename, value, len);
     }
   } else if (prop == LogLevel) {
     try {
@@ -557,7 +558,7 @@ void SystemProperties::processProperty(const char* property,
     if (value != NULL) {
       size_t len = strlen(value) + 1;
       m_name = new char[len];
-      ACE_OS::strncpy(m_name, value, len);
+      std::strncpy(m_name, value, len);
     }
   } else if (prop == DurableClientId) {
     if (m_durableClientId != NULL) {
@@ -567,7 +568,7 @@ void SystemProperties::processProperty(const char* property,
     if (value != NULL) {
       size_t len = strlen(value) + 1;
       m_durableClientId = new char[len];
-      ACE_OS::strncpy(m_durableClientId, value, len);
+      std::strncpy(m_durableClientId, value, len);
     }
   } else if (prop == SslKeyStore) {
     if (m_sslKeyStore != NULL) {
@@ -577,7 +578,7 @@ void SystemProperties::processProperty(const char* property,
     if (value != NULL) {
       size_t len = strlen(value) + 1;
       m_sslKeyStore = new char[len];
-      ACE_OS::strncpy(m_sslKeyStore, value, len);
+      std::strncpy(m_sslKeyStore, value, len);
     }
   } else if (prop == SslTrustStore) {
     if (m_sslTrustStore != NULL) {
@@ -587,7 +588,7 @@ void SystemProperties::processProperty(const char* property,
     if (value != NULL) {
       size_t len = strlen(value) + 1;
       m_sslTrustStore = new char[len];
-      ACE_OS::strncpy(m_sslTrustStore, value, len);
+      std::strncpy(m_sslTrustStore, value, len);
     }
     // adongre: Added for Ticket #758
   } else if (prop == SslKeystorePassword) {
@@ -598,7 +599,7 @@ void SystemProperties::processProperty(const char* property,
     if (value != NULL) {
       size_t len = strlen(value) + 1;
       m_sslKeystorePassword = new char[len];
-      ACE_OS::strncpy(m_sslKeystorePassword, value, len);
+      std::strncpy(m_sslKeystorePassword, value, len);
     }
   } else if (prop == ConflateEvents) {
     if (m_conflateEvents != NULL) {
@@ -608,7 +609,7 @@ void SystemProperties::processProperty(const char* property,
     if (value != NULL) {
       size_t len = strlen(value) + 1;
       m_conflateEvents = new char[len];
-      ACE_OS::strncpy(m_conflateEvents, value, len);
+      std::strncpy(m_conflateEvents, value, len);
     }
   } else if (prop == LicenseFilename) {
     // ignore license-file
@@ -621,7 +622,7 @@ void SystemProperties::processProperty(const char* property,
     if (value != NULL) {
       size_t len = strlen(value) + 1;
       m_cacheXMLFile = new char[len];
-      ACE_OS::strncpy(m_cacheXMLFile, value, len);
+      std::strncpy(m_cacheXMLFile, value, len);
     }
 
   } else if (prop == LogFileSizeLimit) {
@@ -738,8 +739,8 @@ void SystemProperties::processProperty(const char* property,
     }
   } else {
     char msg[1000];
-    ACE_OS::snprintf(msg, 1000, "SystemProperties: unknown property: %s = %s",
-                     property, value);
+    std::snprintf(msg, 1000, "SystemProperties: unknown property: %s = %s",
+                  property, value);
     throwError(msg);
   }
 }
@@ -754,18 +755,18 @@ void SystemProperties::logSettings() {
   settings += "\n  appdomain-enabled = ";
   settings += isAppDomainEnabled() ? "true" : "false";
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, statsDiskSpaceLimit());
+  std::snprintf(buf, 2048, "%" PRIu32, statsDiskSpaceLimit());
   settings += "\n  archive-disk-space-limit = ";
   settings += buf;
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, statsFileSizeLimit());
+  std::snprintf(buf, 2048, "%" PRIu32, statsFileSizeLimit());
   settings += "\n  archive-file-size-limit = ";
   settings += buf;
 
   settings += "\n  auto-ready-for-events = ";
   settings += autoReadyForEvents() ? "true" : "false";
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, bucketWaitTimeout());
+  std::snprintf(buf, 2048, "%" PRIu32, bucketWaitTimeout());
   settings += "\n  bucket-wait-timeout = ";
   settings += buf;
 
@@ -775,15 +776,15 @@ void SystemProperties::logSettings() {
   settings += "\n  conflate-events = ";
   settings += conflateEvents();
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, connectTimeout());
+  std::snprintf(buf, 2048, "%" PRIu32, connectTimeout());
   settings += "\n  connect-timeout = ";
   settings += buf;
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, javaConnectionPoolSize());
+  std::snprintf(buf, 2048, "%" PRIu32, javaConnectionPoolSize());
   settings += "\n  connection-pool-size = ";
   settings += buf;
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, connectWaitTimeout());
+  std::snprintf(buf, 2048, "%" PRIu32, connectWaitTimeout());
   settings += "\n  connect-wait-timeout = ";
   settings += buf;
 
@@ -799,7 +800,7 @@ void SystemProperties::logSettings() {
   settings += "\n  durable-client-id = ";
   settings += durableClientId();
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, durableTimeout());
+  std::snprintf(buf, 2048, "%" PRIu32, durableTimeout());
   settings += "\n  durable-timeout = ";
   settings += buf;
 
@@ -811,13 +812,13 @@ void SystemProperties::logSettings() {
   settings += "\n  grid-client = ";
   settings += isGridClient() ? "true" : "false";
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, heapLRUDelta());
+  std::snprintf(buf, 2048, "%" PRIu32, heapLRUDelta());
   settings += "\n  heap-lru-delta = ";
   settings += buf;
   /* adongre  - Coverity II
    * CID 29195: Printf arg type mismatch (PW.PRINTF_ARG_MISMATCH)
    */
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, static_cast<int>(heapLRULimit()));
+  std::snprintf(buf, 2048, "%" PRIu32, static_cast<int>(heapLRULimit()));
   settings += "\n  heap-lru-limit = ";
   settings += buf;
 
@@ -827,33 +828,33 @@ void SystemProperties::logSettings() {
   // settings += "\n  license-type = ";
   // settings += licenseType();
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, logDiskSpaceLimit());
+  std::snprintf(buf, 2048, "%" PRIu32, logDiskSpaceLimit());
   settings += "\n  log-disk-space-limit = ";
   settings += buf;
 
   settings += "\n  log-file = ";
   settings += logFilename();
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, logFileSizeLimit());
+  std::snprintf(buf, 2048, "%" PRIu32, logFileSizeLimit());
   settings += "\n  log-file-size-limit = ";
   settings += buf;
 
   settings += "\n  log-level = ";
   settings += Log::levelToChars(logLevel());
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, threadPoolSize());
+  std::snprintf(buf, 2048, "%" PRIu32, threadPoolSize());
   settings += "\n  max-fe-threads = ";
   settings += buf;
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, maxSocketBufferSize());
+  std::snprintf(buf, 2048, "%" PRIu32, maxSocketBufferSize());
   settings += "\n  max-socket-buffer-size = ";
   settings += buf;
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIi32, notifyAckInterval());
+  std::snprintf(buf, 2048, "%" PRIi32, notifyAckInterval());
   settings += "\n  notify-ack-interval = ";
   settings += buf;
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIi32, notifyDupCheckLife());
+  std::snprintf(buf, 2048, "%" PRIi32, notifyDupCheckLife());
   settings += "\n  notify-dupcheck-life = ";
   settings += buf;
 
@@ -862,14 +863,14 @@ void SystemProperties::logSettings() {
 
   // *** PLEASE ADD IN ALPHABETICAL ORDER - USER VISIBLE ***
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIi32, pingInterval());
+  std::snprintf(buf, 2048, "%" PRIi32, pingInterval());
   settings += "\n  ping-interval = ";
   settings += buf;
 
   settings += "\n  read-timeout-unit-in-millis = ";
   settings += readTimeoutUnitInMillis() ? "true" : "false";
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIi32, redundancyMonitorInterval());
+  std::snprintf(buf, 2048, "%" PRIi32, redundancyMonitorInterval());
   settings += "\n  redundancy-monitor-interval = ";
   settings += buf;
 
@@ -906,16 +907,16 @@ void SystemProperties::logSettings() {
   settings += "\n  statistic-sampling-enabled = ";
   settings += statisticsEnabled() ? "true" : "false";
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, statisticsSampleInterval());
+  std::snprintf(buf, 2048, "%" PRIu32, statisticsSampleInterval());
   settings += "\n  statistic-sample-rate = ";
   settings += buf;
 
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, suspendedTxTimeout());
+  std::snprintf(buf, 2048, "%" PRIu32, suspendedTxTimeout());
   settings += "\n  suspended-tx-timeout = ";
   settings += buf;
 
   // tombstone-timeout
-  ACE_OS::snprintf(buf, 2048, "%" PRIu32, tombstoneTimeoutInMSec());
+  std::snprintf(buf, 2048, "%" PRIu32, tombstoneTimeoutInMSec());
   settings += "\n  tombstone-timeout = ";
   settings += buf;
 

--- a/src/cppcache/src/TcpConn.cpp
+++ b/src/cppcache/src/TcpConn.cpp
@@ -20,6 +20,7 @@
 #include <gfcpp/SystemProperties.hpp>
 #include <gfcpp/Log.hpp>
 
+#include <cstdio>
 #include <memory.h>
 
 #include <ace/INET_Addr.h>
@@ -121,8 +122,8 @@ void TcpConn::init() {
     LOGERROR("Failed to create socket. Errno: %d: %s", lastError,
              ACE_OS::strerror(lastError));
     char msg[256];
-    ACE_OS::snprintf(msg, 256, "TcpConn::connect failed with errno: %d: %s",
-                     lastError, ACE_OS::strerror(lastError));
+    std::snprintf(msg, 256, "TcpConn::connect failed with errno: %d: %s",
+                  lastError, ACE_OS::strerror(lastError));
     throw GeodeIOException(msg);
   }
 
@@ -197,17 +198,15 @@ void TcpConn::listen(ACE_INET_Addr addr, uint32_t waitSeconds) {
       * arbitrarily long string,
       * callers must be careful not to overflow the actual space of the
       * destination.
-      * Use snprintf() instead, or correct precision specifiers.
-      * Fix : using ACE_OS::snprintf
       */
-      ACE_OS::snprintf(
+      std::snprintf(
           msg, 256,
           "TcpConn::listen Attempt to listen timed out after %d seconds.",
           waitSeconds);
       throw TimeoutException(msg);
     }
-    ACE_OS::snprintf(msg, 256, "TcpConn::listen failed with errno: %d: %s",
-                     lastError, ACE_OS::strerror(lastError));
+    std::snprintf(msg, 256, "TcpConn::listen failed with errno: %d: %s",
+                  lastError, ACE_OS::strerror(lastError));
     throw GeodeIOException(msg);
   }
 }
@@ -258,7 +257,7 @@ void TcpConn::connect() {
     char msg[256];
     int32_t lastError = ACE_OS::last_error();
     if (lastError == ETIME || lastError == ETIMEDOUT) {
-      ACE_OS::snprintf(
+      std::snprintf(
           msg, 256,
           "TcpConn::connect Attempt to connect timed out after %d seconds.",
           waitSeconds);
@@ -266,8 +265,8 @@ void TcpConn::connect() {
       GF_SAFE_DELETE(m_io);
       throw TimeoutException(msg);
     }
-    ACE_OS::snprintf(msg, 256, "TcpConn::connect failed with errno: %d: %s",
-                     lastError, ACE_OS::strerror(lastError));
+    std::snprintf(msg, 256, "TcpConn::connect failed with errno: %d: %s",
+                  lastError, ACE_OS::strerror(lastError));
     //  this is only called by constructor, so we must delete m_io
     GF_SAFE_DELETE(m_io);
     throw GeodeIOException(msg);
@@ -276,8 +275,8 @@ void TcpConn::connect() {
   if (-1 == rc) {
     char msg[250];
     int32_t lastError = ACE_OS::last_error();
-    ACE_OS::snprintf(msg, 256, "TcpConn::NONBLOCK: %d: %s", lastError,
-                     ACE_OS::strerror(lastError));
+    std::snprintf(msg, 256, "TcpConn::NONBLOCK: %d: %s", lastError,
+                  ACE_OS::strerror(lastError));
 
     LOGINFO(msg);
   }

--- a/src/cppcache/src/TcpSslConn.cpp
+++ b/src/cppcache/src/TcpSslConn.cpp
@@ -16,6 +16,8 @@
  */
 #include "TcpSslConn.hpp"
 
+#include <cstdio>
+
 #include <gfcpp/SystemProperties.hpp>
 #include <gfcpp/DistributedSystem.hpp>
 #include "../../cryptoimpl/GFSsl.hpp"
@@ -27,7 +29,7 @@ GFSsl* TcpSslConn::getSSLImpl(ACE_SOCKET sock, const char* pubkeyfile,
   const char* libName = "cryptoImpl";
   if (m_dll.open(libName, RTLD_NOW | RTLD_GLOBAL, 0) == -1) {
     char msg[1000] = {0};
-    ACE_OS::snprintf(msg, 1000, "cannot open library: %s", libName);
+    std::snprintf(msg, 1000, "cannot open library: %s", libName);
     LOGERROR(msg);
     throw FileNotFoundException(msg);
   }
@@ -36,9 +38,9 @@ GFSsl* TcpSslConn::getSSLImpl(ACE_SOCKET sock, const char* pubkeyfile,
       reinterpret_cast<gf_create_SslImpl>(m_dll.symbol("gf_create_SslImpl"));
   if (func == NULL) {
     char msg[1000];
-    ACE_OS::snprintf(msg, 1000,
-                     "cannot find function %s in library gf_create_SslImpl",
-                     "cryptoImpl");
+    std::snprintf(msg, 1000,
+                  "cannot find function %s in library gf_create_SslImpl",
+                  "cryptoImpl");
     LOGERROR(msg);
     throw IllegalStateException(msg);
   }
@@ -75,12 +77,10 @@ void TcpSslConn::listen(ACE_INET_Addr addr, uint32_t waitSeconds) {
        * arbitrarily long string,
        * callers must be careful not to overflow the actual space of the
        * destination.
-       * Use snprintf() instead, or correct precision specifiers.
-       * Fix : using ACE_OS::snprintf
        */
       // sprintf( msg, "TcpSslConn::listen Attempt to listen timed out after %d
       // seconds.", waitSeconds );
-      ACE_OS::snprintf(
+      std::snprintf(
           msg, 256,
           "TcpSslConn::listen Attempt to listen timed out after %d seconds.",
           waitSeconds);
@@ -88,8 +88,8 @@ void TcpSslConn::listen(ACE_INET_Addr addr, uint32_t waitSeconds) {
     }
     // sprintf( msg, "TcpSslConn::listen failed with errno: %d: %s", lastError,
     // ACE_OS::strerror(lastError) );
-    ACE_OS::snprintf(msg, 255, "TcpSslConn::listen failed with errno: %d: %s",
-                     lastError, ACE_OS::strerror(lastError));
+    std::snprintf(msg, 255, "TcpSslConn::listen failed with errno: %d: %s",
+                  lastError, ACE_OS::strerror(lastError));
     throw GeodeIOException(msg);
   }
 }
@@ -119,7 +119,7 @@ void TcpSslConn::connect() {
     char msg[256];
     int32_t lastError = ACE_OS::last_error();
     if (lastError == ETIME || lastError == ETIMEDOUT) {
-      ACE_OS::snprintf(
+      std::snprintf(
           msg, 256,
           "TcpSslConn::connect Attempt to connect timed out after %d seconds.",
           m_waitSeconds);
@@ -127,8 +127,8 @@ void TcpSslConn::connect() {
       GF_SAFE_DELETE(m_ssl);
       throw TimeoutException(msg);
     }
-    ACE_OS::snprintf(msg, 256, "TcpSslConn::connect failed with errno: %d: %s",
-                     lastError, ACE_OS::strerror(lastError));
+    std::snprintf(msg, 256, "TcpSslConn::connect failed with errno: %d: %s",
+                  lastError, ACE_OS::strerror(lastError));
     // this is only called by constructor, so we must delete m_ssl
     GF_SAFE_DELETE(m_ssl);
     throw GeodeIOException(msg);

--- a/src/cppcache/src/TcrMessage.hpp
+++ b/src/cppcache/src/TcrMessage.hpp
@@ -1114,10 +1114,10 @@ class TcrMessageHelper {
     } else if (!isObj) {
       // otherwise we're currently always expecting an object
       char exMsg[256];
-      ACE_OS::snprintf(exMsg, 255,
-                       "TcrMessageHelper::readChunkPartHeader: "
-                       "%s: part is not object",
-                       methodName);
+      std::snprintf(exMsg, 255,
+                    "TcrMessageHelper::readChunkPartHeader: "
+                    "%s: part is not object",
+                    methodName);
       LOGDEBUG("%s ", exMsg);
       // throw MessageException(exMsg);
       return EXCEPTION;
@@ -1135,7 +1135,7 @@ class TcrMessageHelper {
         return EXCEPTION;
       } else {
         char exMsg[256];
-        ACE_OS::snprintf(
+        std::snprintf(
             exMsg, 255,
             "TcrMessageHelper::readChunkPartHeader: %s: cannot handle "
             "java serializable object from server",
@@ -1150,10 +1150,10 @@ class TcrMessageHelper {
     if (expectedFirstType > 0) {
       if (partType != expectedFirstType) {
         char exMsg[256];
-        ACE_OS::snprintf(exMsg, 255,
-                         "TcrMessageHelper::readChunkPartHeader: "
-                         "%s: got unhandled object class = %d",
-                         methodName, partType);
+        std::snprintf(exMsg, 255,
+                      "TcrMessageHelper::readChunkPartHeader: "
+                      "%s: got unhandled object class = %d",
+                      methodName, partType);
         throw MessageException(exMsg);
       }
       // This is for GETALL
@@ -1170,10 +1170,10 @@ class TcrMessageHelper {
     }
     if (compId != expectedPartType) {
       char exMsg[256];
-      ACE_OS::snprintf(exMsg, 255,
-                       "TcrMessageHelper::readChunkPartHeader: "
-                       "%s: got unhandled object type = %d",
-                       methodName, compId);
+      std::snprintf(exMsg, 255,
+                    "TcrMessageHelper::readChunkPartHeader: "
+                    "%s: got unhandled object type = %d",
+                    methodName, compId);
       throw MessageException(exMsg);
     }
     return OBJECT;
@@ -1192,10 +1192,10 @@ class TcrMessageHelper {
     } else if (!isObj) {
       // otherwise we're currently always expecting an object
       char exMsg[256];
-      ACE_OS::snprintf(exMsg, 255,
-                       "TcrMessageHelper::readChunkPartHeader: "
-                       "%s: part is not object",
-                       methodName);
+      std::snprintf(exMsg, 255,
+                    "TcrMessageHelper::readChunkPartHeader: "
+                    "%s: part is not object",
+                    methodName);
       throw MessageException(exMsg);
     }
 
@@ -1209,7 +1209,7 @@ class TcrMessageHelper {
         return static_cast<int8_t>(EXCEPTION);
       } else {
         char exMsg[256];
-        ACE_OS::snprintf(
+        std::snprintf(
             exMsg, 255,
             "TcrMessageHelper::readChunkPartHeader: %s: cannot handle "
             "java serializable object from server",

--- a/src/cppcache/src/ThinClientPoolDM.cpp
+++ b/src/cppcache/src/ThinClientPoolDM.cpp
@@ -562,9 +562,9 @@ std::string ThinClientPoolDM::selectEndpoint(
     getStats().incLoctorResposes();
 
     char epNameStr[128] = {0};
-    ACE_OS::snprintf(epNameStr, 128, "%s:%d",
-                     outEndpoint.getServerName().c_str(),
-                     outEndpoint.getPort());
+    std::snprintf(epNameStr, 128, "%s:%d",
+                  outEndpoint.getServerName().c_str(),
+                  outEndpoint.getPort());
     LOGFINE("ThinClientPoolDM: Locator returned endpoint [%s]", epNameStr);
     return epNameStr;
   } else if (m_attrs->m_initServList
@@ -731,8 +731,8 @@ const CacheableStringArrayPtr ThinClientPoolDM::getServers() {
     int i = 0;
     for (it = vec.begin(); it < vec.end(); it++) {
       ServerLocation serLoc = *it;
-      ACE_OS::snprintf(buffer, 256, "%s:%d", serLoc.getServerName().c_str(),
-                       serLoc.getPort());
+      std::snprintf(buffer, 256, "%s:%d", serLoc.getServerName().c_str(),
+                    serLoc.getPort());
       ptrArr[i++] = CacheableString::create(buffer);
     }
   }
@@ -2038,7 +2038,7 @@ TcrEndpoint* ThinClientPoolDM::addEP(ServerLocation& serverLoc) {
   std::string serverName = serverLoc.getServerName();
   int port = serverLoc.getPort();
   char endpointName[100];
-  ACE_OS::snprintf(endpointName, 100, "%s:%d", serverName.c_str(), port);
+  std::snprintf(endpointName, 100, "%s:%d", serverName.c_str(), port);
 
   return addEP(endpointName);
 }

--- a/src/cppcache/src/ThinClientRegion.cpp
+++ b/src/cppcache/src/ThinClientRegion.cpp
@@ -37,6 +37,8 @@
 #include "VersionedCacheableObjectPartList.hpp"
 //#include "PutAllPartialResult.hpp"
 
+#include <cstring>
+
 using namespace apache::geode::client;
 
 namespace apache {
@@ -621,7 +623,7 @@ SelectResultsPtr ThinClientRegion::query(const char* predicate,
 
   bool isFullQuery = false;
 
-  size_t predlen = ACE_OS::strlen(predicate);
+  size_t predlen = std::strlen(predicate);
 
   if (predlen > 6)  // perhaps it has 'select' or 'import' if its > 6
   {
@@ -641,8 +643,8 @@ SelectResultsPtr ThinClientRegion::query(const char* predicate,
             ACE_OS::ace_tolower(predicate[charpos + skipspace]);
       }
 
-      if (!ACE_OS::strcmp(firstWord, "select") ||
-          !ACE_OS::strcmp(firstWord, "import")) {
+      if (!std::strcmp(firstWord, "select") ||
+          !std::strcmp(firstWord, "import")) {
         isFullQuery = true;
       }
     }
@@ -4134,7 +4136,7 @@ void ChunkedDurableCQListResponse::handleChunk(
   if (!isObj) {
     // we're currently always expecting an object
     char exMsg[256];
-    ACE_OS::snprintf(
+    std::snprintf(
         exMsg, 255,
         "ChunkedDurableCQListResponse::handleChunk: part is not object");
     throw MessageException(exMsg);

--- a/src/cppcache/src/Utils.cpp
+++ b/src/cppcache/src/Utils.cpp
@@ -20,6 +20,7 @@
 #include "NanoTimer.hpp"
 #include <ace/Recursive_Thread_Mutex.h>
 #include <ace/INET_Addr.h>
+#include <cstring>
 
 extern "C" {
 #include <stdio.h>
@@ -189,7 +190,7 @@ std::string Utils::convertHostToCanonicalForm(const char* endpoints) {
     struct hostent* host;
     host = ACE_OS::gethostbyname(hostName);
     if (host) {
-      ACE_OS::snprintf(fullName, 256, "%s:%d", host->h_name, port);
+      std::snprintf(fullName, 256, "%s:%d", host->h_name, port);
       return fullName;
     }
   } else {
@@ -197,7 +198,7 @@ std::string Utils::convertHostToCanonicalForm(const char* endpoints) {
     if (pos != std::string::npos) {
       ACE_INET_Addr addr(endpoints);
       addr.get_host_name(hostName, 256);
-      ACE_OS::snprintf(fullName, 256, "%s:%d", hostName, port);
+      std::snprintf(fullName, 256, "%s:%d", hostName, port);
       return fullName;
     }
   }
@@ -250,7 +251,7 @@ CacheableStringPtr Utils::convertBytesToString(const uint8_t* bytes,
     size_t totalBytes = 0;
     char byteStr[20];
     for (int32_t index = 0; index < length; ++index) {
-      int len = ACE_OS::snprintf(byteStr, 20, "%d ", bytes[index]);
+      int len = std::snprintf(byteStr, 20, "%d ", bytes[index]);
       totalBytes += len;
       // no use going beyond maxLength since LOG* methods will truncate
       // in any case
@@ -268,7 +269,7 @@ CacheableStringPtr Utils::convertBytesToString(const uint8_t* bytes,
 int32_t Utils::logWideString(char* buf, size_t maxLen, const wchar_t* wStr) {
   if (wStr != NULL) {
     mbstate_t state;
-    ACE_OS::memset(&state, 0, sizeof(mbstate_t));
+    std::memset(&state, 0, sizeof(mbstate_t));
     const char* bufStart = buf;
     do {
       if (maxLen < static_cast<size_t>(MB_CUR_MAX)) {
@@ -277,7 +278,7 @@ int32_t Utils::logWideString(char* buf, size_t maxLen, const wchar_t* wStr) {
       size_t numChars = wcrtomb(buf, *wStr, &state);
       if (numChars == static_cast<size_t>(-1)) {
         // write short when conversion cannot be done
-        numChars = ACE_OS::snprintf(buf, maxLen, "<%u>", *wStr);
+        numChars = std::snprintf(buf, maxLen, "<%u>", *wStr);
       }
       buf += numChars;
       if (numChars >= maxLen) {
@@ -287,6 +288,6 @@ int32_t Utils::logWideString(char* buf, size_t maxLen, const wchar_t* wStr) {
     } while (*wStr++ != L'\0');
     return static_cast<int32_t>(buf - bufStart);
   } else {
-    return ACE_OS::snprintf(buf, maxLen, "null");
+    return std::snprintf(buf, maxLen, "null");
   }
 }

--- a/src/cppcache/src/statistics/AtomicStatisticsImpl.cpp
+++ b/src/cppcache/src/statistics/AtomicStatisticsImpl.cpp
@@ -165,7 +165,7 @@ void AtomicStatisticsImpl::close() {
 void AtomicStatisticsImpl::_setInt(int32 offset, int32 value) {
   if (offset >= statsType->getIntStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128, "setInt:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
     throw IllegalArgumentException(s);
@@ -183,12 +183,10 @@ void AtomicStatisticsImpl::_setLong(int32 offset, int64 value) {
      * arbitrarily long string,
      * callers must be careful not to overflow the actual space of the
      * destination.
-     * Use snprintf() instead, or correct precision specifiers.
-     * Fix : using ACE_OS::snprintf
      */
     // sprintf(s, "setLong:The id (%d) of the Statistic Descriptor is not valid
     // ", offset);
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128, "setLong:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
     throw IllegalArgumentException(s);
@@ -200,7 +198,7 @@ void AtomicStatisticsImpl::_setLong(int32 offset, int64 value) {
 void AtomicStatisticsImpl::_setDouble(int32 offset, double value) {
   if (offset >= statsType->getDoubleStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128,
         "setDouble:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
@@ -215,7 +213,7 @@ void AtomicStatisticsImpl::_setDouble(int32 offset, double value) {
 int32 AtomicStatisticsImpl::_getInt(int32 offset) {
   if (offset >= statsType->getIntStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128, "getInt:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
     throw IllegalArgumentException(s);
@@ -227,7 +225,7 @@ int32 AtomicStatisticsImpl::_getInt(int32 offset) {
 int64 AtomicStatisticsImpl::_getLong(int32 offset) {
   if (offset >= statsType->getLongStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128, "getLong:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
     throw IllegalArgumentException(s);
@@ -238,7 +236,7 @@ int64 AtomicStatisticsImpl::_getLong(int32 offset) {
 double AtomicStatisticsImpl::_getDouble(int32 offset) {
   if (offset >= statsType->getDoubleStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128,
         "getDouble:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
@@ -286,7 +284,7 @@ int64 AtomicStatisticsImpl::getRawBits(StatisticDescriptor* descriptor) {
 int32 AtomicStatisticsImpl::_incInt(int32 offset, int32 delta) {
   if (offset >= statsType->getIntStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128, "incInt:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
     throw IllegalArgumentException(s);
@@ -305,13 +303,11 @@ int64 AtomicStatisticsImpl::_incLong(int32 offset, int64 delta) {
      * arbitrarily long string,
      * callers must be careful not to overflow the actual space of the
      * destination.
-     * Use snprintf() instead, or correct precision specifiers.
-     * Fix : using ACE_OS::snprintf
      */
     // sprintf(s, "incLong:The id (%d) of the Statistic Descriptor is not valid
     // ", offset);
 
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128, "incLong:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
     throw IllegalArgumentException(s);
@@ -323,7 +319,7 @@ int64 AtomicStatisticsImpl::_incLong(int32 offset, int64 delta) {
 double AtomicStatisticsImpl::_incDouble(int32 offset, double delta) {
   if (offset >= statsType->getDoubleStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128,
         "incDouble:The id (%d) of the Statistic Descriptor is not valid ",
         offset);

--- a/src/cppcache/src/statistics/HostStatHelper.cpp
+++ b/src/cppcache/src/statistics/HostStatHelper.cpp
@@ -53,9 +53,9 @@ void HostStatHelper::initOSCode() {
     osCode = GFS_OSTYPE_MACOSX;
   } else {
     char buf[1024] = {0};
-    ACE_OS::snprintf(buf, 1024,
-                     "HostStatHelper::initOSTypes:unhandled os type: %s",
-                     osName.c_str());
+    std::snprintf(buf, 1024,
+                  "HostStatHelper::initOSTypes:unhandled os type: %s",
+                  osName.c_str());
     throw IllegalArgumentException(buf);
   }
 }

--- a/src/cppcache/src/statistics/HostStatHelperLinux.cpp
+++ b/src/cppcache/src/statistics/HostStatHelperLinux.cpp
@@ -23,7 +23,6 @@
 #include <glob.h>
 #include "HostStatHelperLinux.hpp"
 #include "LinuxProcessStats.hpp"
-#include <ace/OS.h>
 
 using namespace apache::geode::statistics;
 
@@ -66,7 +65,7 @@ void HostStatHelperLinux::refreshProcess(ProcessStats* processStats) {
   char procFileName[64];
 
   FILE* fPtr;
-  ACE_OS::snprintf(procFileName, 64, "/proc/%" PRIu32 "/stat", (uint32)thePid);
+  std::snprintf(procFileName, 64, "/proc/%" PRIu32 "/stat", (uint32)thePid);
   fPtr = fopen(procFileName, "r"); /* read only */
   if (fPtr != NULL) {
     int32 status = fscanf(

--- a/src/cppcache/src/statistics/HostStatHelperSolaris.cpp
+++ b/src/cppcache/src/statistics/HostStatHelperSolaris.cpp
@@ -18,8 +18,6 @@
 #include <gfcpp/gfcpp_globals.hpp>
 
 #if defined(_SOLARIS)
-#include <ace/OS_NS_sys_utsname.h>
-#include <ace/OS_NS_errno.h>
 #include "HostStatHelperSolaris.hpp"
 #include <procfs.h>
 #include <sys/types.h>
@@ -32,7 +30,6 @@
 #include <glob.h>
 #include <gfcpp/ExceptionTypes.hpp>
 #include "SolarisProcessStats.hpp"
-#include <ace/OS.h>
 
 using namespace apache::geode::statistics;
 
@@ -68,7 +65,7 @@ void HostStatHelperSolaris::refreshProcess(ProcessStats* processStats) {
   prusage_t currentUsage;
   psinfo_t currentInfo;
 
-  ACE_OS::snprintf(procFileName, 64, "/proc/%lu/psinfo", (uint32)thePid);
+  std::snprintf(procFileName, 64, "/proc/%lu/psinfo", (uint32)thePid);
   // fread was returning errno 2 FILENOTFOUND so it was switched to read
   // This matches what was done in the Geode Project also
   fPtr = open(procFileName, O_RDONLY, 0); /* read only */
@@ -86,7 +83,7 @@ void HostStatHelperSolaris::refreshProcess(ProcessStats* processStats) {
     }
     close(fPtr);
   }
-  ACE_OS::snprintf(procFileName, 64, "/proc/%u/usage", (uint32)thePid);
+  std::snprintf(procFileName, 64, "/proc/%u/usage", (uint32)thePid);
   fPtr = open(procFileName, O_RDONLY, 0);
   if (fPtr != -1) {
     if (read(fPtr, &currentUsage, sizeof(currentUsage)) !=
@@ -171,8 +168,8 @@ void HostStatHelperSolaris::getKernelStats(uint32_t* cpuUtil) {
     m_kstat = kstat_open();
     if (m_kstat == NULL) {
       char buf[128];
-      ACE_OS::snprintf(buf, 128, "Unable to obtain kstat data, errno %d",
-                       errno);
+      std::snprintf(buf, 128, "Unable to obtain kstat data, errno %d",
+                    errno);
       throw NullPointerException(buf);
     }
   }

--- a/src/cppcache/src/statistics/HostStatHelperWin.cpp
+++ b/src/cppcache/src/statistics/HostStatHelperWin.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <gfcpp/gfcpp_globals.hpp>
-#include <ace/OS.h>
 
 #include "HostStatHelperWin.hpp"
 
@@ -83,11 +82,11 @@ char* HostStatHelperWin::getInstIdStr(PPERF_INSTANCE_DEFINITION PerfInst,
   static char resbuff[132];
   if (PerfInst->UniqueID == PERF_NO_UNIQUE_ID) {
     short* unicodePtr = (short*)((PBYTE)PerfInst + PerfInst->NameOffset);
-    ACE_OS::snprintf(resbuff, 132, "%S length=%d unicode[0]=%d",
-                     (char*)((PBYTE)PerfInst + PerfInst->NameOffset),
-                     PerfInst->NameLength, unicodePtr[0]);
+    std::snprintf(resbuff, 132, "%S length=%d unicode[0]=%d",
+                  (char*)((PBYTE)PerfInst + PerfInst->NameOffset),
+                  PerfInst->NameLength, unicodePtr[0]);
   } else {
-    ACE_OS::snprintf(resbuff, 132, "%s%d", prefix, PerfInst->UniqueID);
+    std::snprintf(resbuff, 132, "%s%d", prefix, PerfInst->UniqueID);
   }
   return resbuff;
 }

--- a/src/cppcache/src/statistics/HostStatSampler.cpp
+++ b/src/cppcache/src/statistics/HostStatSampler.cpp
@@ -25,6 +25,8 @@
 #include <ace/Dirent.h>
 #include <ace/Dirent_Selector.h>
 #include <ace/OS_NS_sys_stat.h>
+#include <cstdlib>
+#include <cstring>
 #include <utility>
 #include <vector>
 
@@ -68,16 +70,16 @@ int selector(const dirent* d) {
   std::string filebasename = ACE::basename(
       apache::geode::statistics::globals::g_statFileWithExt.c_str());
   size_t actualHyphenPos = filebasename.find_last_of('.');
-  if (strcmp(filebasename.c_str(), d->d_name) == 0) return 1;
+  if (std::strcmp(filebasename.c_str(), d->d_name) == 0) return 1;
   size_t fileExtPos = inputname.find_last_of('.');
   std::string extName = inputname.substr(fileExtPos + 1, inputname.length());
-  if (strcmp(extName.c_str(), "gfs") != 0) return 0;
+  if (std::strcmp(extName.c_str(), "gfs") != 0) return 0;
   if (fileExtPos != std::string::npos) {
     std::string tempname = inputname.substr(0, fileExtPos);
     size_t fileHyphenPos = tempname.find_last_of('-');
     if (fileHyphenPos != std::string::npos) {
       std::string buff1 = tempname.substr(0, fileHyphenPos);
-      if (ACE_OS::strstr(filebasename.c_str(), buff1.c_str()) == 0) {
+      if (std::strstr(filebasename.c_str(), buff1.c_str()) == 0) {
         return 0;
       }
       if (fileHyphenPos != actualHyphenPos) return 0;
@@ -104,7 +106,7 @@ int comparator(const dirent** d1, const dirent** d2) {
   } else if (strlen((*d1)->d_name) > strlen((*d2)->d_name)) {
     return 1;
   }
-  int diff = ACE_OS::strcmp((*d1)->d_name, (*d2)->d_name);
+  int diff = std::strcmp((*d1)->d_name, (*d2)->d_name);
   if (diff < 0) {
     return -1;
   } else if (diff > 0) {
@@ -177,7 +179,7 @@ HostStatSampler::HostStatSampler(const char* filePath, int64 sampleIntervalMs,
     // replace all '\' with '/' to make everything easier..
     size_t len = g_statFile.length() + 1;
     char* slashtmp = new char[len];
-    ACE_OS::strncpy(slashtmp, g_statFile.c_str(), len);
+    std::strncpy(slashtmp, g_statFile.c_str(), len);
     for (size_t i = 0; i < g_statFile.length(); i++) {
       if (slashtmp[i] == '/') {
         slashtmp[i] = '\\';
@@ -205,7 +207,7 @@ HostStatSampler::HostStatSampler(const char* filePath, int64 sampleIntervalMs,
           if (fileHyphenPos != std::string::npos) {
             std::string buff =
                 tempname.substr(fileHyphenPos + 1, tempname.length());
-            rollIndex = ACE_OS::atoi(buff.c_str()) + 1;
+            rollIndex = std::atoi(buff.c_str()) + 1;
           }
         }
       }
@@ -264,11 +266,11 @@ std::string HostStatSampler::createArchiveFileName() {
     int32 len = static_cast<int32>(m_archiveFileName.length());
     size_t fileExtPos = m_archiveFileName.find_last_of('.', len);
     if (fileExtPos == std::string::npos) {
-      ACE_OS::snprintf(buff, 1024, "%s-%d.gfs", m_archiveFileName.c_str(), pid);
+      std::snprintf(buff, 1024, "%s-%d.gfs", m_archiveFileName.c_str(), pid);
     } else {
       std::string tmp;
       tmp = m_archiveFileName.substr(0, fileExtPos);
-      ACE_OS::snprintf(buff, 1024, "%s-%d.gfs", tmp.c_str(), pid);
+      std::snprintf(buff, 1024, "%s-%d.gfs", tmp.c_str(), pid);
     }
     m_archiveFileName = buff;
     return m_archiveFileName;
@@ -460,13 +462,13 @@ int32 HostStatSampler::rollArchive(std::string filename) {
   while (!gotNewFileName) {
     char newfilename[1000] = {0};
     if (i < 10) {
-      ACE_OS::snprintf(newfilename, 1000, "%s%c%s-%d.%s", statsdirname.c_str(),
-                       ACE_DIRECTORY_SEPARATOR_CHAR, fnameBeforeExt.c_str(), i,
-                       extName.c_str());
+      std::snprintf(newfilename, 1000, "%s%c%s-%d.%s", statsdirname.c_str(),
+                    ACE_DIRECTORY_SEPARATOR_CHAR, fnameBeforeExt.c_str(), i,
+                    extName.c_str());
     } else {
-      ACE_OS::snprintf(newfilename, 1000, "%s%c%s-%d.%s", statsdirname.c_str(),
-                       ACE_DIRECTORY_SEPARATOR_CHAR, fnameBeforeExt.c_str(), i,
-                       extName.c_str());
+      std::snprintf(newfilename, 1000, "%s%c%s-%d.%s", statsdirname.c_str(),
+                    ACE_DIRECTORY_SEPARATOR_CHAR, fnameBeforeExt.c_str(), i,
+                    extName.c_str());
     }
     FILE* fp = fopen(newfilename, "r");
 
@@ -654,8 +656,8 @@ void HostStatSampler::checkDiskLimit() {
   int status = sds.open(dirname.c_str(), selector, comparator);
   if (status != -1) {
     for (int i = 1; i < sds.length(); i++) {
-      ACE_OS::snprintf(fullpath, 512, "%s%c%s", dirname.c_str(),
-                       ACE_DIRECTORY_SEPARATOR_CHAR, sds[i]->d_name);
+      std::snprintf(fullpath, 512, "%s%c%s", dirname.c_str(),
+                    ACE_DIRECTORY_SEPARATOR_CHAR, sds[i]->d_name);
       ACE_OS::stat(fullpath, &statBuf);
       g_fileInfoPair = std::make_pair(fullpath, statBuf.st_size);
       fileInfo.push_back(g_fileInfoPair);

--- a/src/cppcache/src/statistics/OsStatisticsImpl.cpp
+++ b/src/cppcache/src/statistics/OsStatisticsImpl.cpp
@@ -19,7 +19,7 @@
 #include "StatisticsTypeImpl.hpp"
 #include "StatisticDescriptorImpl.hpp"
 
-#include "ace/OS.h"
+#include <cstring>
 
 using namespace apache::geode::statistics;
 
@@ -44,7 +44,7 @@ int64 OsStatisticsImpl::calcNumericId(StatisticsFactory* system,
 
 const char* OsStatisticsImpl::calcTextId(StatisticsFactory* system,
                                          const char* userValue) {
-  if (userValue != NULL && strcmp(userValue, "") != 0) {
+  if (userValue != NULL && std::strcmp(userValue, "") != 0) {
     return userValue;
   } else {
     if (system != NULL) {
@@ -159,7 +159,7 @@ void OsStatisticsImpl::close() {
 void OsStatisticsImpl::_setInt(int32 offset, int32 value) {
   if (offset >= statsType->getIntStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128, "setInt:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
     throw IllegalArgumentException(s);
@@ -177,12 +177,10 @@ void OsStatisticsImpl::_setLong(int32 offset, int64 value) {
      * arbitrarily long string,
      * callers must be careful not to overflow the actual space of the
      * destination.
-     * Use snprintf() instead, or correct precision specifiers.
-     * Fix : using ACE_OS::snprintf
      */
     // sprintf(s, "setLong:The id (%d) of the Statistic Descriptor is not valid
     // ", offset);
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128, "setLong:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
     throw IllegalArgumentException(s);
@@ -193,7 +191,7 @@ void OsStatisticsImpl::_setLong(int32 offset, int64 value) {
 void OsStatisticsImpl::_setDouble(int32 offset, double value) {
   if (offset >= statsType->getDoubleStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128,
         "setDouble:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
@@ -207,7 +205,7 @@ void OsStatisticsImpl::_setDouble(int32 offset, double value) {
 int32 OsStatisticsImpl::_getInt(int32 offset) {
   if (offset >= statsType->getIntStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128, "getInt:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
     throw IllegalArgumentException(s);
@@ -219,7 +217,7 @@ int32 OsStatisticsImpl::_getInt(int32 offset) {
 int64 OsStatisticsImpl::_getLong(int32 offset) {
   if (offset >= statsType->getLongStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128, "getLong:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
     throw IllegalArgumentException(s);
@@ -231,7 +229,7 @@ int64 OsStatisticsImpl::_getLong(int32 offset) {
 double OsStatisticsImpl::_getDouble(int32 offset) {
   if (offset >= statsType->getDoubleStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128,
         "getDouble:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
@@ -269,7 +267,7 @@ int64 OsStatisticsImpl::_getRawBits(StatisticDescriptor* statDscp) {
 int32 OsStatisticsImpl::_incInt(int32 offset, int32 delta) {
   if (offset >= statsType->getIntStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128, "incInt:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
     throw IllegalArgumentException(s);
@@ -289,13 +287,11 @@ int64 OsStatisticsImpl::_incLong(int32 offset, int64 delta) {
      * arbitrarily long string,
      * callers must be careful not to overflow the actual space of the
      * destination.
-     * Use snprintf() instead, or correct precision specifiers.
-     * Fix : using ACE_OS::snprintf
      */
     // sprintf(s, "incLong:The id (%d) of the Statistic Descriptor is not valid
     // ", offset);
 
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128, "incLong:The id (%d) of the Statistic Descriptor is not valid ",
         offset);
     throw IllegalArgumentException(s);
@@ -307,7 +303,7 @@ int64 OsStatisticsImpl::_incLong(int32 offset, int64 delta) {
 double OsStatisticsImpl::_incDouble(int32 offset, double delta) {
   if (offset >= statsType->getDoubleStatCount()) {
     char s[128] = {'\0'};
-    ACE_OS::snprintf(
+    std::snprintf(
         s, 128,
         "incDouble:The id (%d) of the Statistic Descriptor is not valid ",
         offset);

--- a/src/cppcache/src/statistics/StatisticDescriptorImpl.cpp
+++ b/src/cppcache/src/statistics/StatisticDescriptorImpl.cpp
@@ -17,7 +17,7 @@
 
 #include "StatisticDescriptorImpl.hpp"
 
-#include <ace/OS.h>
+#include <cstring>
 
 using namespace apache::geode::statistics;
 
@@ -45,12 +45,12 @@ StatisticDescriptorImpl::StatisticDescriptorImpl(const char* statName,
                                                  int8 statIsStatLargerBetter) {
   name = statName;
   descriptorType = statDescriptorType;
-  if (strcmp(statDescription, "") == 0) {
+  if (std::strcmp(statDescription, "") == 0) {
     description = "";
   } else {
     description = statDescription;
   }
-  if (strcmp(statUnit, "") == 0) {
+  if (std::strcmp(statUnit, "") == 0) {
     unit = "";
   } else {
     unit = statUnit;
@@ -167,7 +167,7 @@ const char* StatisticDescriptorImpl::getTypeCodeName(FieldType code) throw(
       return DoubleTypeName;
     default: {
       char buf[20];
-      ACE_OS::snprintf(buf, 20, "%d", code);
+      std::snprintf(buf, 20, "%d", code);
       std::string temp(buf);
       std::string s = "Unknown type code:" + temp;
       throw IllegalArgumentException(s.c_str());

--- a/src/cppcache/src/statistics/StatisticsTypeImpl.cpp
+++ b/src/cppcache/src/statistics/StatisticsTypeImpl.cpp
@@ -18,7 +18,7 @@
 #include "StatisticsTypeImpl.hpp"
 #include "StatisticDescriptorImpl.hpp"
 #include <string>
-#include <ace/OS.h>
+#include <cstring>
 using namespace apache::geode::statistics;
 
 /**
@@ -61,11 +61,11 @@ StatisticsTypeImpl::StatisticsTypeImpl(const char* nameArg,
   }
   if (statsLengthArg > MAX_DESCRIPTORS_PER_TYPE) {
     char buffer[100];
-    ACE_OS::snprintf(buffer, 100, "%d", statsLengthArg);
+    std::snprintf(buffer, 100, "%d", statsLengthArg);
     std::string temp(buffer);
     std::string s = "The requested descriptor count " + temp +
                     " exceeds the maximum which is ";
-    ACE_OS::snprintf(buffer, 100, "%d", MAX_DESCRIPTORS_PER_TYPE);
+    std::snprintf(buffer, 100, "%d", MAX_DESCRIPTORS_PER_TYPE);
     std::string buf(buffer);
     s += buf + ".";
     throw IllegalArgumentException(s.c_str());


### PR DESCRIPTION
Rather than call ACE library functions, lets try using standard functions, like `std::snprintf` which was introduced in C++11.