### PR TITLE
GEODE-2516: Fix quickstart install to retain permissions.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -231,7 +231,7 @@ if (${BUILD_CLI})
   add_subdirectory(plugins/SQLiteCLI)
 endif()
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/quickstart/ DESTINATION SampleCode/quickstart)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/quickstart/ DESTINATION SampleCode/quickstart USE_SOURCE_PERMISSIONS)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cppcache/integration-test/keystore/ DESTINATION SampleCode/quickstart/keystore)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/xsds/ DESTINATION xsds)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/defaultSystem/ DESTINATION defaultSystem)


### PR DESCRIPTION
- By default cmake install unsets the execute bit. To retain it add USE_SOURCE_PERMISSIONS flag.