### PR TITLE
GEODE-2486: Initialize OpenSSL for DEFAULT cipher support.

### DIFF
--- a/src/cppcache/integration-test/CacheHelper.cpp
+++ b/src/cppcache/integration-test/CacheHelper.cpp
@@ -1816,7 +1816,7 @@ std::string CacheHelper::generateGeodeProperties(const std::string& path,
     msg += "jmx-manager-ssl-enabled=false\n";
     msg += "cluster-ssl-enabled=true\n";
     msg += "cluster-ssl-require-authentication=true\n";
-    msg += "cluster-ssl-ciphers=SSL_RSA_WITH_NULL_MD5\n";
+    msg += "cluster-ssl-ciphers=TLS_RSA_WITH_AES_128_CBC_SHA\n";
     msg += "cluster-ssl-keystore-type=jks\n";
     msg += "cluster-ssl-keystore=" + keystore + "/server_keystore.jks\n";
     msg += "cluster-ssl-keystore-password=gemstone\n";


### PR DESCRIPTION
- Init SSLv23_client mode to support negotiation of all SSL/TLS
  versions.
- Cleanup C++ style issues.
- Update tests to use NON-NULL cipher.