### PR TITLE
GEODE-2501 Update docker build container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ services:
   - docker
 
 install:
-  - docker build -t apachegeode/geode-native-build:1.0 --build-arg GEODE_VERSION=1.0.0-incubating docker/
+  - docker pull apachegeode/geode-native-build
 
 script: 
   - DOCKER_ARGS="--volume=${TRAVIS_BUILD_DIR}:/geode-native --workdir=/geode-native"
-  - docker run ${DOCKER_ARGS} apachegeode/geode-native-build:1.0 bash -c "mkdir build && cd build && cmake ../src && cmake --build . -- -j 8 && ./cppcache/test/apache-geode_unittests"
+  - docker run ${DOCKER_ARGS} apachegeode/geode-native-build bash -c "mkdir build && cd build && cmake ../src && cmake --build . -- -j 8 && ./cppcache/test/apache-geode_unittests"
   - docker stop $(docker ps -l -q)
 
 notifications:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,18 +17,17 @@
 FROM ubuntu
 LABEL maintainer Apache Geode <dev@geode.apache.org>
 
-ARG GEODE_VERSION
-
-RUN apt-get update
-RUN apt-get install -y build-essential cmake doxygen git openjdk-8-jdk \
-                       wget zlib1g-dev
-
 RUN \
-  wget "https://www.apache.org/dyn/closer.cgi?action=download&filename=geode/1.0.0-incubating/apache-geode-${GEODE_VERSION}.tar.gz" && \
-  tar xzf "closer.cgi?action=download&filename=geode%2F1.0.0-incubating%2Fapache-geode-${GEODE_VERSION}.tar.gz" && \
-  rm "closer.cgi?action=download&filename=geode%2F1.0.0-incubating%2Fapache-geode-${GEODE_VERSION}.tar.gz"
+    apt-get update \
+    && apt-get install -y build-essential cmake doxygen git openjdk-8-jdk wget zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-ENV GEODE /apache-geode-${GEODE_VERSION}
+ENV GEODE_VERSION 1.1.0
+RUN \
+    wget "https://www.apache.org/dyn/closer.cgi?action=download&filename=geode/${GEODE_VERSION}/apache-geode-${GEODE_VERSION}.tar.gz" -O - | tar xzf -
+
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV GEODE_HOME /apache-geode-${GEODE_VERSION}
+ENV PATH $PATH:$GEODE_HOME/bin
 
 CMD ["bash"]


### PR DESCRIPTION
Update the docker build container to use Geode v1.1.0. Push the
container to the Geode dockerhub repository

apachegeode/geode-native-build:latest

Update the travis-ci config to pull the docker container to speed
up the build.