### PR TITLE
GEODE-2440: Switch hashcode() return type.

### DIFF
--- a/src/clicache/src/impl/ManagedCacheableDelta.cpp
+++ b/src/clicache/src/impl/ManagedCacheableDelta.cpp
@@ -252,7 +252,7 @@ namespace apache
 
       }
 
-      uint32_t ManagedCacheableDeltaGeneric::hashcode() const
+      int32_t ManagedCacheableDeltaGeneric::hashcode() const
       {
         throw gcnew System::NotSupportedException;
       }

--- a/src/clicache/src/impl/ManagedCacheableDelta.hpp
+++ b/src/clicache/src/impl/ManagedCacheableDelta.hpp
@@ -136,7 +136,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual uint32_t hashcode() const;
+        virtual int32_t hashcode() const;
 
         /// <summary>
         /// return true if this key matches other CacheableKey

--- a/src/clicache/src/impl/ManagedCacheableDeltaBytes.cpp
+++ b/src/clicache/src/impl/ManagedCacheableDeltaBytes.cpp
@@ -303,7 +303,7 @@ namespace apache
         return false;
       }
 
-      uint32_t ManagedCacheableDeltaBytesGeneric::hashcode() const
+      int32_t ManagedCacheableDeltaBytesGeneric::hashcode() const
       {
         throw gcnew System::NotSupportedException;
       }

--- a/src/clicache/src/impl/ManagedCacheableDeltaBytes.hpp
+++ b/src/clicache/src/impl/ManagedCacheableDeltaBytes.hpp
@@ -175,7 +175,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual uint32_t hashcode() const;
+        virtual int32_t hashcode() const;
 
         /// <summary>
         /// return true if this key matches other CacheableKey

--- a/src/clicache/src/impl/ManagedCacheableKey.cpp
+++ b/src/clicache/src/impl/ManagedCacheableKey.cpp
@@ -202,7 +202,7 @@ namespace apache
         return false;
       }
 
-      uint32_t ManagedCacheableKeyGeneric::hashcode() const
+      int32_t ManagedCacheableKeyGeneric::hashcode() const
       {
         if (m_hashcode != 0)
           return m_hashcode;

--- a/src/clicache/src/impl/ManagedCacheableKey.hpp
+++ b/src/clicache/src/impl/ManagedCacheableKey.hpp
@@ -125,7 +125,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual uint32_t hashcode() const;
+        virtual int32_t hashcode() const;
 
         /// <summary>
         /// Copy the string form of a key into a char* buffer for logging purposes.

--- a/src/clicache/src/impl/ManagedCacheableKeyBytes.cpp
+++ b/src/clicache/src/impl/ManagedCacheableKeyBytes.cpp
@@ -229,7 +229,7 @@ namespace apache
         return false;
       }
 
-      uint32_t ManagedCacheableKeyBytesGeneric::hashcode() const
+      int32_t ManagedCacheableKeyBytesGeneric::hashcode() const
       {
         return m_hashCode;
       }

--- a/src/clicache/src/impl/ManagedCacheableKeyBytes.hpp
+++ b/src/clicache/src/impl/ManagedCacheableKeyBytes.hpp
@@ -150,7 +150,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual uint32_t hashcode() const;
+        virtual int32_t hashcode() const;
 
         /// <summary>
         /// Copy the string form of a key into a char* buffer for logging purposes.

--- a/src/clicache/src/impl/PdxManagedCacheableKey.cpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKey.cpp
@@ -191,7 +191,7 @@ namespace apache
         return false;
       }
 
-      uint32_t PdxManagedCacheableKey::hashcode() const
+      int32_t PdxManagedCacheableKey::hashcode() const
       {
         if (m_hashcode != 0)
           return m_hashcode;

--- a/src/clicache/src/impl/PdxManagedCacheableKey.hpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKey.hpp
@@ -148,7 +148,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual uint32_t hashcode() const;
+        virtual int32_t hashcode() const;
 
         /// <summary>
         /// Copy the string form of a key into a char* buffer for logging purposes.

--- a/src/clicache/src/impl/PdxManagedCacheableKeyBytes.cpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKeyBytes.cpp
@@ -234,7 +234,7 @@ namespace apache
         return false;
       }
 
-      uint32_t PdxManagedCacheableKeyBytes::hashcode() const
+      int32_t PdxManagedCacheableKeyBytes::hashcode() const
       {
         return m_hashCode;
       }

--- a/src/clicache/src/impl/PdxManagedCacheableKeyBytes.hpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKeyBytes.hpp
@@ -175,7 +175,7 @@ namespace apache
     /// <summary>
     /// return the hashcode for this key.
     /// </summary>
-    virtual uint32_t hashcode( ) const;
+    virtual int32_t hashcode( ) const;
 
     /// <summary>
     /// Copy the string form of a key into a char* buffer for logging purposes.

--- a/src/cppcache/include/gfcpp/CacheableBuiltins.hpp
+++ b/src/cppcache/include/gfcpp/CacheableBuiltins.hpp
@@ -96,7 +96,7 @@ class CacheableKeyType : public CacheableKey {
   // CacheableKey methods
 
   /** Return the hashcode for this key. */
-  virtual uint32_t hashcode() const {
+  virtual int32_t hashcode() const {
     return apache::geode::client::serializer::hashcode(m_value);
   }
 

--- a/src/cppcache/include/gfcpp/CacheableDate.hpp
+++ b/src/cppcache/include/gfcpp/CacheableDate.hpp
@@ -120,7 +120,7 @@ class CPPCACHE_EXPORT CacheableDate : public CacheableKey {
    * milliseconds() method.
    *
    * @return the hashcode for this object. */
-  virtual uint32_t hashcode() const;
+  virtual int32_t hashcode() const;
 
   operator time_t() const { return m_timevalue / 1000; }
   operator time_point() const {

--- a/src/cppcache/include/gfcpp/CacheableEnum.hpp
+++ b/src/cppcache/include/gfcpp/CacheableEnum.hpp
@@ -124,7 +124,7 @@ class CPPCACHE_EXPORT CacheableEnum : public CacheableKey {
   int32_t getEnumOrdinal() const { return m_ordinal; }
 
   /** @return the hashcode for this key. */
-  virtual uint32_t hashcode() const;
+  virtual int32_t hashcode() const;
 
   /** @return true if this key matches other. */
   virtual bool operator==(const CacheableKey& other) const;

--- a/src/cppcache/include/gfcpp/CacheableFileName.hpp
+++ b/src/cppcache/include/gfcpp/CacheableFileName.hpp
@@ -100,7 +100,7 @@ class CPPCACHE_EXPORT CacheableFileName : public CacheableString {
   virtual const char* className() const { return "CacheableFileName"; }
 
   /** return the hashcode for this key. */
-  virtual uint32_t hashcode() const;
+  virtual int32_t hashcode() const;
 
  protected:
   /** Default constructor. */

--- a/src/cppcache/include/gfcpp/CacheableKey.hpp
+++ b/src/cppcache/include/gfcpp/CacheableKey.hpp
@@ -46,7 +46,7 @@ class CPPCACHE_EXPORT CacheableKey : public Cacheable {
   virtual bool operator==(const CacheableKey& other) const = 0;
 
   /** return the hashcode for this key. */
-  virtual uint32_t hashcode() const = 0;
+  virtual int32_t hashcode() const = 0;
 
   /** Copy the string form of a key into a char* buffer for logging purposes.
    *

--- a/src/cppcache/include/gfcpp/CacheableString.hpp
+++ b/src/cppcache/include/gfcpp/CacheableString.hpp
@@ -102,7 +102,7 @@ class CPPCACHE_EXPORT CacheableString : public CacheableKey {
   virtual bool operator==(const CacheableKey& other) const;
 
   /** return the hashcode for this key. */
-  virtual uint32_t hashcode() const;
+  virtual int32_t hashcode() const;
 
   /**
    * Factory method for creating an instance of CacheableString from

--- a/src/cppcache/include/gfcpp/PdxInstance.hpp
+++ b/src/cppcache/include/gfcpp/PdxInstance.hpp
@@ -478,7 +478,7 @@ class CPPCACHE_EXPORT PdxInstance : public PdxSerializable {
   *
   * @see Serializable::registerPdxType
   */
-  virtual uint32_t hashcode() const = 0;
+  virtual int32_t hashcode() const = 0;
 
   /**
   * Prints out all of the identity fields of this PdxInstance.

--- a/src/cppcache/include/gfcpp/PdxSerializable.hpp
+++ b/src/cppcache/include/gfcpp/PdxSerializable.hpp
@@ -71,7 +71,7 @@ class CPPCACHE_EXPORT PdxSerializable : public CacheableKey {
   virtual bool operator==(const CacheableKey& other) const;
 
   /** return the hashcode for this key. */
-  virtual uint32_t hashcode() const;
+  virtual int32_t hashcode() const;
 
   /**
    *@brief serialize this object

--- a/src/cppcache/include/gfcpp/PdxWrapper.hpp
+++ b/src/cppcache/include/gfcpp/PdxWrapper.hpp
@@ -66,7 +66,7 @@ class CPPCACHE_EXPORT PdxWrapper : public PdxSerializable {
   bool operator==(const CacheableKey& other) const;
 
   /** return the hashcode for this key. */
-  uint32_t hashcode() const;
+  int32_t hashcode() const;
 
   /**
   *@brief serialize this object in geode PDX format

--- a/src/cppcache/src/CacheableDate.cpp
+++ b/src/cppcache/src/CacheableDate.cpp
@@ -87,7 +87,7 @@ int CacheableDate::year() const {
 
 int64_t CacheableDate::milliseconds() const { return m_timevalue; }
 
-uint32_t CacheableDate::hashcode() const {
+int32_t CacheableDate::hashcode() const {
   return static_cast<int>(m_timevalue) ^ static_cast<int>(m_timevalue >> 32);
 }
 

--- a/src/cppcache/src/CacheableEnum.cpp
+++ b/src/cppcache/src/CacheableEnum.cpp
@@ -61,7 +61,7 @@ Serializable* CacheableEnum::fromData(apache::geode::client::DataInput& input) {
   return enumVal.ptr();
 }
 
-uint32_t CacheableEnum::hashcode() const {
+int32_t CacheableEnum::hashcode() const {
   int localHash = 1;
   if (m_hashcode == 0) {
     int prime = 31;

--- a/src/cppcache/src/CacheableFileName.cpp
+++ b/src/cppcache/src/CacheableFileName.cpp
@@ -43,7 +43,7 @@ int8_t CacheableFileName::typeId() const {
   return GeodeTypeIds::CacheableFileName;
 }
 
-uint32_t CacheableFileName::hashcode() const {
+int32_t CacheableFileName::hashcode() const {
 #ifndef _WIN32
   if (m_hashcode == 0) {
     m_hashcode = CacheableString::hashcode() ^ 1234321;

--- a/src/cppcache/src/CacheableString.cpp
+++ b/src/cppcache/src/CacheableString.cpp
@@ -127,7 +127,7 @@ bool CacheableString::operator==(const CacheableKey& other) const {
   }
 }
 
-uint32_t CacheableString::hashcode() const {
+int32_t CacheableString::hashcode() const {
   if (m_str == NULL) {
     return 0;
   }

--- a/src/cppcache/src/ClientProxyMembershipID.hpp
+++ b/src/cppcache/src/ClientProxyMembershipID.hpp
@@ -86,7 +86,7 @@ class ClientProxyMembershipID : public DSMemberForVersionStamp {
   uint32_t getHostPort() const { return m_hostPort; }
   virtual std::string getHashKey();
   virtual int16_t compareTo(DSMemberForVersionStampPtr);
-  virtual uint32_t hashcode() const {
+  virtual int32_t hashcode() const {
     uint32_t result = 0;
     char hostInfo[255] = {0};
     uint32_t offset = 0;

--- a/src/cppcache/src/DSMemberForVersionStamp.hpp
+++ b/src/cppcache/src/DSMemberForVersionStamp.hpp
@@ -40,7 +40,7 @@ class DSMemberForVersionStamp : public CacheableKey {
   virtual bool operator==(const CacheableKey& other) const = 0;
 
   /** return the hashcode for this key. */
-  virtual uint32_t hashcode() const = 0;
+  virtual int32_t hashcode() const = 0;
 };
 }  // namespace client
 }  // namespace geode

--- a/src/cppcache/src/DiskStoreId.hpp
+++ b/src/cppcache/src/DiskStoreId.hpp
@@ -79,7 +79,7 @@ class DiskStoreId : public DSMemberForVersionStamp {
   static Serializable* createDeserializable() { return new DiskStoreId(); }
   std::string getHashKey();
 
-  virtual uint32_t hashcode() const {
+  virtual int32_t hashcode() const {
     static uint32_t prime = 31;
     uint32_t result = 1;
     result =

--- a/src/cppcache/src/EnumInfo.cpp
+++ b/src/cppcache/src/EnumInfo.cpp
@@ -34,7 +34,7 @@ EnumInfo::EnumInfo(const char *enumClassName, const char *enumName,
   m_enumName = CacheableString::create(enumName);
 }
 
-uint32_t EnumInfo::hashcode() const {
+int32_t EnumInfo::hashcode() const {
   return ((m_enumClassName != NULLPTR ? m_enumClassName->hashcode() : 0) +
           (m_enumName != NULLPTR ? m_enumName->hashcode() : 0));
 }

--- a/src/cppcache/src/EnumInfo.hpp
+++ b/src/cppcache/src/EnumInfo.hpp
@@ -54,7 +54,7 @@ class CPPCACHE_EXPORT EnumInfo : public CacheableKey {
     return CacheableString::create("EnumInfo");
   }
   virtual bool operator==(const CacheableKey& other) const;
-  virtual uint32_t hashcode() const;
+  virtual int32_t hashcode() const;
 
   virtual int8_t DSFID() const;
   CacheableStringPtr getEnumClassName() const { return m_enumClassName; }

--- a/src/cppcache/src/EventIdMap.cpp
+++ b/src/cppcache/src/EventIdMap.cpp
@@ -197,7 +197,7 @@ int32_t EventSource::getMemIdLen() { return m_srcIdLen - sizeof(m_thrId); }
 
 int64_t EventSource::getThrId() { return m_thrId; }
 
-uint32_t EventSource::hashcode() {
+int32_t EventSource::hashcode() {
   if (m_srcId == NULL || m_srcIdLen <= 0) {
     return 0;
   }

--- a/src/cppcache/src/EventIdMap.hpp
+++ b/src/cppcache/src/EventIdMap.hpp
@@ -150,7 +150,7 @@ class CPPCACHE_EXPORT EventSource : public SharedBase {
   EventSource(const char *memId, int32_t memIdLen, int64_t thrId);
   ~EventSource();
 
-  uint32_t hashcode();
+  int32_t hashcode();
   bool operator==(const EventSource &rhs) const;
 
   // Accessors

--- a/src/cppcache/src/PdxInstanceImpl.cpp
+++ b/src/cppcache/src/PdxInstanceImpl.cpp
@@ -737,7 +737,7 @@ int PdxInstanceImpl::deepArrayHashCode(CacheablePtr obj) {
   }
 }
 
-uint32_t PdxInstanceImpl::hashcode() const {
+int32_t PdxInstanceImpl::hashcode() const {
   int hashCode = 1;
 
   PdxTypePtr pt = getPdxType();

--- a/src/cppcache/src/PdxInstanceImpl.hpp
+++ b/src/cppcache/src/PdxInstanceImpl.hpp
@@ -932,7 +932,7 @@ class CPPCACHE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
   *
   * @see Serializable::registerPdxType
   */
-  virtual uint32_t hashcode() const;
+  virtual int32_t hashcode() const;
 
   /**
   * Prints out all of the identity fields of this PdxInstance.

--- a/src/cppcache/src/PdxSerializable.cpp
+++ b/src/cppcache/src/PdxSerializable.cpp
@@ -57,7 +57,7 @@ bool PdxSerializable::operator==(const CacheableKey& other) const {
   return (this == &other);
 }
 
-uint32_t PdxSerializable::hashcode() const {
+int32_t PdxSerializable::hashcode() const {
   uint64_t hash = static_cast<uint64_t>((intptr_t)this);
   return apache::geode::client::serializer::hashcode(hash);
 }

--- a/src/cppcache/src/PdxWrapper.cpp
+++ b/src/cppcache/src/PdxWrapper.cpp
@@ -124,7 +124,7 @@ bool PdxWrapper::operator==(const CacheableKey &other) const {
   return (intptr_t)m_userObject == (intptr_t)wrapper->m_userObject;
 }
 
-uint32_t PdxWrapper::hashcode() const {
+int32_t PdxWrapper::hashcode() const {
   uint64_t hash = static_cast<uint64_t>((intptr_t)m_userObject);
   return apache::geode::client::serializer::hashcode(hash);
 }


### PR DESCRIPTION
- Convert from uint32_t to int32_t to match server.