### PR TITLE
GEODE-2309: Remove or ignore apache-rat flagged files

### DIFF
--- a/.ratignore
+++ b/.ratignore
@@ -23,10 +23,12 @@
 
 # expect script
 .*changepasswd$
+.*winrm.cloud-init$
 
 # doxygen
 .*package-list$
 .*testframeworkdox.txt$
+docs
 
 # patches
 .*patches$

--- a/packer/solaris/files/etc/resolv.conf
+++ b/packer/solaris/files/etc/resolv.conf
@@ -1,9 +1,0 @@
-#######################################################################
-#  Puppet controlled file, Do not hand-edit
-#  Source: puppet:///modules/resolv/resolv.conf
-#######################################################################
-domain gemstone.com
-nameserver 10.138.44.100
-nameserver 10.118.32.200
-nameserver 10.118.32.201
-#search gemstone.com pune.gemstone.com ad.gemstone.com eng.vmware.com vmware.com


### PR DESCRIPTION
`resolv.config` used to work around Solaris SPARC networking issues on a local OpenStack instance.  It should not be needed going forward.