### PR TITLE
GEODE-2478: Replace gf with geode.

### DIFF
--- a/src/clicache/include/gfcli/Utils.hpp
+++ b/src/clicache/include/gfcli/Utils.hpp
@@ -19,8 +19,8 @@
 
 #pragma once
 
-#include <geode/gf_base.hpp>
-#include "gf_defs.hpp"
+#include <geode/geode_base.hpp>
+#include "geode_defs.hpp"
 //#include "SystemProperties.hpp"
 //#include "../../impl/NativeWrapper.hpp"
 //#include "../../Log.hpp"

--- a/src/clicache/integration-test/CacheableWrapper.cs
+++ b/src/clicache/integration-test/CacheableWrapper.cs
@@ -35,12 +35,12 @@ namespace Apache.Geode.Client.UnitTests
   {
     #region Protected members
 
-    protected IGFSerializable m_cacheableObject = null;
+    protected IGeodeSerializable m_cacheableObject = null;
     protected uint m_typeId;
 
     #endregion
 
-    public virtual IGFSerializable Cacheable
+    public virtual IGeodeSerializable Cacheable
     {
       get
       {
@@ -62,7 +62,7 @@ namespace Apache.Geode.Client.UnitTests
 
     public abstract void InitRandomValue(int maxSize);
 
-    public abstract uint GetChecksum(IGFSerializable cacheableObject);
+    public abstract uint GetChecksum(IGeodeSerializable cacheableObject);
 
     public virtual uint GetChecksum()
     {
@@ -79,7 +79,7 @@ namespace Apache.Geode.Client.UnitTests
   /// </remarks>
   public abstract class CacheableKeyWrapper : CacheableWrapper
   {
-    public override IGFSerializable Cacheable
+    public override IGeodeSerializable Cacheable
     {
       get
       {

--- a/src/clicache/integration-test/DefaultCacheableN.cs
+++ b/src/clicache/integration-test/DefaultCacheableN.cs
@@ -36,8 +36,8 @@ namespace Apache.Geode.Client.UnitTests
     }
   }
 
-  // VJR: TODO: IGFSerializable should be replaced by IPdxSerializable when ready
-  class DefaultType : IGFSerializable
+  // VJR: TODO: IGeodeSerializable should be replaced by IPdxSerializable when ready
+  class DefaultType : IGeodeSerializable
   {
     bool m_cacheableBoolean;
     int m_cacheableInt32;
@@ -155,14 +155,14 @@ namespace Apache.Geode.Client.UnitTests
       get { return m_cacheableObject; }
     }
 
-    #region IGFSerializable Members
+    #region IGeodeSerializable Members
 
     public uint ClassId
     {
       get { return 0x04; }
     }
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       if (!m_initialized)
       {
@@ -253,7 +253,7 @@ namespace Apache.Geode.Client.UnitTests
 
     #endregion
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new DefaultType();
     }

--- a/src/clicache/integration-test/DupListenerN.cs
+++ b/src/clicache/integration-test/DupListenerN.cs
@@ -32,7 +32,7 @@ namespace Apache.Geode.Client.UnitTests
 
     private int m_ops = 0;
     private Dictionary<object, object> m_map = new Dictionary<object, object>();
-    //ICacheableKey, IGFSerializable
+    //ICacheableKey, IGeodeSerializable
 
     #endregion
 

--- a/src/clicache/integration-test/ExpirationTestsN.cs
+++ b/src/clicache/integration-test/ExpirationTestsN.cs
@@ -185,7 +185,7 @@ namespace Apache.Geode.Client.UnitTests
       m_regionName = "RT1";
       SetupRegion(0, 0, 0, 0);
       PutKeyTouch(5);
-      IGFSerializable val = m_region.Get(m_key);
+      IGeodeSerializable val = m_region.Get(m_key);
       m_region.Destroy(m_key);
       val = m_region.Get(m_key);
       CheckRegion(false, 0);

--- a/src/clicache/integration-test/NetTests.cs
+++ b/src/clicache/integration-test/NetTests.cs
@@ -73,7 +73,7 @@ namespace Apache.Geode.Client.UnitTests
       CacheHelper.CreateDistribRegion(TestRegion, false, true);
       m_region = CacheHelper.GetVerifyRegion(TestRegion);
       DoGets(m_region, num);
-      IGFSerializable[] arr = m_region.GetKeys();
+      IGeodeSerializable[] arr = m_region.GetKeys();
       Assert.AreEqual(num, arr.Length);
     }
 
@@ -83,7 +83,7 @@ namespace Apache.Geode.Client.UnitTests
       Util.Log("Calling doGets for verify");
       //Thread.Sleep(2000);
       //doGets(m_region, load);
-      IGFSerializable[] arr = m_region.GetKeys();
+      IGeodeSerializable[] arr = m_region.GetKeys();
       Assert.AreEqual(num, arr.Length);
     }
 
@@ -97,7 +97,7 @@ namespace Apache.Geode.Client.UnitTests
       Thread.Sleep(100);
       DoGets(m_region, num);
       Assert.AreEqual(num, m_ldr.Loads);
-      IGFSerializable[] arr = m_region.GetKeys();
+      IGeodeSerializable[] arr = m_region.GetKeys();
       Assert.AreEqual(num, arr.Length);
     }
 

--- a/src/clicache/integration-test/OverflowTestsN.cs
+++ b/src/clicache/integration-test/OverflowTestsN.cs
@@ -169,7 +169,7 @@ namespace Apache.Geode.Client.UnitTests
       }
     }
 
-    private bool IsOverflowed(/*IGFSerializable*/ object cVal)
+    private bool IsOverflowed(/*IGeodeSerializable*/ object cVal)
     {
       //Util.Log("IsOverflowed:: value is: {0}; type is: {1}", cVal.ToString(), cVal.GetType());
       return cVal.ToString() == "CacheableToken::OVERFLOWED";
@@ -177,7 +177,7 @@ namespace Apache.Geode.Client.UnitTests
 
     private void CheckOverflowToken(IRegion<object, object> region, int num, int lruLimit)
     {
-      //IGFSerializable cVal;
+      //IGeodeSerializable cVal;
       //ICacheableKey[] cKeys = region.GetKeys();
 
       object cVal;

--- a/src/clicache/integration-test/PutGetPerfTests.cs
+++ b/src/clicache/integration-test/PutGetPerfTests.cs
@@ -174,7 +174,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       int numKeys = 0;
       string message;
-      IGFSerializable[] keys = CacheHelper.CurrentRegion.GetKeys();
+      IGeodeSerializable[] keys = CacheHelper.CurrentRegion.GetKeys();
       if (keys != null)
       {
         numKeys = keys.Length;

--- a/src/clicache/integration-test/RegionEntryTests.cs
+++ b/src/clicache/integration-test/RegionEntryTests.cs
@@ -66,7 +66,7 @@ namespace Apache.Geode.Client.UnitTests
           regionName + ": value of " + i.ToString());
       }
       ICacheableKey[] cKeys = region.GetKeys();
-      IGFSerializable[] cValues = region.GetValues();
+      IGeodeSerializable[] cValues = region.GetValues();
       Assert.AreEqual(num, cKeys.Length, "Number of keys in region is incorrect.");
       Assert.AreEqual(num, cValues.Length, "Number of values in region is incorrect.");
 

--- a/src/clicache/integration-test/SerializationTestsN.cs
+++ b/src/clicache/integration-test/SerializationTestsN.cs
@@ -70,9 +70,9 @@ namespace Apache.Geode.Client.UnitTests
       base.EndTest();
     }
 
-    private IGFSerializable CreateOtherType(int i, int otherType)
+    private IGeodeSerializable CreateOtherType(int i, int otherType)
     {
-      IGFSerializable ot;
+      IGeodeSerializable ot;
       switch (otherType)
       {
         case OTHER_TYPE1: ot = new OtherType(i, i + 20000); break;
@@ -147,7 +147,7 @@ namespace Apache.Geode.Client.UnitTests
       IRegion<object, object> region = CacheHelper.GetVerifyRegion<object, object>(RegionNames[0]);
       for (int i = 0; i < n; i++)
       {
-        IGFSerializable ot = CreateOtherType(i, otherType);
+        IGeodeSerializable ot = CreateOtherType(i, otherType);
         region[i + 10] = ot;
       }
     }
@@ -158,7 +158,7 @@ namespace Apache.Geode.Client.UnitTests
       for (int i = 0; i < n; i++)
       {
         object val = region[i + 10];
-        IGFSerializable ot = CreateOtherType(i, otherType);
+        IGeodeSerializable ot = CreateOtherType(i, otherType);
         Assert.IsTrue(ot.Equals(val), "Found unexpected value");
       }
     }
@@ -385,7 +385,7 @@ namespace Apache.Geode.Client.UnitTests
 
   };
 
-  public class OtherType : IGFSerializable
+  public class OtherType : IGeodeSerializable
   {
     private CData m_struct;
     private ExceptionType m_exType;
@@ -427,19 +427,19 @@ namespace Apache.Geode.Client.UnitTests
       }
     }
 
-    public static IGFSerializable Duplicate(IGFSerializable orig)
+    public static IGeodeSerializable Duplicate(IGeodeSerializable orig)
     {
       DataOutput dout = new DataOutput();
       orig.ToData(dout);
 
       DataInput din = new DataInput(dout.GetBuffer());
-      IGFSerializable dup = (IGFSerializable)din.ReadObject();
+      IGeodeSerializable dup = (IGeodeSerializable)din.ReadObject();
       return dup;
     }
 
-    #region IGFSerializable Members
+    #region IGeodeSerializable Members
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       m_struct.First = input.ReadInt32();
       m_struct.Second = input.ReadInt64();
@@ -512,7 +512,7 @@ namespace Apache.Geode.Client.UnitTests
 
     #endregion
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new OtherType();
     }
@@ -533,7 +533,7 @@ namespace Apache.Geode.Client.UnitTests
     }
   }
 
-  public class OtherType2 : IGFSerializable
+  public class OtherType2 : IGeodeSerializable
   {
     private CData m_struct;
     private ExceptionType m_exType;
@@ -575,19 +575,19 @@ namespace Apache.Geode.Client.UnitTests
       }
     }
 
-    public static IGFSerializable Duplicate(IGFSerializable orig)
+    public static IGeodeSerializable Duplicate(IGeodeSerializable orig)
     {
       DataOutput dout = new DataOutput();
       orig.ToData(dout);
 
       DataInput din = new DataInput(dout.GetBuffer());
-      IGFSerializable dup = (IGFSerializable)din.ReadObject();
+      IGeodeSerializable dup = (IGeodeSerializable)din.ReadObject();
       return dup;
     }
 
-    #region IGFSerializable Members
+    #region IGeodeSerializable Members
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       m_struct.First = input.ReadInt32();
       m_struct.Second = input.ReadInt64();
@@ -660,7 +660,7 @@ namespace Apache.Geode.Client.UnitTests
 
     #endregion
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new OtherType2();
     }
@@ -682,7 +682,7 @@ namespace Apache.Geode.Client.UnitTests
 
   }
 
-  public class OtherType22 : IGFSerializable
+  public class OtherType22 : IGeodeSerializable
   {
     private CData m_struct;
     private ExceptionType m_exType;
@@ -724,19 +724,19 @@ namespace Apache.Geode.Client.UnitTests
       }
     }
 
-    public static IGFSerializable Duplicate(IGFSerializable orig)
+    public static IGeodeSerializable Duplicate(IGeodeSerializable orig)
     {
       DataOutput dout = new DataOutput();
       orig.ToData(dout);
 
       DataInput din = new DataInput(dout.GetBuffer());
-      IGFSerializable dup = (IGFSerializable)din.ReadObject();
+      IGeodeSerializable dup = (IGeodeSerializable)din.ReadObject();
       return dup;
     }
 
-    #region IGFSerializable Members
+    #region IGeodeSerializable Members
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       m_struct.First = input.ReadInt32();
       m_struct.Second = input.ReadInt64();
@@ -809,7 +809,7 @@ namespace Apache.Geode.Client.UnitTests
 
     #endregion
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new OtherType22();
     }
@@ -830,7 +830,7 @@ namespace Apache.Geode.Client.UnitTests
     }
   }
 
-  public class OtherType4 : IGFSerializable
+  public class OtherType4 : IGeodeSerializable
   {
     private CData m_struct;
     private ExceptionType m_exType;
@@ -872,19 +872,19 @@ namespace Apache.Geode.Client.UnitTests
       }
     }
 
-    public static IGFSerializable Duplicate(IGFSerializable orig)
+    public static IGeodeSerializable Duplicate(IGeodeSerializable orig)
     {
       DataOutput dout = new DataOutput();
       orig.ToData(dout);
 
       DataInput din = new DataInput(dout.GetBuffer());
-      IGFSerializable dup = (IGFSerializable)din.ReadObject();
+      IGeodeSerializable dup = (IGeodeSerializable)din.ReadObject();
       return dup;
     }
 
-    #region IGFSerializable Members
+    #region IGeodeSerializable Members
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       m_struct.First = input.ReadInt32();
       m_struct.Second = input.ReadInt64();
@@ -957,7 +957,7 @@ namespace Apache.Geode.Client.UnitTests
 
     #endregion
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new OtherType4();
     }
@@ -979,7 +979,7 @@ namespace Apache.Geode.Client.UnitTests
 
   }
 
-  public class OtherType42 : IGFSerializable
+  public class OtherType42 : IGeodeSerializable
   {
     private CData m_struct;
     private ExceptionType m_exType;
@@ -1021,19 +1021,19 @@ namespace Apache.Geode.Client.UnitTests
       }
     }
 
-    public static IGFSerializable Duplicate(IGFSerializable orig)
+    public static IGeodeSerializable Duplicate(IGeodeSerializable orig)
     {
       DataOutput dout = new DataOutput();
       orig.ToData(dout);
 
       DataInput din = new DataInput(dout.GetBuffer());
-      IGFSerializable dup = (IGFSerializable)din.ReadObject();
+      IGeodeSerializable dup = (IGeodeSerializable)din.ReadObject();
       return dup;
     }
 
-    #region IGFSerializable Members
+    #region IGeodeSerializable Members
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       m_struct.First = input.ReadInt32();
       m_struct.Second = input.ReadInt64();
@@ -1106,7 +1106,7 @@ namespace Apache.Geode.Client.UnitTests
 
     #endregion
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new OtherType42();
     }
@@ -1128,7 +1128,7 @@ namespace Apache.Geode.Client.UnitTests
 
   }
 
-  public class OtherType43 : IGFSerializable
+  public class OtherType43 : IGeodeSerializable
   {
     private CData m_struct;
     private ExceptionType m_exType;
@@ -1170,19 +1170,19 @@ namespace Apache.Geode.Client.UnitTests
       }
     }
 
-    public static IGFSerializable Duplicate(IGFSerializable orig)
+    public static IGeodeSerializable Duplicate(IGeodeSerializable orig)
     {
       DataOutput dout = new DataOutput();
       orig.ToData(dout);
 
       DataInput din = new DataInput(dout.GetBuffer());
-      IGFSerializable dup = (IGFSerializable)din.ReadObject();
+      IGeodeSerializable dup = (IGeodeSerializable)din.ReadObject();
       return dup;
     }
 
-    #region IGFSerializable Members
+    #region IGeodeSerializable Members
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       m_struct.First = input.ReadInt32();
       m_struct.Second = input.ReadInt64();
@@ -1255,7 +1255,7 @@ namespace Apache.Geode.Client.UnitTests
 
     #endregion
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new OtherType43();
     }

--- a/src/clicache/integration-test/TallyListener.cs
+++ b/src/clicache/integration-test/TallyListener.cs
@@ -32,8 +32,8 @@ namespace Apache.Geode.Client.UnitTests
     private int m_destroys = 0;
     private int m_clears = 0;
     private Apache.Geode.Client.ICacheableKey m_lastKey = null;
-    private Apache.Geode.Client.IGFSerializable m_lastValue = null;
-    private Apache.Geode.Client.IGFSerializable m_callbackArg = null;
+    private Apache.Geode.Client.IGeodeSerializable m_lastValue = null;
+    private Apache.Geode.Client.IGeodeSerializable m_callbackArg = null;
     private bool m_ignoreTimeout = false;
     private bool m_quiet = false;
     private bool isListenerInvoke = false;
@@ -83,7 +83,7 @@ namespace Apache.Geode.Client.UnitTests
       }
     }
 
-    public Apache.Geode.Client.IGFSerializable LastKey
+    public Apache.Geode.Client.IGeodeSerializable LastKey
     {
       get
       {
@@ -107,7 +107,7 @@ namespace Apache.Geode.Client.UnitTests
       }
     }
 
-    public Apache.Geode.Client.IGFSerializable LastValue
+    public Apache.Geode.Client.IGeodeSerializable LastValue
     {
       get
       {
@@ -131,7 +131,7 @@ namespace Apache.Geode.Client.UnitTests
       }
     }
 
-     public void SetCallBackArg(Apache.Geode.Client.IGFSerializable callbackArg)
+     public void SetCallBackArg(Apache.Geode.Client.IGeodeSerializable callbackArg)
     {
       m_callbackArg = callbackArg;
     }
@@ -145,7 +145,7 @@ namespace Apache.Geode.Client.UnitTests
         isListenerInvoke = true;
       if (m_callbackArg != null)
       {
-        Apache.Geode.Client.IGFSerializable callbkArg = (Apache.Geode.Client.IGFSerializable)ev.CallbackArgument;
+        Apache.Geode.Client.IGeodeSerializable callbkArg = (Apache.Geode.Client.IGeodeSerializable)ev.CallbackArgument;
         if (m_callbackArg.Equals(callbkArg))
           isCallbackCalled = true;
       }
@@ -238,7 +238,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       m_creates++;
       m_lastKey = (Apache.Geode.Client.ICacheableKey)ev.Key;
-      m_lastValue = (Apache.Geode.Client.IGFSerializable)ev.NewValue;
+      m_lastValue = (Apache.Geode.Client.IGeodeSerializable)ev.NewValue;
       CheckcallbackArg(ev);
 
       string keyString = m_lastKey.ToString();
@@ -257,7 +257,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       m_updates++;
       m_lastKey = (Apache.Geode.Client.ICacheableKey)ev.Key;
-      m_lastValue = (Apache.Geode.Client.IGFSerializable)ev.NewValue;
+      m_lastValue = (Apache.Geode.Client.IGeodeSerializable)ev.NewValue;
       CheckcallbackArg(ev);
      
       string keyString = m_lastKey.ToString();

--- a/src/clicache/integration-test/TallyListenerN.cs
+++ b/src/clicache/integration-test/TallyListenerN.cs
@@ -152,8 +152,8 @@ namespace Apache.Geode.Client.UnitTests
       /*
       if (m_callbackArg != null)
       {
-        IGFSerializable callbkArg1 = ev.CallbackArgument as IGFSerializable;
-        IGFSerializable callbkArg2 = m_callbackArg as IGFSerializable;
+        IGeodeSerializable callbkArg1 = ev.CallbackArgument as IGeodeSerializable;
+        IGeodeSerializable callbkArg2 = m_callbackArg as IGeodeSerializable;
         if (callbkArg2 != null && callbkArg2.Equals(callbkArg1))
         {
           isCallbackCalled = true;

--- a/src/clicache/integration-test/TallyWriter.cs
+++ b/src/clicache/integration-test/TallyWriter.cs
@@ -30,10 +30,10 @@ namespace Apache.Geode.Client.UnitTests
     private int m_updates = 0;
     private int m_invalidates = 0;
     private int m_destroys = 0;
-    private Apache.Geode.Client.IGFSerializable m_callbackArg = null;
+    private Apache.Geode.Client.IGeodeSerializable m_callbackArg = null;
     private int m_clears = 0;
-    private Apache.Geode.Client.IGFSerializable m_lastKey = null;
-    private Apache.Geode.Client.IGFSerializable m_lastValue = null;
+    private Apache.Geode.Client.IGeodeSerializable m_lastKey = null;
+    private Apache.Geode.Client.IGeodeSerializable m_lastValue = null;
     private bool isWriterFailed = false;
     private bool isWriterInvoke = false;
     private bool isCallbackCalled = false;
@@ -82,7 +82,7 @@ namespace Apache.Geode.Client.UnitTests
     }
 
 
-    public Apache.Geode.Client.IGFSerializable LastKey
+    public Apache.Geode.Client.IGeodeSerializable LastKey
     {
       get
       {
@@ -90,7 +90,7 @@ namespace Apache.Geode.Client.UnitTests
       }
     }
 
-    public Apache.Geode.Client.IGFSerializable CallbackArgument
+    public Apache.Geode.Client.IGeodeSerializable CallbackArgument
     {
       get
       {
@@ -99,7 +99,7 @@ namespace Apache.Geode.Client.UnitTests
     }
 
 
-    public Apache.Geode.Client.IGFSerializable LastValue
+    public Apache.Geode.Client.IGeodeSerializable LastValue
     {
       get
       {
@@ -112,7 +112,7 @@ namespace Apache.Geode.Client.UnitTests
     isWriterFailed = true;
    }
 
-  public void SetCallBackArg( Apache.Geode.Client.IGFSerializable callbackArg )
+  public void SetCallBackArg( Apache.Geode.Client.IGeodeSerializable callbackArg )
   {
     m_callbackArg = callbackArg;
   }
@@ -174,7 +174,7 @@ namespace Apache.Geode.Client.UnitTests
           isWriterInvoke = true;
         if (m_callbackArg != null)
         {
-          Apache.Geode.Client.IGFSerializable callbkArg = (Apache.Geode.Client.IGFSerializable)ev.CallbackArgument;
+          Apache.Geode.Client.IGeodeSerializable callbkArg = (Apache.Geode.Client.IGeodeSerializable)ev.CallbackArgument;
           if (m_callbackArg.Equals(callbkArg))
             isCallbackCalled = true;
         }  

--- a/src/clicache/integration-test/TallyWriterN.cs
+++ b/src/clicache/integration-test/TallyWriterN.cs
@@ -178,8 +178,8 @@ namespace Apache.Geode.Client.UnitTests
       /*
         if (m_callbackArg != null)
         {
-          IGFSerializable callbkArg1 = ev.CallbackArgument as IGFSerializable;
-          IGFSerializable callbkArg2 = m_callbackArg as IGFSerializable;
+          IGeodeSerializable callbkArg1 = ev.CallbackArgument as IGeodeSerializable;
+          IGeodeSerializable callbkArg2 = m_callbackArg as IGeodeSerializable;
           if (callbkArg1 != null && callbkArg1.Equals(callbkArg2))
           {
             isCallbackCalled = true;

--- a/src/clicache/integration-test/ThinClientCqTestsN.cs
+++ b/src/clicache/integration-test/ThinClientCqTestsN.cs
@@ -69,7 +69,7 @@ namespace Apache.Geode.Client.UnitTests
       else
         m_eventCountBefore++;
 
-      //IGFSerializable val = ev.getNewValue();
+      //IGeodeSerializable val = ev.getNewValue();
       //ICacheableKey key = ev.getKey();
 
       TResult val = (TResult)ev.getNewValue();

--- a/src/clicache/integration-test/ThinClientDeltaTestN.cs
+++ b/src/clicache/integration-test/ThinClientDeltaTestN.cs
@@ -79,7 +79,7 @@ namespace Apache.Geode.Client.UnitTests
     private int m_valueCount;
   }
 
-  public class DeltaTestAD : IGFDelta, IGFSerializable
+  public class DeltaTestAD : IGeodeDelta, IGeodeSerializable
   {
     private int _deltaUpdate;
     private string _staticData;
@@ -96,7 +96,7 @@ namespace Apache.Geode.Client.UnitTests
     }
 
 
-    #region IGFDelta Members
+    #region IGeodeDelta Members
 
     public void FromDelta(DataInput input)
     {
@@ -118,14 +118,14 @@ namespace Apache.Geode.Client.UnitTests
 
     #endregion
 
-    #region IGFSerializable Members
+    #region IGeodeSerializable Members
 
     public uint ClassId
     {
       get { return 151; }
     }
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       _deltaUpdate = input.ReadInt32();
       _staticData = input.ReadUTF();

--- a/src/clicache/integration-test/ThinClientPdxTests.cs
+++ b/src/clicache/integration-test/ThinClientPdxTests.cs
@@ -1128,7 +1128,7 @@ namespace Apache.Geode.Client.UnitTests
      {
        try
        {
-         Serializable.RegisterTypeGeneric(PdxTests.PdxInsideIGFSerializable.CreateDeserializable);
+         Serializable.RegisterTypeGeneric(PdxTests.PdxInsideIGeodeSerializable.CreateDeserializable);
          Serializable.RegisterPdxType(NestedPdx.CreateDeserializable);
          Serializable.RegisterPdxType(PdxTypes1.CreateDeserializable);
          Serializable.RegisterPdxType(PdxTypes2.CreateDeserializable);
@@ -1144,10 +1144,10 @@ namespace Apache.Geode.Client.UnitTests
        }
 
        Region region0 = CacheHelper.GetVerifyRegion<object, object>(m_regionNames[0]);
-       PdxInsideIGFSerializable np = new PdxInsideIGFSerializable();
+       PdxInsideIGeodeSerializable np = new PdxInsideIGeodeSerializable();
        region0[1] = np;
 
-       PdxInsideIGFSerializable pRet = (PdxInsideIGFSerializable)region0[1];
+       PdxInsideIGeodeSerializable pRet = (PdxInsideIGeodeSerializable)region0[1];
 
        Assert.AreEqual(np, pRet);
      }
@@ -1156,7 +1156,7 @@ namespace Apache.Geode.Client.UnitTests
      {
        try
        {
-         Serializable.RegisterTypeGeneric(PdxTests.PdxInsideIGFSerializable.CreateDeserializable);
+         Serializable.RegisterTypeGeneric(PdxTests.PdxInsideIGeodeSerializable.CreateDeserializable);
          Serializable.RegisterPdxType(NestedPdx.CreateDeserializable);
          Serializable.RegisterPdxType(PdxTypes1.CreateDeserializable);
          Serializable.RegisterPdxType(PdxTypes2.CreateDeserializable);
@@ -1173,8 +1173,8 @@ namespace Apache.Geode.Client.UnitTests
 
        Region region0 = CacheHelper.GetVerifyRegion<object, object>(m_regionNames[0]);
 
-       PdxInsideIGFSerializable orig = new PdxInsideIGFSerializable();
-       PdxInsideIGFSerializable pRet = (PdxInsideIGFSerializable)region0[1];
+       PdxInsideIGeodeSerializable orig = new PdxInsideIGeodeSerializable();
+       PdxInsideIGeodeSerializable pRet = (PdxInsideIGeodeSerializable)region0[1];
 
        Assert.AreEqual(orig, pRet);
      }
@@ -1371,7 +1371,7 @@ namespace Apache.Geode.Client.UnitTests
      {
        try
        {
-         Serializable.RegisterTypeGeneric(PdxTests.PdxInsideIGFSerializable.CreateDeserializable);
+         Serializable.RegisterTypeGeneric(PdxTests.PdxInsideIGeodeSerializable.CreateDeserializable);
          Serializable.RegisterPdxType(NestedPdx.CreateDeserializable);
          Serializable.RegisterPdxType(PdxTypes1.CreateDeserializable);
          Serializable.RegisterPdxType(PdxTypes2.CreateDeserializable);
@@ -1514,7 +1514,7 @@ namespace Apache.Geode.Client.UnitTests
      {
          try
          {
-             Serializable.RegisterTypeGeneric(PdxTests.PdxInsideIGFSerializable.CreateDeserializable);
+             Serializable.RegisterTypeGeneric(PdxTests.PdxInsideIGeodeSerializable.CreateDeserializable);
              Serializable.RegisterPdxType(NestedPdx.CreateDeserializable);
              Serializable.RegisterPdxType(PdxTypes1.CreateDeserializable);
              Serializable.RegisterPdxType(PdxTypes2.CreateDeserializable);
@@ -7165,7 +7165,7 @@ namespace javaobject
 {
   using Apache.Geode.Client;
   #region Pdx Delta class
-  public class PdxDelta : IPdxSerializable, IGFDelta, ICloneable
+  public class PdxDelta : IPdxSerializable, IGeodeDelta, ICloneable
   {
     public static int GotDelta = 0;
     int _delta = 0;
@@ -7196,7 +7196,7 @@ namespace javaobject
     {
       get { return _delta; }
     }
-    #region IGFDelta Members
+    #region IGeodeDelta Members
 
     public void FromDelta(DataInput input)
     {

--- a/src/clicache/integration-test/ThinClientQueryTestsN.cs
+++ b/src/clicache/integration-test/ThinClientQueryTestsN.cs
@@ -1471,9 +1471,9 @@ namespace Apache.Geode.Client.UnitTests
     //  if (map1.Count != map2.Count)
     //    Assert.Fail("Number of Keys dont match");
     //  if (map1.Count == 0) return;
-    //  foreach (KeyValuePair<ICacheableKey, IGFSerializable> entry in map1)
+    //  foreach (KeyValuePair<ICacheableKey, IGeodeSerializable> entry in map1)
     //  {
-    //    IGFSerializable value;
+    //    IGeodeSerializable value;
     //    if (!(map2.TryGetValue(entry.Key,out value)))
     //    {
     //      Assert.Fail("Key was not found");

--- a/src/clicache/integration-test/ThinClientRegionTestsN.cs
+++ b/src/clicache/integration-test/ThinClientRegionTestsN.cs
@@ -241,7 +241,7 @@ namespace Apache.Geode.Client.UnitTests
       m_accountid = accId;
     }
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       m_id = input.ReadInt32();
       m_accountid = input.ReadInt32();
@@ -273,7 +273,7 @@ namespace Apache.Geode.Client.UnitTests
       }
     }
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new TradeKey();
     }
@@ -908,7 +908,7 @@ namespace Apache.Geode.Client.UnitTests
     //  else {
     //    region0 = CacheHelper.CreateTCRegion(RegionNames[0], true, true, null, endpoints, true); //caching enable true
     //  }
-    //  Dictionary<ICacheableKey, IGFSerializable> values = new Dictionary<ICacheableKey, IGFSerializable>();
+    //  Dictionary<ICacheableKey, IGeodeSerializable> values = new Dictionary<ICacheableKey, IGeodeSerializable>();
     //  Dictionary<ICacheableKey, Exception> exceptions = new Dictionary<ICacheableKey, Exception>();
     //  resultKeys.Clear();
     //  try {

--- a/src/clicache/integration-test/ThinClientStringArrayTestsN.cs
+++ b/src/clicache/integration-test/ThinClientStringArrayTestsN.cs
@@ -161,7 +161,7 @@ namespace Apache.Geode.Client.UnitTests
 
       while (iter.HasNext)
       {
-        /*IGFSerializable*/ object item = iter.Next();
+        /*IGeodeSerializable*/ object item = iter.Next();
         Portfolio port = item as Portfolio;
         if (port == null)
         {

--- a/src/clicache/src/AttributesFactory.cpp
+++ b/src/clicache/src/AttributesFactory.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "AttributesFactory.hpp"
 #include "Region.hpp"
 #include "impl/ManagedCacheLoader.hpp"

--- a/src/clicache/src/AttributesFactory.hpp
+++ b/src/clicache/src/AttributesFactory.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/AttributesFactory.hpp>
 //#include "impl/NativeWrapper.hpp"
 #include "ExpirationAction.hpp"

--- a/src/clicache/src/AttributesMutator.cpp
+++ b/src/clicache/src/AttributesMutator.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "AttributesMutator.hpp"
 //#include "Region.hpp"
 #include "impl/ManagedCacheListener.hpp"

--- a/src/clicache/src/AttributesMutator.hpp
+++ b/src/clicache/src/AttributesMutator.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/AttributesMutator.hpp>
 //#include "impl/NativeWrapper.hpp"
 #include "ExpirationAction.hpp"

--- a/src/clicache/src/Cache.cpp
+++ b/src/clicache/src/Cache.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "Cache.hpp"
 #include "ExceptionTypes.hpp"
 #include "DistributedSystem.hpp"

--- a/src/clicache/src/Cache.hpp
+++ b/src/clicache/src/Cache.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 //#include <geode/Cache.hpp>
 //#include "impl/NativeWrapper.hpp"
 #include "RegionShortcut.hpp"

--- a/src/clicache/src/CacheFactory.cpp
+++ b/src/clicache/src/CacheFactory.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 
 #include "ExceptionTypes.hpp"
 

--- a/src/clicache/src/CacheFactory.hpp
+++ b/src/clicache/src/CacheFactory.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "impl/NativeWrapper.hpp"
 #include <geode/CacheFactory.hpp>
 #include "Properties.hpp"

--- a/src/clicache/src/CacheListenerAdapter.hpp
+++ b/src/clicache/src/CacheListenerAdapter.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "ICacheListener.hpp"
 
 

--- a/src/clicache/src/CacheStatistics.cpp
+++ b/src/clicache/src/CacheStatistics.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CacheStatistics.hpp"
 
 

--- a/src/clicache/src/CacheStatistics.hpp
+++ b/src/clicache/src/CacheStatistics.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CacheStatistics.hpp>
 #include "impl/NativeWrapper.hpp"
 

--- a/src/clicache/src/CacheTransactionManager.cpp
+++ b/src/clicache/src/CacheTransactionManager.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "impl/SafeConvert.hpp"
 #include "impl/ManagedTransactionListener.hpp"
 #include "impl/ManagedTransactionWriter.hpp"

--- a/src/clicache/src/CacheTransactionManager.hpp
+++ b/src/clicache/src/CacheTransactionManager.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CacheTransactionManager.hpp>
 #include <geode/InternalCacheTransactionManager2PC.hpp>
 #include "TransactionId.hpp"

--- a/src/clicache/src/CacheWriterAdapter.hpp
+++ b/src/clicache/src/CacheWriterAdapter.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "ICacheWriter.hpp"
 
 

--- a/src/clicache/src/CacheableArrayList.hpp
+++ b/src/clicache/src/CacheableArrayList.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "CacheableVector.hpp"
 
 
@@ -32,7 +32,7 @@ namespace Apache
     {
 
       /// <summary>
-      /// A mutable <c>IGFSerializable</c> vector wrapper that can serve as
+      /// A mutable <c>IGeodeSerializable</c> vector wrapper that can serve as
       /// a distributable object for caching. This class extends .NET generic
       /// <c>List</c> class.
       /// </summary>
@@ -65,7 +65,7 @@ namespace Apache
         }
 
 
-        // Region: IGFSerializable Members
+        // Region: IGeodeSerializable Members
 
         /// <summary>
         /// Returns the classId of the instance being serialized.
@@ -81,12 +81,12 @@ namespace Apache
           }
         }
 
-        // End Region: IGFSerializable Members
+        // End Region: IGeodeSerializable Members
 
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableArrayList(gcnew System::Collections::Generic::List<Object^>());
         }

--- a/src/clicache/src/CacheableBuiltins.hpp
+++ b/src/clicache/src/CacheableBuiltins.hpp
@@ -19,7 +19,7 @@
 
 
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CacheableBuiltins.hpp>
 #include "CacheableKey.hpp"
 #include "Serializable.hpp"
@@ -185,7 +185,7 @@ namespace Apache
           output->WriteObject(m_value);
         }
 
-        virtual IGFSerializable^ FromData(DataInput^ input) override
+        virtual IGeodeSerializable^ FromData(DataInput^ input) override
         {
           input->ReadObject(m_value);
           return this;
@@ -358,13 +358,13 @@ namespace Apache
             * Factory function to register this class.
             * </summary>
             */                                                                   \
-            static IGFSerializable^ CreateDeserializable()                        \
+            static IGeodeSerializable^ CreateDeserializable()                        \
            {                                                                     \
            return gcnew m();                                       \
            }                                                                     \
            \
            internal:                                                               \
-           static IGFSerializable^ Create(apache::geode::client::Serializable* obj)            \
+           static IGeodeSerializable^ Create(apache::geode::client::Serializable* obj)            \
            {                                                                     \
            return (obj != nullptr ? gcnew m(obj) : nullptr);                   \
            }                                                                     \
@@ -421,13 +421,13 @@ namespace Apache
        * Factory function to register this class.
        * </summary>
        */                                                                   \
-       static IGFSerializable^ CreateDeserializable()                        \
+       static IGeodeSerializable^ CreateDeserializable()                        \
       {                                                                     \
       return gcnew m();                                                   \
       }                                                                     \
       \
             internal:                                                               \
-              static IGFSerializable^ Create(apache::geode::client::Serializable* obj)            \
+              static IGeodeSerializable^ Create(apache::geode::client::Serializable* obj)            \
       {                                                                     \
       return (obj != nullptr ? gcnew m(obj) : nullptr);                   \
       }                                                                     \

--- a/src/clicache/src/CacheableDate.cpp
+++ b/src/clicache/src/CacheableDate.cpp
@@ -18,7 +18,7 @@
 
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CacheableDate.hpp"
 #include "DataInput.hpp"
 #include "DataOutput.hpp"
@@ -57,7 +57,7 @@ namespace Apache
         //Log::Fine("CacheableDate::Todata time " + m_dateTime.Ticks);
       }
 
-      IGFSerializable^ CacheableDate::FromData(DataInput^ input)
+      IGeodeSerializable^ CacheableDate::FromData(DataInput^ input)
       {
         DateTime epochTime = EpochTime;
         int64_t millisSinceEpoch = input->ReadInt64();

--- a/src/clicache/src/CacheableDate.hpp
+++ b/src/clicache/src/CacheableDate.hpp
@@ -19,7 +19,7 @@
 
 
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "ICacheableKey.hpp"
 
 
@@ -72,7 +72,7 @@ namespace Apache
           return gcnew CacheableDate(dateTime);
         }
 
-        // Region: IGFSerializable Members
+        // Region: IGeodeSerializable Members
 
         /// <summary>
         /// Serializes this object.
@@ -90,7 +90,7 @@ namespace Apache
         /// the DataInput stream to use for reading the object data
         /// </param>
         /// <returns>the deserialized object</returns>
-        virtual IGFSerializable^ FromData(DataInput^ input);
+        virtual IGeodeSerializable^ FromData(DataInput^ input);
 
         /// <summary>
         /// return the size of this object in bytes
@@ -119,7 +119,7 @@ namespace Apache
         /// </summary>
         virtual String^ ToString() override;
 
-        // End Region: IGFSerializable Members
+        // End Region: IGeodeSerializable Members
 
 
         // Region: ICacheableKey Members
@@ -161,7 +161,7 @@ namespace Apache
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableDate();
         }

--- a/src/clicache/src/CacheableFileName.cpp
+++ b/src/clicache/src/CacheableFileName.cpp
@@ -18,7 +18,7 @@
 
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CacheableFileName.hpp"
 #include "DataOutput.hpp"
 #include "DataInput.hpp"
@@ -44,7 +44,7 @@ namespace Apache
         }
       }
 
-      IGFSerializable^ CacheableFileName::FromData(DataInput^ input)
+      IGeodeSerializable^ CacheableFileName::FromData(DataInput^ input)
       {
         unsigned char filetype = input->ReadByte();
         if (filetype == apache::geode::client::GeodeTypeIds::CacheableString) {

--- a/src/clicache/src/CacheableFileName.hpp
+++ b/src/clicache/src/CacheableFileName.hpp
@@ -19,7 +19,7 @@
 
 
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "ICacheableKey.hpp"
 
 
@@ -59,7 +59,7 @@ namespace Apache
             gcnew CacheableFileName(value) : nullptr);
         }
 
-        // Region: IGFSerializable Members
+        // Region: IGeodeSerializable Members
 
         /// <summary>
         /// Serializes this object.
@@ -77,7 +77,7 @@ namespace Apache
         /// the DataInput stream to use for reading the object data
         /// </param>
         /// <returns>the deserialized object</returns>
-        virtual IGFSerializable^ FromData(DataInput^ input);
+        virtual IGeodeSerializable^ FromData(DataInput^ input);
 
         /// <summary>
         /// return the size of this object in bytes
@@ -107,7 +107,7 @@ namespace Apache
           return m_str;
         }
 
-        // End Region: IGFSerializable Members
+        // End Region: IGeodeSerializable Members
 
         // Region: ICacheableKey Members
 
@@ -143,7 +143,7 @@ namespace Apache
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableFileName((String^)nullptr);
         }

--- a/src/clicache/src/CacheableHashMap.cpp
+++ b/src/clicache/src/CacheableHashMap.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CacheableHashMap.hpp"
 #include "DataOutput.hpp"
 #include "DataInput.hpp"
@@ -31,14 +31,14 @@ namespace Apache
     namespace Client
     {
 
-      // Region: IGFSerializable Members
+      // Region: IGeodeSerializable Members
 
       void Client::CacheableHashMap::ToData(DataOutput^ output)
       {
         output->WriteDictionary((System::Collections::IDictionary^)m_dictionary);        
       }
 
-      IGFSerializable^ Client::CacheableHashMap::FromData(DataInput^ input)
+      IGeodeSerializable^ Client::CacheableHashMap::FromData(DataInput^ input)
       {
         m_dictionary = input->ReadDictionary();
         return this;

--- a/src/clicache/src/CacheableHashMap.hpp
+++ b/src/clicache/src/CacheableHashMap.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
-#include "IGFSerializable.hpp"
+#include "geode_defs.hpp"
+#include "IGeodeSerializable.hpp"
 #include "ICacheableKey.hpp"
 #include "GeodeClassIds.hpp"
 
@@ -35,12 +35,12 @@ namespace Apache
     {
 
       /// <summary>
-      /// A mutable <c>ICacheableKey</c> to <c>IGFSerializable</c> hash map
+      /// A mutable <c>ICacheableKey</c> to <c>IGeodeSerializable</c> hash map
       /// that can serve as a distributable object for caching. This class
       /// extends .NET generic <c>Dictionary</c> class.
       /// </summary>
       ref class CacheableHashMap
-        : public IGFSerializable
+        : public IGeodeSerializable
       {
       protected:
         Object^ m_dictionary;
@@ -81,7 +81,7 @@ namespace Apache
         }
 
 
-        // Region: IGFSerializable Members
+        // Region: IGeodeSerializable Members
 
         /// <summary>
         /// Serializes this object.
@@ -99,7 +99,7 @@ namespace Apache
         /// the DataInput stream to use for reading the object data
         /// </param>
         /// <returns>the deserialized object</returns>
-        virtual IGFSerializable^ FromData(DataInput^ input);
+        virtual IGeodeSerializable^ FromData(DataInput^ input);
 
         /// <summary>
         /// return the size of this object in bytes
@@ -131,12 +131,12 @@ namespace Apache
           }
         }
 
-        // End Region: IGFSerializable Members
+        // End Region: IGeodeSerializable Members
 
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableHashMap();
         }

--- a/src/clicache/src/CacheableHashSet.hpp
+++ b/src/clicache/src/CacheableHashSet.hpp
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CacheableBuiltins.hpp>
 #include "Serializable.hpp"
 #include "ExceptionTypes.hpp"
@@ -63,7 +63,7 @@ namespace Apache
             }
           }
 
-          virtual IGFSerializable^ FromData(DataInput^ input) override
+          virtual IGeodeSerializable^ FromData(DataInput^ input) override
           {
             int len = input->ReadArrayLen();
             if (len > 0)
@@ -476,7 +476,7 @@ namespace Apache
           /// <summary>
           /// Factory function to register wrapper
           /// </summary>
-          static IGFSerializable^ Create(apache::geode::client::Serializable* obj)
+          static IGeodeSerializable^ Create(apache::geode::client::Serializable* obj)
           {
             return (obj != NULL ?
                     gcnew CacheableHashSetType<TYPEID, HSTYPE>(obj) : nullptr);
@@ -566,13 +566,13 @@ namespace Apache
        * Factory function to register this class.
        * </summary>
        */                                                                   \
-       static IGFSerializable^ CreateDeserializable()                        \
+       static IGeodeSerializable^ CreateDeserializable()                        \
       {                                                                     \
       return gcnew m();                                                   \
       }                                                                     \
       \
             internal:                                                               \
-              static IGFSerializable^ Create(apache::geode::client::Serializable* obj)            \
+              static IGeodeSerializable^ Create(apache::geode::client::Serializable* obj)            \
       {                                                                     \
       return gcnew m(obj);                                                \
       }                                                                     \

--- a/src/clicache/src/CacheableHashTable.hpp
+++ b/src/clicache/src/CacheableHashTable.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "CacheableHashMap.hpp"
 #include "DataInput.hpp"
 
@@ -33,7 +33,7 @@ namespace Apache
     {
 
       /// <summary>
-      /// A mutable <c>ICacheableKey</c> to <c>IGFSerializable</c> hash table
+      /// A mutable <c>ICacheableKey</c> to <c>IGeodeSerializable</c> hash table
       /// that can serve as a distributable object for caching. This class
       /// extends .NET generic <c>Dictionary</c> class.
       /// </summary>
@@ -70,7 +70,7 @@ namespace Apache
         { }
 
 
-        // Region: IGFSerializable Members
+        // Region: IGeodeSerializable Members
 
         /// <summary>
         /// Returns the classId of the instance being serialized.
@@ -86,17 +86,17 @@ namespace Apache
           }
         }
 
-        // End Region: IGFSerializable Members
+        // End Region: IGeodeSerializable Members
 
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableHashTable();
         }
 
-        virtual IGFSerializable^ FromData(DataInput^ input) override
+        virtual IGeodeSerializable^ FromData(DataInput^ input) override
         {
           m_dictionary = input->ReadHashtable();
           return this;
@@ -106,7 +106,7 @@ namespace Apache
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ Create(Object^ hashtable)
+        static IGeodeSerializable^ Create(Object^ hashtable)
         {
           return gcnew CacheableHashTable(hashtable);
         }

--- a/src/clicache/src/CacheableIdentityHashMap.hpp
+++ b/src/clicache/src/CacheableIdentityHashMap.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "CacheableHashMap.hpp"
 
 
@@ -32,7 +32,7 @@ namespace Apache
     {
 
       /// <summary>
-      /// A mutable <c>ICacheableKey</c> to <c>IGFSerializable</c> hash map
+      /// A mutable <c>ICacheableKey</c> to <c>IGeodeSerializable</c> hash map
       /// that can serve as a distributable object for caching. This class
       /// extends .NET generic <c>Dictionary</c> class. This class is meant
       /// as a means to interoperate with java server side
@@ -96,7 +96,7 @@ namespace Apache
           return gcnew CacheableIdentityHashMap(capacity);
         }
 
-        // Region: IGFSerializable Members
+        // Region: IGeodeSerializable Members
 
         /// <summary>
         /// Returns the classId of the instance being serialized.
@@ -112,12 +112,12 @@ namespace Apache
           }
         }
 
-        // End Region: IGFSerializable Members
+        // End Region: IGeodeSerializable Members
 
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableIdentityHashMap();
         }

--- a/src/clicache/src/CacheableKey.cpp
+++ b/src/clicache/src/CacheableKey.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CacheableKey.hpp"
 #include "CacheableString.hpp"
 #include "CacheableBuiltins.hpp"

--- a/src/clicache/src/CacheableKey.hpp
+++ b/src/clicache/src/CacheableKey.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CacheableKey.hpp>
 //#include "impl/NativeWrapper.hpp"
 #include "Serializable.hpp"
@@ -35,7 +35,7 @@ namespace Apache
 
       /// <summary>
       /// This class wraps the native C++ <c>apache::geode::client::Serializable</c> objects
-      /// as managed <see cref="../../IGFSerializable" /> objects.
+      /// as managed <see cref="../../IGeodeSerializable" /> objects.
       /// </summary>
       public ref class CacheableKey
         : public Serializable, public ICacheableKey

--- a/src/clicache/src/CacheableLinkedList.hpp
+++ b/src/clicache/src/CacheableLinkedList.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "CacheableVector.hpp"
 
 
@@ -32,12 +32,12 @@ namespace Apache
     {
 
       /// <summary>
-      /// A mutable <c>IGFSerializable</c> vector wrapper that can serve as
+      /// A mutable <c>IGeodeSerializable</c> vector wrapper that can serve as
       /// a distributable object for caching. This class extends .NET generic
       /// <c>List</c> class.
       /// </summary>
       ref class CacheableLinkedList
-        : public IGFSerializable
+        : public IGeodeSerializable
       {
         System::Collections::Generic::LinkedList<Object^>^ m_linkedList;
       public:
@@ -67,7 +67,7 @@ namespace Apache
         }
 
 
-        // Region: IGFSerializable Members
+        // Region: IGeodeSerializable Members
 
         /// <summary>
         /// Returns the classId of the instance being serialized.
@@ -83,7 +83,7 @@ namespace Apache
           }
         }
 
-        // Region: IGFSerializable Members
+        // Region: IGeodeSerializable Members
 
         virtual void ToData(DataOutput^ output)
         {
@@ -99,7 +99,7 @@ namespace Apache
             output->WriteByte(0xFF);
         }
 
-        virtual IGFSerializable^ FromData(DataInput^ input)
+        virtual IGeodeSerializable^ FromData(DataInput^ input)
         {
           int len = input->ReadArrayLen();
           for (int i = 0; i < len; i++)
@@ -113,7 +113,7 @@ namespace Apache
         {
         //TODO::
         uint32_t size = static_cast<uint32_t> (sizeof(CacheableVector^));
-        for each (IGFSerializable^ val in this) {
+        for each (IGeodeSerializable^ val in this) {
         if (val != nullptr) {
         size += val->ObjectSize;
         }
@@ -136,12 +136,12 @@ namespace Apache
             return m_linkedList;
           }
         }
-        // End Region: IGFSerializable Members
+        // End Region: IGeodeSerializable Members
 
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableLinkedList(gcnew System::Collections::Generic::LinkedList<Object^>());
         }

--- a/src/clicache/src/CacheableObject.cpp
+++ b/src/clicache/src/CacheableObject.cpp
@@ -16,13 +16,13 @@
  */
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CacheableObject.hpp"
 #include "DataInput.hpp"
 #include "DataOutput.hpp"
-#include "impl/GFNullStream.hpp"
-#include "impl/GFDataInputStream.hpp"
-#include "impl/GFDataOutputStream.hpp"
+#include "impl/GeodeNullStream.hpp"
+#include "impl/GeodeDataInputStream.hpp"
+#include "impl/GeodeDataOutputStream.hpp"
 
 using namespace System;
 using namespace System::IO;
@@ -41,7 +41,7 @@ namespace Apache
         {
           output->AdvanceCursor(4); // placeholder for object size bytes needed while reading back.
 
-          GFDataOutputStream dos(output);
+          GeodeDataOutputStream dos(output);
           BinaryFormatter bf;
           int64_t checkpoint = dos.Length;
           bf.Serialize(%dos, m_obj);
@@ -53,10 +53,10 @@ namespace Apache
         }
       }
 
-      IGFSerializable^ CacheableObject::FromData(DataInput^ input)
+      IGeodeSerializable^ CacheableObject::FromData(DataInput^ input)
       {
         int maxSize = input->ReadInt32();
-        GFDataInputStream dis(input, maxSize);
+        GeodeDataInputStream dis(input, maxSize);
         uint32_t checkpoint = dis.BytesRead;
         BinaryFormatter bf;
         m_obj = bf.Deserialize(%dis);
@@ -67,7 +67,7 @@ namespace Apache
       uint32_t CacheableObject::ObjectSize::get()
       { 
         if (m_objectSize == 0) {
-          GFNullStream ns;
+          GeodeNullStream ns;
           BinaryFormatter bf;
           bf.Serialize(%ns, m_obj);
 

--- a/src/clicache/src/CacheableObject.hpp
+++ b/src/clicache/src/CacheableObject.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
-#include "IGFSerializable.hpp"
+#include "geode_defs.hpp"
+#include "IGeodeSerializable.hpp"
 #include "GeodeClassIds.hpp"
 
 using namespace System;
@@ -40,7 +40,7 @@ namespace Apache
       /// [Serializable] attribute set or implements
       /// <see cref="System.Runtime.Serialization.ISerializable" /> interface.
       /// However, for better efficiency the latter should be avoided and the
-      /// user should implement <see cref="../../IGFSerializable" /> instead.
+      /// user should implement <see cref="../../IGeodeSerializable" /> instead.
       /// </para><para>
       /// The user must keep in mind that the rules that apply to runtime
       /// serialization would be the rules that apply to this class. For
@@ -51,7 +51,7 @@ namespace Apache
       /// </para>
       /// </remarks>
       public ref class CacheableObject
-        : public IGFSerializable
+        : public IGeodeSerializable
       {
       public:
         /// <summary>
@@ -83,7 +83,7 @@ namespace Apache
         /// the DataInput stream to use for reading the object data
         /// </param>
         /// <returns>the deserialized object</returns>
-        virtual IGFSerializable^ FromData(DataInput^ input);
+        virtual IGeodeSerializable^ FromData(DataInput^ input);
 
         /// <summary>
         /// return the size of this object in bytes
@@ -132,7 +132,7 @@ namespace Apache
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableObject(nullptr);
         }

--- a/src/clicache/src/CacheableObjectArray.cpp
+++ b/src/clicache/src/CacheableObjectArray.cpp
@@ -17,7 +17,7 @@
 
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include <GeodeTypeIdsImpl.hpp>
 #include "CacheableObjectArray.hpp"
 #include "DataOutput.hpp"
@@ -37,7 +37,7 @@ namespace Apache
     namespace Client
     {
 
-      // Region: IGFSerializable Members
+      // Region: IGeodeSerializable Members
 
       void CacheableObjectArray::ToData(DataOutput^ output)
       {
@@ -58,7 +58,7 @@ namespace Apache
           nativeOutput.write((int8_t)apache::geode::client::GeodeTypeIdsImpl::Class);
           nativeOutput.write((int8_t)apache::geode::client::GeodeTypeIds::CacheableASCIIString);
           nativeOutput.writeASCII("java.lang.Object");
-          for each (IGFSerializable^ obj in this) {
+          for each (IGeodeSerializable^ obj in this) {
             apache::geode::client::SerializablePtr objPtr(SafeMSerializableConvert(obj));
             nativeOutput.writeObject(objPtr);
           }
@@ -66,7 +66,7 @@ namespace Apache
         _GF_MG_EXCEPTION_CATCH_ALL*/
       }
 
-      IGFSerializable^ CacheableObjectArray::FromData(DataInput^ input)
+      IGeodeSerializable^ CacheableObjectArray::FromData(DataInput^ input)
       {
         int len = input->ReadArrayLen();
         if (len >= 0) {
@@ -109,7 +109,7 @@ namespace Apache
       uint32_t CacheableObjectArray::ObjectSize::get()
       { 
        /* uint32_t size = static_cast<uint32_t> (sizeof(CacheableObjectArray^));
-        for each (IGFSerializable^ val in this) {
+        for each (IGeodeSerializable^ val in this) {
           if (val != nullptr) {
             size += val->ObjectSize;
           }

--- a/src/clicache/src/CacheableObjectArray.hpp
+++ b/src/clicache/src/CacheableObjectArray.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
-#include "IGFSerializable.hpp"
+#include "geode_defs.hpp"
+#include "IGeodeSerializable.hpp"
 #include "GeodeClassIds.hpp"
 
 
@@ -33,13 +33,13 @@ namespace Apache
     {
 
       /// <summary>
-      /// A mutable <c>IGFSerializable</c> object array wrapper that can serve
+      /// A mutable <c>IGeodeSerializable</c> object array wrapper that can serve
       /// as a distributable object for caching. Though this class provides
       /// compatibility with java Object[] serialization, it provides the
       /// semantics of .NET generic <c>List</c> class.
       /// </summary>
       public ref class CacheableObjectArray
-        : public List<Object^>, public IGFSerializable
+        : public List<Object^>, public IGeodeSerializable
       {
       public:
         /// <summary>
@@ -95,7 +95,7 @@ namespace Apache
           return gcnew CacheableObjectArray(capacity);
         }
 
-        // Region: IGFSerializable Members
+        // Region: IGeodeSerializable Members
 
         /// <summary>
         /// Serializes this object.
@@ -113,7 +113,7 @@ namespace Apache
         /// the DataInput stream to use for reading the object data
         /// </param>
         /// <returns>the deserialized object</returns>
-        virtual IGFSerializable^ FromData(DataInput^ input);
+        virtual IGeodeSerializable^ FromData(DataInput^ input);
 
         /// <summary>
         /// return the size of this object in bytes
@@ -137,12 +137,12 @@ namespace Apache
           }
         }
 
-        // End Region: IGFSerializable Members
+        // End Region: IGeodeSerializable Members
 
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableObjectArray();
         }

--- a/src/clicache/src/CacheableObjectXml.cpp
+++ b/src/clicache/src/CacheableObjectXml.cpp
@@ -17,14 +17,14 @@
 
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CacheableObjectXml.hpp"
 #include "DataInput.hpp"
 #include "DataOutput.hpp"
 #include "Log.hpp"
-#include "impl/GFNullStream.hpp"
-#include "impl/GFDataInputStream.hpp"
-#include "impl/GFDataOutputStream.hpp"
+#include "impl/GeodeNullStream.hpp"
+#include "impl/GeodeDataInputStream.hpp"
+#include "impl/GeodeDataOutputStream.hpp"
 
 using namespace System;
 using namespace System::IO;
@@ -52,7 +52,7 @@ namespace Apache
           output->AdvanceCursor(4); // placeholder for object size bytes needed while reading back.
 
           XmlSerializer xs(objType);
-          GFDataOutputStream dos(output);
+          GeodeDataOutputStream dos(output);
           int64_t checkpoint = dos.Length;
           xs.Serialize(%dos, m_obj);
           m_objectSize = (uint32_t) (dos.Length - checkpoint);
@@ -63,7 +63,7 @@ namespace Apache
         }
       }
 
-      IGFSerializable^ CacheableObjectXml::FromData(DataInput^ input)
+      IGeodeSerializable^ CacheableObjectXml::FromData(DataInput^ input)
       {
         Byte isNull = input->ReadByte();
         if (isNull) {
@@ -80,7 +80,7 @@ namespace Apache
           }
           else {
             int maxSize = input->ReadInt32();
-            GFDataInputStream dis(input, maxSize);
+            GeodeDataInputStream dis(input, maxSize);
             XmlSerializer xs(objType);
             uint32_t checkpoint = dis.BytesRead;
             m_obj = xs.Deserialize(%dis);
@@ -96,7 +96,7 @@ namespace Apache
           if (m_obj != nullptr) {
             Type^ objType = m_obj->GetType();
             XmlSerializer xs(objType);
-            GFNullStream ns;
+            GeodeNullStream ns;
             xs.Serialize(%ns, m_obj);
 
             m_objectSize = (uint32_t)sizeof(CacheableObjectXml^) + (uint32_t)ns.Length;

--- a/src/clicache/src/CacheableObjectXml.hpp
+++ b/src/clicache/src/CacheableObjectXml.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
-#include "IGFSerializable.hpp"
+#include "geode_defs.hpp"
+#include "IGeodeSerializable.hpp"
 #include "GeodeClassIds.hpp"
 
 using namespace System;
@@ -43,7 +43,7 @@ namespace Apache
       /// of the object (or implement the <see cref="System.Xml.Serialization.IXmlSerializable" />)
       /// to change the serialization/deserialization. However, the latter should
       /// be avoided for efficiency reasons and the user should implement
-      /// <see cref="../../IGFSerializable" /> instead.
+      /// <see cref="../../IGeodeSerializable" /> instead.
       /// </para><para>
       /// The user must keep in mind that the rules that apply to <c>XmlSerializer</c>
       /// would be the rules that apply to this class. For instance the user
@@ -54,7 +54,7 @@ namespace Apache
       /// </para>
       /// </remarks>
       public ref class CacheableObjectXml
-        : public IGFSerializable
+        : public IGeodeSerializable
       {
       public:
         /// <summary>
@@ -86,7 +86,7 @@ namespace Apache
         /// the DataInput stream to use for reading the object data
         /// </param>
         /// <returns>the deserialized object</returns>
-        virtual IGFSerializable^ FromData(DataInput^ input);
+        virtual IGeodeSerializable^ FromData(DataInput^ input);
 
         /// <summary>
         /// return the size of this object in bytes
@@ -135,7 +135,7 @@ namespace Apache
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableObjectXml(nullptr);
         }

--- a/src/clicache/src/CacheableStack.cpp
+++ b/src/clicache/src/CacheableStack.cpp
@@ -17,7 +17,7 @@
 
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CacheableStack.hpp"
 #include "DataOutput.hpp"
 #include "DataInput.hpp"
@@ -35,7 +35,7 @@ namespace Apache
     namespace Client
     {
 
-      // Region: IGFSerializable Members
+      // Region: IGeodeSerializable Members
 
       void CacheableStack::ToData(DataOutput^ output)
       {
@@ -52,7 +52,7 @@ namespace Apache
         }
       }
 
-      IGFSerializable^ CacheableStack::FromData(DataInput^ input)
+      IGeodeSerializable^ CacheableStack::FromData(DataInput^ input)
       {
         int len = input->ReadArrayLen();
         if (len > 0)
@@ -76,7 +76,7 @@ namespace Apache
       {
         //TODO:
         /*uint32_t size = static_cast<uint32_t> (sizeof(CacheableStack^));
-        for each (IGFSerializable^ val in this) {
+        for each (IGeodeSerializable^ val in this) {
         if (val != nullptr) {
         size += val->ObjectSize;
         }

--- a/src/clicache/src/CacheableStack.hpp
+++ b/src/clicache/src/CacheableStack.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
-#include "IGFSerializable.hpp"
+#include "geode_defs.hpp"
+#include "IGeodeSerializable.hpp"
 
 
 using namespace System;
@@ -32,11 +32,11 @@ namespace Apache
     {
 
       /// <summary>
-      /// A mutable <c>IGFSerializable</c> vector wrapper that can serve as
+      /// A mutable <c>IGeodeSerializable</c> vector wrapper that can serve as
       /// a distributable object for caching.
       /// </summary>
       ref class CacheableStack
-        : public IGFSerializable
+        : public IGeodeSerializable
       {
       public:
         /// <summary>
@@ -65,7 +65,7 @@ namespace Apache
 
         
         
-        // Region: IGFSerializable Members
+        // Region: IGeodeSerializable Members
 
         /// <summary>
         /// Serializes this object.
@@ -83,7 +83,7 @@ namespace Apache
         /// the DataInput stream to use for reading the object data
         /// </param>
         /// <returns>the deserialized object</returns>
-        virtual IGFSerializable^ FromData(DataInput^ input);
+        virtual IGeodeSerializable^ FromData(DataInput^ input);
 
         /// <summary>
         /// return the size of this object in bytes
@@ -111,12 +111,12 @@ namespace Apache
             return m_stack;
           }
         }
-        // End Region: IGFSerializable Members
+        // End Region: IGeodeSerializable Members
 
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableStack(gcnew System::Collections::Generic::Stack<Object^>());
         }

--- a/src/clicache/src/CacheableString.cpp
+++ b/src/clicache/src/CacheableString.cpp
@@ -20,7 +20,7 @@
 #include "DataOutput.hpp"
 #include "DataInput.hpp"
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CacheableString.hpp"
 #include "ExceptionTypes.hpp"
 
@@ -50,7 +50,7 @@ namespace Apache
         }
       }
 
-      IGFSerializable^ CacheableString::FromData(DataInput^ input)
+      IGeodeSerializable^ CacheableString::FromData(DataInput^ input)
       {
         if (m_type == GeodeClassIds::CacheableASCIIString ||
             m_type == GeodeClassIds::CacheableString)

--- a/src/clicache/src/CacheableString.hpp
+++ b/src/clicache/src/CacheableString.hpp
@@ -19,7 +19,7 @@
 
 
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CacheableString.hpp>
 #include "impl/ManagedString.hpp"
 #include "CacheableKey.hpp"
@@ -87,13 +87,13 @@ namespace Apache
 
         /// <summary>
         /// Deserializes the managed object -- returns an instance of the
-        /// <c>IGFSerializable</c> class.
+        /// <c>IGeodeSerializable</c> class.
         /// </summary>
         /// <param name="input">
         /// the DataInput stream to use for reading the object data
         /// </param>
         /// <returns>the deserialized object</returns>
-        virtual IGFSerializable^ FromData(DataInput^ input) override;
+        virtual IGeodeSerializable^ FromData(DataInput^ input) override;
 
         // <summary>
         /// Returns the classId of the instance being serialized.
@@ -217,29 +217,29 @@ namespace Apache
         }
 
       internal:
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableString(GeodeClassIds::CacheableASCIIString);
         }
 
-        static IGFSerializable^ createDeserializableHuge()
+        static IGeodeSerializable^ createDeserializableHuge()
         {
           return gcnew CacheableString(GeodeClassIds::CacheableASCIIStringHuge);
         }
 
-        static IGFSerializable^ createUTFDeserializable()
+        static IGeodeSerializable^ createUTFDeserializable()
         {
           return gcnew CacheableString(GeodeClassIds::CacheableString);
         }
 
-        static IGFSerializable^ createUTFDeserializableHuge()
+        static IGeodeSerializable^ createUTFDeserializableHuge()
         {
           return gcnew CacheableString(GeodeClassIds::CacheableStringHuge);
         }
         /// <summary>
         /// Factory function to register wrapper
         /// </summary>
-        static IGFSerializable^ Create(apache::geode::client::Serializable* obj)
+        static IGeodeSerializable^ Create(apache::geode::client::Serializable* obj)
         {
           return (obj != nullptr ?
                   gcnew CacheableString(obj) : nullptr);

--- a/src/clicache/src/CacheableStringArray.cpp
+++ b/src/clicache/src/CacheableStringArray.cpp
@@ -69,7 +69,7 @@ namespace Apache
       }
         
     
-      IGFSerializable^ CacheableStringArray::FromData(DataInput^ input)
+      IGeodeSerializable^ CacheableStringArray::FromData(DataInput^ input)
       {
         int len = input->ReadArrayLen();
         if ( len == -1)

--- a/src/clicache/src/CacheableStringArray.hpp
+++ b/src/clicache/src/CacheableStringArray.hpp
@@ -19,7 +19,7 @@
 
 
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CacheableBuiltins.hpp>
 #include "Serializable.hpp"
 #include "GeodeClassIds.hpp"
@@ -71,13 +71,13 @@ namespace Apache
 
         /// <summary>
         /// Deserializes the managed object -- returns an instance of the
-        /// <c>IGFSerializable</c> class.
+        /// <c>IGeodeSerializable</c> class.
         /// </summary>
         /// <param name="input">
         /// the DataInput stream to use for reading the object data
         /// </param>
         /// <returns>the deserialized object</returns>
-        virtual IGFSerializable^ FromData(DataInput^ input) override;
+        virtual IGeodeSerializable^ FromData(DataInput^ input) override;
 
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace Apache
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableStringArray();
         }
@@ -152,7 +152,7 @@ namespace Apache
         /// <summary>
         /// Factory function to register wrapper
         /// </summary>
-        static IGFSerializable^ Create(apache::geode::client::Serializable* obj)
+        static IGeodeSerializable^ Create(apache::geode::client::Serializable* obj)
         {
           return (obj != nullptr ?
                   gcnew CacheableStringArray(obj) : nullptr);

--- a/src/clicache/src/CacheableUndefined.cpp
+++ b/src/clicache/src/CacheableUndefined.cpp
@@ -17,7 +17,7 @@
 
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CacheableUndefined.hpp"
 #include "DataOutput.hpp"
 #include "DataInput.hpp"
@@ -32,13 +32,13 @@ namespace Apache
     namespace Client
     {
 
-      // Region: IGFSerializable Members
+      // Region: IGeodeSerializable Members
 
       void CacheableUndefined::ToData(DataOutput^ output)
       {
       }
 
-      IGFSerializable^ CacheableUndefined::FromData(DataInput^ input)
+      IGeodeSerializable^ CacheableUndefined::FromData(DataInput^ input)
       {
         return this;
       }

--- a/src/clicache/src/CacheableUndefined.hpp
+++ b/src/clicache/src/CacheableUndefined.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
-#include "IGFSerializable.hpp"
+#include "geode_defs.hpp"
+#include "IGeodeSerializable.hpp"
 #include "GeodeClassIds.hpp"
 #include "Log.hpp"
 
@@ -35,7 +35,7 @@ namespace Apache
       /// Encapsulate an undefined result.
       /// </summary>
       public ref class CacheableUndefined
-        : public IGFSerializable
+        : public IGeodeSerializable
       {
       public:
         /// <summary>
@@ -51,7 +51,7 @@ namespace Apache
           return gcnew CacheableUndefined();
         }
 
-        // Region: IGFSerializable Members
+        // Region: IGeodeSerializable Members
 
         /// <summary>
         /// Serializes this object.
@@ -69,7 +69,7 @@ namespace Apache
         /// the DataInput stream to use for reading the object data
         /// </param>
         /// <returns>the deserialized object</returns>
-        virtual IGFSerializable^ FromData(DataInput^ input);
+        virtual IGeodeSerializable^ FromData(DataInput^ input);
 
         /// <summary>
         /// return the size of this object in bytes
@@ -93,12 +93,12 @@ namespace Apache
           }
         }
 
-        // End Region: IGFSerializable Members
+        // End Region: IGeodeSerializable Members
 
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableUndefined();
         }

--- a/src/clicache/src/CacheableVector.cpp
+++ b/src/clicache/src/CacheableVector.cpp
@@ -17,7 +17,7 @@
 
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CacheableVector.hpp"
 #include "DataOutput.hpp"
 #include "DataInput.hpp"
@@ -34,7 +34,7 @@ namespace Apache
     namespace Client
     {
 
-      // Region: IGFSerializable Members
+      // Region: IGeodeSerializable Members
 
       void CacheableVector::ToData(DataOutput^ output)
       {
@@ -50,7 +50,7 @@ namespace Apache
           output->WriteByte(0xFF);
       }
 
-      IGFSerializable^ CacheableVector::FromData(DataInput^ input)
+      IGeodeSerializable^ CacheableVector::FromData(DataInput^ input)
       {
         int len = input->ReadArrayLen();
         for( int i = 0; i < len; i++)
@@ -64,7 +64,7 @@ namespace Apache
       { 
         //TODO::
         /*uint32_t size = static_cast<uint32_t> (sizeof(CacheableVector^));
-        for each (IGFSerializable^ val in this) {
+        for each (IGeodeSerializable^ val in this) {
           if (val != nullptr) {
             size += val->ObjectSize;
           }

--- a/src/clicache/src/CacheableVector.hpp
+++ b/src/clicache/src/CacheableVector.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
-#include "IGFSerializable.hpp"
+#include "geode_defs.hpp"
+#include "IGeodeSerializable.hpp"
 #include "GeodeClassIds.hpp"
 
 
@@ -33,12 +33,12 @@ namespace Apache
     {
 
       /// <summary>
-      /// A mutable <c>IGFSerializable</c> vector wrapper that can serve as
+      /// A mutable <c>IGeodeSerializable</c> vector wrapper that can serve as
       /// a distributable object for caching. This class extends .NET generic
       /// <c>List</c> class.
       /// </summary>
       ref class CacheableVector
-        : public IGFSerializable
+        : public IGeodeSerializable
       {
       public:
         /// <summary>
@@ -67,7 +67,7 @@ namespace Apache
         }
 
 
-        // Region: IGFSerializable Members
+        // Region: IGeodeSerializable Members
 
         /// <summary>
         /// Serializes this object.
@@ -85,7 +85,7 @@ namespace Apache
         /// the DataInput stream to use for reading the object data
         /// </param>
         /// <returns>the deserialized object</returns>
-        virtual IGFSerializable^ FromData(DataInput^ input);
+        virtual IGeodeSerializable^ FromData(DataInput^ input);
 
         /// <summary>
         /// return the size of this object in bytes
@@ -117,12 +117,12 @@ namespace Apache
           }
         }
 
-        // End Region: IGFSerializable Members
+        // End Region: IGeodeSerializable Members
 
         /// <summary>
         /// Factory function to register this class.
         /// </summary>
-        static IGFSerializable^ CreateDeserializable()
+        static IGeodeSerializable^ CreateDeserializable()
         {
           return gcnew CacheableVector(gcnew System::Collections::ArrayList());
         }

--- a/src/clicache/src/CqAttributes.cpp
+++ b/src/clicache/src/CqAttributes.cpp
@@ -16,7 +16,7 @@
  */
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CqAttributes.hpp"
 #include "impl/ManagedCqListener.hpp"
 #include "ICqListener.hpp"

--- a/src/clicache/src/CqAttributes.hpp
+++ b/src/clicache/src/CqAttributes.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CqAttributes.hpp>
 #include "impl/NativeWrapper.hpp"
 

--- a/src/clicache/src/CqAttributesFactory.cpp
+++ b/src/clicache/src/CqAttributesFactory.cpp
@@ -16,7 +16,7 @@
  */
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CqAttributesFactory.hpp"
 #include "impl/ManagedCqListener.hpp"
 #include "ICqListener.hpp"

--- a/src/clicache/src/CqAttributesFactory.hpp
+++ b/src/clicache/src/CqAttributesFactory.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CqAttributesFactory.hpp>
 //#include "impl/NativeWrapper.hpp"
 #include "impl/SafeConvert.hpp"

--- a/src/clicache/src/CqAttributesMutator.cpp
+++ b/src/clicache/src/CqAttributesMutator.cpp
@@ -16,7 +16,7 @@
  */
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CqAttributesMutator.hpp"
 #include "impl/ManagedCqListener.hpp"
 #include "impl/ManagedCqStatusListener.hpp"

--- a/src/clicache/src/CqAttributesMutator.hpp
+++ b/src/clicache/src/CqAttributesMutator.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CqAttributesMutator.hpp>
 #include "impl/NativeWrapper.hpp"
 

--- a/src/clicache/src/CqEvent.cpp
+++ b/src/clicache/src/CqEvent.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CqEvent.hpp"
 #include "Log.hpp"
 #include "impl/SafeConvert.hpp"

--- a/src/clicache/src/CqEvent.hpp
+++ b/src/clicache/src/CqEvent.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CqEvent.hpp>
 #include "CqQuery.hpp"
 #include "CqOperation.hpp"
@@ -35,7 +35,7 @@ namespace Apache
     namespace Client
     {
 
-			interface class IGFSerializable;
+			interface class IGeodeSerializable;
       //interface class ICqEvent;
       //interface class ICacheableKey;
 

--- a/src/clicache/src/CqListener.hpp
+++ b/src/clicache/src/CqListener.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "ICqListener.hpp"
 //#include "impl/NativeWrapper.hpp"
 
@@ -38,7 +38,7 @@ namespace Apache
 
       /// <summary>
       /// This class wraps the native C++ <c>apache::geode::client::Serializable</c> objects
-      /// as managed <see cref="../../IGFSerializable" /> objects.
+      /// as managed <see cref="../../IGeodeSerializable" /> objects.
       /// </summary>
       generic<class TKey, class TResult>    
       public ref class CqListener

--- a/src/clicache/src/CqOperation.hpp
+++ b/src/clicache/src/CqOperation.hpp
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CqOperation.hpp>
 
 

--- a/src/clicache/src/CqQuery.cpp
+++ b/src/clicache/src/CqQuery.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CqQuery.hpp"
 #include "Query.hpp"
 #include "CqAttributes.hpp"

--- a/src/clicache/src/CqQuery.hpp
+++ b/src/clicache/src/CqQuery.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "CqState.hpp"
 #include <geode/CqQuery.hpp>
 //#include "impl/NativeWrapper.hpp"

--- a/src/clicache/src/CqServiceStatistics.cpp
+++ b/src/clicache/src/CqServiceStatistics.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CqServiceStatistics.hpp"
 
 

--- a/src/clicache/src/CqServiceStatistics.hpp
+++ b/src/clicache/src/CqServiceStatistics.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CqServiceStatistics.hpp>
 #include "impl/NativeWrapper.hpp"
 

--- a/src/clicache/src/CqState.cpp
+++ b/src/clicache/src/CqState.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CqState.hpp"
 #include <vcclr.h>
 

--- a/src/clicache/src/CqState.hpp
+++ b/src/clicache/src/CqState.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CqState.hpp>
 #include "impl/NativeWrapper.hpp"
 

--- a/src/clicache/src/CqStatistics.cpp
+++ b/src/clicache/src/CqStatistics.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "CqStatistics.hpp"
 
 

--- a/src/clicache/src/CqStatistics.hpp
+++ b/src/clicache/src/CqStatistics.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CqStatistics.hpp>
 #include "impl/NativeWrapper.hpp"
 

--- a/src/clicache/src/DataInput.cpp
+++ b/src/clicache/src/DataInput.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "DataInput.hpp"
 #include <geode/Cache.hpp>
 //#include "CacheFactory.hpp"
@@ -731,7 +731,7 @@ namespace Apache
 
         bool isPdxDeserialization = m_ispdxDesrialization;
         m_ispdxDesrialization = false;//for nested objects
-        IGFSerializable^ newObj = createType();
+        IGeodeSerializable^ newObj = createType();
         newObj->FromData(this);
         m_ispdxDesrialization = isPdxDeserialization;
         return newObj;
@@ -837,7 +837,7 @@ namespace Apache
 
         if (createType != nullptr)
         {
-          IGFSerializable^ newObj = createType();
+          IGeodeSerializable^ newObj = createType();
           newObj->FromData(this);
           return newObj;
         }

--- a/src/clicache/src/DataInput.hpp
+++ b/src/clicache/src/DataInput.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/DataInput.hpp>
 #include "impl/NativeWrapper.hpp"
 #include "Log.hpp"
@@ -35,11 +35,11 @@ namespace Apache
     namespace Client
     {
 
-      interface class IGFSerializable;
+      interface class IGeodeSerializable;
 
       /// <summary>
       /// Provides operations for reading primitive data values, byte arrays,
-      /// strings, <c>IGFSerializable</c> objects from a byte stream.
+      /// strings, <c>IGeodeSerializable</c> objects from a byte stream.
       /// </summary>
       public ref class DataInput sealed
 				: public Client::Internal::UMWrap<apache::geode::client::DataInput>

--- a/src/clicache/src/DataOutput.cpp
+++ b/src/clicache/src/DataOutput.cpp
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "DataOutput.hpp"
 #include <GeodeTypeIdsImpl.hpp>
 #include <vcclr.h>
 
-#include "IGFSerializable.hpp"
+#include "IGeodeSerializable.hpp"
 #include "CacheableObjectArray.hpp"
 #include "impl/PdxHelper.hpp"
 #include "impl/PdxWrapper.hpp"
@@ -401,12 +401,12 @@ namespace Apache
 
       /*void DataOutput::WriteObject( Object^ obj )
       {
-      WriteObjectInternal((IGFSerializable^)obj);
+      WriteObjectInternal((IGeodeSerializable^)obj);
       }*/
 
       /*void DataOutput::WriteObject( Object^ obj )
       {
-      WriteObject( (IGFSerializable^)obj );
+      WriteObject( (IGeodeSerializable^)obj );
       }*/
 
       int8_t DataOutput::GetTypeId(uint32_t classId)
@@ -647,7 +647,7 @@ namespace Apache
               return;
             }
 
-            IGFSerializable^ ct = dynamic_cast<IGFSerializable^>(obj);
+            IGeodeSerializable^ ct = dynamic_cast<IGeodeSerializable^>(obj);
             if (ct != nullptr) {
               WriteObjectInternal(ct);
               return;
@@ -682,7 +682,7 @@ namespace Apache
           WriteByte(-1);
       }
 
-      void DataOutput::WriteObjectInternal(IGFSerializable^ obj)
+      void DataOutput::WriteObjectInternal(IGeodeSerializable^ obj)
       {
         //CacheableKey^ key = gcnew CacheableKey();
         if (obj == nullptr) {

--- a/src/clicache/src/DataOutput.hpp
+++ b/src/clicache/src/DataOutput.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/DataOutput.hpp>
 //#include "impl/NativeWrapper.hpp"
 #include "Log.hpp"
@@ -40,11 +40,11 @@ namespace Apache
     namespace Client
     {
 
-      interface class IGFSerializable;
+      interface class IGeodeSerializable;
 
       /// <summary>
       /// Provides operations for writing primitive data values, and
-      /// user-defined objects implementing IGFSerializable, to a byte stream.
+      /// user-defined objects implementing IGeodeSerializable, to a byte stream.
       /// This class is intentionally not thread safe.
       /// </summary>
       public ref class DataOutput sealed
@@ -231,16 +231,16 @@ namespace Apache
         void WriteASCIIHuge( String^ value );
 
         /// <summary>
-        /// Write an <c>IGFSerializable</c> object to the <c>DataOutput</c>.
+        /// Write an <c>IGeodeSerializable</c> object to the <c>DataOutput</c>.
         /// </summary>
         /// <param name="obj">The object to write.</param>
-       // void WriteObject( IGFSerializable^ obj );
+       // void WriteObject( IGeodeSerializable^ obj );
 
         /// <summary>
         /// Write a <c>Serializable</c> object to the <c>DataOutput</c>.
         /// This is provided to conveniently pass primitive types (like string)
         /// that shall be implicitly converted to corresponding
-        /// <c>IGFSerializable</c> wrapper types.
+        /// <c>IGeodeSerializable</c> wrapper types.
         /// </summary>
         /// <param name="obj">The object to write.</param>
         void WriteObject( Object^ obj );
@@ -485,7 +485,7 @@ namespace Apache
         
         static int8_t DSFID(uint32_t classId);        
   
-        void WriteObjectInternal( IGFSerializable^ obj );     
+        void WriteObjectInternal( IGeodeSerializable^ obj );     
 
         void WriteBytesToUMDataOutput();
         

--- a/src/clicache/src/DiskPolicyType.hpp
+++ b/src/clicache/src/DiskPolicyType.hpp
@@ -19,7 +19,7 @@
 
 
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/DiskPolicyType.hpp>
 
 

--- a/src/clicache/src/DistributedSystem.cpp
+++ b/src/clicache/src/DistributedSystem.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "version.h"
 #include "Serializable.hpp"
 #include "DistributedSystem.hpp"

--- a/src/clicache/src/DistributedSystem.hpp
+++ b/src/clicache/src/DistributedSystem.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/DistributedSystem.hpp>
 //#include "impl/NativeWrapper.hpp"
 #include "SystemProperties.hpp"

--- a/src/clicache/src/EntryEvent.cpp
+++ b/src/clicache/src/EntryEvent.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "EntryEvent.hpp"
 #include "Region.hpp"
 #include "impl/SafeConvert.hpp"

--- a/src/clicache/src/EntryEvent.hpp
+++ b/src/clicache/src/EntryEvent.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/EntryEvent.hpp>
 #include "impl/NativeWrapper.hpp"
 #include "IRegion.hpp"
@@ -32,7 +32,7 @@ namespace Apache
     namespace Client
     {
 
-        interface class IGFSerializable;
+        interface class IGeodeSerializable;
 
      // ref class Region;
       //interface class ICacheableKey;

--- a/src/clicache/src/ExceptionTypes.cpp
+++ b/src/clicache/src/ExceptionTypes.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "ExceptionTypes.hpp"
 #include <stdlib.h>
 

--- a/src/clicache/src/ExceptionTypes.hpp
+++ b/src/clicache/src/ExceptionTypes.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/ExceptionTypes.hpp>
 #include "impl/ManagedString.hpp"
 

--- a/src/clicache/src/Execution.cpp
+++ b/src/clicache/src/Execution.cpp
@@ -16,7 +16,7 @@
  */
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "Execution.hpp"
 #include <geode/Execution.hpp>
 #include "ResultCollector.hpp"

--- a/src/clicache/src/Execution.hpp
+++ b/src/clicache/src/Execution.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/Execution.hpp>
 #include "impl/NativeWrapper.hpp"
 //#include "impl/ResultCollectorProxy.hpp"

--- a/src/clicache/src/ExpirationAction.hpp
+++ b/src/clicache/src/ExpirationAction.hpp
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/ExpirationAction.hpp>
 
 

--- a/src/clicache/src/FunctionService.cpp
+++ b/src/clicache/src/FunctionService.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "FunctionService.hpp"
 #include "Pool.hpp"
 #include "Region.hpp"

--- a/src/clicache/src/FunctionService.hpp
+++ b/src/clicache/src/FunctionService.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/FunctionService.hpp>
 #include "Cache.hpp"
 //#include "impl/NativeWrapper.hpp"

--- a/src/clicache/src/GeodeClassIds.hpp
+++ b/src/clicache/src/GeodeClassIds.hpp
@@ -19,7 +19,7 @@
 
 
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/GeodeTypeIds.hpp>
 
 

--- a/src/clicache/src/IAuthInitialize.hpp
+++ b/src/clicache/src/IAuthInitialize.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 
 #include "Properties.hpp"
 

--- a/src/clicache/src/ICacheListener.hpp
+++ b/src/clicache/src/ICacheListener.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "IRegion.hpp"
 //#include "Region.hpp"
 

--- a/src/clicache/src/ICacheLoader.hpp
+++ b/src/clicache/src/ICacheLoader.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CacheLoader.hpp>
 #include "IRegion.hpp"
 //#include "Region.hpp"

--- a/src/clicache/src/ICacheWriter.hpp
+++ b/src/clicache/src/ICacheWriter.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "IRegion.hpp"
 //#include "Region.hpp"
 

--- a/src/clicache/src/ICacheableKey.hpp
+++ b/src/clicache/src/ICacheableKey.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
-#include "IGFSerializable.hpp"
+#include "geode_defs.hpp"
+#include "IGeodeSerializable.hpp"
 
 
 using namespace System;
@@ -44,7 +44,7 @@ namespace Apache
       /// and will not work correctly.
       /// </remarks>
       public interface class ICacheableKey
-        : public IGFSerializable
+        : public IGeodeSerializable
       {
       public:
 

--- a/src/clicache/src/ICqAttributes.hpp
+++ b/src/clicache/src/ICqAttributes.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 
 
 namespace Apache

--- a/src/clicache/src/ICqEvent.hpp
+++ b/src/clicache/src/ICqEvent.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 
 #include "ICacheableKey.hpp"
 
@@ -28,7 +28,7 @@ namespace Apache
     namespace Client
     {
 
-      interface class IGFSerializable;
+      interface class IGeodeSerializable;
 
 
       generic<class TKey, class TResult>

--- a/src/clicache/src/ICqListener.hpp
+++ b/src/clicache/src/ICqListener.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "CqEvent.hpp"
 using namespace System;
 namespace Apache

--- a/src/clicache/src/ICqResults.hpp
+++ b/src/clicache/src/ICqResults.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/SelectResults.hpp>
 //#include "impl/NativeWrapper.hpp"
 #include "ISelectResults.hpp"

--- a/src/clicache/src/ICqStatusListener.hpp
+++ b/src/clicache/src/ICqStatusListener.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "ICqListener.hpp"
 
 using namespace System;

--- a/src/clicache/src/IFixedPartitionResolver.hpp
+++ b/src/clicache/src/IFixedPartitionResolver.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "IPartitionResolver.hpp"
 
 //using System::Collections::Generics;
@@ -29,7 +29,7 @@ namespace Apache
     namespace Client
     {
 
-      interface class IGFSerializable;
+      interface class IGeodeSerializable;
       /// <summary>
       /// Implementers of interface <code>FixedPartitionResolver</code> helps to
       /// achieve explicit mapping of a "user defined" partition to a data member node.

--- a/src/clicache/src/IGeodeCache.hpp
+++ b/src/clicache/src/IGeodeCache.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "IRegionService.hpp"
 #include "DistributedSystem.hpp"
 #include "CacheTransactionManager.hpp"

--- a/src/clicache/src/IGeodeDelta.hpp
+++ b/src/clicache/src/IGeodeDelta.hpp
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 
 
 namespace Apache
@@ -32,14 +32,14 @@ namespace Apache
 
       /// <summary>
       /// This interface is used for delta propagation.
-      /// To use delta propagation, an application class must implement interfaces <c>IGFDelta</c> as well as <c>IGFSerializable</c>.
-      /// The <c>IGFDelta</c> interface methods <c>HasDelta( ), ToDelta( )</c> and <c>FromDelta( )</c> must be implemented by the class, as these methods are used by Geode
+      /// To use delta propagation, an application class must implement interfaces <c>IGeodeDelta</c> as well as <c>IGeodeSerializable</c>.
+      /// The <c>IGeodeDelta</c> interface methods <c>HasDelta( ), ToDelta( )</c> and <c>FromDelta( )</c> must be implemented by the class, as these methods are used by Geode
       /// to detect the presence of delta in an object, to serialize the delta, and to apply a serialized delta to an existing object
       /// of the class.
       /// If a customized cloning method is required, the class must also implement the interface <c>System.ICloneable</c>.
       /// To use cloning in delta propagation for a region, the region attribute for cloning must be enabled.
       /// </summary>
-      public interface class IGFDelta
+      public interface class IGeodeDelta
       {
       public:
 
@@ -66,9 +66,9 @@ namespace Apache
         void FromDelta(DataInput^ in);
 
         /// <summary>
-        /// <c>HasDelta( )</c> is invoked by Geode during <c>Region.Put( ICacheableKey, IGFSerializable )</c> to determine if the object contains a delta.
+        /// <c>HasDelta( )</c> is invoked by Geode during <c>Region.Put( ICacheableKey, IGeodeSerializable )</c> to determine if the object contains a delta.
         /// If <c>HasDelta( )</c> returns true, the delta in the object is serialized by invoking <c>ToDelta( DataOutput )</c>.
-        /// If <c>HasDelta( )</c> returns false, the object is serialized by invoking <c>IGFSerializable.ToData( DataOutput )</c>.
+        /// If <c>HasDelta( )</c> returns false, the object is serialized by invoking <c>IGeodeSerializable.ToData( DataOutput )</c>.
         /// </summary>
         bool HasDelta();
       };

--- a/src/clicache/src/IGeodeSerializable.hpp
+++ b/src/clicache/src/IGeodeSerializable.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
-#include "geode/gf_types.hpp"
+#include "geode_defs.hpp"
+#include "geode/geode_types.hpp"
 
 using namespace System;
 
@@ -37,7 +37,7 @@ namespace Apache
       /// This interface class is the superclass of all user objects 
       /// in the cache that can be serialized.
       /// </summary>
-      public interface class IGFSerializable
+      public interface class IGeodeSerializable
       {
       public:
 
@@ -59,7 +59,7 @@ namespace Apache
         /// the DataInput stream to use for reading the object data
         /// </param>
         /// <returns>the deserialized object</returns>
-        IGFSerializable^ FromData( DataInput^ input );
+        IGeodeSerializable^ FromData( DataInput^ input );
 
         /// <summary>
         /// Get the size of this object in bytes.
@@ -82,7 +82,7 @@ namespace Apache
         /// <remarks>
         /// The classId must be unique within an application suite
         /// and in the range 0 to ((2^31)-1) both inclusive. An application can
-        /// thus define upto 2^31 custom <c>IGFSerializable</c> classes.
+        /// thus define upto 2^31 custom <c>IGeodeSerializable</c> classes.
         /// Returning a value greater than ((2^31)-1) may result in undefined
         /// behaviour.
         /// </remarks>

--- a/src/clicache/src/IPartitionResolver.hpp
+++ b/src/clicache/src/IPartitionResolver.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 //#include "ICacheableKey.hpp"
 
 #include "EntryEvent.hpp"
@@ -29,7 +29,7 @@ namespace Apache
     namespace Client
     {
 
-      interface class IGFSerializable;
+      interface class IGeodeSerializable;
 
 
       /// <summary>

--- a/src/clicache/src/IPdxReader.hpp
+++ b/src/clicache/src/IPdxReader.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "IRegion.hpp"
 #include "IPdxUnreadFields.hpp"
 namespace Apache

--- a/src/clicache/src/IPdxSerializable.hpp
+++ b/src/clicache/src/IPdxSerializable.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "IPdxWriter.hpp"
 #include "IPdxReader.hpp"
 

--- a/src/clicache/src/IPdxSerializer.hpp
+++ b/src/clicache/src/IPdxSerializer.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "IPdxWriter.hpp"
 #include "IPdxReader.hpp"
 

--- a/src/clicache/src/IPdxWriter.hpp
+++ b/src/clicache/src/IPdxWriter.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 //#include "IRegion.hpp"
 #include "IPdxUnreadFields.hpp"
 using namespace System;

--- a/src/clicache/src/IPersistenceManager.hpp
+++ b/src/clicache/src/IPersistenceManager.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "IRegion.hpp"
 #include "Properties.hpp"
 using namespace System;

--- a/src/clicache/src/IRegion.hpp
+++ b/src/clicache/src/IRegion.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "ISubscriptionService.hpp"
 #include <geode/DataOutput.hpp>
 //#include "ExceptionTypes.hpp"
@@ -39,7 +39,7 @@ namespace Apache
 
       ref class Cache;
       ref class CacheStatistics;
-      //interface class IGFSerializable;
+      //interface class IGeodeSerializable;
       interface class IRegionService;
 
       generic<class TResult>
@@ -920,7 +920,7 @@ namespace Apache
           /// </param>
           /// <param name="callbackArg">
           /// An argument passed into the CacheLoader if loader is used.
-          /// Has to be Serializable (i.e. implement <c>IGFSerializable</c>);
+          /// Has to be Serializable (i.e. implement <c>IGeodeSerializable</c>);
           /// can be null.
           /// </param>
           /// <returns>

--- a/src/clicache/src/IRegionService.hpp
+++ b/src/clicache/src/IRegionService.hpp
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
-//#include "gf_includes.hpp"
+#include "geode_defs.hpp"
+//#include "geode_includes.hpp"
 #include "QueryService.hpp"
 #include "Region.hpp"
 

--- a/src/clicache/src/IResultCollector.hpp
+++ b/src/clicache/src/IResultCollector.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 
 using namespace System;
 namespace Apache
@@ -28,7 +28,7 @@ namespace Apache
     namespace Client
     {
 
-      interface class IGFSerializable;
+      interface class IGeodeSerializable;
       /*
       generic<class TKey>
       ref class ResultCollector;

--- a/src/clicache/src/ISelectResults.hpp
+++ b/src/clicache/src/ISelectResults.hpp
@@ -17,10 +17,10 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/SelectResults.hpp>
 //#include "impl/NativeWrapper.hpp"
-#include "IGFSerializable.hpp"
+#include "IGeodeSerializable.hpp"
 
 using namespace System;
 
@@ -39,7 +39,7 @@ namespace Apache
       /// </summary>
       generic<class TResult>
       public interface class ISelectResults
-        : public System::Collections::Generic::IEnumerable</*IGFSerializable^*/TResult>
+        : public System::Collections::Generic::IEnumerable</*IGeodeSerializable^*/TResult>
       {
       public:
 
@@ -62,9 +62,9 @@ namespace Apache
         /// <summary>
         /// Get an object at the given index.
         /// </summary>
-        property /*Apache::Geode::Client::IGFSerializable^*/TResult GFINDEXER( size_t )
+        property /*Apache::Geode::Client::IGeodeSerializable^*/TResult GFINDEXER( size_t )
         {
-          /*Apache::Geode::Client::IGFSerializable^*/TResult get( size_t index );
+          /*Apache::Geode::Client::IGeodeSerializable^*/TResult get( size_t index );
         }
 
         /// <summary>

--- a/src/clicache/src/ISubscriptionService.hpp
+++ b/src/clicache/src/ISubscriptionService.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 //#include "ExceptionTypes.hpp"
 using namespace System;
 namespace Apache

--- a/src/clicache/src/ITransactionListener.hpp
+++ b/src/clicache/src/ITransactionListener.hpp
@@ -17,7 +17,7 @@
 #ifdef CSTX_COMMENTED
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "TransactionEvent.hpp"
 
 

--- a/src/clicache/src/ITransactionWriter.hpp
+++ b/src/clicache/src/ITransactionWriter.hpp
@@ -17,7 +17,7 @@
 #ifdef CSTX_COMMENTED
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "TransactionEvent.hpp"
 
 

--- a/src/clicache/src/LocalRegion.cpp
+++ b/src/clicache/src/LocalRegion.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "LocalRegion.hpp"
 #include "Cache.hpp"
 #include "CacheStatistics.hpp"

--- a/src/clicache/src/LocalRegion.hpp
+++ b/src/clicache/src/LocalRegion.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/Cache.hpp>
 //#include "impl/NativeWrapper.hpp"
 #include "IRegion.hpp"

--- a/src/clicache/src/Log.cpp
+++ b/src/clicache/src/Log.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "Log.hpp"
 #include "impl/ManagedString.hpp"
 #include "impl/SafeConvert.hpp"

--- a/src/clicache/src/Log.hpp
+++ b/src/clicache/src/Log.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/Log.hpp>
 
 

--- a/src/clicache/src/PdxIdentityFieldAttribute.hpp
+++ b/src/clicache/src/PdxIdentityFieldAttribute.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 using namespace System;
 using namespace System::Reflection;
 

--- a/src/clicache/src/Pool.cpp
+++ b/src/clicache/src/Pool.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "Pool.hpp"
 #include "QueryService.hpp"
 #include "CacheableString.hpp"

--- a/src/clicache/src/Pool.hpp
+++ b/src/clicache/src/Pool.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/Pool.hpp>
 #include "impl/NativeWrapper.hpp"
 

--- a/src/clicache/src/PoolFactory.cpp
+++ b/src/clicache/src/PoolFactory.cpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "Pool.hpp"
 #include "PoolFactory.hpp"
 

--- a/src/clicache/src/PoolFactory.hpp
+++ b/src/clicache/src/PoolFactory.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/PoolFactory.hpp>
 //#include "impl/NativeWrapper.hpp"
 

--- a/src/clicache/src/PoolManager.cpp
+++ b/src/clicache/src/PoolManager.cpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "Region.hpp"
 #include "Pool.hpp"
 #include "PoolManager.hpp"

--- a/src/clicache/src/PoolManager.hpp
+++ b/src/clicache/src/PoolManager.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/PoolManager.hpp>
 //#include "impl/NativeWrapper.hpp"
 

--- a/src/clicache/src/Properties.cpp
+++ b/src/clicache/src/Properties.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "Properties.hpp"
 #include "impl/ManagedVisitor.hpp"
 #include "impl/ManagedString.hpp"
@@ -45,7 +45,7 @@ namespace Apache
         inline PropertyToString( ) : m_str( "{" )
         { }
 
-        void Visit( Apache::Geode::Client::ICacheableKey^ key, IGFSerializable^ value )
+        void Visit( Apache::Geode::Client::ICacheableKey^ key, IGeodeSerializable^ value )
         {
           if ( m_str->Length > 1 ) {
             m_str += ",";
@@ -80,7 +80,7 @@ namespace Apache
        // _GF_MG_EXCEPTION_CATCH_ALL2
       }
 
-      /*IGFSerializable^ Properties::Find( Apache::Geode::Client::ICacheableKey^ key)
+      /*IGeodeSerializable^ Properties::Find( Apache::Geode::Client::ICacheableKey^ key)
       {
         CacheableString^ cStr = dynamic_cast<CacheableString ^>(key);
 
@@ -112,7 +112,7 @@ namespace Apache
 
       /*
        generic<class TPropKey, class TPropValue>
-       IGFSerializable^ Properties<TPropKey, TPropValue>::ConvertCacheableString(apache::geode::client::CacheablePtr& value)
+       IGeodeSerializable^ Properties<TPropKey, TPropValue>::ConvertCacheableString(apache::geode::client::CacheablePtr& value)
        {
          apache::geode::client::CacheableString * cs =  dynamic_cast<apache::geode::client::CacheableString *>( value.ptr() );
           if ( cs == NULL) {
@@ -133,7 +133,7 @@ namespace Apache
         }
       */
 
-      /*IGFSerializable^ Properties::Find( CacheableKey^ key)
+      /*IGeodeSerializable^ Properties::Find( CacheableKey^ key)
       {
         CacheableString^ cStr = dynamic_cast<CacheableString ^>(key);
 
@@ -193,7 +193,7 @@ namespace Apache
         _GF_MG_EXCEPTION_CATCH_ALL2
       }*/
 
-      /*void Properties::Insert( Apache::Geode::Client::ICacheableKey^ key, IGFSerializable^ value)
+      /*void Properties::Insert( Apache::Geode::Client::ICacheableKey^ key, IGeodeSerializable^ value)
       {
         CacheableString^ cStr = dynamic_cast<CacheableString ^>(key);
         if (cStr != nullptr) {
@@ -223,7 +223,7 @@ namespace Apache
         }
       }*/
 
-      /*void Properties::Insert( CacheableKey^ key, IGFSerializable^ value)
+      /*void Properties::Insert( CacheableKey^ key, IGeodeSerializable^ value)
       {
         CacheableString^ cStr = dynamic_cast<CacheableString ^>(key);
         if (cStr != nullptr) {
@@ -461,7 +461,7 @@ namespace Apache
 				return "";
       }
 
-      // IGFSerializable methods
+      // IGeodeSerializable methods
 
       generic<class TPropKey, class TPropValue>
       void Properties<TPropKey, TPropValue>::ToData( DataOutput^ output )
@@ -489,7 +489,7 @@ namespace Apache
       }
 
       generic<class TPropKey, class TPropValue>
-      IGFSerializable^ Properties<TPropKey, TPropValue>::FromData( DataInput^ input )
+      IGeodeSerializable^ Properties<TPropKey, TPropValue>::FromData( DataInput^ input )
       {
         if(input->IsManagedObject()) {
           input->AdvanceUMCursor();

--- a/src/clicache/src/Properties.hpp
+++ b/src/clicache/src/Properties.hpp
@@ -17,10 +17,10 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 
 //#include "impl/NativeWrapper.hpp"
-#include "IGFSerializable.hpp"
+#include "IGeodeSerializable.hpp"
 #include "ICacheableKey.hpp"
 #include "DataInput.hpp"
 #include "DataOutput.hpp"
@@ -41,7 +41,7 @@ namespace Apache
     namespace Client
     {
 
-      delegate void PropertyVisitor(Apache::Geode::Client::ICacheableKey^ key, Apache::Geode::Client::IGFSerializable^ value);
+      delegate void PropertyVisitor(Apache::Geode::Client::ICacheableKey^ key, Apache::Geode::Client::IGeodeSerializable^ value);
 
       generic <class TPropKey, class TPropValue>
       ref class PropertyVisitorProxy;
@@ -67,7 +67,7 @@ namespace Apache
       /// or an integer.
       /// </summary>
       public ref class Properties sealed
-        : public Internal::SBWrap<apache::geode::client::Properties>, public IGFSerializable,
+        : public Internal::SBWrap<apache::geode::client::Properties>, public IGeodeSerializable,
         public ISerializable
       {
       public:
@@ -155,7 +155,7 @@ namespace Apache
         /// </returns>
         virtual String^ ToString( ) override;
 
-        // IGFSerializable members
+        // IGeodeSerializable members
 
         /// <summary>
         /// Serializes this Properties object.
@@ -172,7 +172,7 @@ namespace Apache
         /// the DataInput stream to use for reading data
         /// </param>
         /// <returns>the deserialized Properties object</returns>
-        virtual IGFSerializable^ FromData( DataInput^ input );
+        virtual IGeodeSerializable^ FromData( DataInput^ input );
 
         /// <summary>
         /// return the size of this object in bytes
@@ -186,7 +186,7 @@ namespace Apache
         /// Returns the classId of this class for serialization.
         /// </summary>
         /// <returns>classId of the Properties class</returns>
-        /// <seealso cref="IGFSerializable.ClassId" />
+        /// <seealso cref="IGeodeSerializable.ClassId" />
         virtual property uint32_t ClassId
         {
           inline virtual uint32_t get( )
@@ -195,7 +195,7 @@ namespace Apache
           }
         }
 
-        // End: IGFSerializable members
+        // End: IGeodeSerializable members
 
         // ISerializable members
 
@@ -216,7 +216,7 @@ namespace Apache
         }
 
         /*
-        inline static IGFSerializable^ ConvertCacheableString(apache::geode::client::CacheablePtr& value);
+        inline static IGeodeSerializable^ ConvertCacheableString(apache::geode::client::CacheablePtr& value);
         inline static apache::geode::client::CacheableKey *  ConvertCacheableStringKey(CacheableString^ cStr);
         */
         
@@ -261,7 +261,7 @@ namespace Apache
             gcnew Properties<TPropKey, TPropValue>( nativeptr ) : nullptr );
         }
 
-        inline static IGFSerializable^ CreateDeserializable( )
+        inline static IGeodeSerializable^ CreateDeserializable( )
         {
           return Create<String^, String^>(  );
         }
@@ -269,7 +269,7 @@ namespace Apache
         /// <summary>
         /// Factory function to register wrapper
         /// </summary>
-        inline static IGFSerializable^ CreateDeserializable(
+        inline static IGeodeSerializable^ CreateDeserializable(
           apache::geode::client::Serializable* nativeptr )
         {
           return Create<String^, String^>( nativeptr );
@@ -290,7 +290,7 @@ namespace Apache
       {
       public:
         void Visit(Apache::Geode::Client::ICacheableKey^ key,
-          Apache::Geode::Client::IGFSerializable^ value)
+          Apache::Geode::Client::IGeodeSerializable^ value)
         {
           TPropKey tpkey = Apache::Geode::Client::Serializable::
             GetManagedValueGeneric<TPropKey>(SerializablePtr(SafeMSerializableConvertGeneric(key)));

--- a/src/clicache/src/Query.cpp
+++ b/src/clicache/src/Query.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "Query.hpp"
 #include "ISelectResults.hpp"
 #include "ResultSet.hpp"

--- a/src/clicache/src/Query.hpp
+++ b/src/clicache/src/Query.hpp
@@ -17,11 +17,11 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/Query.hpp>
 #include "impl/NativeWrapper.hpp"
 
-#include "IGFSerializable.hpp"
+#include "IGeodeSerializable.hpp"
 
 using namespace System;
 

--- a/src/clicache/src/QueryService.cpp
+++ b/src/clicache/src/QueryService.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "QueryService.hpp"
 #include "Query.hpp"
 #include "Log.hpp"

--- a/src/clicache/src/QueryService.hpp
+++ b/src/clicache/src/QueryService.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "impl/NativeWrapper.hpp"
 #include <geode/QueryService.hpp>
 

--- a/src/clicache/src/ReflectionBasedAutoSerializer.hpp
+++ b/src/clicache/src/ReflectionBasedAutoSerializer.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "IPdxSerializer.hpp"
 #include "PdxIdentityFieldAttribute.hpp"
 using namespace System;

--- a/src/clicache/src/Region.cpp
+++ b/src/clicache/src/Region.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "Region.hpp"
 #include "Cache.hpp"
 #include "CacheStatistics.hpp"
@@ -23,7 +23,7 @@
 #include "AttributesMutator.hpp"
 #include "RegionEntry.hpp"
 #include "ISelectResults.hpp"
-#include "IGFSerializable.hpp"
+#include "IGeodeSerializable.hpp"
 #include "ResultSet.hpp"
 #include "StructSet.hpp"
 #include "impl/AuthenticatedCache.hpp"

--- a/src/clicache/src/Region.hpp
+++ b/src/clicache/src/Region.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/Cache.hpp>
 #include "impl/NativeWrapper.hpp"
 #include "IRegion.hpp"

--- a/src/clicache/src/RegionAttributes.cpp
+++ b/src/clicache/src/RegionAttributes.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "RegionAttributes.hpp"
 //#include "Region.hpp"
 #include "impl/ManagedCacheLoader.hpp"
@@ -58,7 +58,7 @@ namespace Apache
       }
 
       generic <class TKey, class TValue>
-      Apache::Geode::Client::IGFSerializable^ Client::RegionAttributes<TKey, TValue>::FromData(
+      Apache::Geode::Client::IGeodeSerializable^ Client::RegionAttributes<TKey, TValue>::FromData(
         Apache::Geode::Client::DataInput^ input )
       {
         apache::geode::client::DataInput* nativeInput =

--- a/src/clicache/src/RegionAttributes.hpp
+++ b/src/clicache/src/RegionAttributes.hpp
@@ -17,10 +17,10 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/RegionAttributes.hpp>
 //#include "impl/NativeWrapper.hpp"
-#include "IGFSerializable.hpp"
+#include "IGeodeSerializable.hpp"
 #include "ExpirationAction.hpp"
 #include "DiskPolicyType.hpp"
 #include "GeodeClassIds.hpp"
@@ -68,7 +68,7 @@ namespace Apache
       /// <seealso cref="Region.Attributes" />
       generic <class TKey, class TValue>
       public ref class RegionAttributes sealed
-        : public Client::Internal::SBWrap<apache::geode::client::RegionAttributes>, public IGFSerializable
+        : public Client::Internal::SBWrap<apache::geode::client::RegionAttributes>, public IGeodeSerializable
       {
       public:
 
@@ -444,7 +444,7 @@ namespace Apache
         /// </summary>
         /// <param name="input">the DataInput stream to use for reading data</param>
         /// <returns>the deserialized Properties object</returns>
-        virtual IGFSerializable^ FromData(DataInput^ input);
+        virtual IGeodeSerializable^ FromData(DataInput^ input);
 
         /// <summary>
         /// return the size of this object in bytes
@@ -461,7 +461,7 @@ namespace Apache
         /// Returns the classId of this class for serialization.
         /// </summary>
         /// <returns>classId of the Properties class</returns>
-        /// <seealso cref="../../IGFSerializable.ClassId" />
+        /// <seealso cref="../../IGeodeSerializable.ClassId" />
         virtual property uint32_t ClassId
         {
           inline virtual uint32_t get()

--- a/src/clicache/src/RegionEntry.cpp
+++ b/src/clicache/src/RegionEntry.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "RegionEntry.hpp"
 #include "Region.hpp"
 #include "CacheStatistics.hpp"

--- a/src/clicache/src/RegionEntry.hpp
+++ b/src/clicache/src/RegionEntry.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/RegionEntry.hpp>
 #include "impl/NativeWrapper.hpp"
 //#include "ICacheableKey.hpp"

--- a/src/clicache/src/RegionEvent.cpp
+++ b/src/clicache/src/RegionEvent.cpp
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "RegionEvent.hpp"
 #include "Region.hpp"
-#include "IGFSerializable.hpp"
+#include "IGeodeSerializable.hpp"
 #include "impl/SafeConvert.hpp"
 using namespace System;
 

--- a/src/clicache/src/RegionEvent.hpp
+++ b/src/clicache/src/RegionEvent.hpp
@@ -17,10 +17,10 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/RegionEvent.hpp>
 //#include "impl/NativeWrapper.hpp"
-#include "IGFSerializable.hpp"
+#include "IGeodeSerializable.hpp"
 #include "IRegion.hpp"
 #include "Region.hpp"
 

--- a/src/clicache/src/RegionFactory.cpp
+++ b/src/clicache/src/RegionFactory.cpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "RegionFactory.hpp"
 //#include "AttributesFactory.hpp"
 #include "RegionAttributes.hpp"

--- a/src/clicache/src/RegionFactory.hpp
+++ b/src/clicache/src/RegionFactory.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/AttributesFactory.hpp>
 //#include "impl/NativeWrapper.hpp"
 #include "ExpirationAction.hpp"

--- a/src/clicache/src/RegionShortcut.hpp
+++ b/src/clicache/src/RegionShortcut.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 
 using namespace System;
 //using namespace System::Runtime::InteropServices;

--- a/src/clicache/src/ResultCollector.cpp
+++ b/src/clicache/src/ResultCollector.cpp
@@ -16,7 +16,7 @@
  */
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "ResultCollector.hpp"
 #include "impl/ManagedString.hpp"
 #include "ExceptionTypes.hpp"
@@ -36,7 +36,7 @@ namespace Apache
       {
         _GF_MG_EXCEPTION_TRY2/* due to auto replace */
 
-          apache::geode::client::Serializable * result = SafeGenericMSerializableConvert((IGFSerializable^)rs);
+          apache::geode::client::Serializable * result = SafeGenericMSerializableConvert((IGeodeSerializable^)rs);
         NativePtr->addResult( result==NULL ? (NULLPTR) : (apache::geode::client::CacheablePtr(result)) );
 
         _GF_MG_EXCEPTION_CATCH_ALL2/* due to auto replace */

--- a/src/clicache/src/ResultCollector.hpp
+++ b/src/clicache/src/ResultCollector.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "IResultCollector.hpp"
 #include <geode/ResultCollector.hpp>
 #include "impl/NativeWrapper.hpp"

--- a/src/clicache/src/ResultSet.cpp
+++ b/src/clicache/src/ResultSet.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "ResultSet.hpp"
 #include "SelectResultsIterator.hpp"
 #include "impl/ManagedString.hpp"
@@ -44,7 +44,7 @@ namespace Apache
       }
 
       generic<class TResult>
-      /*IGFSerializable^*/TResult ResultSet<TResult>::default::get( size_t index )
+      /*IGeodeSerializable^*/TResult ResultSet<TResult>::default::get( size_t index )
       {
           //return SafeUMSerializableConvertGeneric(NativePtr->operator[](static_cast<int32_t>(index)).ptr());
            return (Serializable::GetManagedValueGeneric<TResult>(NativePtr->operator[](static_cast<int32_t>(index))));
@@ -60,7 +60,7 @@ namespace Apache
       }
 
       generic<class TResult>
-      System::Collections::Generic::IEnumerator</*IGFSerializable^*/TResult>^
+      System::Collections::Generic::IEnumerator</*IGeodeSerializable^*/TResult>^
         ResultSet<TResult>::GetEnumerator( )
       {
         return GetIterator( );

--- a/src/clicache/src/ResultSet.hpp
+++ b/src/clicache/src/ResultSet.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/ResultSet.hpp>
 #include "impl/NativeWrapper.hpp"
 #include "ISelectResults.hpp"
@@ -32,7 +32,7 @@ namespace Apache
     namespace Client
     {
 
-      interface class IGFSerializable;
+      interface class IGeodeSerializable;
 
       generic<class TResult>
       ref class SelectResultsIterator;
@@ -66,9 +66,9 @@ namespace Apache
         /// <summary>
         /// Get an object at the given index.
         /// </summary>
-        virtual property /*IGFSerializable^*/TResult GFINDEXER(size_t)
+        virtual property /*IGeodeSerializable^*/TResult GFINDEXER(size_t)
         {
-          virtual /*IGFSerializable^*/TResult get(size_t index);
+          virtual /*IGeodeSerializable^*/TResult get(size_t index);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace Apache
         /// A <c>System.Collections.Generic.IEnumerator</c> that
         /// can be used to iterate through the <c>ResultSet</c>.
         /// </returns>
-        virtual System::Collections::Generic::IEnumerator</*IGFSerializable^*/TResult>^
+        virtual System::Collections::Generic::IEnumerator</*IGeodeSerializable^*/TResult>^
           GetEnumerator();
 
 

--- a/src/clicache/src/SelectResultsIterator.cpp
+++ b/src/clicache/src/SelectResultsIterator.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "SelectResultsIterator.hpp"
 
 #include "impl/SafeConvert.hpp"
@@ -29,7 +29,7 @@ namespace Apache
     {
 
       generic<class TResult>
-      /*Apache::Geode::Client::IGFSerializable^*/TResult SelectResultsIterator<TResult>::Current::get( )
+      /*Apache::Geode::Client::IGeodeSerializable^*/TResult SelectResultsIterator<TResult>::Current::get( )
       {
         //return SafeUMSerializableConvertGeneric( NativePtr->current( ).ptr( ) ); 
         return Serializable::GetManagedValueGeneric<TResult>(NativePtr->current( ));
@@ -48,7 +48,7 @@ namespace Apache
       }
 
       generic<class TResult>
-      /*Apache::Geode::Client::IGFSerializable^*/TResult SelectResultsIterator<TResult>::Next( )
+      /*Apache::Geode::Client::IGeodeSerializable^*/TResult SelectResultsIterator<TResult>::Next( )
       {
         //return SafeUMSerializableConvertGeneric( NativePtr->next( ).ptr( ) );
         return Serializable::GetManagedValueGeneric<TResult>(NativePtr->next( ));

--- a/src/clicache/src/SelectResultsIterator.hpp
+++ b/src/clicache/src/SelectResultsIterator.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/SelectResultsIterator.hpp>
 #include "impl/NativeWrapper.hpp"
 
@@ -31,7 +31,7 @@ namespace Apache
     namespace Client
     {
 
-      interface class IGFSerializable;
+      interface class IGeodeSerializable;
 
       /// <summary>
       /// Iterator for a query result.
@@ -39,7 +39,7 @@ namespace Apache
       generic<class TResult>
       public ref class SelectResultsIterator sealed
         : public Internal::UMWrap<apache::geode::client::SelectResultsIterator>,
-        public System::Collections::Generic::IEnumerator</*Apache::Geode::Client::IGFSerializable^*/TResult>
+        public System::Collections::Generic::IEnumerator</*Apache::Geode::Client::IGeodeSerializable^*/TResult>
       {
       public:
 
@@ -51,9 +51,9 @@ namespace Apache
         /// The element in the collection at the current position
         /// of the enumerator.
         /// </returns>
-        virtual property /*Apache::Geode::Client::IGFSerializable^*/TResult Current
+        virtual property /*Apache::Geode::Client::IGeodeSerializable^*/TResult Current
         {
-          virtual /*Apache::Geode::Client::IGFSerializable^*/TResult get( );
+          virtual /*Apache::Geode::Client::IGeodeSerializable^*/TResult get( );
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Apache
         /// <summary>
         /// Get the current element and move to the next one.
         /// </summary>
-        /*Apache::Geode::Client::IGFSerializable^*/TResult Next( );
+        /*Apache::Geode::Client::IGeodeSerializable^*/TResult Next( );
 
         /// <summary>
         /// Check if there is a next element.

--- a/src/clicache/src/Serializable.cpp
+++ b/src/clicache/src/Serializable.cpp
@@ -17,7 +17,7 @@
 
 #include <SerializationRegistry.hpp>
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "Serializable.hpp"
 #include "impl/DelegateWrapper.hpp"
 #include "DataOutput.hpp"
@@ -78,7 +78,7 @@ namespace Apache
           output->SetBuffer();
         }
       }
-      Apache::Geode::Client::IGFSerializable^
+      Apache::Geode::Client::IGeodeSerializable^
         Apache::Geode::Client::Serializable::FromData(
         Apache::Geode::Client::DataInput^ input)
       {
@@ -218,13 +218,13 @@ namespace Apache
         return (Apache::Geode::Client::Serializable^)CacheableStringArray::Create(value);
       }
 
-      int32 Serializable::GetPDXIdForType(const char* poolName, IGFSerializable^ pdxType)
+      int32 Serializable::GetPDXIdForType(const char* poolName, IGeodeSerializable^ pdxType)
       {
         apache::geode::client::CacheablePtr kPtr(SafeMSerializableConvertGeneric(pdxType));
         return apache::geode::client::SerializationRegistry::GetPDXIdForType(poolName, kPtr);
       }
 
-      IGFSerializable^ Serializable::GetPDXTypeById(const char* poolName, int32 typeId)
+      IGeodeSerializable^ Serializable::GetPDXTypeById(const char* poolName, int32 typeId)
       {
         SerializablePtr sPtr = apache::geode::client::SerializationRegistry::GetPDXTypeById(poolName, typeId);
         return SafeUMSerializableConvertGeneric(sPtr.ptr());
@@ -511,7 +511,7 @@ namespace Apache
         NativeDelegatesGeneric->Add(nativeDelegate);
 
         // register the type in the DelegateMap, this is pure c# for create domain object 
-        IGFSerializable^ tmp = creationMethod();
+        IGeodeSerializable^ tmp = creationMethod();
         Log::Fine("Registering serializable class ID " + tmp->ClassId +
                   ", AppDomain ID " + System::Threading::Thread::GetDomainID());
         DelegateMapGeneric[tmp->ClassId] = creationMethod;
@@ -547,7 +547,7 @@ namespace Apache
           ManagedDelegatesGeneric->Add(typeId + 0x80000000, creationMethod);
 
         // register the type in the DelegateMap
-        IGFSerializable^ tmp = creationMethod();
+        IGeodeSerializable^ tmp = creationMethod();
         Log::Finer("Registering(,) serializable class ID " + tmp->ClassId +
                    ", AppDomain ID " + System::Threading::Thread::GetDomainID());
         DelegateMapGeneric[tmp->ClassId] = creationMethod;
@@ -699,7 +699,7 @@ namespace Apache
           case apache::geode::client::GeodeTypeIdsImpl::CacheableUserData4:
           {
             //TODO::split 
-            IGFSerializable^ ret = SafeUMSerializableConvertGeneric(val.ptr());
+            IGeodeSerializable^ ret = SafeUMSerializableConvertGeneric(val.ptr());
             return safe_cast<TValue>(ret);
             //return TValue();
           }
@@ -1110,99 +1110,99 @@ namespace Apache
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableBytes:
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableBytes::Create((array<Byte>^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableBytes::Create((array<Byte>^)key)));
                     return kPtr;
                     /*if( managedType == Type::GetType("System.Byte[]") ) {
-                      apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableBytes::Create((array<Byte>^)key)));
+                      apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableBytes::Create((array<Byte>^)key)));
                       return kPtr;
                       }
                       else {
-                      apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableBytes::Create(getSByteArray((array<SByte>^)key))));
+                      apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableBytes::Create(getSByteArray((array<SByte>^)key))));
                       return kPtr;
                       }*/
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableDoubleArray:
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableDoubleArray::Create((array<Double>^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableDoubleArray::Create((array<Double>^)key)));
                     return kPtr;
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableFloatArray:
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableFloatArray::Create((array<float>^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableFloatArray::Create((array<float>^)key)));
                     return kPtr;
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableInt16Array:
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableInt16Array::Create((array<Int16>^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableInt16Array::Create((array<Int16>^)key)));
                     return kPtr;
                     /* if( managedType == Type::GetType("System.Int16[]") ) {
-                       apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableInt16Array::Create((array<Int16>^)key)));
+                       apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableInt16Array::Create((array<Int16>^)key)));
                        return kPtr;
                        }
                        else {
-                       apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableInt16Array::Create(getInt16Array((array<uint16_t>^)key))));
+                       apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableInt16Array::Create(getInt16Array((array<uint16_t>^)key))));
                        return kPtr;
                        }  */
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableInt32Array:
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableInt32Array::Create((array<Int32>^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableInt32Array::Create((array<Int32>^)key)));
                     return kPtr;
                     /*  if( managedType == Type::GetType("System.Int32[]") ) {
-                        apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableInt32Array::Create((array<Int32>^)key)));
+                        apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableInt32Array::Create((array<Int32>^)key)));
                         return kPtr;
                         }
                         else {
-                        apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableInt32Array::Create(getInt32Array((array<uint32_t>^)key))));
+                        apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableInt32Array::Create(getInt32Array((array<uint32_t>^)key))));
                         return kPtr;
                         }       */
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableInt64Array:
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableInt64Array::Create((array<Int64>^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableInt64Array::Create((array<Int64>^)key)));
                     return kPtr;
                     /*if( managedType == Type::GetType("System.Int64[]") ) {
-                      apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableInt64Array::Create((array<Int64>^)key)));
+                      apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableInt64Array::Create((array<Int64>^)key)));
                       return kPtr;
                       }
                       else {
-                      apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableInt64Array::Create(getInt64Array((array<uint64_t>^)key))));
+                      apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableInt64Array::Create(getInt64Array((array<uint64_t>^)key))));
                       return kPtr;
                       }     */
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableStringArray:
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableStringArray::Create((array<String^>^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableStringArray::Create((array<String^>^)key)));
                     return kPtr;
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableFileName:
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)(Apache::Geode::Client::CacheableFileName^)key));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)(Apache::Geode::Client::CacheableFileName^)key));
                     return kPtr;
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableHashTable://collection::hashtable
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableHashTable::Create((System::Collections::Hashtable^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableHashTable::Create((System::Collections::Hashtable^)key)));
                     return kPtr;
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableHashMap://generic dictionary
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableHashMap::Create((System::Collections::IDictionary^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableHashMap::Create((System::Collections::IDictionary^)key)));
                     return kPtr;
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableVector://collection::arraylist
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)CacheableVector::Create((System::Collections::IList^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)CacheableVector::Create((System::Collections::IList^)key)));
                     return kPtr;
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableArrayList://generic ilist
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableArrayList::Create((System::Collections::IList^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableArrayList::Create((System::Collections::IList^)key)));
                     return kPtr;
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableLinkedList://generic linked list
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableLinkedList::Create((System::Collections::Generic::LinkedList<Object^>^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableLinkedList::Create((System::Collections::Generic::LinkedList<Object^>^)key)));
                     return kPtr;
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableStack:
@@ -1242,23 +1242,23 @@ namespace Apache
                   }
                   case apache::geode::client::GeodeTypeIds::CacheableDate:
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CacheableDate::Create((System::DateTime)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CacheableDate::Create((System::DateTime)key)));
                     return kPtr;
                   }
                   case apache::geode::client::GeodeTypeIds::BooleanArray:
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::BooleanArray::Create((array<bool>^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::BooleanArray::Create((array<bool>^)key)));
                     return kPtr;
                   }
                   case apache::geode::client::GeodeTypeIds::CharArray:
                   {
-                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGFSerializable^)Apache::Geode::Client::CharArray::Create((array<Char>^)key)));
+                    apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert((IGeodeSerializable^)Apache::Geode::Client::CharArray::Create((array<Char>^)key)));
                     return kPtr;
                   }
                   default:
                   {
                     apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert(key));
-                    /*IGFSerializable^ ct = safe_cast<IGFSerializable^>(key);
+                    /*IGeodeSerializable^ ct = safe_cast<IGeodeSerializable^>(key);
                     if(ct != nullptr) {
                     apache::geode::client::CacheablePtr kPtr(SafeGenericMSerializableConvert(ct));
                     return kPtr;

--- a/src/clicache/src/Serializable.hpp
+++ b/src/clicache/src/Serializable.hpp
@@ -17,11 +17,11 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/CacheableKey.hpp>
 #include <geode/CacheableBuiltins.hpp>
-#include "IGFSerializable.hpp"
-#include "IGFDelta.hpp"
+#include "IGeodeSerializable.hpp"
+#include "IGeodeDelta.hpp"
 #include "impl/ManagedString.hpp"
 #include "impl/NativeWrapper.hpp"
 #include "impl/EnumInfo.hpp"
@@ -58,17 +58,17 @@ namespace Apache
       /// The delegate shall be stored in the internal <c>DelegateWrapper</c>
       /// class and an instance will be initialized in the
       /// <c>DelegateWrapper.NativeDelegate</c> method by a call to
-      /// <see cref="IGFSerializable.FromData" />.
+      /// <see cref="IGeodeSerializable.FromData" />.
       /// </summary>
-      public delegate Apache::Geode::Client::IGFSerializable^ TypeFactoryMethodGeneric();
+      public delegate Apache::Geode::Client::IGeodeSerializable^ TypeFactoryMethodGeneric();
       /// <summary>
       /// Delegate to wrap a native <c>apache::geode::client::Serializable</c> type.
       /// </summary>
       /// <remarks>
-      /// This delegate should return an object of type <c>IGFSerializable</c>
+      /// This delegate should return an object of type <c>IGeodeSerializable</c>
       /// given a native object.
       /// </remarks>
-      delegate Apache::Geode::Client::IGFSerializable^ WrapperDelegateGeneric(apache::geode::client::Serializable* obj);
+      delegate Apache::Geode::Client::IGeodeSerializable^ WrapperDelegateGeneric(apache::geode::client::Serializable* obj);
 
 			/// <summary>
       /// Signature of function delegates passed to
@@ -81,11 +81,11 @@ namespace Apache
       
       /// <summary>
       /// This class wraps the native C++ <c>apache::geode::client::Serializable</c> objects
-      /// as managed <see cref="IGFSerializable" /> objects.
+      /// as managed <see cref="IGeodeSerializable" /> objects.
       /// </summary>
       public ref class Serializable
         : public Apache::Geode::Client::Internal::SBWrap<apache::geode::client::Serializable>,
-        public Apache::Geode::Client::IGFSerializable
+        public Apache::Geode::Client::IGeodeSerializable
       {
       public:
         /// <summary>
@@ -104,7 +104,7 @@ namespace Apache
         /// the DataInput stream to use for reading the object data
         /// </param>
         /// <returns>the deserialized object</returns>
-        virtual Apache::Geode::Client::IGFSerializable^
+        virtual Apache::Geode::Client::IGeodeSerializable^
           FromData(Apache::Geode::Client::DataInput^ input);
         
         /// <summary>
@@ -247,7 +247,7 @@ namespace Apache
         /// <summary>
         /// Register an instance factory method for a given type.
         /// This should be used when registering types that implement
-        /// IGFSerializable.
+        /// IGeodeSerializable.
         /// </summary>
         /// <param name="creationMethod">
         /// the creation function to register
@@ -295,8 +295,8 @@ namespace Apache
 
       internal:
 
-				static int32 GetPDXIdForType(const char* poolName, IGFSerializable^ pdxType);
-				static IGFSerializable^ GetPDXTypeById(const char* poolName, int32 typeId);
+				static int32 GetPDXIdForType(const char* poolName, IGeodeSerializable^ pdxType);
+				static IGeodeSerializable^ GetPDXTypeById(const char* poolName, int32 typeId);
 				static IPdxSerializable^ Serializable::GetPdxType(String^ className);
 				static void RegisterPDXManagedCacheableKey(bool appDomainEnable);
         static bool IsObjectAndPdxSerializerRegistered(String^ className);
@@ -427,7 +427,7 @@ namespace Apache
         /// <summary>
         /// Register an instance factory method for a given type and typeId.
         /// This should be used when registering types that implement
-        /// IGFSerializable.
+        /// IGeodeSerializable.
         /// </summary>
         /// <param name="typeId">typeId of the type being registered.</param>
         /// <param name="creationMethod">

--- a/src/clicache/src/StatisticDescriptor.cpp
+++ b/src/clicache/src/StatisticDescriptor.cpp
@@ -17,7 +17,7 @@
 
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "StatisticDescriptor.hpp"
 #include "impl/ManagedString.hpp"
 

--- a/src/clicache/src/StatisticDescriptor.hpp
+++ b/src/clicache/src/StatisticDescriptor.hpp
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "impl/NativeWrapper.hpp"
 #include <geode/statistics/StatisticDescriptor.hpp>
 

--- a/src/clicache/src/Statistics.cpp
+++ b/src/clicache/src/Statistics.cpp
@@ -17,7 +17,7 @@
 
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "Statistics.hpp"
 #include "StatisticDescriptor.hpp"
 #include "StatisticsType.hpp"

--- a/src/clicache/src/Statistics.hpp
+++ b/src/clicache/src/Statistics.hpp
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "impl/NativeWrapper.hpp"
 #include <geode/statistics/Statistics.hpp>
 #include <geode/statistics/StatisticDescriptor.hpp>

--- a/src/clicache/src/StatisticsFactory.cpp
+++ b/src/clicache/src/StatisticsFactory.cpp
@@ -17,7 +17,7 @@
 
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "StatisticsFactory.hpp"
 #include "StatisticsType.hpp"
 #include "StatisticDescriptor.hpp"

--- a/src/clicache/src/StatisticsFactory.hpp
+++ b/src/clicache/src/StatisticsFactory.hpp
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "impl/NativeWrapper.hpp"
 #include <geode/statistics/StatisticsFactory.hpp>
 #include <geode/statistics/StatisticsType.hpp>

--- a/src/clicache/src/StatisticsType.cpp
+++ b/src/clicache/src/StatisticsType.cpp
@@ -17,7 +17,7 @@
 
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "StatisticsType.hpp"
 #include "StatisticDescriptor.hpp"
 

--- a/src/clicache/src/StatisticsType.hpp
+++ b/src/clicache/src/StatisticsType.hpp
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "impl/NativeWrapper.hpp"
 #include <geode/statistics/StatisticsType.hpp>
 #include <geode/statistics/StatisticDescriptor.hpp>

--- a/src/clicache/src/Struct.cpp
+++ b/src/clicache/src/Struct.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include <geode/Struct.hpp>
 #include "Struct.hpp"
 #include "StructSet.hpp"

--- a/src/clicache/src/Struct.hpp
+++ b/src/clicache/src/Struct.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "Serializable.hpp"
 #include <geode/Struct.hpp>
 
@@ -54,9 +54,9 @@ namespace Apache
         /// <returns>
         /// The value of the field or null if index is out of bounds.
         /// </returns>
-        property /*Apache::Geode::Client::IGFSerializable^*//*TResult*/ Object^ GFINDEXER( size_t )
+        property /*Apache::Geode::Client::IGeodeSerializable^*//*TResult*/ Object^ GFINDEXER( size_t )
         {
-          /*Apache::Geode::Client::IGFSerializable^*/ /*TResult*/ Object^ get( size_t index );
+          /*Apache::Geode::Client::IGeodeSerializable^*/ /*TResult*/ Object^ get( size_t index );
         }
 
         /// <summary>
@@ -66,9 +66,9 @@ namespace Apache
         /// <exception cref="IllegalArgumentException">
         /// if the field name is not found.
         /// </exception>
-        property /*Apache::Geode::Client::IGFSerializable^*//*TResult*/Object^ GFINDEXER( String^ )
+        property /*Apache::Geode::Client::IGeodeSerializable^*//*TResult*/Object^ GFINDEXER( String^ )
         {
-          /*Apache::Geode::Client::IGFSerializable^*//*TResult*/Object^ get( String^ fieldName );
+          /*Apache::Geode::Client::IGeodeSerializable^*//*TResult*/Object^ get( String^ fieldName );
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace Apache
         /// A reference to the next item in the <c>Struct</c>
         /// or null if no more available.
         /// </returns>
-        /*Apache::Geode::Client::IGFSerializable^*//*TResult*/Object^ Next( );
+        /*Apache::Geode::Client::IGeodeSerializable^*//*TResult*/Object^ Next( );
 
 
       private:
@@ -125,7 +125,7 @@ namespace Apache
         /// <summary>
         /// Factory function to register wrapper
         /// </summary>
-        inline static Apache::Geode::Client::IGFSerializable^ /*Struct^*/ /*<TResult>*/ Create( ::apache::geode::client::Serializable* obj )
+        inline static Apache::Geode::Client::IGeodeSerializable^ /*Struct^*/ /*<TResult>*/ Create( ::apache::geode::client::Serializable* obj )
         {
           return ( obj != nullptr ?
             gcnew Apache::Geode::Client::Struct/*<TResult>*/( obj ) : nullptr );
@@ -133,7 +133,7 @@ namespace Apache
             gcnew Struct( obj ) : nullptr );*/
         }
 
-        inline static Apache::Geode::Client::IGFSerializable^ CreateDeserializable( )
+        inline static Apache::Geode::Client::IGeodeSerializable^ CreateDeserializable( )
         {
           return gcnew Apache::Geode::Client::Struct/*<TResult>*/(  ) ;
           //return gcnew Struct(  ) ;

--- a/src/clicache/src/StructSet.cpp
+++ b/src/clicache/src/StructSet.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "StructSet.hpp"
 #include "SelectResultsIterator.hpp"
 #include "ExceptionTypes.hpp"
@@ -43,7 +43,7 @@ namespace Apache
       }
 
       generic<class TResult>
-      /*Apache::Geode::Client::IGFSerializable^*/ TResult StructSet<TResult>::default::get( size_t index )
+      /*Apache::Geode::Client::IGeodeSerializable^*/ TResult StructSet<TResult>::default::get( size_t index )
       {
         //return SafeUMSerializableConvertGeneric((NativePtr->operator[](static_cast<int32_t>(index))).ptr());
         return Serializable::GetManagedValueGeneric<TResult>((NativePtr->operator[](static_cast<int32_t>(index))));
@@ -58,7 +58,7 @@ namespace Apache
       }
 
       generic<class TResult>
-      System::Collections::Generic::IEnumerator</*Apache::Geode::Client::IGFSerializable^*/TResult>^
+      System::Collections::Generic::IEnumerator</*Apache::Geode::Client::IGeodeSerializable^*/TResult>^
         StructSet<TResult>::GetEnumerator( )
       {
         return GetIterator( );

--- a/src/clicache/src/StructSet.hpp
+++ b/src/clicache/src/StructSet.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/StructSet.hpp>
 #include "impl/NativeWrapper.hpp"
 #include "ICqResults.hpp"
@@ -32,7 +32,7 @@ namespace Apache
     namespace Client
     {
 
-      interface class IGFSerializable;
+      interface class IGeodeSerializable;
 
       generic<class TResult>
       ref class SelectResultsIterator;
@@ -73,9 +73,9 @@ namespace Apache
         /// if the index is out of bounds.
         /// </exception>
         /// <returns>Item at the given index.</returns>
-        virtual property /*Apache::Geode::Client::IGFSerializable^*/TResult GFINDEXER( size_t )
+        virtual property /*Apache::Geode::Client::IGeodeSerializable^*/TResult GFINDEXER( size_t )
         {
-          virtual /*Apache::Geode::Client::IGFSerializable^*/TResult get( size_t index );
+          virtual /*Apache::Geode::Client::IGeodeSerializable^*/TResult get( size_t index );
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Apache
         String^ GetFieldName( size_t index );
 
 
-        // Region: IEnumerable<IGFSerializable^> Members
+        // Region: IEnumerable<IGeodeSerializable^> Members
 
         /// <summary>
         /// Returns an enumerator that iterates through the <c>StructSet</c>.
@@ -122,10 +122,10 @@ namespace Apache
         /// A <c>System.Collections.Generic.IEnumerator</c> that
         /// can be used to iterate through the <c>StructSet</c>.
         /// </returns>
-        virtual System::Collections::Generic::IEnumerator</*Apache::Geode::Client::IGFSerializable^*/TResult>^
+        virtual System::Collections::Generic::IEnumerator</*Apache::Geode::Client::IGeodeSerializable^*/TResult>^
           GetEnumerator( );
 
-        // End Region: IEnumerable<IGFSerializable^> Members
+        // End Region: IEnumerable<IGeodeSerializable^> Members
 
 
       internal:

--- a/src/clicache/src/SystemProperties.cpp
+++ b/src/clicache/src/SystemProperties.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "SystemProperties.hpp"
 #include "impl/SafeConvert.hpp"
 

--- a/src/clicache/src/SystemProperties.hpp
+++ b/src/clicache/src/SystemProperties.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/SystemProperties.hpp>
 #include "impl/NativeWrapper.hpp"
 #include "Log.hpp"

--- a/src/clicache/src/TransactionEvent.cpp
+++ b/src/clicache/src/TransactionEvent.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 #ifdef CSTX_COMMENTED
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "TransactionEvent.hpp"
 #include "Log.hpp"
 #include "impl/SafeConvert.hpp"

--- a/src/clicache/src/TransactionEvent.hpp
+++ b/src/clicache/src/TransactionEvent.hpp
@@ -18,7 +18,7 @@
 #ifdef CSTX_COMMENTED
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <cppcache/TransactionEvent.hpp>
 #include "impl/NativeWrapper.hpp"
 //#include "TransactionId.hpp"

--- a/src/clicache/src/TransactionId.hpp
+++ b/src/clicache/src/TransactionId.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include <geode/TransactionId.hpp>
 #include "impl/NativeWrapper.hpp"
 

--- a/src/clicache/src/TransactionListenerAdapter.hpp
+++ b/src/clicache/src/TransactionListenerAdapter.hpp
@@ -17,7 +17,7 @@
 #ifdef CSTX_COMMENTED
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "ITransactionListener.hpp"
 
 

--- a/src/clicache/src/TransactionWriterAdapte.hpp
+++ b/src/clicache/src/TransactionWriterAdapte.hpp
@@ -17,7 +17,7 @@
 #ifdef CSTX_COMMENTED
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "ITransactionWriter.hpp"
 
 

--- a/src/clicache/src/UserFunctionExecutionException.cpp
+++ b/src/clicache/src/UserFunctionExecutionException.cpp
@@ -28,14 +28,14 @@ namespace Apache
     namespace Client
     {
 
-        // IGFSerializable methods
+        // IGeodeSerializable methods
 
         void UserFunctionExecutionException::ToData( DataOutput^ output )
         {
           throw gcnew IllegalStateException("UserFunctionExecutionException::ToData is not intended for use.");
         }
 
-        IGFSerializable^ UserFunctionExecutionException::FromData( DataInput^ input )
+        IGeodeSerializable^ UserFunctionExecutionException::FromData( DataInput^ input )
         {
           throw gcnew IllegalStateException("UserFunctionExecutionException::FromData is not intended for use.");
           return this;

--- a/src/clicache/src/UserFunctionExecutionException.hpp
+++ b/src/clicache/src/UserFunctionExecutionException.hpp
@@ -18,9 +18,9 @@
 
 #pragma once
 
-#include "gf_defs.hpp"
+#include "geode_defs.hpp"
 #include "geode/UserFunctionExecutionException.hpp"
-#include "IGFSerializable.hpp"
+#include "IGeodeSerializable.hpp"
 #include "DataInput.hpp"
 #include "DataOutput.hpp"
 
@@ -37,10 +37,10 @@ namespace Apache
       /// UserFunctionExecutionException class is used to encapsulate geode sendException in case of Function execution. 
       /// </summary>
       public ref class UserFunctionExecutionException sealed
-        : public Internal::SBWrap<apache::geode::client::UserFunctionExecutionException>, public IGFSerializable
+        : public Internal::SBWrap<apache::geode::client::UserFunctionExecutionException>, public IGeodeSerializable
       {
       public:
-        // IGFSerializable members
+        // IGeodeSerializable members
 
         /// <summary>
         /// Serializes this object.
@@ -65,7 +65,7 @@ namespace Apache
         /// If this api is called from User code.
         /// </exception>
         /// <returns>the deserialized object</returns>
-        virtual IGFSerializable^ FromData(DataInput^ input);
+        virtual IGeodeSerializable^ FromData(DataInput^ input);
 
         /// <summary>
         /// Returns the classId of this class for serialization.
@@ -75,7 +75,7 @@ namespace Apache
         /// If this api is called from User code.
         /// </exception>
         /// <returns>classId of this class</returns>
-        /// <seealso cref="IGFSerializable.ClassId" />
+        /// <seealso cref="IGeodeSerializable.ClassId" />
         virtual property uint32_t ClassId
         {
           inline virtual uint32_t get()
@@ -97,7 +97,7 @@ namespace Apache
           virtual uint32_t get();
         }
 
-        // End: IGFSerializable members   
+        // End: IGeodeSerializable members   
 
         /// <summary>
         /// return as String the Exception message returned from geode sendException api.          

--- a/src/clicache/src/Utils.cpp
+++ b/src/clicache/src/Utils.cpp
@@ -16,7 +16,7 @@
  */
 
 
-//#include "gf_includes.hpp"
+//#include "geode_includes.hpp"
 #include "gfcli/Utils.hpp"
 #include <Utils.hpp>
 

--- a/src/clicache/src/geode_defs.hpp
+++ b/src/clicache/src/geode_defs.hpp
@@ -19,7 +19,7 @@
 
 // These definitions are to help parsing by Doxygen.
 
-/// @file gf_defs.hpp
+/// @file geode_defs.hpp
 /// API documentation helper file for the Doxygen source-comment-extraction tool.
 
 #define STATICCLASS abstract sealed
@@ -50,7 +50,7 @@
 /// @namespace Apache::Geode::Client::Template
 /// This namespace contains internal Geode .NET template classes.
 
-/// @file gf_includes.hpp
+/// @file geode_includes.hpp
 /// Provides a commonly-used set of include directives.
 
 /// @file AttributesFactory.hpp
@@ -190,8 +190,8 @@
 /// @file ICacheWriter.hpp
 /// Declares the ICacheWriter interface.
 
-/// @file IGFSerializable.hpp
-/// Declares the IGFSerializable interface.
+/// @file IGeodeSerializable.hpp
+/// Declares the IGeodeSerializable interface.
 
 /// @file ISelectResults.hpp
 /// Declares the ISelectResults interface.

--- a/src/clicache/src/geode_includes.hpp
+++ b/src/clicache/src/geode_includes.hpp
@@ -1,8 +1,3 @@
-#pragma once
-
-#ifndef GEODE_CRYPTOIMPL_GFSSL_H_
-#define GEODE_CRYPTOIMPL_GFSSL_H_
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,26 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * GFSsl.hpp
- *
- *  Created on: 28-Apr-2010
- *      Author: ankurs
- */
 
-#include <ace/INET_Addr.h>
-#include <ace/OS.h>
+// geode_includes.hpp : include file for standard system include files,
+// and all project specific include files.
 
-class GFSsl {
- public:
-  virtual ~GFSsl(){};
-  virtual int setOption(int, int, void*, int) = 0;
-  virtual int listen(ACE_INET_Addr, unsigned) = 0;
-  virtual int connect(ACE_INET_Addr, unsigned) = 0;
-  virtual ssize_t recv(void*, size_t, const ACE_Time_Value*, size_t*) = 0;
-  virtual ssize_t send(const void*, size_t, const ACE_Time_Value*, size_t*) = 0;
-  virtual int getLocalAddr(ACE_Addr&) = 0;
-  virtual void close() = 0;
-};
+#pragma once
 
-#endif  // GEODE_CRYPTOIMPL_GFSSL_H_
+//#include "impl/ManagedCacheableKeyGCHandle.hpp"
+#include "impl/SafeConvert.hpp"
+
+#include <string>

--- a/src/clicache/src/geodeclicache.vcxproj.filters
+++ b/src/clicache/src/geodeclicache.vcxproj.filters
@@ -91,22 +91,22 @@ limitations under the License.
     <ClInclude Include="impl\DelegateWrapper.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="impl\GFDataInputStream.hpp">
+    <ClInclude Include="impl\GeodeDataInputStream.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="impl\GFDataOutputStream.hpp">
+    <ClInclude Include="impl\GeodeDataOutputStream.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="impl\GFNullStream.hpp">
+    <ClInclude Include="impl\GeodeNullStream.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="impl\AuthenticatedCacheM.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="gf_includes.hpp">
+    <ClInclude Include="geode_includes.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="gf_defs.hpp">
+    <ClInclude Include="geode_defs.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="com\vmware\impl\ResultCollectorProxyMN.hpp">
@@ -244,13 +244,13 @@ limitations under the License.
     <ClInclude Include="com\vmware\impl\FixedPartitionResolverMN.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="com\vmware\impl\GFDataInputStreamN.hpp">
+    <ClInclude Include="com\vmware\impl\GeodeDataInputStreamN.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="com\vmware\impl\GFDataOutputStreamN.hpp">
+    <ClInclude Include="com\vmware\impl\GeodeDataOutputStreamN.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="com\vmware\impl\GFNullStreamN.hpp">
+    <ClInclude Include="com\vmware\impl\GeodeNullStreamN.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="com\vmware\impl\CqStatusListenerProxyMN.hpp">
@@ -439,10 +439,10 @@ limitations under the License.
     <ClInclude Include="com\vmware\IGemFireCacheN.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="com\vmware\IGFDeltaN.hpp">
+    <ClInclude Include="com\vmware\IGeodeDeltaN.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="com\vmware\IGFSerializableN.hpp">
+    <ClInclude Include="com\vmware\IGeodeSerializableN.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="com\vmware\IPartitionResolverN.hpp">
@@ -676,7 +676,7 @@ limitations under the License.
     <ClInclude Include="IGemFireCache.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="IGFSerializable.hpp">
+    <ClInclude Include="IGeodeSerializable.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="IPartitionResolver.hpp">
@@ -688,7 +688,7 @@ limitations under the License.
      <ClInclude Include="IFixedPartitionResolver.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="IGFDelta.hpp">
+    <ClInclude Include="IGeodeDelta.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="GemFireClassIdsM.hpp">

--- a/src/clicache/src/impl/AuthenticatedCache.cpp
+++ b/src/clicache/src/impl/AuthenticatedCache.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "../Cache.hpp"
 #include "../DistributedSystem.hpp"
 #include "../Region.hpp"

--- a/src/clicache/src/impl/AuthenticatedCache.hpp
+++ b/src/clicache/src/impl/AuthenticatedCache.hpp
@@ -17,12 +17,12 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <geode/RegionService.hpp>
 #include "NativeWrapper.hpp"
 #include "../RegionShortcut.hpp"
 #include "../RegionFactory.hpp"
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "../IRegionService.hpp"
 #include "../Region.hpp"
 

--- a/src/clicache/src/impl/CacheListener.hpp
+++ b/src/clicache/src/impl/CacheListener.hpp
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "../ICacheListener.hpp"
 #include "../CacheListenerAdapter.hpp"
 #include "../ICacheListener.hpp"

--- a/src/clicache/src/impl/CacheLoader.hpp
+++ b/src/clicache/src/impl/CacheLoader.hpp
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 //#include "../../../ICacheLoader.hpp"
 #include "../ICacheLoader.hpp"
 //#include "../Serializable.hpp"

--- a/src/clicache/src/impl/CacheWriter.hpp
+++ b/src/clicache/src/impl/CacheWriter.hpp
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 //#include "../../../ICacheWriter.hpp"
 #include "../CacheWriterAdapter.hpp"
 #include "../ICacheWriter.hpp"

--- a/src/clicache/src/impl/CliCallbackDelgate.hpp
+++ b/src/clicache/src/impl/CliCallbackDelgate.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include "../Serializable.hpp"
 #include "ManagedCacheableKey.hpp"
 #include "SafeConvert.hpp"

--- a/src/clicache/src/impl/CqListenerProxy.hpp
+++ b/src/clicache/src/impl/CqListenerProxy.hpp
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 //#include "../../../ICqListener.hpp"
 //#include "../../../CqListener.hpp"
 #include "../ICqListener.hpp"

--- a/src/clicache/src/impl/DelegateWrapper.hpp
+++ b/src/clicache/src/impl/DelegateWrapper.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include "../Serializable.hpp"
 #include "ManagedCacheableKey.hpp"
 #include "SafeConvert.hpp"
@@ -34,7 +34,7 @@ namespace Apache
 
       /// <summary>
       /// Template class to wrap a managed <see cref="TypeFactoryMethod" />
-      /// delegate that returns an <see cref="IGFSerializable" /> object. It contains
+      /// delegate that returns an <see cref="IGeodeSerializable" /> object. It contains
       /// a method that converts the managed object gotten by invoking the
       /// delegate to the native <c>apache::geode::client::Serializable</c> object
       /// (using the provided wrapper class constructor).
@@ -76,9 +76,9 @@ namespace Apache
         /// </returns>
         apache::geode::client::Serializable* NativeDelegateGeneric( )
         {
-          IGFSerializable^ tempObj = m_delegate( );
-          IGFDelta^ tempDelta =
-            dynamic_cast<IGFDelta^>(tempObj);
+          IGeodeSerializable^ tempObj = m_delegate( );
+          IGeodeDelta^ tempDelta =
+            dynamic_cast<IGeodeDelta^>(tempObj);
           if( tempDelta != nullptr )
           {
             if(!SafeConvertClassGeneric::isAppDomainEnabled)

--- a/src/clicache/src/impl/EnumInfo.cpp
+++ b/src/clicache/src/impl/EnumInfo.cpp
@@ -38,7 +38,7 @@ namespace Apache
           output->WriteInt32(_hashcode);
         }
         
-        IGFSerializable^ EnumInfo::FromData( DataInput^ input )
+        IGeodeSerializable^ EnumInfo::FromData( DataInput^ input )
         {
           _enumClassName = input->ReadString();
           _enumName = input->ReadString();

--- a/src/clicache/src/impl/EnumInfo.hpp
+++ b/src/clicache/src/impl/EnumInfo.hpp
@@ -16,7 +16,7 @@
  */
 
 #pragma once
-#include "../IGFSerializable.hpp"
+#include "../IGeodeSerializable.hpp"
 #include "../GeodeClassIds.hpp"
 using namespace System;
 using namespace System::Collections::Generic;
@@ -30,7 +30,7 @@ namespace Apache
 
       namespace Internal
       {
-        public ref class EnumInfo : public IGFSerializable
+        public ref class EnumInfo : public IGeodeSerializable
         {
         private:
           String^ _enumClassName;
@@ -50,12 +50,12 @@ namespace Apache
             _hashcode = hashcode;
           }
 
-          static IGFSerializable^ CreateDeserializable()
+          static IGeodeSerializable^ CreateDeserializable()
           {
             return gcnew EnumInfo();
           }
           virtual void ToData(DataOutput^ output);
-          virtual IGFSerializable^ FromData(DataInput^ input);
+          virtual IGeodeSerializable^ FromData(DataInput^ input);
           virtual property uint32_t ObjectSize
           {
             uint32_t get(){ return 0; }

--- a/src/clicache/src/impl/ManagedAuthInitialize.cpp
+++ b/src/clicache/src/impl/ManagedAuthInitialize.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "ManagedAuthInitialize.hpp"
 #include "../IAuthInitialize.hpp"
 #include "ManagedString.hpp"

--- a/src/clicache/src/impl/ManagedAuthInitialize.hpp
+++ b/src/clicache/src/impl/ManagedAuthInitialize.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <geode/AuthInitialize.hpp>
 #include <vcclr.h>
 #include "../IAuthInitialize.hpp"

--- a/src/clicache/src/impl/ManagedCacheListener.cpp
+++ b/src/clicache/src/impl/ManagedCacheListener.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "ManagedCacheListener.hpp"
 #include "../ICacheListener.hpp"
 #include "../EntryEvent.hpp"

--- a/src/clicache/src/impl/ManagedCacheListener.hpp
+++ b/src/clicache/src/impl/ManagedCacheListener.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/CacheListener.hpp>
 #include "../ICacheListener.hpp"

--- a/src/clicache/src/impl/ManagedCacheLoader.cpp
+++ b/src/clicache/src/impl/ManagedCacheLoader.cpp
@@ -224,7 +224,7 @@ namespace apache
 
           ICacheableKey^ mkey = SafeGenericUMKeyConvert( key.ptr( ) );
 
-          IGFSerializable^ mcallbackArg = SafeGenericUMSerializableConvert(aCallbackArgument.ptr());
+          IGeodeSerializable^ mcallbackArg = SafeGenericUMSerializableConvert(aCallbackArgument.ptr());
           */
 
           /*

--- a/src/clicache/src/impl/ManagedCacheLoader.hpp
+++ b/src/clicache/src/impl/ManagedCacheLoader.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/CacheLoader.hpp>
 

--- a/src/clicache/src/impl/ManagedCacheWriter.cpp
+++ b/src/clicache/src/impl/ManagedCacheWriter.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "ManagedCacheWriter.hpp"
 #include "../ICacheWriter.hpp"
 #include "../Region.hpp"

--- a/src/clicache/src/impl/ManagedCacheWriter.hpp
+++ b/src/clicache/src/impl/ManagedCacheWriter.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/CacheWriter.hpp>
 #include "../ICacheWriter.hpp"

--- a/src/clicache/src/impl/ManagedCacheableDelta.cpp
+++ b/src/clicache/src/impl/ManagedCacheableDelta.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "ManagedCacheableDelta.hpp"
 #include "../DataInput.hpp"
 #include "../DataOutput.hpp"
@@ -196,10 +196,10 @@ namespace apache
       {
         try {
           ICloneable^ cloneable = dynamic_cast<ICloneable^>((
-            Apache::Geode::Client::IGFDelta^) m_managedptr);
+            Apache::Geode::Client::IGeodeDelta^) m_managedptr);
           if (cloneable) {
-            Apache::Geode::Client::IGFSerializable^ Mclone =
-              dynamic_cast<Apache::Geode::Client::IGFSerializable^>(cloneable->Clone());
+            Apache::Geode::Client::IGeodeSerializable^ Mclone =
+              dynamic_cast<Apache::Geode::Client::IGeodeSerializable^>(cloneable->Clone());
             return DeltaPtr(static_cast<ManagedCacheableDeltaGeneric*>(
               SafeMSerializableConvertGeneric(Mclone)));
           }

--- a/src/clicache/src/impl/ManagedCacheableDelta.hpp
+++ b/src/clicache/src/impl/ManagedCacheableDelta.hpp
@@ -17,11 +17,11 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/Delta.hpp>
-#include "../IGFDelta.hpp"
-#include "../IGFSerializable.hpp"
+#include "../IGeodeDelta.hpp"
+#include "../IGeodeSerializable.hpp"
 
 
 using namespace System;
@@ -34,8 +34,8 @@ namespace Apache
     namespace Client
     {
 
-      interface class IGFSerializable;
-      interface class IGFDelta;
+      interface class IGeodeSerializable;
+      interface class IGeodeDelta;
     }  // namespace Client
   }  // namespace Geode
 }  // namespace Apache
@@ -49,7 +49,7 @@ namespace apache
     {
 
       /// <summary>
-      /// Wraps the managed <see cref="Apache.Geode.Client.IGFDelta" />
+      /// Wraps the managed <see cref="Apache.Geode.Client.IGeodeDelta" />
       /// object and implements the native <c>apache::geode::client::CacheableKey</c> interface.
       /// </summary>
       class ManagedCacheableDeltaGeneric
@@ -68,20 +68,20 @@ namespace apache
         /// The managed object.
         /// </param>
         inline ManagedCacheableDeltaGeneric(
-          Apache::Geode::Client::IGFDelta^ managedptr)
+          Apache::Geode::Client::IGeodeDelta^ managedptr)
           : m_managedptr(managedptr)
         {
-          m_managedSerializableptr = dynamic_cast <Apache::Geode::Client::IGFSerializable^> (managedptr);
+          m_managedSerializableptr = dynamic_cast <Apache::Geode::Client::IGeodeSerializable^> (managedptr);
           m_classId = m_managedSerializableptr->ClassId;
           m_objectSize = 0;
         }
 
         inline ManagedCacheableDeltaGeneric(
-          Apache::Geode::Client::IGFDelta^ managedptr, int hashcode, int classId)
+          Apache::Geode::Client::IGeodeDelta^ managedptr, int hashcode, int classId)
           : m_managedptr(managedptr) {
           m_hashcode = hashcode;
           m_classId = classId;
-          m_managedSerializableptr = dynamic_cast <Apache::Geode::Client::IGFSerializable^> (managedptr);
+          m_managedSerializableptr = dynamic_cast <Apache::Geode::Client::IGeodeSerializable^> (managedptr);
           m_objectSize = 0;
         }
 
@@ -160,7 +160,7 @@ namespace apache
         /// <summary>
         /// Returns the wrapped managed object reference.
         /// </summary>
-        inline Apache::Geode::Client::IGFDelta^ ptr() const
+        inline Apache::Geode::Client::IGeodeDelta^ ptr() const
         {
           return m_managedptr;
         }
@@ -170,12 +170,12 @@ namespace apache
 
         /// <summary>
         /// Using gcroot to hold the managed delegate pointer (since it cannot be stored directly).
-        /// Note: not using auto_gcroot since it will result in 'Dispose' of the IGFDelta
+        /// Note: not using auto_gcroot since it will result in 'Dispose' of the IGeodeDelta
         /// to be called which is not what is desired when this object is destroyed. Normally this
         /// managed object may be created by the user and will be handled automatically by the GC.
         /// </summary>
-        gcroot<Apache::Geode::Client::IGFDelta^> m_managedptr;
-        gcroot<Apache::Geode::Client::IGFSerializable^> m_managedSerializableptr;
+        gcroot<Apache::Geode::Client::IGeodeDelta^> m_managedptr;
+        gcroot<Apache::Geode::Client::IGeodeSerializable^> m_managedSerializableptr;
         // Disable the copy and assignment constructors
         ManagedCacheableDeltaGeneric(const ManagedCacheableDeltaGeneric&);
         ManagedCacheableDeltaGeneric& operator = (const ManagedCacheableDeltaGeneric&);

--- a/src/clicache/src/impl/ManagedCacheableDeltaBytes.cpp
+++ b/src/clicache/src/impl/ManagedCacheableDeltaBytes.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "ManagedCacheableDeltaBytes.hpp"
 #include "../DataInput.hpp"
 #include "../DataOutput.hpp"
@@ -55,7 +55,7 @@ namespace apache
           Apache::Geode::Client::DataInput mg_input(&input, true);
           const uint8_t* objStartPos = input.currentBufferPosition();
 
-          Apache::Geode::Client::IGFSerializable^ obj =
+          Apache::Geode::Client::IGeodeSerializable^ obj =
             Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId)();
           obj->FromData(%mg_input);
           input.advanceCursor(mg_input.BytesReadInternally);
@@ -150,7 +150,7 @@ namespace apache
 
       bool ManagedCacheableDeltaBytesGeneric::hasDelta()
       {
-        //Apache::Geode::Client::IGFDelta^ deltaObj = this->getManagedObject();
+        //Apache::Geode::Client::IGeodeDelta^ deltaObj = this->getManagedObject();
         //return deltaObj->HasDelta();
         return m_hasDelta;
       }
@@ -159,7 +159,7 @@ namespace apache
       {
         try {
           Apache::Geode::Client::Log::Debug("ManagedCacheableDeltaBytes::toDelta: current domain ID: " + System::Threading::Thread::GetDomainID() + " for object: " + System::Convert::ToString((int)this) + " with its domain ID: " + m_domainId);
-          Apache::Geode::Client::IGFDelta^ deltaObj = this->getManagedObject();
+          Apache::Geode::Client::IGeodeDelta^ deltaObj = this->getManagedObject();
           Apache::Geode::Client::DataOutput mg_output(&output, true);
           deltaObj->ToDelta(%mg_output);
           mg_output.WriteBytesToUMDataOutput();
@@ -176,12 +176,12 @@ namespace apache
       {
         try {
           Apache::Geode::Client::Log::Debug("ManagedCacheableDeltaBytes::fromDelta:");
-          Apache::Geode::Client::IGFDelta^ deltaObj = this->getManagedObject();
+          Apache::Geode::Client::IGeodeDelta^ deltaObj = this->getManagedObject();
           Apache::Geode::Client::DataInput mg_input(&input, true);
           deltaObj->FromDelta(%mg_input);
 
-          Apache::Geode::Client::IGFSerializable^ managedptr =
-            dynamic_cast <Apache::Geode::Client::IGFSerializable^> (deltaObj);
+          Apache::Geode::Client::IGeodeSerializable^ managedptr =
+            dynamic_cast <Apache::Geode::Client::IGeodeSerializable^> (deltaObj);
           if (managedptr != nullptr)
           {
             Apache::Geode::Client::Log::Debug("ManagedCacheableDeltaBytes::fromDelta: current domain ID: " + System::Threading::Thread::GetDomainID() + " for object: " + System::Convert::ToString((int)this) + " with its domain ID: " + m_domainId);
@@ -212,11 +212,11 @@ namespace apache
       DeltaPtr ManagedCacheableDeltaBytesGeneric::clone()
       {
         try {
-          Apache::Geode::Client::IGFDelta^ deltaObj = this->getManagedObject();
-          ICloneable^ cloneable = dynamic_cast<ICloneable^>((Apache::Geode::Client::IGFDelta^) deltaObj);
+          Apache::Geode::Client::IGeodeDelta^ deltaObj = this->getManagedObject();
+          ICloneable^ cloneable = dynamic_cast<ICloneable^>((Apache::Geode::Client::IGeodeDelta^) deltaObj);
           if (cloneable) {
-            Apache::Geode::Client::IGFSerializable^ Mclone =
-              dynamic_cast<Apache::Geode::Client::IGFSerializable^>(cloneable->Clone());
+            Apache::Geode::Client::IGeodeSerializable^ Mclone =
+              dynamic_cast<Apache::Geode::Client::IGeodeSerializable^>(cloneable->Clone());
             return DeltaPtr(static_cast<ManagedCacheableDeltaBytesGeneric*>(
               SafeMSerializableConvertGeneric(Mclone)));
           }
@@ -233,7 +233,7 @@ namespace apache
         return NULLPTR;
       }
 
-      Apache::Geode::Client::IGFDelta^
+      Apache::Geode::Client::IGeodeDelta^
         ManagedCacheableDeltaBytesGeneric::getManagedObject() const
       {
 
@@ -243,10 +243,10 @@ namespace apache
         Apache::Geode::Client::DataInput mg_dinp(&dinp, true);
         Apache::Geode::Client::TypeFactoryMethodGeneric^ creationMethod =
           Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId);
-        Apache::Geode::Client::IGFSerializable^ newObj = creationMethod();
+        Apache::Geode::Client::IGeodeSerializable^ newObj = creationMethod();
 
-        Apache::Geode::Client::IGFDelta^ managedDeltaptr =
-          dynamic_cast <Apache::Geode::Client::IGFDelta^> (newObj->FromData(%mg_dinp));
+        Apache::Geode::Client::IGeodeDelta^ managedDeltaptr =
+          dynamic_cast <Apache::Geode::Client::IGeodeDelta^> (newObj->FromData(%mg_dinp));
         return managedDeltaptr;
       }
 
@@ -261,7 +261,7 @@ namespace apache
           if (p_other != NULL) {
             apache::geode::client::DataInput di(m_bytes, m_size);
             Apache::Geode::Client::DataInput mg_input(&di, true);
-            Apache::Geode::Client::IGFSerializable^ obj =
+            Apache::Geode::Client::IGeodeSerializable^ obj =
               Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId)();
             obj->FromData(%mg_input);
             bool ret = obj->Equals(p_other->ptr());
@@ -285,7 +285,7 @@ namespace apache
           Apache::Geode::Client::Log::Debug("ManagedCacheableDeltaBytesGeneric::equal. ");
           apache::geode::client::DataInput di(m_bytes, m_size);
           Apache::Geode::Client::DataInput mg_input(&di, true);
-          Apache::Geode::Client::IGFSerializable^ obj =
+          Apache::Geode::Client::IGeodeSerializable^ obj =
             Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId)();
           obj->FromData(%mg_input);
           bool ret = obj->Equals(other.ptr());
@@ -311,7 +311,7 @@ namespace apache
       size_t ManagedCacheableDeltaBytesGeneric::logString(char* buffer, size_t maxLength) const
       {
         try {
-          Apache::Geode::Client::IGFDelta^ manageObject = getManagedObject();
+          Apache::Geode::Client::IGeodeDelta^ manageObject = getManagedObject();
           if (manageObject != nullptr)
           {
             if (maxLength > 0) {

--- a/src/clicache/src/impl/ManagedCacheableDeltaBytes.hpp
+++ b/src/clicache/src/impl/ManagedCacheableDeltaBytes.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/Delta.hpp>
 #include "../Log.hpp"
@@ -32,8 +32,8 @@ namespace Apache
     namespace Client
     {
 
-      interface class IGFSerializable;
-      interface class IGFDelta;
+      interface class IGeodeSerializable;
+      interface class IGeodeDelta;
     }  // namespace Client
   }  // namespace Geode
 }  // namespace Apache
@@ -48,7 +48,7 @@ namespace apache
 
 
       /// <summary>
-      /// Wraps the managed <see cref="Apache.Geode.Client.IGFDelta" />
+      /// Wraps the managed <see cref="Apache.Geode.Client.IGeodeDelta" />
       /// object and implements the native <c>apache::geode::client::CacheableKey</c> interface.
       /// </summary>
       class ManagedCacheableDeltaBytesGeneric
@@ -63,7 +63,7 @@ namespace apache
         /// The managed object.
         /// </param>
         inline ManagedCacheableDeltaBytesGeneric(
-          Apache::Geode::Client::IGFDelta^ managedDeltaptr, bool storeBytes)
+          Apache::Geode::Client::IGeodeDelta^ managedDeltaptr, bool storeBytes)
           : m_domainId(System::Threading::Thread::GetDomainID()),
           m_classId(0),
           m_bytes(NULL),
@@ -73,8 +73,8 @@ namespace apache
         {
           if (storeBytes)
             m_hasDelta = managedDeltaptr->HasDelta();
-          Apache::Geode::Client::IGFSerializable^ managedptr =
-            dynamic_cast <Apache::Geode::Client::IGFSerializable^> (managedDeltaptr);
+          Apache::Geode::Client::IGeodeSerializable^ managedptr =
+            dynamic_cast <Apache::Geode::Client::IGeodeSerializable^> (managedDeltaptr);
           if (managedptr != nullptr)
           {
             m_classId = managedptr->ClassId;
@@ -99,7 +99,7 @@ namespace apache
         }
         /*
             inline ManagedCacheableDeltaBytes(
-            Apache::Geode::Client::IGFDelta^ managedDeltaptr,  bool storeBytes)
+            Apache::Geode::Client::IGeodeDelta^ managedDeltaptr,  bool storeBytes)
             : m_domainId(System::Threading::Thread::GetDomainID()),
             m_classId(0),
             m_bytes(NULL),
@@ -107,7 +107,7 @@ namespace apache
             m_hashCode(0)
             {
             Apache::Geode::Client::Log::Fine("ManagedCacheableDeltaBytes::Constructor: not storing bytes ");
-            Apache::Geode::Client::IGFSerializable^ managedptr = dynamic_cast <Apache::Geode::Client::IGFSerializable^> ( managedDeltaptr );
+            Apache::Geode::Client::IGeodeSerializable^ managedptr = dynamic_cast <Apache::Geode::Client::IGeodeSerializable^> ( managedDeltaptr );
             if(managedptr != nullptr)
             {
             m_classId = managedptr->ClassId;
@@ -199,7 +199,7 @@ namespace apache
         /// <summary>
         /// Returns the wrapped managed object reference.
         /// </summary>
-        inline Apache::Geode::Client::IGFDelta^ ptr() const
+        inline Apache::Geode::Client::IGeodeDelta^ ptr() const
         {
           return getManagedObject();
         }
@@ -211,15 +211,15 @@ namespace apache
         }
 
       private:
-        Apache::Geode::Client::IGFDelta^ getManagedObject() const;
+        Apache::Geode::Client::IGeodeDelta^ getManagedObject() const;
         /// <summary>
         /// Using gcroot to hold the managed delegate pointer (since it cannot be stored directly).
-        /// Note: not using auto_gcroot since it will result in 'Dispose' of the IGFDelta
+        /// Note: not using auto_gcroot since it will result in 'Dispose' of the IGeodeDelta
         /// to be called which is not what is desired when this object is destroyed. Normally this
         /// managed object may be created by the user and will be handled automatically by the GC.
         /// </summary>
-        //gcroot<Apache::Geode::Client::IGFDelta^> m_managedptr;
-        //gcroot<Apache::Geode::Client::IGFSerializable^> m_managedSerializableptr;
+        //gcroot<Apache::Geode::Client::IGeodeDelta^> m_managedptr;
+        //gcroot<Apache::Geode::Client::IGeodeSerializable^> m_managedSerializableptr;
 
         int m_domainId;
         UInt32 m_classId;

--- a/src/clicache/src/impl/ManagedCacheableKey.cpp
+++ b/src/clicache/src/impl/ManagedCacheableKey.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "../ICacheableKey.hpp"
 #include "ManagedCacheableKey.hpp"
 #include "../DataInput.hpp"
@@ -172,7 +172,7 @@ namespace apache
             dynamic_cast<const ManagedCacheableKeyGeneric*>(&other);
           if (p_other != NULL) {
             return static_cast<Apache::Geode::Client::ICacheableKey^>(
-              (static_cast<Apache::Geode::Client::IGFSerializable^>((Apache::Geode::Client::IGFSerializable^)m_managedptr)))->Equals(
+              (static_cast<Apache::Geode::Client::IGeodeSerializable^>((Apache::Geode::Client::IGeodeSerializable^)m_managedptr)))->Equals(
               static_cast<Apache::Geode::Client::ICacheableKey^>(p_other->ptr()));
           }
           return false;
@@ -190,7 +190,7 @@ namespace apache
       {
         try {
           return static_cast<Apache::Geode::Client::ICacheableKey^>(
-            (Apache::Geode::Client::IGFSerializable^)(Apache::Geode::Client::IGFSerializable^)m_managedptr)->Equals(
+            (Apache::Geode::Client::IGeodeSerializable^)(Apache::Geode::Client::IGeodeSerializable^)m_managedptr)->Equals(
             static_cast<Apache::Geode::Client::ICacheableKey^>(other.ptr()));
         }
         catch (Apache::Geode::Client::GeodeException^ ex) {
@@ -210,7 +210,7 @@ namespace apache
 
           ManagedCacheableKeyGeneric* tmp = const_cast<ManagedCacheableKeyGeneric*>(this);
           tmp->m_hashcode = ((Apache::Geode::Client::ICacheableKey^)
-                             (Apache::Geode::Client::IGFSerializable^)m_managedptr)
+                             (Apache::Geode::Client::IGeodeSerializable^)m_managedptr)
                              ->GetHashCode();
           return m_hashcode;
         }

--- a/src/clicache/src/impl/ManagedCacheableKey.hpp
+++ b/src/clicache/src/impl/ManagedCacheableKey.hpp
@@ -17,11 +17,11 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/CacheableKey.hpp>
 #include <GeodeTypeIdsImpl.hpp>
-#include "../IGFSerializable.hpp"
+#include "../IGeodeSerializable.hpp"
 
 using namespace System;
 
@@ -33,7 +33,7 @@ namespace apache
     {
 
       /// <summary>
-      /// Wraps the managed <see cref="Apache.Geode.Client.IGFSerializable" />
+      /// Wraps the managed <see cref="Apache.Geode.Client.IGeodeSerializable" />
       /// object and implements the native <c>apache::geode::client::CacheableKey</c> interface.
       /// </summary>
       class ManagedCacheableKeyGeneric
@@ -46,7 +46,7 @@ namespace apache
       public:
 
         inline ManagedCacheableKeyGeneric(
-          Apache::Geode::Client::IGFSerializable^ managedptr, int hashcode, int classId)
+          Apache::Geode::Client::IGeodeSerializable^ managedptr, int hashcode, int classId)
           : m_managedptr(managedptr) {
           m_hashcode = hashcode;
           m_classId = classId;
@@ -58,7 +58,7 @@ namespace apache
         /// <param name="managedptr">
         /// The managed object.
         /// </param>
-        inline ManagedCacheableKeyGeneric(Apache::Geode::Client::IGFSerializable^ managedptr)
+        inline ManagedCacheableKeyGeneric(Apache::Geode::Client::IGeodeSerializable^ managedptr)
           : m_managedptr(managedptr) {
           // m_hashcode = managedptr->GetHashCode();
           m_hashcode = 0;
@@ -139,7 +139,7 @@ namespace apache
         /// <summary>
         /// Returns the wrapped managed object reference.
         /// </summary>
-        inline Apache::Geode::Client::IGFSerializable^ ptr() const
+        inline Apache::Geode::Client::IGeodeSerializable^ ptr() const
         {
           return m_managedptr;
         }
@@ -149,11 +149,11 @@ namespace apache
 
         /// <summary>
         /// Using gcroot to hold the managed delegate pointer (since it cannot be stored directly).
-        /// Note: not using auto_gcroot since it will result in 'Dispose' of the IGFSerializable
+        /// Note: not using auto_gcroot since it will result in 'Dispose' of the IGeodeSerializable
         /// to be called which is not what is desired when this object is destroyed. Normally this
         /// managed object may be created by the user and will be handled automatically by the GC.
         /// </summary>
-        gcroot<Apache::Geode::Client::IGFSerializable^> m_managedptr;
+        gcroot<Apache::Geode::Client::IGeodeSerializable^> m_managedptr;
 
         // Disable the copy and assignment constructors
         ManagedCacheableKeyGeneric(const ManagedCacheableKeyGeneric&);

--- a/src/clicache/src/impl/ManagedCacheableKeyBytes.cpp
+++ b/src/clicache/src/impl/ManagedCacheableKeyBytes.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "ManagedCacheableKeyBytes.hpp"
 #include "../DataInput.hpp"
 #include "../DataOutput.hpp"
@@ -57,7 +57,7 @@ namespace apache
           Apache::Geode::Client::DataInput mg_input(&input, true);
           const uint8_t* objStartPos = input.currentBufferPosition();
 
-          Apache::Geode::Client::IGFSerializable^ obj = Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId)();
+          Apache::Geode::Client::IGeodeSerializable^ obj = Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId)();
           obj->FromData(%mg_input);
 
           input.advanceCursor(mg_input.BytesReadInternally);
@@ -158,7 +158,7 @@ namespace apache
       apache::geode::client::CacheableStringPtr ManagedCacheableKeyBytesGeneric::toString() const
       {
         try {
-          Apache::Geode::Client::IGFSerializable^ manageObject = getManagedObject();
+          Apache::Geode::Client::IGeodeSerializable^ manageObject = getManagedObject();
           if (manageObject != nullptr)
           {
             apache::geode::client::CacheableStringPtr cStr;
@@ -187,7 +187,7 @@ namespace apache
           if (p_other != NULL) {
             apache::geode::client::DataInput di(m_bytes, m_size);
             Apache::Geode::Client::DataInput mg_input(&di, true);
-            Apache::Geode::Client::IGFSerializable^ obj =
+            Apache::Geode::Client::IGeodeSerializable^ obj =
               Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId)();
             obj->FromData(%mg_input);
             bool ret = obj->Equals(p_other->ptr());
@@ -211,7 +211,7 @@ namespace apache
           Apache::Geode::Client::Log::Debug("ManagedCacheableKeyBytesGeneric::equal. ");
           apache::geode::client::DataInput di(m_bytes, m_size);
           Apache::Geode::Client::DataInput mg_input(&di, true);
-          Apache::Geode::Client::IGFSerializable^ obj =
+          Apache::Geode::Client::IGeodeSerializable^ obj =
             Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId)();
           obj->FromData(%mg_input);
           bool ret = obj->Equals(other.ptr());
@@ -237,7 +237,7 @@ namespace apache
       size_t ManagedCacheableKeyBytesGeneric::logString(char* buffer, size_t maxLength) const
       {
         try {
-          Apache::Geode::Client::IGFSerializable^ manageObject = getManagedObject();
+          Apache::Geode::Client::IGeodeSerializable^ manageObject = getManagedObject();
           if (manageObject != nullptr)
           {
             if (maxLength > 0) {
@@ -257,7 +257,7 @@ namespace apache
         return 0;
       }
 
-      Apache::Geode::Client::IGFSerializable^
+      Apache::Geode::Client::IGeodeSerializable^
         ManagedCacheableKeyBytesGeneric::getManagedObject() const
       {
 
@@ -276,7 +276,7 @@ namespace apache
         Apache::Geode::Client::DataInput mg_dinp(&dinp, true);
         Apache::Geode::Client::TypeFactoryMethodGeneric^ creationMethod =
           Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId);
-        Apache::Geode::Client::IGFSerializable^ newObj = creationMethod();
+        Apache::Geode::Client::IGeodeSerializable^ newObj = creationMethod();
         return newObj->FromData(%mg_dinp);
       }
     }  // namespace client

--- a/src/clicache/src/impl/ManagedCacheableKeyBytes.hpp
+++ b/src/clicache/src/impl/ManagedCacheableKeyBytes.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/CacheableKey.hpp>
 #include "../Log.hpp"
@@ -33,7 +33,7 @@ namespace Apache
     namespace Client
     {
 
-      interface class IGFSerializable;
+      interface class IGeodeSerializable;
     }  // namespace Client
   }  // namespace Geode
 }  // namespace Apache
@@ -47,7 +47,7 @@ namespace apache
     {
 
       /// <summary>
-      /// Wraps the managed <see cref="Apache.Geode.Client.IGFSerializable" />
+      /// Wraps the managed <see cref="Apache.Geode.Client.IGeodeSerializable" />
       /// object and implements the native <c>apache::geode::client::CacheableKey</c> interface.
       /// </summary>
       class ManagedCacheableKeyBytesGeneric
@@ -62,7 +62,7 @@ namespace apache
         /// The managed object.
         /// </param>
         inline ManagedCacheableKeyBytesGeneric(
-          Apache::Geode::Client::IGFSerializable^ managedptr, bool storeBytes)
+          Apache::Geode::Client::IGeodeSerializable^ managedptr, bool storeBytes)
           : m_domainId(System::Threading::Thread::GetDomainID()),
           m_classId(managedptr->ClassId),
           m_bytes(NULL),
@@ -164,7 +164,7 @@ namespace apache
         /// <summary>
         /// Returns the wrapped managed object reference.
         /// </summary>
-        inline Apache::Geode::Client::IGFSerializable^ ptr() const
+        inline Apache::Geode::Client::IGeodeSerializable^ ptr() const
         {
           return getManagedObject();
         }
@@ -180,15 +180,15 @@ namespace apache
 
       private:
 
-        Apache::Geode::Client::IGFSerializable^ getManagedObject() const;
+        Apache::Geode::Client::IGeodeSerializable^ getManagedObject() const;
 
         /// <summary>
         /// Using gcroot to hold the managed delegate pointer (since it cannot be stored directly).
-        /// Note: not using auto_gcroot since it will result in 'Dispose' of the IGFSerializable
+        /// Note: not using auto_gcroot since it will result in 'Dispose' of the IGeodeSerializable
         /// to be called which is not what is desired when this object is destroyed. Normally this
         /// managed object may be created by the user and will be handled automatically by the GC.
         /// </summary>
-        //    gcroot<IGFSerializable^> m_managedptr;
+        //    gcroot<IGeodeSerializable^> m_managedptr;
         int m_domainId;
         UInt32 m_classId;
         uint8_t * m_bytes;

--- a/src/clicache/src/impl/ManagedCqListener.cpp
+++ b/src/clicache/src/impl/ManagedCqListener.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "ManagedCqListener.hpp"
 #include "../ICqListener.hpp"
 #include "../CqEvent.hpp"

--- a/src/clicache/src/impl/ManagedCqListener.hpp
+++ b/src/clicache/src/impl/ManagedCqListener.hpp
@@ -16,7 +16,7 @@
  */
 
 #pragma once
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/CqListener.hpp>
 //#include "../ICqListener.hpp"

--- a/src/clicache/src/impl/ManagedCqStatusListener.hpp
+++ b/src/clicache/src/impl/ManagedCqStatusListener.hpp
@@ -17,7 +17,7 @@
 
 
 #pragma once
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/CqStatusListener.hpp>
 #include "../ICqStatusListener.hpp"

--- a/src/clicache/src/impl/ManagedFixedPartitionResolver.hpp
+++ b/src/clicache/src/impl/ManagedFixedPartitionResolver.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/FixedPartitionResolver.hpp>
 

--- a/src/clicache/src/impl/ManagedPartitionResolver.cpp
+++ b/src/clicache/src/impl/ManagedPartitionResolver.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "ManagedPartitionResolver.hpp"
 #include "../IPartitionResolver.hpp"
 #include "../Region.hpp"

--- a/src/clicache/src/impl/ManagedPartitionResolver.hpp
+++ b/src/clicache/src/impl/ManagedPartitionResolver.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/PartitionResolver.hpp>
 

--- a/src/clicache/src/impl/ManagedPersistenceManager.hpp
+++ b/src/clicache/src/impl/ManagedPersistenceManager.hpp
@@ -17,7 +17,7 @@
 
 
 #pragma once
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/PersistenceManager.hpp>
 #include "PersistenceManagerProxy.hpp"

--- a/src/clicache/src/impl/ManagedResultCollector.cpp
+++ b/src/clicache/src/impl/ManagedResultCollector.cpp
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-//#include "../../gf_includes.hpp"
-//#include "../../../gf_includes.hpp"
+//#include "../../geode_includes.hpp"
+//#include "../../../geode_includes.hpp"
 #include "ManagedResultCollector.hpp"
-//#include "../../../IGFSerializable.hpp"
+//#include "../../../IGeodeSerializable.hpp"
 
 
-//#include "../IGFSerializable.hpp"
+//#include "../IGeodeSerializable.hpp"
 #include "ManagedString.hpp"
 #include "SafeConvert.hpp"
 #include "../ExceptionTypes.hpp"
@@ -149,7 +149,7 @@ namespace apache
       void ManagedResultCollectorGeneric::addResult(CacheablePtr& result)
       {
         try {
-          //Apache::Geode::Client::IGFSerializable^ res = SafeUMSerializableConvertGeneric(result.ptr());
+          //Apache::Geode::Client::IGeodeSerializable^ res = SafeUMSerializableConvertGeneric(result.ptr());
           Object^ rs = Apache::Geode::Client::Serializable::GetManagedValueGeneric<Object^>(result);
           m_managedptr->AddResult(rs);
           //m_managedptr->AddResult( SafeUMSerializableConvert( result.ptr( ) ) );
@@ -169,11 +169,11 @@ namespace apache
       CacheableVectorPtr ManagedResultCollectorGeneric::getResult(uint32_t timeout)
       {
         try {
-          //array<IGFSerializable^>^ rs = m_managedptr->GetResult(timeout);
+          //array<IGeodeSerializable^>^ rs = m_managedptr->GetResult(timeout);
           //apache::geode::client::CacheableVectorPtr rsptr = apache::geode::client::CacheableVector::create();
           //for( int index = 0; index < rs->Length; index++ )
           //{
-          //  //apache::geode::client::CacheablePtr valueptr(Apache::Geode::Client::Serializable::GetUnmanagedValueGeneric<IGFSerializable^>(rs[ index]));
+          //  //apache::geode::client::CacheablePtr valueptr(Apache::Geode::Client::Serializable::GetUnmanagedValueGeneric<IGeodeSerializable^>(rs[ index]));
           //  apache::geode::client::CacheablePtr valueptr (SafeMSerializableConvert(rs[ index]));
           //  rsptr->push_back(valueptr);
           //}

--- a/src/clicache/src/impl/ManagedResultCollector.hpp
+++ b/src/clicache/src/impl/ManagedResultCollector.hpp
@@ -16,7 +16,7 @@
  */
 
 #pragma once
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/ResultCollector.hpp>
 //#include "../ResultCollector.hpp"

--- a/src/clicache/src/impl/ManagedString.hpp
+++ b/src/clicache/src/impl/ManagedString.hpp
@@ -19,7 +19,7 @@
 
 
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 
 #ifdef _WIN32
 #define snprintf _snprintf

--- a/src/clicache/src/impl/ManagedTransactionListener.cpp
+++ b/src/clicache/src/impl/ManagedTransactionListener.cpp
@@ -16,7 +16,7 @@
  */
 
 #ifdef CSTX_COMMENTED
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "ManagedTransactionListener.hpp"
 //#include "../TransactionEvent.hpp"
 #include "../Log.hpp"

--- a/src/clicache/src/impl/ManagedTransactionListener.hpp
+++ b/src/clicache/src/impl/ManagedTransactionListener.hpp
@@ -17,7 +17,7 @@
 #ifdef CSTX_COMMENTED
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <cppcache/TransactionListener.hpp>
 #include "../ITransactionListener.hpp"

--- a/src/clicache/src/impl/ManagedTransactionWriter.cpp
+++ b/src/clicache/src/impl/ManagedTransactionWriter.cpp
@@ -16,7 +16,7 @@
  */
 
 #ifdef CSTX_COMMENTED
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "ManagedTransactionWriter.hpp"
 //#include "../TransactionEvent.hpp"
 #include "../Log.hpp"

--- a/src/clicache/src/impl/ManagedTransactionWriter.hpp
+++ b/src/clicache/src/impl/ManagedTransactionWriter.hpp
@@ -17,7 +17,7 @@
 #ifdef CSTX_COMMENTED
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <cppcache/TransactionWriter.hpp>
 #include "../ITransactionWriter.hpp"

--- a/src/clicache/src/impl/ManagedVisitor.cpp
+++ b/src/clicache/src/impl/ManagedVisitor.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "../../../../gf_includes.hpp"
+//#include "../../../../geode_includes.hpp"
 #include "ManagedVisitor.hpp"
 #include "SafeConvert.hpp"
 #include "../ExceptionTypes.hpp"
@@ -35,9 +35,9 @@ namespace apache
         using namespace Apache::Geode::Client;
         try {
           ICacheableKey^ mg_key(SafeGenericUMKeyConvert<ICacheableKey^>(key.ptr()));
-          IGFSerializable^ mg_value(SafeUMSerializableConvertGeneric(value.ptr()));
+          IGeodeSerializable^ mg_value(SafeUMSerializableConvertGeneric(value.ptr()));
 
-          m_visitor->Invoke(mg_key, (Apache::Geode::Client::IGFSerializable^)mg_value);
+          m_visitor->Invoke(mg_key, (Apache::Geode::Client::IGeodeSerializable^)mg_value);
         }
         catch (GeodeException^ ex) {
           ex->ThrowNative();

--- a/src/clicache/src/impl/ManagedVisitor.hpp
+++ b/src/clicache/src/impl/ManagedVisitor.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/Properties.hpp>
 #include "../Properties.hpp"

--- a/src/clicache/src/impl/MemoryPressureHandler.cpp
+++ b/src/clicache/src/impl/MemoryPressureHandler.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "../gf_includes.hpp"
+#include "../geode_includes.hpp"
 #include "MemoryPressureHandler.hpp"
 #include "windows.h"
 #include "psapi.h"

--- a/src/clicache/src/impl/NativeWrapper.hpp
+++ b/src/clicache/src/impl/NativeWrapper.hpp
@@ -19,7 +19,7 @@
 
 
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 
 using namespace System;
 

--- a/src/clicache/src/impl/PartitionResolver.hpp
+++ b/src/clicache/src/impl/PartitionResolver.hpp
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 //#include "../../../IPartitionResolver.hpp"
 #include "../IPartitionResolver.hpp"
 #include "../Region.hpp"

--- a/src/clicache/src/impl/PdxFieldType.cpp
+++ b/src/clicache/src/impl/PdxFieldType.cpp
@@ -136,7 +136,7 @@ namespace Apache
           output->WriteBoolean(m_isIdentityField);
         }
 
-        IGFSerializable^ PdxFieldType::FromData(DataInput^ input)
+        IGeodeSerializable^ PdxFieldType::FromData(DataInput^ input)
         {
           m_fieldName = input->ReadString();
           m_sequenceId = input->ReadInt32();

--- a/src/clicache/src/impl/PdxFieldType.hpp
+++ b/src/clicache/src/impl/PdxFieldType.hpp
@@ -31,7 +31,7 @@ namespace Apache
 
       namespace Internal
       {
-        public ref class PdxFieldType : IGFSerializable
+        public ref class PdxFieldType : IGeodeSerializable
         {
         private:
           String^ m_fieldName;
@@ -129,7 +129,7 @@ namespace Apache
           virtual Int32 GetHashCode() override;
 
           virtual void ToData(DataOutput^ output);
-          virtual IGFSerializable^ FromData(DataInput^ input);
+          virtual IGeodeSerializable^ FromData(DataInput^ input);
           virtual property uint32_t ObjectSize
           {
             uint32_t get(){ return 0; }

--- a/src/clicache/src/impl/PdxLocalReader.hpp
+++ b/src/clicache/src/impl/PdxLocalReader.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include "../IPdxReader.hpp"
 #include "PdxType.hpp"
 //#include "../DataInput.hpp"

--- a/src/clicache/src/impl/PdxLocalWriter.hpp
+++ b/src/clicache/src/impl/PdxLocalWriter.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include "../IPdxWriter.hpp"
 #include "PdxType.hpp"
 #include "../GeodeClassIds.hpp"

--- a/src/clicache/src/impl/PdxManagedCacheableKey.cpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKey.cpp
@@ -62,7 +62,7 @@ namespace apache
           //m_managedptr = m_managedptr->FromData( %mg_input );
           Apache::Geode::Client::IPdxSerializable^ tmp = Apache::Geode::Client::Internal::PdxHelper::DeserializePdx(%mg_input, false);
           m_managedptr = tmp;
-          m_managedDeltaptr = dynamic_cast<Apache::Geode::Client::IGFDelta^>(tmp);
+          m_managedDeltaptr = dynamic_cast<Apache::Geode::Client::IGeodeDelta^>(tmp);
 
           //this will move the cursor in c++ layer
           input.advanceCursor(mg_input.BytesReadInternally);
@@ -278,7 +278,7 @@ namespace apache
       {
         try {
           ICloneable^ cloneable = dynamic_cast<ICloneable^>((
-            Apache::Geode::Client::IGFDelta^) m_managedDeltaptr);
+            Apache::Geode::Client::IGeodeDelta^) m_managedDeltaptr);
           if (cloneable) {
             Apache::Geode::Client::IPdxSerializable^ Mclone =
               dynamic_cast<Apache::Geode::Client::IPdxSerializable^>(cloneable->Clone());

--- a/src/clicache/src/impl/PdxManagedCacheableKey.hpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKey.hpp
@@ -17,13 +17,13 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/CacheableKey.hpp>
 #include <GeodeTypeIdsImpl.hpp>
 #include "../IPdxSerializable.hpp"
 #include <geode/Delta.hpp>
-#include "../IGFDelta.hpp"
+#include "../IGeodeDelta.hpp"
 using namespace System;
 using namespace apache::geode::client;
 namespace Apache
@@ -67,7 +67,7 @@ namespace apache
           Apache::Geode::Client::IPdxSerializable^ managedptr, int hashcode)
           : m_managedptr(managedptr), m_objectSize(0) {
           m_hashcode = hashcode;
-          m_managedDeltaptr = dynamic_cast<Apache::Geode::Client::IGFDelta^>(managedptr);
+          m_managedDeltaptr = dynamic_cast<Apache::Geode::Client::IGeodeDelta^>(managedptr);
         }
         /// <summary>
         /// Constructor to initialize with the provided managed object.
@@ -79,7 +79,7 @@ namespace apache
           Apache::Geode::Client::IPdxSerializable^ managedptr)
           : m_managedptr(managedptr), m_objectSize(0) {
           m_hashcode = 0;//it can be zero while initializing the object
-          m_managedDeltaptr = dynamic_cast<Apache::Geode::Client::IGFDelta^>(managedptr);
+          m_managedDeltaptr = dynamic_cast<Apache::Geode::Client::IGeodeDelta^>(managedptr);
         }
 
         /// <summary>
@@ -176,12 +176,12 @@ namespace apache
 
         /// <summary>
         /// Using gcroot to hold the managed delegate pointer (since it cannot be stored directly).
-        /// Note: not using auto_gcroot since it will result in 'Dispose' of the IGFSerializable
+        /// Note: not using auto_gcroot since it will result in 'Dispose' of the IGeodeSerializable
         /// to be called which is not what is desired when this object is destroyed. Normally this
         /// managed object may be created by the user and will be handled automatically by the GC.
         /// </summary>
         gcroot<Apache::Geode::Client::IPdxSerializable^> m_managedptr;
-        gcroot<Apache::Geode::Client::IGFDelta^> m_managedDeltaptr;
+        gcroot<Apache::Geode::Client::IGeodeDelta^> m_managedDeltaptr;
 
         // Disable the copy and assignment constructors
         PdxManagedCacheableKey(const PdxManagedCacheableKey&);

--- a/src/clicache/src/impl/PdxManagedCacheableKeyBytes.cpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKeyBytes.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "PdxManagedCacheableKeyBytes.hpp"
 #include "../DataInput.hpp"
 #include "../DataOutput.hpp"
@@ -59,7 +59,7 @@ namespace apache
 
           Apache::Geode::Client::IPdxSerializable^ obj = Apache::Geode::Client::Internal::PdxHelper::DeserializePdx(%mg_input, false);
 
-          //Apache::Geode::Client::IGFSerializable^ obj = Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId)();
+          //Apache::Geode::Client::IGeodeSerializable^ obj = Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId)();
           //obj->FromData(%mg_input);
 
           input.advanceCursor(mg_input.BytesReadInternally);
@@ -190,7 +190,7 @@ namespace apache
           if (p_other != NULL) {
             apache::geode::client::DataInput di(m_bytes, m_size);
             Apache::Geode::Client::DataInput mg_input(&di, true);
-            /* Apache::Geode::Client::IGFSerializable^ obj =
+            /* Apache::Geode::Client::IGeodeSerializable^ obj =
                Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId)();
                obj->FromData(%mg_input);*/
             Apache::Geode::Client::IPdxSerializable^ obj = getManagedObject();
@@ -215,7 +215,7 @@ namespace apache
           //Apache::Geode::Client::Log::Debug("PdxManagedCacheableKeyBytes::equal. ");
           apache::geode::client::DataInput di(m_bytes, m_size);
           Apache::Geode::Client::DataInput mg_input(&di, true);
-          /*Apache::Geode::Client::IGFSerializable^ obj =
+          /*Apache::Geode::Client::IGeodeSerializable^ obj =
             Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId)();
             obj->FromData(%mg_input);*/
           Apache::Geode::Client::IPdxSerializable^ obj = getManagedObject();
@@ -272,14 +272,14 @@ namespace apache
         Apache::Geode::Client::DataInput mg_dinp(&dinp, true);
         /*TypeFactoryMethodGeneric^ creationMethod =
           Apache::Geode::Client::Serializable::GetTypeFactoryMethodGeneric(m_classId);
-          Apache::Geode::Client::IGFSerializable^ newObj = creationMethod();
+          Apache::Geode::Client::IGeodeSerializable^ newObj = creationMethod();
           return newObj->FromData(%mg_dinp);*/
         return  Apache::Geode::Client::Internal::PdxHelper::DeserializePdx(%mg_dinp, false);
       }
 
       bool PdxManagedCacheableKeyBytes::hasDelta()
       {
-        /* Apache::Geode::Client::IGFDelta^ deltaObj = dynamic_cast<Apache::Geode::Client::IGFDelta^>(this->getManagedObject());
+        /* Apache::Geode::Client::IGeodeDelta^ deltaObj = dynamic_cast<Apache::Geode::Client::IGeodeDelta^>(this->getManagedObject());
 
          if(deltaObj)
          return deltaObj->HasDelta();*/
@@ -290,7 +290,7 @@ namespace apache
       {
         try {
           Apache::Geode::Client::Log::Debug("PdxManagedCacheableKeyBytes::toDelta: current domain ID: " + System::Threading::Thread::GetDomainID() + " for object: " + System::Convert::ToString((int)this) + " with its domain ID: " + m_domainId);
-          Apache::Geode::Client::IGFDelta^ deltaObj = dynamic_cast<Apache::Geode::Client::IGFDelta^>(this->getManagedObject());
+          Apache::Geode::Client::IGeodeDelta^ deltaObj = dynamic_cast<Apache::Geode::Client::IGeodeDelta^>(this->getManagedObject());
           Apache::Geode::Client::DataOutput mg_output(&output, true);
           deltaObj->ToDelta(%mg_output);
           mg_output.WriteBytesToUMDataOutput();
@@ -307,7 +307,7 @@ namespace apache
       {
         try {
           Apache::Geode::Client::Log::Debug("PdxManagedCacheableKeyBytes::fromDelta:");
-          Apache::Geode::Client::IGFDelta^ deltaObj = dynamic_cast<Apache::Geode::Client::IGFDelta^>(this->getManagedObject());
+          Apache::Geode::Client::IGeodeDelta^ deltaObj = dynamic_cast<Apache::Geode::Client::IGeodeDelta^>(this->getManagedObject());
           Apache::Geode::Client::DataInput mg_input(&input, true);
           deltaObj->FromDelta(%mg_input);
 
@@ -346,8 +346,8 @@ namespace apache
       DeltaPtr PdxManagedCacheableKeyBytes::clone()
       {
         try {
-          Apache::Geode::Client::IGFDelta^ deltaObj = dynamic_cast<Apache::Geode::Client::IGFDelta^>(this->getManagedObject());
-          ICloneable^ cloneable = dynamic_cast<ICloneable^>((Apache::Geode::Client::IGFDelta^) deltaObj);
+          Apache::Geode::Client::IGeodeDelta^ deltaObj = dynamic_cast<Apache::Geode::Client::IGeodeDelta^>(this->getManagedObject());
+          ICloneable^ cloneable = dynamic_cast<ICloneable^>((Apache::Geode::Client::IGeodeDelta^) deltaObj);
           if (cloneable) {
             Apache::Geode::Client::IPdxSerializable^ Mclone =
               dynamic_cast<Apache::Geode::Client::IPdxSerializable^>(cloneable->Clone());

--- a/src/clicache/src/impl/PdxManagedCacheableKeyBytes.hpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKeyBytes.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include <vcclr.h>
 #include <geode/CacheableKey.hpp>
 #include "../Log.hpp"
@@ -48,7 +48,7 @@ namespace apache
     {
 
   /// <summary>
-  /// Wraps the managed <see cref="Apache.Geode.Client.IGFSerializable" />
+  /// Wraps the managed <see cref="Apache.Geode.Client.IGeodeSerializable" />
   /// object and implements the native <c>apache::geode::client::CacheableKey</c> interface.
   /// </summary>
   class PdxManagedCacheableKeyBytes
@@ -72,7 +72,7 @@ namespace apache
       m_hasDelta = false;
       if(storeBytes)
       {
-        Apache::Geode::Client::IGFDelta^ deltaObj = dynamic_cast<Apache::Geode::Client::IGFDelta^>(managedptr);
+        Apache::Geode::Client::IGeodeDelta^ deltaObj = dynamic_cast<Apache::Geode::Client::IGeodeDelta^>(managedptr);
 
         if(deltaObj != nullptr)
           m_hasDelta = deltaObj->HasDelta();
@@ -214,11 +214,11 @@ namespace apache
     
     /// <summary>
     /// Using gcroot to hold the managed delegate pointer (since it cannot be stored directly).
-    /// Note: not using auto_gcroot since it will result in 'Dispose' of the IGFSerializable
+    /// Note: not using auto_gcroot since it will result in 'Dispose' of the IGeodeSerializable
     /// to be called which is not what is desired when this object is destroyed. Normally this
     /// managed object may be created by the user and will be handled automatically by the GC.
     /// </summary>
-//    gcroot<IGFSerializable^> m_managedptr;
+//    gcroot<IGeodeSerializable^> m_managedptr;
     int m_domainId;
     UInt32 m_classId;
     uint8_t * m_bytes;

--- a/src/clicache/src/impl/PdxReaderWithTypeCollector.hpp
+++ b/src/clicache/src/impl/PdxReaderWithTypeCollector.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include "PdxLocalReader.hpp"
 
 using namespace System;

--- a/src/clicache/src/impl/PdxRemoteReader.hpp
+++ b/src/clicache/src/impl/PdxRemoteReader.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include "PdxLocalReader.hpp"
 
 using namespace System;

--- a/src/clicache/src/impl/PdxRemoteWriter.hpp
+++ b/src/clicache/src/impl/PdxRemoteWriter.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include "PdxLocalWriter.hpp"
 
 using namespace System;

--- a/src/clicache/src/impl/PdxType.cpp
+++ b/src/clicache/src/impl/PdxType.cpp
@@ -85,7 +85,7 @@ namespace Apache
           }
         }
 
-        IGFSerializable^ PdxType::FromData(DataInput^ input)
+        IGeodeSerializable^ PdxType::FromData(DataInput^ input)
         {
           //defaulf java Dataserializable require this
           Byte val = input->ReadByte();//DS

--- a/src/clicache/src/impl/PdxType.hpp
+++ b/src/clicache/src/impl/PdxType.hpp
@@ -35,7 +35,7 @@ namespace Apache
       ref class DataInput;
       namespace Internal
       {
-        public ref class PdxType : public IGFSerializable
+        public ref class PdxType : public IGeodeSerializable
         {
         private:
           Object^                 m_lockObj;
@@ -110,7 +110,7 @@ namespace Apache
             m_geodeTypeId = 0;
           }
 
-          static IGFSerializable^ CreateDeserializable()
+          static IGeodeSerializable^ CreateDeserializable()
           {
             return gcnew PdxType();
           }
@@ -171,7 +171,7 @@ namespace Apache
             void set(bool val) { m_isLocal = val; }
           }
           virtual void ToData(DataOutput^ output);
-          virtual IGFSerializable^ FromData(DataInput^ input);
+          virtual IGeodeSerializable^ FromData(DataInput^ input);
           virtual property uint32_t ObjectSize
           {
             uint32_t get(){ return 0; }

--- a/src/clicache/src/impl/PdxWriterWithTypeCollector.hpp
+++ b/src/clicache/src/impl/PdxWriterWithTypeCollector.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include "PdxLocalWriter.hpp"
 #include "PdxType.hpp"
 //#include "../DataOutput.hpp"

--- a/src/clicache/src/impl/RegionImpl.cpp
+++ b/src/clicache/src/impl/RegionImpl.cpp
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"

--- a/src/clicache/src/impl/RegionImpl.hpp
+++ b/src/clicache/src/impl/RegionImpl.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include "../../../IRegion.hpp"
 #include <geode/Cache.hpp>
 #include "NativeWrapper.hpp"

--- a/src/clicache/src/impl/ResultCollectorProxy.hpp
+++ b/src/clicache/src/impl/ResultCollectorProxy.hpp
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//#include "../../../gf_includes.hpp"
+//#include "../../../geode_includes.hpp"
 //#include "../../../IResultCollector.hpp"
 //#include "../../../ResultCollector.hpp"
 #include "../IResultCollector.hpp"

--- a/src/clicache/src/impl/SafeConvert.hpp
+++ b/src/clicache/src/impl/SafeConvert.hpp
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "../gf_defs.hpp"
+#include "../geode_defs.hpp"
 #include "NativeWrapper.hpp"
 #include "ManagedCacheableKey.hpp"
 #include "ManagedCacheableDelta.hpp"
@@ -55,9 +55,9 @@ namespace Apache
 
       /// <summary>
       /// Helper function to convert native <c>apache::geode::client::Serializable</c> object
-      /// to managed <see cref="IGFSerializable" /> object.
+      /// to managed <see cref="IGeodeSerializable" /> object.
       /// </summary>
-      inline static Apache::Geode::Client::IGFSerializable^
+      inline static Apache::Geode::Client::IGeodeSerializable^
         SafeUMSerializableConvertGeneric( apache::geode::client::Serializable* obj )
       {
 
@@ -91,11 +91,11 @@ namespace Apache
           
           if( mg_obj_delta != nullptr )
           {
-            return dynamic_cast<Apache::Geode::Client::IGFSerializable^>(mg_obj_delta->ptr( ));
+            return dynamic_cast<Apache::Geode::Client::IGeodeSerializable^>(mg_obj_delta->ptr( ));
           }
           else if(mg_bytesObj_delta != nullptr)
           {
-            return dynamic_cast<Apache::Geode::Client::IGFSerializable^>(mg_bytesObj_delta->ptr( ));
+            return dynamic_cast<Apache::Geode::Client::IGeodeSerializable^>(mg_bytesObj_delta->ptr( ));
           }
           else
           {
@@ -128,7 +128,7 @@ namespace Apache
       /// <para>
       /// Consider the scenario that we have both native objects of class
       /// <c>apache::geode::client::Serializable</c> and managed objects of class
-      /// <see cref="IGFSerializable" /> in a Region.
+      /// <see cref="IGeodeSerializable" /> in a Region.
       /// </para><para>
       /// The former would be passed wrapped inside the
       /// <see cref="Serializable" /> class.
@@ -149,7 +149,7 @@ namespace Apache
       inline static NativeType* SafeM2UMConvertGeneric( ManagedType^ mg_obj )
       {
         /*
-        *return SafeM2UMConvertGeneric<IGFSerializable, apache::geode::client::ManagedCacheableKey,
+        *return SafeM2UMConvertGeneric<IGeodeSerializable, apache::geode::client::ManagedCacheableKey,
           apache::geode::client::Serializable, Serializable>( mg_obj );
         */
         //TODO: need to look this further for all types
@@ -164,8 +164,8 @@ namespace Apache
         //}
         //else 
         {
-          Apache::Geode::Client::IGFDelta^ sDelta =
-            dynamic_cast<Apache::Geode::Client::IGFDelta^> (mg_obj);
+          Apache::Geode::Client::IGeodeDelta^ sDelta =
+            dynamic_cast<Apache::Geode::Client::IGeodeDelta^> (mg_obj);
           if(sDelta != nullptr){
             if(!SafeConvertClassGeneric::isAppDomainEnabled)
               return new apache::geode::client::ManagedCacheableDeltaGeneric( sDelta);
@@ -252,15 +252,15 @@ namespace Apache
       }
 
       /// <summary>
-      /// Helper function to convert managed <see cref="IGFSerializable" />
+      /// Helper function to convert managed <see cref="IGeodeSerializable" />
       /// object to native <c>apache::geode::client::Serializable</c> object using
       /// <c>SafeM2UMConvert</c>.
       /// </summary>
       inline static apache::geode::client::Serializable* SafeMSerializableConvertGeneric(
-        Apache::Geode::Client::IGFSerializable^ mg_obj )
+        Apache::Geode::Client::IGeodeSerializable^ mg_obj )
       {
         //it is called for cacheables types  only
-        return SafeM2UMConvertGeneric<Apache::Geode::Client::IGFSerializable,
+        return SafeM2UMConvertGeneric<Apache::Geode::Client::IGeodeSerializable,
           apache::geode::client::ManagedCacheableKeyGeneric, apache::geode::client::Serializable,
           Apache::Geode::Client::Serializable>( mg_obj );
       }
@@ -293,8 +293,8 @@ namespace Apache
 						return new apache::geode::client::PdxManagedCacheableKeyBytes(pdxType, true);
         }
       
-				Apache::Geode::Client::IGFDelta^ sDelta =
-            dynamic_cast<Apache::Geode::Client::IGFDelta^> (mg_obj);
+				Apache::Geode::Client::IGeodeDelta^ sDelta =
+            dynamic_cast<Apache::Geode::Client::IGeodeDelta^> (mg_obj);
           if(sDelta != nullptr)
 					{
             if(!SafeConvertClassGeneric::isAppDomainEnabled)
@@ -304,8 +304,8 @@ namespace Apache
           }
           else
 					{
-						Apache::Geode::Client::IGFSerializable^ tmpIGFS = 
-							dynamic_cast<Apache::Geode::Client::IGFSerializable^>(mg_obj);
+						Apache::Geode::Client::IGeodeSerializable^ tmpIGFS = 
+							dynamic_cast<Apache::Geode::Client::IGeodeSerializable^>(mg_obj);
 						if(tmpIGFS != nullptr)
 						{
 							if(!SafeConvertClassGeneric::isAppDomainEnabled)

--- a/src/clicache/src/impl/TransactionListener.hpp
+++ b/src/clicache/src/impl/TransactionListener.hpp
@@ -19,7 +19,7 @@
 
 
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "../TransactionListenerAdapter.hpp"
 #include "../ITransactionListener.hpp"
 #include "../TransactionEvent.hpp"

--- a/src/clicache/src/impl/TransactionWriter.hpp
+++ b/src/clicache/src/impl/TransactionWriter.hpp
@@ -18,7 +18,7 @@
 #pragma once 
 
 
-//#include "../gf_includes.hpp"
+//#include "../geode_includes.hpp"
 #include "../TransactionWriterAdapter.hpp"
 #include "../ITransactionWriter.hpp"
 #include "SafeConvert.hpp"

--- a/src/cppcache/include/geode/AttributesFactory.hpp
+++ b/src/cppcache/include/geode/AttributesFactory.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "ExceptionTypes.hpp"
 #include "ExpirationAction.hpp"
 #include "CacheLoader.hpp"

--- a/src/cppcache/include/geode/AttributesMutator.hpp
+++ b/src/cppcache/include/geode/AttributesMutator.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "ExpirationAction.hpp"
 /**
  * @file

--- a/src/cppcache/include/geode/AuthInitialize.hpp
+++ b/src/cppcache/include/geode/AuthInitialize.hpp
@@ -25,7 +25,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 
 namespace apache {
 namespace geode {

--- a/src/cppcache/include/geode/Cache.hpp
+++ b/src/cppcache/include/geode/Cache.hpp
@@ -20,9 +20,9 @@
  * limitations under the License.
  */
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "GeodeCache.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "Region.hpp"
 #include "DistributedSystem.hpp"
 #include "QueryService.hpp"

--- a/src/cppcache/include/geode/CacheAttributes.hpp
+++ b/src/cppcache/include/geode/CacheAttributes.hpp
@@ -25,7 +25,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 
 namespace apache {
 namespace geode {

--- a/src/cppcache/include/geode/CacheFactory.hpp
+++ b/src/cppcache/include/geode/CacheFactory.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "DistributedSystem.hpp"
 #include "Cache.hpp"
 #include "CacheAttributes.hpp"

--- a/src/cppcache/include/geode/CacheListener.hpp
+++ b/src/cppcache/include/geode/CacheListener.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "SharedPtr.hpp"
 
 /**

--- a/src/cppcache/include/geode/CacheLoader.hpp
+++ b/src/cppcache/include/geode/CacheLoader.hpp
@@ -25,7 +25,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "CacheableKey.hpp"
 #include "Cacheable.hpp"
 #include "UserData.hpp"

--- a/src/cppcache/include/geode/CacheStatistics.hpp
+++ b/src/cppcache/include/geode/CacheStatistics.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 /**
  * @file
  */

--- a/src/cppcache/include/geode/CacheTransactionManager.hpp
+++ b/src/cppcache/include/geode/CacheTransactionManager.hpp
@@ -27,7 +27,7 @@
 //#### Warning: DO NOT directly include Region.hpp, include Cache.hpp instead.
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 
 namespace apache {
 namespace geode {

--- a/src/cppcache/include/geode/CacheWriter.hpp
+++ b/src/cppcache/include/geode/CacheWriter.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 
 /**
  * @file

--- a/src/cppcache/include/geode/CacheableDate.hpp
+++ b/src/cppcache/include/geode/CacheableDate.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "CacheableKey.hpp"
 #include "CacheableString.hpp"
 #include "GeodeTypeIds.hpp"

--- a/src/cppcache/include/geode/CacheableFileName.hpp
+++ b/src/cppcache/include/geode/CacheableFileName.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "CacheableKey.hpp"
 #include "CacheableString.hpp"
 

--- a/src/cppcache/include/geode/CacheableKey.hpp
+++ b/src/cppcache/include/geode/CacheableKey.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "Cacheable.hpp"
 
 /**

--- a/src/cppcache/include/geode/CacheableObjectArray.hpp
+++ b/src/cppcache/include/geode/CacheableObjectArray.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "VectorT.hpp"
 
 /** @file

--- a/src/cppcache/include/geode/CacheableString.hpp
+++ b/src/cppcache/include/geode/CacheableString.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "CacheableKey.hpp"
 #include "GeodeTypeIds.hpp"
 #include "ExceptionTypes.hpp"

--- a/src/cppcache/include/geode/CacheableUndefined.hpp
+++ b/src/cppcache/include/geode/CacheableUndefined.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "Cacheable.hpp"
 
 /** @file

--- a/src/cppcache/include/geode/CqAttributes.hpp
+++ b/src/cppcache/include/geode/CqAttributes.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "VectorT.hpp"
 
 #include "CqListener.hpp"

--- a/src/cppcache/include/geode/CqAttributesFactory.hpp
+++ b/src/cppcache/include/geode/CqAttributesFactory.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "CqAttributes.hpp"
 #include "CqListener.hpp"
 

--- a/src/cppcache/include/geode/CqAttributesMutator.hpp
+++ b/src/cppcache/include/geode/CqAttributesMutator.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "VectorT.hpp"
 
 /**

--- a/src/cppcache/include/geode/CqEvent.hpp
+++ b/src/cppcache/include/geode/CqEvent.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "Exception.hpp"
 #include "CqOperation.hpp"
 #include "Cacheable.hpp"

--- a/src/cppcache/include/geode/CqListener.hpp
+++ b/src/cppcache/include/geode/CqListener.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "CqEvent.hpp"
 
 /**

--- a/src/cppcache/include/geode/CqQuery.hpp
+++ b/src/cppcache/include/geode/CqQuery.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 
 #include "CqResults.hpp"
 #include "CqStatistics.hpp"

--- a/src/cppcache/include/geode/CqResults.hpp
+++ b/src/cppcache/include/geode/CqResults.hpp
@@ -25,7 +25,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "ExceptionTypes.hpp"
 #include "Serializable.hpp"
 #include "CacheableBuiltins.hpp"

--- a/src/cppcache/include/geode/CqServiceStatistics.hpp
+++ b/src/cppcache/include/geode/CqServiceStatistics.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 
 /**
  * @file

--- a/src/cppcache/include/geode/CqState.hpp
+++ b/src/cppcache/include/geode/CqState.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 
 /**
  * @file

--- a/src/cppcache/include/geode/CqStatistics.hpp
+++ b/src/cppcache/include/geode/CqStatistics.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 
 /**
  * @file

--- a/src/cppcache/include/geode/DataInput.hpp
+++ b/src/cppcache/include/geode/DataInput.hpp
@@ -23,7 +23,7 @@
 #include "geode_globals.hpp"
 #include "ExceptionTypes.hpp"
 #include <string.h>
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "Serializable.hpp"
 #include "CacheableString.hpp"
 

--- a/src/cppcache/include/geode/DistributedSystem.hpp
+++ b/src/cppcache/include/geode/DistributedSystem.hpp
@@ -25,7 +25,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "ExceptionTypes.hpp"
 #include "Properties.hpp"
 #include "VectorT.hpp"

--- a/src/cppcache/include/geode/EntryEvent.hpp
+++ b/src/cppcache/include/geode/EntryEvent.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "Region.hpp"
 #include "CacheableKey.hpp"
 #include "UserData.hpp"

--- a/src/cppcache/include/geode/Exception.hpp
+++ b/src/cppcache/include/geode/Exception.hpp
@@ -25,7 +25,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 
 namespace apache {
 namespace geode {

--- a/src/cppcache/include/geode/Execution.hpp
+++ b/src/cppcache/include/geode/Execution.hpp
@@ -26,7 +26,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "VectorT.hpp"
 #include "SharedPtr.hpp"
 #include "CacheableBuiltins.hpp"

--- a/src/cppcache/include/geode/FunctionService.hpp
+++ b/src/cppcache/include/geode/FunctionService.hpp
@@ -26,7 +26,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "Execution.hpp"
 
 /**

--- a/src/cppcache/include/geode/GeodeCache.hpp
+++ b/src/cppcache/include/geode/GeodeCache.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "RegionService.hpp"
 
 /**

--- a/src/cppcache/include/geode/PdxInstanceFactory.hpp
+++ b/src/cppcache/include/geode/PdxInstanceFactory.hpp
@@ -22,7 +22,7 @@
 
 #include "PdxInstance.hpp"
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "CacheableBuiltins.hpp"
 #include "CacheableDate.hpp"
 #include "CacheableObjectArray.hpp"

--- a/src/cppcache/include/geode/PdxUnreadFields.hpp
+++ b/src/cppcache/include/geode/PdxUnreadFields.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 
-#include "gf_base.hpp"
+#include "geode_base.hpp"
 #include "SharedBase.hpp"
 
 namespace apache {

--- a/src/cppcache/include/geode/PdxWriter.hpp
+++ b/src/cppcache/include/geode/PdxWriter.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "CacheableBuiltins.hpp"
 #include "CacheableDate.hpp"
 

--- a/src/cppcache/include/geode/PersistenceManager.hpp
+++ b/src/cppcache/include/geode/PersistenceManager.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "DistributedSystem.hpp"
 #include "ExceptionTypes.hpp"
 #include "CacheableKey.hpp"

--- a/src/cppcache/include/geode/Pool.hpp
+++ b/src/cppcache/include/geode/Pool.hpp
@@ -22,7 +22,7 @@
 
 #include "geode_globals.hpp"
 #include "SharedBase.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "CacheableBuiltins.hpp"
 #include "Cache.hpp"
 #include "CacheFactory.hpp"

--- a/src/cppcache/include/geode/PoolFactory.hpp
+++ b/src/cppcache/include/geode/PoolFactory.hpp
@@ -22,7 +22,7 @@
 
 #include "geode_globals.hpp"
 #include "SharedBase.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "Pool.hpp"
 
 /**

--- a/src/cppcache/include/geode/PoolManager.hpp
+++ b/src/cppcache/include/geode/PoolManager.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "Pool.hpp"
 #include "PoolFactory.hpp"
 #include "Region.hpp"

--- a/src/cppcache/include/geode/Properties.hpp
+++ b/src/cppcache/include/geode/Properties.hpp
@@ -24,7 +24,7 @@
  * @file
  */
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "Serializable.hpp"
 #include "DataInput.hpp"
 #include "DataOutput.hpp"

--- a/src/cppcache/include/geode/Query.hpp
+++ b/src/cppcache/include/geode/Query.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 
 #include "SelectResults.hpp"
 

--- a/src/cppcache/include/geode/QueryService.hpp
+++ b/src/cppcache/include/geode/QueryService.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "ExceptionTypes.hpp"
 #include "CqQuery.hpp"
 #include "CqAttributes.hpp"

--- a/src/cppcache/include/geode/Region.hpp
+++ b/src/cppcache/include/geode/Region.hpp
@@ -23,7 +23,7 @@
 //#### Warning: DO NOT directly include Region.hpp, include Cache.hpp instead.
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "CacheableKey.hpp"
 #include "CacheableString.hpp"
 #include "CacheStatistics.hpp"

--- a/src/cppcache/include/geode/RegionAttributes.hpp
+++ b/src/cppcache/include/geode/RegionAttributes.hpp
@@ -25,7 +25,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "CacheLoader.hpp"
 #include "ExpirationAttributes.hpp"
 #include "CacheWriter.hpp"

--- a/src/cppcache/include/geode/RegionEntry.hpp
+++ b/src/cppcache/include/geode/RegionEntry.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "CacheableKey.hpp"
 #include "CacheStatistics.hpp"
 

--- a/src/cppcache/include/geode/RegionEvent.hpp
+++ b/src/cppcache/include/geode/RegionEvent.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "Region.hpp"
 #include "CacheableKey.hpp"
 #include "UserData.hpp"

--- a/src/cppcache/include/geode/RegionFactory.hpp
+++ b/src/cppcache/include/geode/RegionFactory.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "AttributesFactory.hpp"
 /**
  * @file

--- a/src/cppcache/include/geode/RegionService.hpp
+++ b/src/cppcache/include/geode/RegionService.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "VectorT.hpp"
 
 /**

--- a/src/cppcache/include/geode/ResultCollector.hpp
+++ b/src/cppcache/include/geode/ResultCollector.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "SharedPtr.hpp"
 #include "VectorT.hpp"
 #include "CacheableBuiltins.hpp"

--- a/src/cppcache/include/geode/ResultSet.hpp
+++ b/src/cppcache/include/geode/ResultSet.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "ExceptionTypes.hpp"
 
 #include "SelectResults.hpp"

--- a/src/cppcache/include/geode/SelectResults.hpp
+++ b/src/cppcache/include/geode/SelectResults.hpp
@@ -25,7 +25,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "ExceptionTypes.hpp"
 #include "Serializable.hpp"
 #include "CacheableBuiltins.hpp"

--- a/src/cppcache/include/geode/SelectResultsIterator.hpp
+++ b/src/cppcache/include/geode/SelectResultsIterator.hpp
@@ -25,7 +25,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "ExceptionTypes.hpp"
 #include "Serializable.hpp"
 

--- a/src/cppcache/include/geode/Serializable.hpp
+++ b/src/cppcache/include/geode/Serializable.hpp
@@ -25,7 +25,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 
 namespace apache {
 namespace geode {

--- a/src/cppcache/include/geode/Struct.hpp
+++ b/src/cppcache/include/geode/Struct.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 #include "CacheableBuiltins.hpp"
 #include "StructSet.hpp"
 #include "SelectResults.hpp"

--- a/src/cppcache/include/geode/StructSet.hpp
+++ b/src/cppcache/include/geode/StructSet.hpp
@@ -21,7 +21,7 @@
  */
 
 #include "geode_globals.hpp"
-#include "gf_types.hpp"
+#include "geode_types.hpp"
 
 #include "CqResults.hpp"
 #include "Struct.hpp"

--- a/src/cppcache/include/geode/geode_base.hpp
+++ b/src/cppcache/include/geode/geode_base.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#ifndef GEODE_GF_BASE_H_
-#define GEODE_GF_BASE_H_
+#ifndef GEODE_BASE_H_
+#define GEODE_BASE_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -355,4 +355,4 @@ void operator delete[](void *p);
     x = NULL;                   \
   }
 
-#endif  // GEODE_GF_BASE_H_
+#endif  // GEODE_BASE_H_

--- a/src/cppcache/include/geode/geode_globals.hpp
+++ b/src/cppcache/include/geode/geode_globals.hpp
@@ -114,7 +114,7 @@
 #endif
 #endif
 
-#include "gf_base.hpp"
+#include "geode_base.hpp"
 
 namespace apache {
 namespace geode {

--- a/src/cppcache/include/geode/geode_types.hpp
+++ b/src/cppcache/include/geode/geode_types.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#ifndef GEODE_GF_TYPES_H_
-#define GEODE_GF_TYPES_H_
+#ifndef GEODE_TYPES_H_
+#define GEODE_TYPES_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -108,4 +108,4 @@ _GF_PTR_DEF_(InternalCacheTransactionManager2PC,
 }  // namespace geode
 }  // namespace apache
 
-#endif  // GEODE_GF_TYPES_H_
+#endif  // GEODE_TYPES_H_

--- a/src/cppcache/integration-test/testEntriesMapForVersioning.cpp
+++ b/src/cppcache/integration-test/testEntriesMapForVersioning.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 
 #include "fw_dunit.hpp"
 

--- a/src/cppcache/integration-test/testSerialization.cpp
+++ b/src/cppcache/integration-test/testSerialization.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"

--- a/src/cppcache/integration-test/testThinClientBigValue.cpp
+++ b/src/cppcache/integration-test/testThinClientBigValue.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"

--- a/src/cppcache/integration-test/testThinClientPdxTests.cpp
+++ b/src/cppcache/integration-test/testThinClientPdxTests.cpp
@@ -1508,7 +1508,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, PutAndVerifyPdxInGFSInGet)
   {
     try {
       Serializable::registerType(
-          PdxInsideIGFSerializable::createDeserializable);
+          PdxInsideIGeodeSerializable::createDeserializable);
     } catch (const IllegalStateException&) {
       // ignore exception
     }
@@ -1565,17 +1565,18 @@ DUNIT_TASK_DEFINITION(CLIENT1, PutAndVerifyPdxInGFSInGet)
     }
 
     RegionPtr regPtr0 = getHelper()->getRegion("DistRegionAck");
-    PdxInsideIGFSerializablePtr np(new PdxInsideIGFSerializable());
+    PdxInsideIGeodeSerializablePtr np(new PdxInsideIGeodeSerializable());
 
     CacheableKeyPtr keyport = CacheableKey::create(1);
     regPtr0->put(keyport, np);
 
     // GET
-    PdxInsideIGFSerializablePtr pRet =
-        dynCast<PdxInsideIGFSerializablePtr>(regPtr0->get(keyport));
-    ASSERT(pRet->equals(np) == true,
-           "TASK PutAndVerifyPdxInIGFSInGet: PdxInsideIGFSerializable objects "
-           "should be equal");
+    PdxInsideIGeodeSerializablePtr pRet =
+        dynCast<PdxInsideIGeodeSerializablePtr>(regPtr0->get(keyport));
+    ASSERT(
+        pRet->equals(np) == true,
+        "TASK PutAndVerifyPdxInIGFSInGet: PdxInsideIGeodeSerializable objects "
+        "should be equal");
   }
 END_TASK_DEFINITION
 
@@ -1583,7 +1584,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, VerifyPdxInGFSGetOnly)
   {
     try {
       Serializable::registerType(
-          PdxInsideIGFSerializable::createDeserializable);
+          PdxInsideIGeodeSerializable::createDeserializable);
     } catch (const IllegalStateException&) {
       // ignore exception
     }
@@ -1640,16 +1641,16 @@ DUNIT_TASK_DEFINITION(CLIENT2, VerifyPdxInGFSGetOnly)
     }
 
     RegionPtr regPtr0 = getHelper()->getRegion("DistRegionAck");
-    PdxInsideIGFSerializablePtr orig(new PdxInsideIGFSerializable());
+    PdxInsideIGeodeSerializablePtr orig(new PdxInsideIGeodeSerializable());
 
     // GET
     CacheableKeyPtr keyport = CacheableKey::create(1);
-    PdxInsideIGFSerializablePtr pRet =
-        dynCast<PdxInsideIGFSerializablePtr>(regPtr0->get(keyport));
-    ASSERT(
-        pRet->equals(orig) == true,
-        "TASK:VerifyPdxInIGFSGetOnly, PdxInsideIGFSerializable objects should "
-        "be equal");
+    PdxInsideIGeodeSerializablePtr pRet =
+        dynCast<PdxInsideIGeodeSerializablePtr>(regPtr0->get(keyport));
+    ASSERT(pRet->equals(orig) == true,
+           "TASK:VerifyPdxInIGFSGetOnly, PdxInsideIGeodeSerializable objects "
+           "should "
+           "be equal");
   }
 END_TASK_DEFINITION
 

--- a/src/cppcache/integration-test/testThinClientPdxTestsWithAuto.cpp
+++ b/src/cppcache/integration-test/testThinClientPdxTestsWithAuto.cpp
@@ -1236,7 +1236,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, PutAndVerifyPdxInGFSInGet)
   {
     try {
       Serializable::registerType(
-          PdxTestsAuto::PdxInsideIGFSerializable::createDeserializable);
+          PdxTestsAuto::PdxInsideIGeodeSerializable::createDeserializable);
     } catch (const IllegalStateException&) {
       // ignore exception
     }
@@ -1302,19 +1302,20 @@ DUNIT_TASK_DEFINITION(CLIENT1, PutAndVerifyPdxInGFSInGet)
     }
 
     RegionPtr regPtr0 = getHelper()->getRegion("DistRegionAck");
-    PdxTestsAuto::PdxInsideIGFSerializablePtr np(
-        new PdxTestsAuto::PdxInsideIGFSerializable());
+    PdxTestsAuto::PdxInsideIGeodeSerializablePtr np(
+        new PdxTestsAuto::PdxInsideIGeodeSerializable());
 
     CacheableKeyPtr keyport = CacheableKey::create(1);
     regPtr0->put(keyport, np);
 
     // GET
-    PdxTestsAuto::PdxInsideIGFSerializablePtr pRet =
-        dynCast<PdxTestsAuto::PdxInsideIGFSerializablePtr>(
+    PdxTestsAuto::PdxInsideIGeodeSerializablePtr pRet =
+        dynCast<PdxTestsAuto::PdxInsideIGeodeSerializablePtr>(
             regPtr0->get(keyport));
-    ASSERT(pRet->equals(np) == true,
-           "TASK PutAndVerifyPdxInIGFSInGet: PdxInsideIGFSerializable objects "
-           "should be equal");
+    ASSERT(
+        pRet->equals(np) == true,
+        "TASK PutAndVerifyPdxInIGFSInGet: PdxInsideIGeodeSerializable objects "
+        "should be equal");
   }
 END_TASK_DEFINITION
 
@@ -1322,7 +1323,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, VerifyPdxInGFSGetOnly)
   {
     try {
       Serializable::registerType(
-          PdxTestsAuto::PdxInsideIGFSerializable::createDeserializable);
+          PdxTestsAuto::PdxInsideIGeodeSerializable::createDeserializable);
     } catch (const IllegalStateException&) {
       // ignore exception
     }
@@ -1388,18 +1389,18 @@ DUNIT_TASK_DEFINITION(CLIENT2, VerifyPdxInGFSGetOnly)
     }
 
     RegionPtr regPtr0 = getHelper()->getRegion("DistRegionAck");
-    PdxTestsAuto::PdxInsideIGFSerializablePtr orig(
-        new PdxTestsAuto::PdxInsideIGFSerializable());
+    PdxTestsAuto::PdxInsideIGeodeSerializablePtr orig(
+        new PdxTestsAuto::PdxInsideIGeodeSerializable());
 
     // GET
     CacheableKeyPtr keyport = CacheableKey::create(1);
-    PdxTestsAuto::PdxInsideIGFSerializablePtr pRet =
-        dynCast<PdxTestsAuto::PdxInsideIGFSerializablePtr>(
+    PdxTestsAuto::PdxInsideIGeodeSerializablePtr pRet =
+        dynCast<PdxTestsAuto::PdxInsideIGeodeSerializablePtr>(
             regPtr0->get(keyport));
-    ASSERT(
-        pRet->equals(orig) == true,
-        "TASK:VerifyPdxInIGFSGetOnly, PdxInsideIGFSerializable objects should "
-        "be equal");
+    ASSERT(pRet->equals(orig) == true,
+           "TASK:VerifyPdxInIGFSGetOnly, PdxInsideIGeodeSerializable objects "
+           "should "
+           "be equal");
   }
 END_TASK_DEFINITION
 

--- a/src/cppcache/src/AdminRegion.hpp
+++ b/src/cppcache/src/AdminRegion.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include "ThinClientCacheDistributionManager.hpp"
 #include "ReadWriteLock.hpp"
 #include <geode/Serializable.hpp>

--- a/src/cppcache/src/CacheTransactionManagerImpl.cpp
+++ b/src/cppcache/src/CacheTransactionManagerImpl.cpp
@@ -21,7 +21,7 @@
  *      Author: ankurs
  */
 
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include "CacheTransactionManagerImpl.hpp"
 #include <geode/TransactionId.hpp>
 #include <geode/ExceptionTypes.hpp>

--- a/src/cppcache/src/CacheableObjectPartList.hpp
+++ b/src/cppcache/src/CacheableObjectPartList.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/DataOutput.hpp>
 #include <geode/DataInput.hpp>
 #include <geode/Cacheable.hpp>

--- a/src/cppcache/src/ClientHealthStats.hpp
+++ b/src/cppcache/src/ClientHealthStats.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/Serializable.hpp>
 #include <geode/Log.hpp>
 #include <geode/CacheableDate.hpp>

--- a/src/cppcache/src/CqAttributesMutatorImpl.hpp
+++ b/src/cppcache/src/CqAttributesMutatorImpl.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/VectorT.hpp>
 #include <geode/CqAttributesMutator.hpp>
 #include <geode/CqAttributes.hpp>

--- a/src/cppcache/src/CqEventImpl.hpp
+++ b/src/cppcache/src/CqEventImpl.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/CqEvent.hpp>
 #include <geode/CqOperation.hpp>
 #include <geode/CqQuery.hpp>

--- a/src/cppcache/src/CqQueryImpl.hpp
+++ b/src/cppcache/src/CqQueryImpl.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 
 #include <geode/CqResults.hpp>
 #include <geode/CqQuery.hpp>

--- a/src/cppcache/src/CqService.hpp
+++ b/src/cppcache/src/CqService.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include "TcrMessage.hpp"
 #include "Queue.hpp"
 #include <ace/ACE.h>

--- a/src/cppcache/src/DistributedSystemImpl.hpp
+++ b/src/cppcache/src/DistributedSystemImpl.hpp
@@ -26,7 +26,7 @@
 
 #include <geode/geode_globals.hpp>
 #include <geode/SharedPtr.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include "ace/Recursive_Thread_Mutex.h"
 #include "ace/Guard_T.h"
 #include "ace/OS.h"

--- a/src/cppcache/src/EventId.hpp
+++ b/src/cppcache/src/EventId.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/Cacheable.hpp>
 #include "GeodeTypeIdsImpl.hpp"
 #include "SpinLock.hpp"

--- a/src/cppcache/src/ExecutionImpl.cpp
+++ b/src/cppcache/src/ExecutionImpl.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include "ExecutionImpl.hpp"
 #include <geode/ExceptionTypes.hpp>
 #include "ThinClientRegion.hpp"

--- a/src/cppcache/src/ExecutionImpl.hpp
+++ b/src/cppcache/src/ExecutionImpl.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/Execution.hpp>
 #include <geode/CacheableBuiltins.hpp>
 #include <geode/ResultCollector.hpp>

--- a/src/cppcache/src/FarSideEntryOp.hpp
+++ b/src/cppcache/src/FarSideEntryOp.hpp
@@ -27,7 +27,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/Cacheable.hpp>
 #include <geode/DataOutput.hpp>
 #include <geode/DataInput.hpp>

--- a/src/cppcache/src/FunctionServiceImpl.hpp
+++ b/src/cppcache/src/FunctionServiceImpl.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include "ProxyCache.hpp"
 #include <geode/FunctionService.hpp>
 /**

--- a/src/cppcache/src/InternalCacheTransactionManager2PCImpl.cpp
+++ b/src/cppcache/src/InternalCacheTransactionManager2PCImpl.cpp
@@ -21,7 +21,7 @@
  *      Author: sshcherbakov
  */
 
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include "InternalCacheTransactionManager2PCImpl.hpp"
 #include "CacheTransactionManagerImpl.hpp"
 #include <geode/TransactionId.hpp>

--- a/src/cppcache/src/NoResult.hpp
+++ b/src/cppcache/src/NoResult.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/ExceptionTypes.hpp>
 #include <geode/ResultCollector.hpp>
 

--- a/src/cppcache/src/PoolAttributes.hpp
+++ b/src/cppcache/src/PoolAttributes.hpp
@@ -24,7 +24,7 @@
 #include "ace/OS.h"
 #include <geode/geode_globals.hpp>
 #include <geode/SharedBase.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/ExceptionTypes.hpp>
 
 /**

--- a/src/cppcache/src/ProxyCache.hpp
+++ b/src/cppcache/src/ProxyCache.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/Region.hpp>
 #include <geode/DistributedSystem.hpp>
 #include <geode/QueryService.hpp>

--- a/src/cppcache/src/ProxyRegion.hpp
+++ b/src/cppcache/src/ProxyRegion.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/CacheableKey.hpp>
 #include <geode/CacheableString.hpp>
 #include <geode/CacheStatistics.hpp>

--- a/src/cppcache/src/RegionCommit.hpp
+++ b/src/cppcache/src/RegionCommit.hpp
@@ -26,7 +26,7 @@
  *      Author: ankurs
  */
 
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/SharedBase.hpp>
 #include <geode/DataInput.hpp>
 #include <geode/VectorOfSharedBase.hpp>

--- a/src/cppcache/src/RemoteQuery.hpp
+++ b/src/cppcache/src/RemoteQuery.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/ExceptionTypes.hpp>
 #include <geode/SharedPtr.hpp>
 

--- a/src/cppcache/src/ResultSetImpl.hpp
+++ b/src/cppcache/src/ResultSetImpl.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/ExceptionTypes.hpp>
 
 #include <geode/ResultSet.hpp>

--- a/src/cppcache/src/StackFrame.cpp
+++ b/src/cppcache/src/StackFrame.cpp
@@ -17,7 +17,7 @@
 #include <ace/OS.h>
 #include <geode/geode_globals.hpp>
 #include "StackFrame.hpp"
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 
 namespace apache {
 namespace geode {

--- a/src/cppcache/src/StructSetImpl.hpp
+++ b/src/cppcache/src/StructSetImpl.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 
 #include <geode/StructSet.hpp>
 #include <geode/Struct.hpp>

--- a/src/cppcache/src/TXCommitMessage.hpp
+++ b/src/cppcache/src/TXCommitMessage.hpp
@@ -27,7 +27,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/DataInput.hpp>
 #include "RegionCommit.hpp"
 #include <geode/VectorOfSharedBase.hpp>

--- a/src/cppcache/src/TXEntryState.hpp
+++ b/src/cppcache/src/TXEntryState.hpp
@@ -26,7 +26,7 @@
  *      Author: ankurs
  */
 
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 
 using namespace apache::geode::client;
 

--- a/src/cppcache/src/TXId.hpp
+++ b/src/cppcache/src/TXId.hpp
@@ -26,7 +26,7 @@
  *      Author: ankurs
  */
 
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/TransactionId.hpp>
 #include <geode/DataOutput.hpp>
 #include "AtomicInc.hpp"

--- a/src/cppcache/src/TXRegionState.hpp
+++ b/src/cppcache/src/TXRegionState.hpp
@@ -26,7 +26,7 @@
  *      Author: ankurs
  */
 
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/HashMapT.hpp>
 #include "TXEntryState.hpp"
 

--- a/src/cppcache/src/Task.hpp
+++ b/src/cppcache/src/Task.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#ifndef GEODE_GF_TASK_T_H_
-#define GEODE_GF_TASK_T_H_
+#ifndef GEODE_Task_H_
+#define GEODE_Task_H_
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -21,7 +21,7 @@
  */
 
 /**
-*@file GF_TASK_T.hpp
+*@file Task.hpp
 *@since   1.0
 *@version 1.0
 */
@@ -33,14 +33,14 @@ namespace geode {
 namespace client {
 const char NC_thread[] = "NC thread";
 template <class T>
-class CPPCACHE_EXPORT GF_TASK_T : public ACE_Task_Base {
+class CPPCACHE_EXPORT Task : public ACE_Task_Base {
  public:
   /// Handle timeout events.
   typedef int (T::*OPERATION)(volatile bool& isRunning);
 
   // op_handler is the receiver of the timeout event. timeout is the method to
   // be executed by op_handler_
-  GF_TASK_T(T* op_handler, OPERATION op)
+  Task(T* op_handler, OPERATION op)
       : op_handler_(op_handler),
         m_op(op),
         m_run(false),
@@ -48,10 +48,10 @@ class CPPCACHE_EXPORT GF_TASK_T : public ACE_Task_Base {
 
   // op_handler is the receiver of the timeout event. timeout is the method to
   // be executed by op_handler_
-  GF_TASK_T(T* op_handler, OPERATION op, const char* tn)
+  Task(T* op_handler, OPERATION op, const char* tn)
       : op_handler_(op_handler), m_op(op), m_run(false), m_threadName(tn) {}
 
-  ~GF_TASK_T() {}
+  ~Task() {}
 
   void start() {
     m_run = true;
@@ -83,4 +83,4 @@ class CPPCACHE_EXPORT GF_TASK_T : public ACE_Task_Base {
 }  // namespace geode
 }  // namespace apache
 
-#endif  // GEODE_GF_TASK_T_H_
+#endif  // GEODE_Task_H_

--- a/src/cppcache/src/TcpSslConn.cpp
+++ b/src/cppcache/src/TcpSslConn.cpp
@@ -18,12 +18,12 @@
 
 #include <geode/SystemProperties.hpp>
 #include <geode/DistributedSystem.hpp>
-#include "../../cryptoimpl/GFSsl.hpp"
+#include "../../cryptoimpl/Ssl.hpp"
 
 using namespace apache::geode::client;
 
-GFSsl* TcpSslConn::getSSLImpl(ACE_SOCKET sock, const char* pubkeyfile,
-                              const char* privkeyfile) {
+Ssl* TcpSslConn::getSSLImpl(ACE_SOCKET sock, const char* pubkeyfile,
+                            const char* privkeyfile) {
   const char* libName = "cryptoImpl";
   if (m_dll.open(libName, RTLD_NOW | RTLD_GLOBAL, 0) == -1) {
     char msg[1000] = {0};
@@ -46,7 +46,7 @@ GFSsl* TcpSslConn::getSSLImpl(ACE_SOCKET sock, const char* pubkeyfile,
   const char* pemPassword =
       DistributedSystem::getSystemProperties()->sslKeystorePassword();
 
-  return reinterpret_cast<GFSsl*>(
+  return reinterpret_cast<Ssl*>(
       func(sock, pubkeyfile, privkeyfile, pemPassword));
 }
 

--- a/src/cppcache/src/TcpSslConn.hpp
+++ b/src/cppcache/src/TcpSslConn.hpp
@@ -22,7 +22,7 @@
 
 #include "TcpConn.hpp"
 #include <ace/DLL.h>
-#include "../../cryptoimpl/GFSsl.hpp"
+#include "../../cryptoimpl/Ssl.hpp"
 
 namespace apache {
 namespace geode {
@@ -30,7 +30,7 @@ namespace client {
 
 class TcpSslConn : public TcpConn {
  private:
-  GFSsl* m_ssl;
+  Ssl* m_ssl;
   ACE_DLL m_dll;
   // adongre: Added for Ticket #758
   // Pass extra parameter for the password
@@ -38,8 +38,8 @@ class TcpSslConn : public TcpConn {
                                      const char*);
   typedef void (*gf_destroy_SslImpl)(void*);
 
-  GFSsl* getSSLImpl(ACE_SOCKET sock, const char* pubkeyfile,
-                    const char* privkeyfile);
+  Ssl* getSSLImpl(ACE_SOCKET sock, const char* pubkeyfile,
+                  const char* privkeyfile);
 
  protected:
   int32_t socketOp(SockOp op, char* buff, int32_t len, uint32_t waitSeconds);

--- a/src/cppcache/src/TcrChunkedContext.hpp
+++ b/src/cppcache/src/TcrChunkedContext.hpp
@@ -29,7 +29,7 @@
 
 #include <ace/Semaphore.h>
 #include <string>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include "Utils.hpp"
 #include "AppDomainContext.hpp"
 

--- a/src/cppcache/src/TcrConnectionManager.cpp
+++ b/src/cppcache/src/TcrConnectionManager.cpp
@@ -113,7 +113,7 @@ void TcrConnectionManager::init(bool isPool) {
       GfErrTypeToException("TcrConnectionManager::init", err);
     }
 
-    m_redundancyTask = new GF_TASK_T<TcrConnectionManager>(
+    m_redundancyTask = new Task<TcrConnectionManager>(
         this, &TcrConnectionManager::redundancy, NC_Redundancy);
     m_redundancyTask->start();
 
@@ -129,7 +129,7 @@ void TcrConnectionManager::startFailoverAndCleanupThreads(bool isPool) {
   if (m_failoverTask == NULL || m_cleanupTask == NULL) {
     ACE_Guard<ACE_Recursive_Thread_Mutex> _guard(m_distMngrsLock);
     if (m_failoverTask == NULL && !isPool) {
-      m_failoverTask = new GF_TASK_T<TcrConnectionManager>(
+      m_failoverTask = new Task<TcrConnectionManager>(
           this, &TcrConnectionManager::failover, NC_Failover);
       m_failoverTask->start();
     }
@@ -137,7 +137,7 @@ void TcrConnectionManager::startFailoverAndCleanupThreads(bool isPool) {
       if (m_redundancyManager->m_HAenabled && !isPool) {
         m_redundancyManager->startPeriodicAck();
       }
-      m_cleanupTask = new GF_TASK_T<TcrConnectionManager>(
+      m_cleanupTask = new Task<TcrConnectionManager>(
           this, &TcrConnectionManager::cleanup, NC_CleanUp);
       m_cleanupTask->start();
     }
@@ -517,7 +517,7 @@ int TcrConnectionManager::redundancy(volatile bool &isRunning) {
 }
 
 void TcrConnectionManager::addNotificationForDeletion(
-    GF_TASK_T<TcrEndpoint> *notifyReceiver, TcrConnection *notifyConnection,
+    Task<TcrEndpoint> *notifyReceiver, TcrConnection *notifyConnection,
     ACE_Semaphore &notifyCleanupSema) {
   ACE_Guard<ACE_Recursive_Thread_Mutex> guard(m_notificationLock);
   m_connectionReleaseList.put(notifyConnection);
@@ -551,7 +551,7 @@ int TcrConnectionManager::cleanup(volatile bool &isRunning) {
 }
 
 void TcrConnectionManager::cleanNotificationLists() {
-  GF_TASK_T<TcrEndpoint> *notifyReceiver;
+  Task<TcrEndpoint> *notifyReceiver;
   TcrConnection *notifyConnection;
   ACE_Semaphore *notifyCleanupSema;
 

--- a/src/cppcache/src/TcrConnectionManager.hpp
+++ b/src/cppcache/src/TcrConnectionManager.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include "GF_TASK_T.hpp"
+#include "Task.hpp"
 #include <string>
 #include <ace/Recursive_Thread_Mutex.h>
 #include <ace/Map_Manager.h>
@@ -92,7 +92,7 @@ class CPPCACHE_EXPORT TcrConnectionManager {
                                        TcrMessageReply* reply);
   GfErrType sendSyncRequestCq(TcrMessage& request, TcrMessageReply& reply);
 
-  void addNotificationForDeletion(GF_TASK_T<TcrEndpoint>* notifyReceiver,
+  void addNotificationForDeletion(Task<TcrEndpoint>* notifyReceiver,
                                   TcrConnection* notifyConnection,
                                   ACE_Semaphore& notifyCleanupSema);
 
@@ -151,7 +151,7 @@ class CPPCACHE_EXPORT TcrConnectionManager {
   ACE_Recursive_Thread_Mutex m_distMngrsLock;
 
   ACE_Semaphore m_failoverSema;
-  GF_TASK_T<TcrConnectionManager>* m_failoverTask;
+  Task<TcrConnectionManager>* m_failoverTask;
 
   bool removeRefToEndpoint(TcrEndpoint* ep, bool keepEndpoint = false);
   TcrEndpoint* addRefToTcrEndpoint(std::string endpointName,
@@ -161,16 +161,16 @@ class CPPCACHE_EXPORT TcrConnectionManager {
   void removeHAEndpoints();
 
   ACE_Semaphore m_cleanupSema;
-  GF_TASK_T<TcrConnectionManager>* m_cleanupTask;
+  Task<TcrConnectionManager>* m_cleanupTask;
 
   long m_pingTaskId;
   long m_servermonitorTaskId;
-  Queue<GF_TASK_T<TcrEndpoint> > m_receiverReleaseList;
+  Queue<Task<TcrEndpoint> > m_receiverReleaseList;
   Queue<TcrConnection> m_connectionReleaseList;
   Queue<ACE_Semaphore> m_notifyCleanupSemaList;
 
   ACE_Semaphore m_redundancySema;
-  GF_TASK_T<TcrConnectionManager>* m_redundancyTask;
+  Task<TcrConnectionManager>* m_redundancyTask;
   ACE_Recursive_Thread_Mutex m_notificationLock;
   bool m_isDurable;
 

--- a/src/cppcache/src/TcrEndpoint.cpp
+++ b/src/cppcache/src/TcrEndpoint.cpp
@@ -476,7 +476,7 @@ GfErrType TcrEndpoint::registerDM(bool clientNotification, bool isSecondary,
                   m_name.c_str());
           return err;
         }
-        m_notifyReceiver = new GF_TASK_T<TcrEndpoint>(
+        m_notifyReceiver = new Task<TcrEndpoint>(
             this, &TcrEndpoint::receiveNotification, NC_Notification);
         m_notifyReceiver->start();
       }
@@ -1265,7 +1265,7 @@ void TcrEndpoint::stopNotifyReceiverAndCleanup() {
     // m_notifyReceiver->stopNoblock();
     m_notifyReceiver->wait();
     bool found = false;
-    for (std::list<GF_TASK_T<TcrEndpoint>*>::iterator it =
+    for (std::list<Task<TcrEndpoint>*>::iterator it =
              m_notifyReceiverList.begin();
          it != m_notifyReceiverList.end(); it++) {
       if (*it == m_notifyReceiver) {
@@ -1285,7 +1285,7 @@ void TcrEndpoint::stopNotifyReceiverAndCleanup() {
   if (m_notifyReceiverList.size() > 0) {
     LOGFINER("TcrEndpoint::stopNotifyReceiverAndCleanup: notifylist size = %d",
              m_notifyReceiverList.size());
-    for (std::list<GF_TASK_T<TcrEndpoint>*>::iterator it =
+    for (std::list<Task<TcrEndpoint>*>::iterator it =
              m_notifyReceiverList.begin();
          it != m_notifyReceiverList.end(); it++) {
       LOGFINER(

--- a/src/cppcache/src/TcrEndpoint.hpp
+++ b/src/cppcache/src/TcrEndpoint.hpp
@@ -25,11 +25,11 @@
 #include <list>
 #include <ace/Recursive_Thread_Mutex.h>
 #include <ace/Semaphore.h>
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 #include "FairQueue.hpp"
 #include "Set.hpp"
 #include "TcrConnection.hpp"
-#include "GF_TASK_T.hpp"
+#include "Task.hpp"
 #include "SpinLock.hpp"
 
 namespace apache {
@@ -199,10 +199,10 @@ class CPPCACHE_EXPORT TcrEndpoint {
   void closeConnection(TcrConnection*& conn);
   virtual void handleNotificationStats(int64 byteLength){};
   virtual void closeNotification();
-  std::list<GF_TASK_T<TcrEndpoint>*> m_notifyReceiverList;
+  std::list<Task<TcrEndpoint>*> m_notifyReceiverList;
   std::list<TcrConnection*> m_notifyConnectionList;
   TcrConnection* m_notifyConnection;
-  GF_TASK_T<TcrEndpoint>* m_notifyReceiver;
+  Task<TcrEndpoint>* m_notifyReceiver;
   int m_numRegionListener;
   bool m_isQueueHosted;
   ACE_Recursive_Thread_Mutex m_notifyReceiverLock;

--- a/src/cppcache/src/TcrHADistributionManager.hpp
+++ b/src/cppcache/src/TcrHADistributionManager.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 #include "ThinClientDistributionManager.hpp"
 #include <geode/CacheAttributes.hpp>
 #include "TcrEndpoint.hpp"

--- a/src/cppcache/src/TcrPoolEndPoint.cpp
+++ b/src/cppcache/src/TcrPoolEndPoint.cpp
@@ -94,7 +94,7 @@ GfErrType TcrPoolEndPoint::registerDM(bool clientNotification, bool isSecondary,
               name().c_str());
       return err;
     }
-    m_notifyReceiver = new GF_TASK_T<TcrEndpoint>(
+    m_notifyReceiver = new Task<TcrEndpoint>(
         this, &TcrEndpoint::receiveNotification, NC_Notification);
     m_notifyReceiver->start();
   }

--- a/src/cppcache/src/ThinClientBaseDM.cpp
+++ b/src/cppcache/src/ThinClientBaseDM.cpp
@@ -246,7 +246,7 @@ int ThinClientBaseDM::processChunks(volatile bool& isRunning) {
 void ThinClientBaseDM::startChunkProcessor() {
   if (m_chunkProcessor == NULL) {
     m_chunks.open();
-    m_chunkProcessor = new GF_TASK_T<ThinClientBaseDM>(
+    m_chunkProcessor = new Task<ThinClientBaseDM>(
         this, &ThinClientBaseDM::processChunks, NC_ProcessChunk);
     m_chunkProcessor->start();
   }

--- a/src/cppcache/src/ThinClientBaseDM.hpp
+++ b/src/cppcache/src/ThinClientBaseDM.hpp
@@ -191,7 +191,7 @@ class ThinClientBaseDM {
   bool m_clientNotification;
 
   Queue<TcrChunkedContext> m_chunks;
-  GF_TASK_T<ThinClientBaseDM>* m_chunkProcessor;
+  Task<ThinClientBaseDM>* m_chunkProcessor;
 
  private:
   static volatile bool s_isDeltaEnabledOnServer;

--- a/src/cppcache/src/ThinClientPoolDM.cpp
+++ b/src/cppcache/src/ThinClientPoolDM.cpp
@@ -255,15 +255,15 @@ PropertiesPtr ThinClientPoolDM::getCredentials(TcrEndpoint* ep) {
 
 void ThinClientPoolDM::startBackgroundThreads() {
   LOGDEBUG("ThinClientPoolDM::startBackgroundThreads: Starting ping thread");
-  m_pingTask = new GF_TASK_T<ThinClientPoolDM>(
-      this, &ThinClientPoolDM::pingServer, NC_Ping_Thread);
+  m_pingTask = new Task<ThinClientPoolDM>(this, &ThinClientPoolDM::pingServer,
+                                          NC_Ping_Thread);
   m_pingTask->start();
 
   SystemProperties* props = DistributedSystem::getSystemProperties();
 
   if (props->onClientDisconnectClearPdxTypeIds() == true) {
     m_cliCallbackTask =
-        new GF_TASK_T<ThinClientPoolDM>(this, &ThinClientPoolDM::cliCallback);
+        new Task<ThinClientPoolDM>(this, &ThinClientPoolDM::cliCallback);
     m_cliCallbackTask->start();
   }
 
@@ -288,8 +288,8 @@ void ThinClientPoolDM::startBackgroundThreads() {
   long updateLocatorListInterval = getUpdateLocatorListInterval();
 
   if (updateLocatorListInterval > 0) {
-    m_updateLocatorListTask = new GF_TASK_T<ThinClientPoolDM>(
-        this, &ThinClientPoolDM::updateLocatorList);
+    m_updateLocatorListTask =
+        new Task<ThinClientPoolDM>(this, &ThinClientPoolDM::updateLocatorList);
     m_updateLocatorListTask->start();
 
     updateLocatorListInterval = updateLocatorListInterval / 1000;  // seconds
@@ -313,7 +313,7 @@ void ThinClientPoolDM::startBackgroundThreads() {
       "ThinClientPoolDM::startBackgroundThreads: Starting manageConnections "
       "thread");
   // Manage Connection Thread
-  m_connManageTask = new GF_TASK_T<ThinClientPoolDM>(
+  m_connManageTask = new Task<ThinClientPoolDM>(
       this, &ThinClientPoolDM::manageConnections, NC_MC_Thread);
   m_connManageTask->start();
 

--- a/src/cppcache/src/ThinClientPoolDM.hpp
+++ b/src/cppcache/src/ThinClientPoolDM.hpp
@@ -28,7 +28,7 @@
 #include "RemoteQueryService.hpp"
 #include <set>
 #include <vector>
-#include "GF_TASK_T.hpp"
+#include "Task.hpp"
 #include <ace/Semaphore.h>
 #include "PoolStatistics.hpp"
 #include "FairQueue.hpp"
@@ -405,10 +405,10 @@ class ThinClientPoolDM
 
   // Manage Connection thread
   ACE_Semaphore m_connSema;
-  GF_TASK_T<ThinClientPoolDM>* m_connManageTask;
-  GF_TASK_T<ThinClientPoolDM>* m_pingTask;
-  GF_TASK_T<ThinClientPoolDM>* m_updateLocatorListTask;
-  GF_TASK_T<ThinClientPoolDM>* m_cliCallbackTask;
+  Task<ThinClientPoolDM>* m_connManageTask;
+  Task<ThinClientPoolDM>* m_pingTask;
+  Task<ThinClientPoolDM>* m_updateLocatorListTask;
+  Task<ThinClientPoolDM>* m_cliCallbackTask;
   long m_pingTaskId;
   long m_updateLocatorListTaskId;
   long m_connManageTaskId;
@@ -477,7 +477,7 @@ class FunctionExecution : public PooledWork<GfErrType> {
     m_poolDM = poolDM;
     m_userAttr = userAttr;
 
-    // m_functionExecutionTask = new GF_TASK_T<FunctionExecution>(this,
+    // m_functionExecutionTask = new Task<FunctionExecution>(this,
     //&FunctionExecution::execute);
   }
 

--- a/src/cppcache/src/ThinClientPoolHADM.cpp
+++ b/src/cppcache/src/ThinClientPoolHADM.cpp
@@ -75,7 +75,7 @@ void ThinClientPoolHADM::startBackgroundThreads() {
   }
 
   m_redundancyManager->startPeriodicAck();
-  m_redundancyTask = new GF_TASK_T<ThinClientPoolHADM>(
+  m_redundancyTask = new Task<ThinClientPoolHADM>(
       this, &ThinClientPoolHADM::redundancy, NC_Redundancy);
   m_redundancyTask->start();
 }

--- a/src/cppcache/src/ThinClientPoolHADM.hpp
+++ b/src/cppcache/src/ThinClientPoolHADM.hpp
@@ -114,7 +114,7 @@ class ThinClientPoolHADM : public ThinClientPoolDM {
   // const char* m_name; // COVERITY -> 30305 Uninitialized pointer field
   TcrConnectionManager& m_theTcrConnManager;
   ACE_Semaphore m_redundancySema;
-  GF_TASK_T<ThinClientPoolHADM>* m_redundancyTask;
+  Task<ThinClientPoolHADM>* m_redundancyTask;
 
   int redundancy(volatile bool& isRunning);
   /*

--- a/src/cppcache/src/ThinClientRedundancyManager.cpp
+++ b/src/cppcache/src/ThinClientRedundancyManager.cpp
@@ -1241,7 +1241,7 @@ void ThinClientRedundancyManager::doPeriodicAck() {
 }
 
 void ThinClientRedundancyManager::startPeriodicAck() {
-  m_periodicAckTask = new GF_TASK_T<ThinClientRedundancyManager>(
+  m_periodicAckTask = new Task<ThinClientRedundancyManager>(
       this, &ThinClientRedundancyManager::periodicAck, NC_PerodicACK);
   m_periodicAckTask->start();
   SystemProperties* props = DistributedSystem::getSystemProperties();

--- a/src/cppcache/src/ThinClientRedundancyManager.hpp
+++ b/src/cppcache/src/ThinClientRedundancyManager.hpp
@@ -126,7 +126,7 @@ class ThinClientRedundancyManager {
 
   inline bool isDurable();
   int processEventIdMap(const ACE_Time_Value&, const void*);
-  GF_TASK_T<ThinClientRedundancyManager>* m_periodicAckTask;
+  Task<ThinClientRedundancyManager>* m_periodicAckTask;
   ACE_Semaphore m_periodicAckSema;
   long m_processEventIdMapTaskId;  // periodic check eventid map for notify ack
                                    // and/or expiry

--- a/src/cppcache/src/TransactionalOperation.hpp
+++ b/src/cppcache/src/TransactionalOperation.hpp
@@ -27,7 +27,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/Cacheable.hpp>
 #include <geode/VectorT.hpp>
 

--- a/src/cppcache/src/Utils.hpp
+++ b/src/cppcache/src/Utils.hpp
@@ -25,7 +25,7 @@
  */
 
 #include <geode/geode_globals.hpp>
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 #include <geode/ExceptionTypes.hpp>
 #include <geode/CacheableString.hpp>
 #include <geode/DataOutput.hpp>

--- a/src/cppcache/src/VersionedCacheableObjectPartList.hpp
+++ b/src/cppcache/src/VersionedCacheableObjectPartList.hpp
@@ -22,7 +22,7 @@
 
 /*
 #include <geode/geode_globals.hpp>
-#include <geode/gf_types.hpp>
+#include <geode/geode_types.hpp>
 #include <geode/DataOutput.hpp>
 #include <geode/DataInput.hpp>
 #include <geode/Cacheable.hpp>

--- a/src/cryptoimpl/DHImpl.hpp
+++ b/src/cryptoimpl/DHImpl.hpp
@@ -27,7 +27,7 @@
 #include <vector>
 #include <string.h>
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 
 #define DH_ERR_NO_ERROR 0
 #define DH_ERR_UNSUPPORTED_ALGO 1

--- a/src/cryptoimpl/SSLImpl.hpp
+++ b/src/cryptoimpl/SSLImpl.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 #include "ace/ACE.h"
 #include "ace/OS.h"
 #include <ace/INET_Addr.h>
@@ -30,9 +30,9 @@
 #include <ace/OS.h>
 #include <ace/Recursive_Thread_Mutex.h>
 #include "ace/Time_Value.h"
-#include "GFSsl.hpp"
+#include "Ssl.hpp"
 
-class SSLImpl : public GFSsl {
+class SSLImpl : public apache::geode::client::Ssl {
  private:
   ACE_SSL_SOCK_Stream* m_io;
   static ACE_Recursive_Thread_Mutex s_mutex;

--- a/src/cryptoimpl/Ssl.hpp
+++ b/src/cryptoimpl/Ssl.hpp
@@ -1,3 +1,8 @@
+#pragma once
+
+#ifndef GEODE_CRYPTOIMPL_SSL_H_
+#define GEODE_CRYPTOIMPL_SSL_H_
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,13 +19,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Ssl.hpp
+ *
+ *  Created on: 28-Apr-2010
+ *      Author: ankurs
+ */
 
-// gf_includes.hpp : include file for standard system include files,
-// and all project specific include files.
+#include <ace/INET_Addr.h>
+#include <ace/OS.h>
 
-#pragma once
+namespace apache {
+namespace geode {
+namespace client {
+class Ssl {
+ public:
+  virtual ~Ssl(){};
+  virtual int setOption(int, int, void*, int) = 0;
+  virtual int listen(ACE_INET_Addr, unsigned) = 0;
+  virtual int connect(ACE_INET_Addr, unsigned) = 0;
+  virtual ssize_t recv(void*, size_t, const ACE_Time_Value*, size_t*) = 0;
+  virtual ssize_t send(const void*, size_t, const ACE_Time_Value*, size_t*) = 0;
+  virtual int getLocalAddr(ACE_Addr&) = 0;
+  virtual void close() = 0;
+};
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
 
-//#include "impl/ManagedCacheableKeyGCHandle.hpp"
-#include "impl/SafeConvert.hpp"
-
-#include <string>
+#endif  // GEODE_CRYPTOIMPL_SSL_H_

--- a/src/dhimpl/DHImpl.hpp
+++ b/src/dhimpl/DHImpl.hpp
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 
 #define DH_ERR_NO_ERROR 0
 #define DH_ERR_UNSUPPORTED_ALGO 1

--- a/src/pdxautoserializer/ASCLIBuiltins.hpp
+++ b/src/pdxautoserializer/ASCLIBuiltins.hpp
@@ -86,7 +86,7 @@ struct YesNoType<false> {
 }
 
 #define TYPE_IS_IGFSERIALIZABLE(T) \
-  TypeHelper::SuperSubclass<IGFSerializable, T>::result
+  TypeHelper::SuperSubclass<IGeodeSerializable, T>::result
 #define TYPE_IS_IGFSERIALIZABLE_TYPE(T) \
   TypeHelper::YesNoType<TYPE_IS_SERIALIZABLE(T)>::value
 

--- a/src/quickstart/csharp/DeltaExample.cs
+++ b/src/quickstart/csharp/DeltaExample.cs
@@ -21,7 +21,7 @@ using Apache.Geode.Client;
 
 namespace Apache.Geode.Client.QuickStart
 {
-  public class DeltaExample : IGFDelta,IGFSerializable, ICloneable
+  public class DeltaExample : IGeodeDelta,IGeodeSerializable, ICloneable
     {
       // data members
       private Int32 m_field1;
@@ -161,7 +161,7 @@ namespace Apache.Geode.Client.QuickStart
         DataOut.WriteInt32(m_field3);
       }
 
-      public IGFSerializable FromData(DataInput DataIn)
+      public IGeodeSerializable FromData(DataInput DataIn)
       {
         m_field1 = DataIn.ReadInt32();
         m_field2 = DataIn.ReadInt32();
@@ -186,7 +186,7 @@ namespace Apache.Geode.Client.QuickStart
         }
       }
    
-      public static IGFSerializable create()
+      public static IGeodeSerializable create()
       {
         return new DeltaExample();
       }

--- a/src/quickstart/csharp/PortfolioN.cs
+++ b/src/quickstart/csharp/PortfolioN.cs
@@ -25,7 +25,7 @@ namespace Apache.Geode.Client.Tests
   /// User class for testing the put functionality for object.
   /// </summary>
   public class Portfolio
-    : IGFSerializable
+    : IGeodeSerializable
   {
     #region Private members and methods
 
@@ -45,7 +45,7 @@ namespace Apache.Geode.Client.Tests
     private static string[] m_secIds = { "SUN", "IBM", "YHOO", "GOOG", "MSFT",
       "AOL", "APPL", "ORCL", "SAP", "DELL" };
 
-    private UInt32 GetObjectSize(IGFSerializable obj)
+    private UInt32 GetObjectSize(IGeodeSerializable obj)
     {
       return (obj == null ? 0 : obj.ObjectSize);
     }
@@ -231,9 +231,9 @@ namespace Apache.Geode.Client.Tests
 
     #endregion
 
-    #region IGFSerializable Members
+    #region IGeodeSerializable Members
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       m_id = input.ReadInt32();
       m_pkid = input.ReadUTF();
@@ -298,7 +298,7 @@ namespace Apache.Geode.Client.Tests
 
     #endregion
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new Portfolio();
     }

--- a/src/quickstart/csharp/PortfolioPdx.cs
+++ b/src/quickstart/csharp/PortfolioPdx.cs
@@ -46,7 +46,7 @@ namespace PdxTests
     private static string[] m_secIds = { "SUN", "IBM", "YHOO", "GOOG", "MSFT",
       "AOL", "APPL", "ORCL", "SAP", "DELL" };
 
-    private UInt32 GetObjectSize(IGFSerializable obj)
+    private UInt32 GetObjectSize(IGeodeSerializable obj)
     {
       return (obj == null ? 0 : obj.ObjectSize);
     }

--- a/src/quickstart/csharp/PositionN.cs
+++ b/src/quickstart/csharp/PositionN.cs
@@ -21,7 +21,7 @@ namespace Apache.Geode.Client.Tests
 {
   using Apache.Geode.Client;
   public class Position
-    : IGFSerializable
+    : IGeodeSerializable
   {
     #region Private members
 
@@ -68,7 +68,7 @@ namespace Apache.Geode.Client.Tests
       m_pid = 0;
     }
 
-    private UInt32 GetObjectSize(IGFSerializable obj)
+    private UInt32 GetObjectSize(IGeodeSerializable obj)
     {
       return (obj == null ? 0 : obj.ObjectSize);
     }
@@ -157,9 +157,9 @@ namespace Apache.Geode.Client.Tests
 
     #endregion
 
-    #region IGFSerializable Members
+    #region IGeodeSerializable Members
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       m_avg20DaysVol = input.ReadInt64();
       m_bondRating = input.ReadUTF();
@@ -237,7 +237,7 @@ namespace Apache.Geode.Client.Tests
 
     #endregion
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new Position();
     }

--- a/src/quickstart/csharp/PositionPdx.cs
+++ b/src/quickstart/csharp/PositionPdx.cs
@@ -68,7 +68,7 @@ namespace PdxTests
       m_pid = 0;
     }
 
-    private UInt32 GetObjectSize(IGFSerializable obj)
+    private UInt32 GetObjectSize(IGeodeSerializable obj)
     {
       return (obj == null ? 0 : obj.ObjectSize);
     }

--- a/src/tests/cli/NewFwkLib/CacheHelper.cs
+++ b/src/tests/cli/NewFwkLib/CacheHelper.cs
@@ -445,7 +445,7 @@ namespace Apache.Geode.Client.FwkLib
       }
     }
 
-    public static void LogValues(IGFSerializable[] cValues)
+    public static void LogValues(IGeodeSerializable[] cValues)
     {
       if (cValues != null)
       {

--- a/src/tests/cli/NewFwkLib/CacheServer.cs
+++ b/src/tests/cli/NewFwkLib/CacheServer.cs
@@ -4624,7 +4624,7 @@ private void checkUpdatedValue(TKey key, TVal value)
 
       TKey key;
       TVal value;
-      //IGFSerializable val;
+      //IGeodeSerializable val;
 
       CqQuery<TKey, object> cq = null;
       string opCode = null;

--- a/src/tests/cli/NewFwkLib/EventTest/ETCacheLoader.cs
+++ b/src/tests/cli/NewFwkLib/EventTest/ETCacheLoader.cs
@@ -30,7 +30,7 @@ namespace Apache.Geode.Client.FwkLib
 
     #region ICacheLoader Members
 
-    public IGFSerializable Load(Region rp, ICacheableKey key, IGFSerializable helper)
+    public IGeodeSerializable Load(Region rp, ICacheableKey key, IGeodeSerializable helper)
     {
       Util.BBIncrement(EventTest.EventCountersBB, "LOAD_CACHEABLE_STRING_COUNT");
       byte[] buffer = new byte[2000];

--- a/src/tests/cli/NewFwkLib/EventTest/EventTests.cs
+++ b/src/tests/cli/NewFwkLib/EventTest/EventTests.cs
@@ -58,7 +58,7 @@ namespace Apache.Geode.Client.FwkLib
         expected = bbExpected;
       }
       Region testReg = CacheHelper.GetRegion(testRegionName);
-      IGFSerializable[] keys = testReg.GetKeys();
+      IGeodeSerializable[] keys = testReg.GetKeys();
       int keyCount = keys.Length;
       double diff = 0;
       if (keyCount > expected)
@@ -92,7 +92,7 @@ namespace Apache.Geode.Client.FwkLib
         {
           return;
         }
-        IGFSerializable[] keys = reg.GetKeys();
+        IGeodeSerializable[] keys = reg.GetKeys();
         int maxkeys = GetUIntValue("distinctKeys");
         int balanceEntries = GetUIntValue("balanceEntries");
         FwkInfo("After getrandomregion inside doentrytest Check 2 balance entries = {0}", balanceEntries);
@@ -704,7 +704,7 @@ namespace Apache.Geode.Client.FwkLib
       }
 
       ICacheableKey key;
-      IGFSerializable value;
+      IGeodeSerializable value;
 
       int entryPassCnt = 0;
       int entryFailCnt = 0;
@@ -768,7 +768,7 @@ namespace Apache.Geode.Client.FwkLib
       }
 
       ICacheableKey key;
-      IGFSerializable value;
+      IGeodeSerializable value;
 
       int entryPassCnt = 0;
       int entryFailCnt = 0;
@@ -939,7 +939,7 @@ namespace Apache.Geode.Client.FwkLib
 
       for (int i = 0; i < numKeys; ++i)
       {
-        IGFSerializable val = region.Get(keys[i]);
+        IGeodeSerializable val = region.Get(keys[i]);
 
         if (val.ToString() != values[i].ToString())
         {
@@ -967,7 +967,7 @@ namespace Apache.Geode.Client.FwkLib
 
       for (int i = 0; i < numKeys; ++i)
       {
-        IGFSerializable val = region.Get(keys[i]);         // get
+        IGeodeSerializable val = region.Get(keys[i]);         // get
 
         if (val.ToString() != values[i].ToString())
         {
@@ -1302,7 +1302,7 @@ namespace Apache.Geode.Client.FwkLib
         return;
       }
 
-      IGFSerializable anObj = randomRegion.Get(keyP);
+      IGeodeSerializable anObj = randomRegion.Get(keyP);
 
       int vsize = GetUIntValue("valueSizes");
       if (vsize < 0)
@@ -1622,7 +1622,7 @@ namespace Apache.Geode.Client.FwkLib
       }
 
       CacheableKey key = null;
-      IGFSerializable value = null;
+      IGeodeSerializable value = null;
 
       for (uint ulIndex = 0; ulIndex < ulKeysInRegion; ulIndex++)
       {

--- a/src/tests/cli/NewFwkLib/FunctionExecution/FunctionExecution.cs
+++ b/src/tests/cli/NewFwkLib/FunctionExecution/FunctionExecution.cs
@@ -667,7 +667,7 @@ namespace Apache.Geode.Client.FwkLib
       ResetKey("distinctKeys");
       Int32 numKeys = GetUIntValue("distinctKeys");
       int clientNum = Util.ClientNum;
-      //IGFSerializable[] filterObj = new IGFSerializable[numKeys];
+      //IGeodeSerializable[] filterObj = new IGeodeSerializable[numKeys];
       Object[] filterObj = new Object[numKeys];
       try
       {
@@ -705,7 +705,7 @@ namespace Apache.Geode.Client.FwkLib
         {
           int clntId = Util.ClientNum;
           filterObj = new Object[1];
-          //filterObj = new IGFSerializable[1];
+          //filterObj = new IGeodeSerializable[1];
           Random rnd = new Random();
           //filterObj[0] = new CacheableString("KEY--" + clntId + "--" + rnd.Next(numKeys));
           filterObj[0] = "KEY--" + clntId + "--" + rnd.Next(numKeys);
@@ -755,7 +755,7 @@ namespace Apache.Geode.Client.FwkLib
             funcName = "RegionOperationsWithOutResultFunction";
         }
         //FwkInfo("ExecuteFunction - function name is{0} ", funcName);
-        //IGFSerializable[] executeFunctionResult = null;
+        //IGeodeSerializable[] executeFunctionResult = null;
         ICollection<object> executeFunctionResult = null;
         if(!isReplicate){
           if(getresult == true){
@@ -1051,11 +1051,11 @@ namespace Apache.Geode.Client.FwkLib
           // ICacheableKey<TKey>[]keys = region.GetKeys();
            ICollection<TKey> keys = region.GetLocalView().Keys;
                       
-           //IGFSerializable[] filterObj = new IGFSerializable[keys.Count];
+           //IGeodeSerializable[] filterObj = new IGeodeSerializable[keys.Count];
            Object[] filterObj = new Object[keys.Count];
            for (int i = 0; i < keys.Count; i++)
            {
-             //filterObj[i] = (IGFSerializable)keys;
+             //filterObj[i] = (IGeodeSerializable)keys;
              filterObj[i] = keys;
            }
            exc = exc.WithFilter(filterObj).WithCollector(myRC);

--- a/src/tests/cli/NewFwkLib/QueryTest/QueryTests.cs
+++ b/src/tests/cli/NewFwkLib/QueryTest/QueryTests.cs
@@ -294,7 +294,7 @@ namespace Apache.Geode.Client.FwkLib
                 string query = QueryStatics.ResultSetParamQueries[index].Query;
                 FwkInfo("QueryTests.VerifyResultSet: Query Category [{0}]," +
                 " QueryString [{1}], NumSet [{2}].", category - 1, query, numSet);
-                //IGFSerializable[] paramList = new IGFSerializable[QueryStatics.NoOfQueryParam[index]];
+                //IGeodeSerializable[] paramList = new IGeodeSerializable[QueryStatics.NoOfQueryParam[index]];
                 object[] paramList = new object[QueryStatics.NoOfQueryParam[index]];
                 Int32 numVal = 0;
                 for (Int32 ind = 0; ind < QueryStatics.NoOfQueryParam[index]; ind++)

--- a/src/tests/cli/NewFwkLib/SecurityTest/Security.cs
+++ b/src/tests/cli/NewFwkLib/SecurityTest/Security.cs
@@ -68,9 +68,9 @@ namespace Apache.Geode.Client.FwkLib
       }
     }
 
-    private IGFSerializable GetUserObject(string objType)
+    private IGeodeSerializable GetUserObject(string objType)
     {
-      IGFSerializable usrObj = null;
+      IGeodeSerializable usrObj = null;
       ResetKey(EntryCount);
       int numOfKeys = GetUIntValue(EntryCount);
       ResetKey(ValueSizes);
@@ -268,8 +268,8 @@ namespace Apache.Geode.Client.FwkLib
       FwkInfo("DoEntryOperations will work for {0} secs using {1} byte values.", secondsToRun, valSize);
 
       CacheableKey key;
-      IGFSerializable value;
-      IGFSerializable tmpValue;
+      IGeodeSerializable value;
+      IGeodeSerializable tmpValue;
       PaceMeter meter = new PaceMeter(opsSec);
       string objectType = GetStringValue(ObjectType);
       while (now < end)
@@ -408,8 +408,8 @@ namespace Apache.Geode.Client.FwkLib
       FwkInfo("DoEntryOperations will work for {0} secs using {1} byte values.", secondsToRun, valSize);
 
       CacheableKey key;
-      IGFSerializable value;
-      IGFSerializable tmpValue;
+      IGeodeSerializable value;
+      IGeodeSerializable tmpValue;
       PaceMeter meter = new PaceMeter(opsSec);
       string objectType = GetStringValue(ObjectType);
       while (now < end)

--- a/src/tests/cli/NewFwkLib/SmokePerf/SmokePerf.cs
+++ b/src/tests/cli/NewFwkLib/SmokePerf/SmokePerf.cs
@@ -148,7 +148,7 @@ namespace Apache.Geode.Client.FwkLib
 
     // VJR: added dummy load/close placeholders.
     /*
-    public IGFSerializable Load( Apache.Geode.Client.Region region, ICacheableKey key, IGFSerializable helper)
+    public IGeodeSerializable Load( Apache.Geode.Client.Region region, ICacheableKey key, IGeodeSerializable helper)
     {
       return new CacheableInt32(m_loads++);
     }

--- a/src/tests/cli/NewFwkLib/SmokePerf/SmokeTasks.cs
+++ b/src/tests/cli/NewFwkLib/SmokePerf/SmokeTasks.cs
@@ -711,12 +711,12 @@ namespace Apache.Geode.Client.FwkLib
             {
               Util.Log("PutAllMap:: key = {0} ", key);
             }
-            foreach (IGFSerializable val in putAllmap.Values)
+            foreach (IGeodeSerializable val in putAllmap.Values)
             {
               Util.Log("PutAllMap:: value = {0} ", val);
             }
             
-            foreach (KeyValuePair<ICacheableKey, IGFSerializable> item in putAllmap)
+            foreach (KeyValuePair<ICacheableKey, IGeodeSerializable> item in putAllmap)
             {
               Util.Log("PutAllMap:: key = {0} value = {1} localcont = {2}", item.Key, item.Value, localcnt);
             }

--- a/src/tests/cli/NewTestObject/BatchObject.cs
+++ b/src/tests/cli/NewTestObject/BatchObject.cs
@@ -63,7 +63,7 @@ namespace Apache.Geode.Client.Tests
       DateTime startTime = DateTime.Now;
       timestamp = startTime.Ticks * (1000000 / TimeSpan.TicksPerMillisecond);
     }
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new BatchObject();
     }
@@ -75,7 +75,7 @@ namespace Apache.Geode.Client.Tests
       batch = anIndex/batchSize;
       byteArray = new byte[size];
     }
-    public override IGFSerializable FromData(DataInput input)
+    public override IGeodeSerializable FromData(DataInput input)
     {
       index = input.ReadInt32();
       timestamp = input.ReadInt64();

--- a/src/tests/cli/NewTestObject/DeltaEx.cs
+++ b/src/tests/cli/NewTestObject/DeltaEx.cs
@@ -20,7 +20,7 @@ using System;
 using Apache.Geode.Client;
 namespace Apache.Geode.Client.Tests
 {
-    public class DeltaEx : Apache.Geode.Client.IGFDelta, Apache.Geode.Client.IGFSerializable, ICloneable
+    public class DeltaEx : Apache.Geode.Client.IGeodeDelta, Apache.Geode.Client.IGeodeSerializable, ICloneable
     {
         private int counter;
         private bool IsDelta;
@@ -67,7 +67,7 @@ namespace Apache.Geode.Client.Tests
             DataOut.WriteInt32( counter );
             ToDataCount++;
         }
-        public Apache.Geode.Client.IGFSerializable FromData(Apache.Geode.Client.DataInput DataIn)
+        public Apache.Geode.Client.IGeodeSerializable FromData(Apache.Geode.Client.DataInput DataIn)
         {
             counter = DataIn.ReadInt32();
             FromDataCount++;
@@ -96,7 +96,7 @@ namespace Apache.Geode.Client.Tests
             IsDelta = isDelta;
         }
 
-        public static Apache.Geode.Client.IGFSerializable create()
+        public static Apache.Geode.Client.IGeodeSerializable create()
         {
             return new DeltaEx();
         }

--- a/src/tests/cli/NewTestObject/DeltaFastAssetAccount.cs
+++ b/src/tests/cli/NewTestObject/DeltaFastAssetAccount.cs
@@ -22,7 +22,7 @@ namespace Apache.Geode.Client.Tests
 {
   using Apache.Geode.Client;
   public class DeltaFastAssetAccount
-    : IGFSerializable, IGFDelta
+    : IGeodeSerializable, IGeodeDelta
   {
     private bool encodeTimestamp;
     private Int32 acctId;
@@ -73,7 +73,7 @@ namespace Apache.Geode.Client.Tests
         return 41;
       }
     }
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       acctId = input.ReadInt32();
       customerName = input.ReadUTF();
@@ -191,7 +191,7 @@ namespace Apache.Geode.Client.Tests
       }
       return clonePtr;
     }
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new DeltaFastAssetAccount();
     }

--- a/src/tests/cli/NewTestObject/DeltaPSTObject.cs
+++ b/src/tests/cli/NewTestObject/DeltaPSTObject.cs
@@ -21,7 +21,7 @@ namespace Apache.Geode.Client.Tests
 {
   using Apache.Geode.Client;
   public class DeltaPSTObject
-    : IGFSerializable, IGFDelta
+    : IGeodeSerializable, IGeodeDelta
   {
     private long timestamp;
     private Int32 field1;
@@ -65,7 +65,7 @@ namespace Apache.Geode.Client.Tests
         return 42;
       }
     }
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       timestamp = input.ReadInt64();
       field1 = input.ReadInt32();
@@ -113,7 +113,7 @@ namespace Apache.Geode.Client.Tests
     {
       return new DeltaPSTObject();
     }
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new DeltaPSTObject();
     }

--- a/src/tests/cli/NewTestObject/DeltaTestImpl.cs
+++ b/src/tests/cli/NewTestObject/DeltaTestImpl.cs
@@ -21,7 +21,7 @@ namespace Apache.Geode.Client.Tests
 {
   using Apache.Geode.Client;
   public class DeltaTestImpl
-    : IGFSerializable, IGFDelta
+    : IGeodeSerializable, IGeodeDelta
   {
     private static sbyte INT_MASK = 0x1;
     private static sbyte STR_MASK = 0X2;
@@ -94,7 +94,7 @@ namespace Apache.Geode.Client.Tests
         return 0x1E;
       }
     }
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new DeltaTestImpl();
     }
@@ -187,7 +187,7 @@ namespace Apache.Geode.Client.Tests
       return hasDelta;
     }
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       intVar = input.ReadInt32();
       str = (string)input.ReadObject();

--- a/src/tests/cli/NewTestObject/EqStruct.cs
+++ b/src/tests/cli/NewTestObject/EqStruct.cs
@@ -151,7 +151,7 @@ namespace Apache.Geode.Client.Tests
                 return 101;
             }
         }
-        public static IGFSerializable CreateDeserializable()
+        public static IGeodeSerializable CreateDeserializable()
         {
             return new PSTObject();
         }
@@ -170,7 +170,7 @@ namespace Apache.Geode.Client.Tests
             return portStr;
         }
 
-        public override IGFSerializable FromData(DataInput input)
+        public override IGeodeSerializable FromData(DataInput input)
         { //Strings
 	      state = input.ReadUTF();
 	      demandInd =input.ReadUTF();

--- a/src/tests/cli/NewTestObject/FastAsset.cs
+++ b/src/tests/cli/NewTestObject/FastAsset.cs
@@ -52,7 +52,7 @@ namespace Apache.Geode.Client.Tests
         return 24;
       }
     }
-    public override IGFSerializable FromData(DataInput input)
+    public override IGeodeSerializable FromData(DataInput input)
     {
       assetId = input.ReadInt32();
       value = input.ReadDouble();
@@ -64,7 +64,7 @@ namespace Apache.Geode.Client.Tests
       output.WriteDouble(value);
     }
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new FastAsset();
     }

--- a/src/tests/cli/NewTestObject/FastAssetAccount.cs
+++ b/src/tests/cli/NewTestObject/FastAssetAccount.cs
@@ -73,7 +73,7 @@ namespace Apache.Geode.Client.Tests
         return 23;
       }
     }
-    public override IGFSerializable FromData(DataInput input)
+    public override IGeodeSerializable FromData(DataInput input)
     {
       acctId = input.ReadInt32();
       customerName = (string)input.ReadObject();
@@ -92,7 +92,7 @@ namespace Apache.Geode.Client.Tests
       output.WriteInt64(timestamp);
     }
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new FastAssetAccount();
     }

--- a/src/tests/cli/NewTestObject/PSTObject.cs
+++ b/src/tests/cli/NewTestObject/PSTObject.cs
@@ -63,7 +63,7 @@ namespace Apache.Geode.Client.Tests
         return 4;
       }
     }
-    public override IGFSerializable FromData(DataInput input)
+    public override IGeodeSerializable FromData(DataInput input)
     {
       timestamp = input.ReadInt64();
       field1 = input.ReadInt32();
@@ -79,7 +79,7 @@ namespace Apache.Geode.Client.Tests
       output.WriteBytes(valueData);
     }
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new PSTObject();
     }

--- a/src/tests/cli/NewTestObject/Portfolio.cs
+++ b/src/tests/cli/NewTestObject/Portfolio.cs
@@ -25,7 +25,7 @@ namespace Apache.Geode.Client.Tests
   /// User class for testing the put functionality for object.
   /// </summary>
   public class Portfolio
-    : IGFSerializable
+    : IGeodeSerializable
   {
     #region Private members and methods
 
@@ -45,7 +45,7 @@ namespace Apache.Geode.Client.Tests
     private static string[] m_secIds = { "SUN", "IBM", "YHOO", "GOOG", "MSFT",
       "AOL", "APPL", "ORCL", "SAP", "DELL" };
 
-    private UInt32 GetObjectSize(IGFSerializable obj)
+    private UInt32 GetObjectSize(IGeodeSerializable obj)
     {
       return (obj == null ? 0 : obj.ObjectSize);
     }
@@ -231,9 +231,9 @@ namespace Apache.Geode.Client.Tests
 
     #endregion
 
-    #region IGFSerializable Members
+    #region IGeodeSerializable Members
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       m_id = input.ReadInt32();
       m_pkid = input.ReadUTF();
@@ -264,7 +264,7 @@ namespace Apache.Geode.Client.Tests
       output.WriteUTF(m_status);
       output.WriteObject(m_names);
       output.WriteBytes(m_newVal);
-      //output.WriteObject((IGFSerializable)(object)m_creationDate); // VJR: TODO
+      //output.WriteObject((IGeodeSerializable)(object)m_creationDate); // VJR: TODO
       //output.WriteObject(CacheableDate.Create(m_creationDate));
       output.WriteDate(m_creationDate);
       output.WriteBytes(m_arrayNull);
@@ -301,7 +301,7 @@ namespace Apache.Geode.Client.Tests
 
     #endregion
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new Portfolio();
     }

--- a/src/tests/cli/NewTestObject/PortfolioPdx.cs
+++ b/src/tests/cli/NewTestObject/PortfolioPdx.cs
@@ -46,7 +46,7 @@ namespace Apache.Geode.Client.Tests
     private static string[] m_secIds = { "SUN", "IBM", "YHOO", "GOOG", "MSFT",
       "AOL", "APPL", "ORCL", "SAP", "DELL" };
 
-    private UInt32 GetObjectSize(IGFSerializable obj)
+    private UInt32 GetObjectSize(IGeodeSerializable obj)
     {
       return (obj == null ? 0 : obj.ObjectSize);
     }

--- a/src/tests/cli/NewTestObject/Position.cs
+++ b/src/tests/cli/NewTestObject/Position.cs
@@ -21,7 +21,7 @@ namespace Apache.Geode.Client.Tests
 {
   using Apache.Geode.Client;
   public class Position
-    : IGFSerializable
+    : IGeodeSerializable
   {
     #region Private members
 
@@ -68,7 +68,7 @@ namespace Apache.Geode.Client.Tests
       m_pid = 0;
     }
 
-    private UInt32 GetObjectSize(IGFSerializable obj)
+    private UInt32 GetObjectSize(IGeodeSerializable obj)
     {
       return (obj == null ? 0 : obj.ObjectSize);
     }
@@ -157,9 +157,9 @@ namespace Apache.Geode.Client.Tests
 
     #endregion
 
-    #region IGFSerializable Members
+    #region IGeodeSerializable Members
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       m_avg20DaysVol = input.ReadInt64();
       m_bondRating = input.ReadUTF();
@@ -237,7 +237,7 @@ namespace Apache.Geode.Client.Tests
 
     #endregion
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new Position();
     }

--- a/src/tests/cli/NewTestObject/PositionPdx.cs
+++ b/src/tests/cli/NewTestObject/PositionPdx.cs
@@ -68,7 +68,7 @@ namespace Apache.Geode.Client.Tests
       m_pid = 0;
     }
 
-    private UInt32 GetObjectSize(IGFSerializable obj)
+    private UInt32 GetObjectSize(IGeodeSerializable obj)
     {
       return (obj == null ? 0 : obj.ObjectSize);
     }

--- a/src/tests/cli/NewTestObject/TestObject1.cs
+++ b/src/tests/cli/NewTestObject/TestObject1.cs
@@ -21,7 +21,7 @@ namespace Apache.Geode.Client.Tests
 {
   using Apache.Geode.Client;
   public class TestObject1
-    : IGFSerializable
+    : IGeodeSerializable
   {
     private string name;
     private byte[] arr;
@@ -52,7 +52,7 @@ namespace Apache.Geode.Client.Tests
         return 0x1F;
       }
     }
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       arr = input.ReadBytes();
       name = (string)input.ReadObject();
@@ -66,7 +66,7 @@ namespace Apache.Geode.Client.Tests
       output.WriteInt32(identifire);
     }
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
       return new TestObject1();
     }

--- a/src/tests/cli/NewTestObject/TimeStampdObject.cs
+++ b/src/tests/cli/NewTestObject/TimeStampdObject.cs
@@ -21,7 +21,7 @@ namespace Apache.Geode.Client.Tests
 {
   using Apache.Geode.Client;
   public class TimeStampdObject
-    : IGFSerializable
+    : IGeodeSerializable
   {
 
     public virtual UInt32 ObjectSize
@@ -38,7 +38,7 @@ namespace Apache.Geode.Client.Tests
         return 0;
       }
     }
-    public virtual IGFSerializable FromData(DataInput input)
+    public virtual IGeodeSerializable FromData(DataInput input)
     {
       return this;
     }

--- a/src/tests/cli/PdxClassLibrary/PortfolioPdx.cs
+++ b/src/tests/cli/PdxClassLibrary/PortfolioPdx.cs
@@ -46,7 +46,7 @@ namespace PdxTests
     private static string[] m_secIds = { "SUN", "IBM", "YHOO", "GOOG", "MSFT",
       "AOL", "APPL", "ORCL", "SAP", "DELL" };
 
-    private UInt32 GetObjectSize(IGFSerializable obj)
+    private UInt32 GetObjectSize(IGeodeSerializable obj)
     {
       return (obj == null ? 0 : obj.ObjectSize);
     }

--- a/src/tests/cli/PdxClassLibrary/PositionPdx.cs
+++ b/src/tests/cli/PdxClassLibrary/PositionPdx.cs
@@ -68,7 +68,7 @@ namespace PdxTests
       m_pid = 0;
     }
 
-    private UInt32 GetObjectSize(IGFSerializable obj)
+    private UInt32 GetObjectSize(IGeodeSerializable obj)
     {
       return (obj == null ? 0 : obj.ObjectSize);
     }

--- a/src/tests/cli/PdxClassLibrary/VariousPdxTypes.cs
+++ b/src/tests/cli/PdxClassLibrary/VariousPdxTypes.cs
@@ -804,7 +804,7 @@ namespace PdxTests
     #endregion
   }
     [Serializable]
-  public class PdxInsideIGFSerializable : IGFSerializable
+  public class PdxInsideIGeodeSerializable : IGeodeSerializable
   {
     NestedPdx m_npdx = new NestedPdx();
     PdxTypes3 m_pdx3 = new PdxTypes3();
@@ -816,9 +816,9 @@ namespace PdxTests
     int m_i4 = 73567;
 
 
-    public static IGFSerializable CreateDeserializable()
+    public static IGeodeSerializable CreateDeserializable()
     {
-      return new PdxInsideIGFSerializable();
+      return new PdxInsideIGeodeSerializable();
     }
     public override int GetHashCode()
     {
@@ -829,7 +829,7 @@ namespace PdxTests
     {
       if (obj == null)
         return false;
-      PdxInsideIGFSerializable pap = obj as PdxInsideIGFSerializable;
+      PdxInsideIGeodeSerializable pap = obj as PdxInsideIGeodeSerializable;
 
       if (pap == null)
         return false;
@@ -850,14 +850,14 @@ namespace PdxTests
       return false;
     }
 
-    #region IGFSerializable Members
+    #region IGeodeSerializable Members
 
     public uint ClassId
     {
       get { return 5005; }
     }
 
-    public IGFSerializable FromData(DataInput input)
+    public IGeodeSerializable FromData(DataInput input)
     {
       m_i1 = input.ReadInt32();
       m_npdx = (NestedPdx)input.ReadObject();

--- a/src/tests/cli/QueryHelper/QueryHelperN.cs
+++ b/src/tests/cli/QueryHelper/QueryHelperN.cs
@@ -345,7 +345,7 @@ namespace Apache.Geode.Client.Tests
         int foundFields = 0;
         for (uint cols = 0; cols < si.Length; cols++)
         {
-          //IGFSerializable field = si[cols];
+          //IGeodeSerializable field = si[cols];
           object field = (object)si[cols];
           foundFields++;
         }

--- a/src/tests/cpp/fwklib/FwkBB.hpp
+++ b/src/tests/cpp/fwklib/FwkBB.hpp
@@ -27,7 +27,7 @@
   * @see
   */
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 #include "fwklib/FwkLog.hpp"
 
 #include <vector>

--- a/src/tests/cpp/fwklib/FwkLog.hpp
+++ b/src/tests/cpp/fwklib/FwkLog.hpp
@@ -30,7 +30,7 @@
 
 // ----------------------------------------------------------------------------
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 
 #include "FwkException.hpp"
 

--- a/src/tests/cpp/fwklib/GsRandom.hpp
+++ b/src/tests/cpp/fwklib/GsRandom.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 
 #include <string>
 

--- a/src/tests/cpp/fwklib/IpcHandler.hpp
+++ b/src/tests/cpp/fwklib/IpcHandler.hpp
@@ -23,7 +23,7 @@
 #include <ace/SOCK_Stream.h>
 #include <ace/OS.h>
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 
 #include <string>
 

--- a/src/tests/cpp/fwklib/MersenneTwister.hpp
+++ b/src/tests/cpp/fwklib/MersenneTwister.hpp
@@ -86,7 +86,7 @@
 #include <math.h>
 
 #include "SpinLock.hpp"
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 
 class MTRand {
   // Data

--- a/src/tests/cpp/fwklib/PerfFwk.hpp
+++ b/src/tests/cpp/fwklib/PerfFwk.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 
 #include <string>
 #include <map>

--- a/src/tests/cpp/fwklib/Service.hpp
+++ b/src/tests/cpp/fwklib/Service.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 #include <AtomicInc.hpp>
 #include "fwklib/FwkLog.hpp"
 

--- a/src/tests/cpp/fwklib/TcpIpc.hpp
+++ b/src/tests/cpp/fwklib/TcpIpc.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 #include <ace/SOCK_Stream.h>
 #include <ace/SOCK_Acceptor.h>
 #include <string>

--- a/src/tests/cpp/fwklib/Timer.hpp
+++ b/src/tests/cpp/fwklib/Timer.hpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 
-#include <geode/gf_base.hpp>
+#include <geode/geode_base.hpp>
 #include "fwklib/FwkLog.hpp"
 
 #include <ace/Time_Value.h>

--- a/src/tests/cpp/testobject/VariousPdxTypes.cpp
+++ b/src/tests/cpp/testobject/VariousPdxTypes.cpp
@@ -860,9 +860,9 @@ void MixedVersionNestedPdx::fromData(PdxReaderPtr pr) {
 }
 
 /************************************************************
- *  PdxInsideIGFSerializable
+ *  PdxInsideIGeodeSerializable
  * *********************************************************/
-PdxInsideIGFSerializable::PdxInsideIGFSerializable() {
+PdxInsideIGeodeSerializable::PdxInsideIGeodeSerializable() {
   m_npdx = new NestedPdx();
   m_pdx3 = new PdxTypes3();
   m_s1 = (char *)"one";
@@ -873,16 +873,17 @@ PdxInsideIGFSerializable::PdxInsideIGFSerializable() {
   m_i4 = 73567;
 }
 
-PdxInsideIGFSerializable::~PdxInsideIGFSerializable() {
+PdxInsideIGeodeSerializable::~PdxInsideIGeodeSerializable() {
   // TODO Auto-generated destructor stub
 }
 
-int32_t PdxInsideIGFSerializable::getHashCode() { return 1; }
+int32_t PdxInsideIGeodeSerializable::getHashCode() { return 1; }
 
-bool PdxInsideIGFSerializable::equals(SerializablePtr obj) {
+bool PdxInsideIGeodeSerializable::equals(SerializablePtr obj) {
   if (obj == NULLPTR) return false;
 
-  PdxInsideIGFSerializablePtr pap = dynCast<PdxInsideIGFSerializablePtr>(obj);
+  PdxInsideIGeodeSerializablePtr pap =
+      dynCast<PdxInsideIGeodeSerializablePtr>(obj);
   if (pap == NULLPTR) return false;
 
   // if (pap == this)
@@ -897,16 +898,16 @@ bool PdxInsideIGFSerializable::equals(SerializablePtr obj) {
   return false;
 }
 
-CacheableStringPtr PdxInsideIGFSerializable::toString() const {
+CacheableStringPtr PdxInsideIGeodeSerializable::toString() const {
   char idbuf[4096];
   sprintf(idbuf,
-          "PdxInsideIGFSerializable:[m_i1=%d] [m_i2=%d] [m_i3=%d] [m_i4=%d] "
+          "PdxInsideIGeodeSerializable:[m_i1=%d] [m_i2=%d] [m_i3=%d] [m_i4=%d] "
           "[m_s1=%s] [m_s2=%s]",
           m_i1, m_i2, m_i3, m_i4, m_s1, m_s2);
   return CacheableString::create(idbuf);
 }
 
-void PdxInsideIGFSerializable::toData(DataOutput &output) const {
+void PdxInsideIGeodeSerializable::toData(DataOutput &output) const {
   output.writeInt(m_i1);
   output.writeObject(m_npdx);
   output.writeInt(m_i2);
@@ -917,7 +918,7 @@ void PdxInsideIGFSerializable::toData(DataOutput &output) const {
   output.writeInt(m_i4);
 }
 
-Serializable *PdxInsideIGFSerializable::fromData(DataInput &input) {
+Serializable *PdxInsideIGeodeSerializable::fromData(DataInput &input) {
   input.readInt(&m_i1);
   input.readObject(m_npdx);
   input.readInt(&m_i2);

--- a/src/tests/cpp/testobject/VariousPdxTypes.hpp
+++ b/src/tests/cpp/testobject/VariousPdxTypes.hpp
@@ -494,10 +494,10 @@ class TESTOBJECT_EXPORT MixedVersionNestedPdx : public PdxSerializable {
 typedef SharedPtr<MixedVersionNestedPdx> MixedVersionNestedPdxPtr;
 
 /************************************************************
- *  PdxInsideIGFSerializable
+ *  PdxInsideIGeodeSerializable
  * *********************************************************/
 
-class TESTOBJECT_EXPORT PdxInsideIGFSerializable : public Serializable {
+class TESTOBJECT_EXPORT PdxInsideIGeodeSerializable : public Serializable {
  private:
   NestedPdxPtr m_npdx;
   PdxTypes3Ptr m_pdx3;
@@ -510,9 +510,9 @@ class TESTOBJECT_EXPORT PdxInsideIGFSerializable : public Serializable {
   int32_t m_i4;
 
  public:
-  PdxInsideIGFSerializable();
+  PdxInsideIGeodeSerializable();
 
-  virtual ~PdxInsideIGFSerializable();
+  virtual ~PdxInsideIGeodeSerializable();
 
   int32_t getHashCode();
 
@@ -527,14 +527,14 @@ class TESTOBJECT_EXPORT PdxInsideIGFSerializable : public Serializable {
   virtual int32_t classId() const { return 0x10; }
 
   const char* getClassName() const {
-    return "PdxTests::PdxInsideIGFSerializable";
+    return "PdxTests::PdxInsideIGeodeSerializable";
   }
 
   static Serializable* createDeserializable() {
-    return new PdxInsideIGFSerializable();
+    return new PdxInsideIGeodeSerializable();
   }
 };
-typedef SharedPtr<PdxInsideIGFSerializable> PdxInsideIGFSerializablePtr;
+typedef SharedPtr<PdxInsideIGeodeSerializable> PdxInsideIGeodeSerializablePtr;
 
 } /* namespace PdxTests */
 

--- a/src/tests/cpp/testobject/VariousPdxTypesWithAuto.cpp
+++ b/src/tests/cpp/testobject/VariousPdxTypesWithAuto.cpp
@@ -788,9 +788,9 @@ CacheableStringPtr NestedPdx::toString() const {
 //}
 
 /************************************************************
- *  PdxInsideIGFSerializable
+ *  PdxInsideIGeodeSerializable
  * *********************************************************/
-PdxInsideIGFSerializable::PdxInsideIGFSerializable() {
+PdxInsideIGeodeSerializable::PdxInsideIGeodeSerializable() {
   m_npdx = new NestedPdx();
   m_pdx3 = new PdxTypes3();
   m_s1 = (char *)"one";
@@ -801,16 +801,17 @@ PdxInsideIGFSerializable::PdxInsideIGFSerializable() {
   m_i4 = 73567;
 }
 
-PdxInsideIGFSerializable::~PdxInsideIGFSerializable() {
+PdxInsideIGeodeSerializable::~PdxInsideIGeodeSerializable() {
   // TODO Auto-generated destructor stub
 }
 
-int32_t PdxInsideIGFSerializable::getHashCode() { return 1; }
+int32_t PdxInsideIGeodeSerializable::getHashCode() { return 1; }
 
-bool PdxInsideIGFSerializable::equals(SerializablePtr obj) {
+bool PdxInsideIGeodeSerializable::equals(SerializablePtr obj) {
   if (obj == NULLPTR) return false;
 
-  PdxInsideIGFSerializablePtr pap = dynCast<PdxInsideIGFSerializablePtr>(obj);
+  PdxInsideIGeodeSerializablePtr pap =
+      dynCast<PdxInsideIGeodeSerializablePtr>(obj);
   if (pap == NULLPTR) return false;
 
   // if (pap == this)
@@ -825,16 +826,16 @@ bool PdxInsideIGFSerializable::equals(SerializablePtr obj) {
   return false;
 }
 
-CacheableStringPtr PdxInsideIGFSerializable::toString() const {
+CacheableStringPtr PdxInsideIGeodeSerializable::toString() const {
   char idbuf[4096];
   sprintf(idbuf,
-          "PdxInsideIGFSerializable:[m_i1=%d] [m_i2=%d] [m_i3=%d] [m_i4=%d] "
+          "PdxInsideIGeodeSerializable:[m_i1=%d] [m_i2=%d] [m_i3=%d] [m_i4=%d] "
           "[m_s1=%s] [m_s2=%s]",
           m_i1, m_i2, m_i3, m_i4, m_s1, m_s2);
   return CacheableString::create(idbuf);
 }
 
-void PdxInsideIGFSerializable::toData(DataOutput &output) const {
+void PdxInsideIGeodeSerializable::toData(DataOutput &output) const {
   output.writeInt(m_i1);
   output.writeObject(m_npdx);
   output.writeInt(m_i2);
@@ -845,7 +846,7 @@ void PdxInsideIGFSerializable::toData(DataOutput &output) const {
   output.writeInt(m_i4);
 }
 
-Serializable *PdxInsideIGFSerializable::fromData(DataInput &input) {
+Serializable *PdxInsideIGeodeSerializable::fromData(DataInput &input) {
   input.readInt(&m_i1);
   input.readObject(m_npdx);
   input.readInt(&m_i2);

--- a/src/tests/cpp/testobject/VariousPdxTypesWithAuto.hpp
+++ b/src/tests/cpp/testobject/VariousPdxTypesWithAuto.hpp
@@ -501,10 +501,10 @@ class GFIGNORE(TESTOBJECT_EXPORT) NestedPdx : public PdxSerializable {
 typedef SharedPtr<NestedPdx> NestedPdxPtr;
 
 /************************************************************
- *  PdxInsideIGFSerializable
+ *  PdxInsideIGeodeSerializable
  * *********************************************************/
 
-class GFIGNORE(TESTOBJECT_EXPORT) PdxInsideIGFSerializable
+class GFIGNORE(TESTOBJECT_EXPORT) PdxInsideIGeodeSerializable
     : public Serializable {
  private:
   NestedPdxPtr m_npdx;
@@ -518,9 +518,9 @@ class GFIGNORE(TESTOBJECT_EXPORT) PdxInsideIGFSerializable
   int32_t m_i4;
 
  public:
-  PdxInsideIGFSerializable();
+  PdxInsideIGeodeSerializable();
 
-  virtual ~PdxInsideIGFSerializable();
+  virtual ~PdxInsideIGeodeSerializable();
 
   int32_t getHashCode();
 
@@ -535,14 +535,14 @@ class GFIGNORE(TESTOBJECT_EXPORT) PdxInsideIGFSerializable
   virtual int32_t classId() const { return 0x10; }
 
   const char* getClassName() const {
-    return "PdxTestsAuto::PdxInsideIGFSerializable";
+    return "PdxTestsAuto::PdxInsideIGeodeSerializable";
   }
 
   static Serializable* createDeserializable() {
-    return new PdxInsideIGFSerializable();
+    return new PdxInsideIGeodeSerializable();
   }
 };
-typedef SharedPtr<PdxInsideIGFSerializable> PdxInsideIGFSerializablePtr;
+typedef SharedPtr<PdxInsideIGeodeSerializable> PdxInsideIGeodeSerializablePtr;
 
 } /* namespace PdxTestsAuto */
 


### PR DESCRIPTION
- Rename directories and files with gf into their name to
  instead use geode and update all references thereto.
- Ensure formatting style guide compliance.
- Elide duplicate GEODE_ from include guards.