### PR TITLE
GEODE-2439: Replace c-style headers with c++ headers

### DIFF
--- a/src/clicache/src/ExceptionTypes.cpp
+++ b/src/clicache/src/ExceptionTypes.cpp
@@ -17,7 +17,7 @@
 
 //#include "geode_includes.hpp"
 #include "ExceptionTypes.hpp"
-#include <stdlib.h>
+#include <cstdlib>
 
 using namespace System;
 

--- a/src/clicache/src/impl/ManagedCacheableDelta.cpp
+++ b/src/clicache/src/impl/ManagedCacheableDelta.cpp
@@ -252,7 +252,7 @@ namespace apache
 
       }
 
-      System::UInt32 ManagedCacheableDeltaGeneric::hashcode() const
+      System::Int32 ManagedCacheableDeltaGeneric::hashcode() const
       {
         throw gcnew System::NotSupportedException;
       }

--- a/src/clicache/src/impl/ManagedCacheableDelta.hpp
+++ b/src/clicache/src/impl/ManagedCacheableDelta.hpp
@@ -136,7 +136,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual System::UInt32 hashcode() const;
+        virtual System::Int32 hashcode() const;
 
         /// <summary>
         /// return true if this key matches other CacheableKey

--- a/src/clicache/src/impl/ManagedCacheableDeltaBytes.cpp
+++ b/src/clicache/src/impl/ManagedCacheableDeltaBytes.cpp
@@ -303,7 +303,7 @@ namespace apache
         return false;
       }
 
-      System::UInt32 ManagedCacheableDeltaBytesGeneric::hashcode() const
+      System::Int32 ManagedCacheableDeltaBytesGeneric::hashcode() const
       {
         throw gcnew System::NotSupportedException;
       }

--- a/src/clicache/src/impl/ManagedCacheableDeltaBytes.hpp
+++ b/src/clicache/src/impl/ManagedCacheableDeltaBytes.hpp
@@ -175,7 +175,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual System::UInt32 hashcode() const;
+        virtual System::Int32 hashcode() const;
 
         /// <summary>
         /// return true if this key matches other CacheableKey

--- a/src/clicache/src/impl/ManagedCacheableKey.cpp
+++ b/src/clicache/src/impl/ManagedCacheableKey.cpp
@@ -202,7 +202,7 @@ namespace apache
         return false;
       }
 
-      System::UInt32 ManagedCacheableKeyGeneric::hashcode() const
+      System::Int32 ManagedCacheableKeyGeneric::hashcode() const
       {
         if (m_hashcode != 0)
           return m_hashcode;

--- a/src/clicache/src/impl/ManagedCacheableKey.hpp
+++ b/src/clicache/src/impl/ManagedCacheableKey.hpp
@@ -125,7 +125,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual System::UInt32 hashcode() const;
+        virtual System::Int32 hashcode() const;
 
         /// <summary>
         /// Copy the string form of a key into a char* buffer for logging purposes.

--- a/src/clicache/src/impl/ManagedCacheableKeyBytes.cpp
+++ b/src/clicache/src/impl/ManagedCacheableKeyBytes.cpp
@@ -229,7 +229,7 @@ namespace apache
         return false;
       }
 
-      System::UInt32 ManagedCacheableKeyBytesGeneric::hashcode() const
+      System::Int32 ManagedCacheableKeyBytesGeneric::hashcode() const
       {
         return m_hashCode;
       }

--- a/src/clicache/src/impl/ManagedCacheableKeyBytes.hpp
+++ b/src/clicache/src/impl/ManagedCacheableKeyBytes.hpp
@@ -150,7 +150,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual System::UInt32 hashcode() const;
+        virtual System::Int32 hashcode() const;
 
         /// <summary>
         /// Copy the string form of a key into a char* buffer for logging purposes.

--- a/src/clicache/src/impl/PdxManagedCacheableKey.cpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKey.cpp
@@ -191,7 +191,7 @@ namespace apache
         return false;
       }
 
-      System::UInt32 PdxManagedCacheableKey::hashcode() const
+      System::Int32 PdxManagedCacheableKey::hashcode() const
       {
         if (m_hashcode != 0)
           return m_hashcode;

--- a/src/clicache/src/impl/PdxManagedCacheableKey.hpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKey.hpp
@@ -148,7 +148,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual System::UInt32 hashcode() const;
+        virtual System::Int32 hashcode() const;
 
         /// <summary>
         /// Copy the string form of a key into a char* buffer for logging purposes.

--- a/src/clicache/src/impl/PdxManagedCacheableKeyBytes.cpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKeyBytes.cpp
@@ -234,7 +234,7 @@ namespace apache
         return false;
       }
 
-      System::UInt32 PdxManagedCacheableKeyBytes::hashcode() const
+      System::Int32 PdxManagedCacheableKeyBytes::hashcode() const
       {
         return m_hashCode;
       }

--- a/src/clicache/src/impl/PdxManagedCacheableKeyBytes.hpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKeyBytes.hpp
@@ -175,7 +175,7 @@ namespace apache
     /// <summary>
     /// return the hashcode for this key.
     /// </summary>
-    virtual System::UInt32 hashcode( ) const;
+    virtual System::Int32 hashcode( ) const;
 
     /// <summary>
     /// Copy the string form of a key into a char* buffer for logging purposes.
@@ -224,7 +224,7 @@ namespace apache
     System::Byte * m_bytes;
     System::UInt32 m_size;
     bool m_hasDelta;
-    System::UInt32 m_hashCode;
+    System::Int32 m_hashCode;
     // Disable the copy and assignment constructors
     PdxManagedCacheableKeyBytes( const PdxManagedCacheableKeyBytes& );
     PdxManagedCacheableKeyBytes& operator = ( const PdxManagedCacheableKeyBytes& );

--- a/src/cppcache/include/geode/CacheableBuiltins.hpp
+++ b/src/cppcache/include/geode/CacheableBuiltins.hpp
@@ -25,6 +25,8 @@
  *         and instantiations for built-in types.
  */
 
+#include <cstring>
+
 #include "Cacheable.hpp"
 #include "CacheableKey.hpp"
 #include "Serializer.hpp"
@@ -144,7 +146,7 @@ class SharedArrayPtr;
 /** Function to copy an array from source to destination. */
 template <typename TObj>
 inline void copyArray(TObj* dest, const TObj* src, int32_t length) {
-  memcpy(dest, src, length * sizeof(TObj));
+  std::memcpy(dest, src, length * sizeof(TObj));
 }
 
 /**

--- a/src/cppcache/include/geode/DataInput.hpp
+++ b/src/cppcache/include/geode/DataInput.hpp
@@ -22,7 +22,8 @@
 
 #include "geode_globals.hpp"
 #include "ExceptionTypes.hpp"
-#include <string.h>
+#include <cstring>
+#include <string>
 #include "geode_types.hpp"
 #include "Serializable.hpp"
 #include "CacheableString.hpp"
@@ -98,7 +99,7 @@ class CPPCACHE_EXPORT DataInput {
   inline void readBytesOnly(uint8_t* buffer, uint32_t len) {
     if (len > 0) {
       checkBufferSize(len);
-      memcpy(buffer, m_buf, len);
+      std::memcpy(buffer, m_buf, len);
       m_buf += len;
     }
   }
@@ -116,7 +117,7 @@ class CPPCACHE_EXPORT DataInput {
   inline void readBytesOnly(int8_t* buffer, uint32_t len) {
     if (len > 0) {
       checkBufferSize(len);
-      memcpy(buffer, m_buf, len);
+      std::memcpy(buffer, m_buf, len);
       m_buf += len;
     }
   }
@@ -139,7 +140,7 @@ class CPPCACHE_EXPORT DataInput {
     if (length > 0) {
       checkBufferSize(length);
       GF_NEW(buffer, uint8_t[length]);
-      memcpy(buffer, m_buf, length);
+      std::memcpy(buffer, m_buf, length);
       m_buf += length;
     }
     *bytes = buffer;
@@ -163,7 +164,7 @@ class CPPCACHE_EXPORT DataInput {
     if (length > 0) {
       checkBufferSize(length);
       GF_NEW(buffer, int8_t[length]);
-      memcpy(buffer, m_buf, length);
+      std::memcpy(buffer, m_buf, length);
       m_buf += length;
     }
     *bytes = buffer;
@@ -938,7 +939,7 @@ class CPPCACHE_EXPORT DataInput {
   static uint8_t* getBufferCopy(const uint8_t* from, uint32_t length) {
     uint8_t* result;
     GF_NEW(result, uint8_t[length]);
-    memcpy(result, from, length);
+    std::memcpy(result, from, length);
 
     return result;
   }
@@ -948,7 +949,7 @@ class CPPCACHE_EXPORT DataInput {
   uint8_t* getBufferCopyFrom(const uint8_t* from, uint32_t length) {
     uint8_t* result;
     GF_NEW(result, uint8_t[length]);
-    memcpy(result, from, length);
+    std::memcpy(result, from, length);
 
     return result;
   }

--- a/src/cppcache/include/geode/DataOutput.hpp
+++ b/src/cppcache/include/geode/DataOutput.hpp
@@ -26,10 +26,9 @@
 #include "Serializable.hpp"
 #include "CacheableString.hpp"
 
-extern "C" {
-#include <string.h>
-#include <stdlib.h>
-}
+#include <cstring>
+#include <string>
+#include <cstdlib>
 
 /**
  * @file
@@ -114,7 +113,7 @@ class CPPCACHE_EXPORT DataOutput {
       ensureCapacity(len + 5);
       writeArrayLen(bytes == NULL ? 0 : len);  // length of bytes...
       if (len > 0 && bytes != NULL) {
-        memcpy(m_buf, bytes, len);
+        std::memcpy(m_buf, bytes, len);
         m_buf += len;
       }
     } else {
@@ -145,7 +144,7 @@ class CPPCACHE_EXPORT DataOutput {
    */
   inline void writeBytesOnly(const uint8_t* bytes, uint32_t len) {
     ensureCapacity(len);
-    memcpy(m_buf, bytes, len);
+    std::memcpy(m_buf, bytes, len);
     m_buf += len;
   }
 
@@ -659,7 +658,7 @@ class CPPCACHE_EXPORT DataOutput {
     uint32_t size = static_cast<uint32_t>(m_buf - m_bytes);
     uint8_t* result;
     GF_ALLOC(result, uint8_t, size);
-    memcpy(result, m_bytes, size);
+    std::memcpy(result, m_bytes, size);
     return result;
   }
 
@@ -719,7 +718,7 @@ class CPPCACHE_EXPORT DataOutput {
   uint8_t* getBufferCopyFrom(const uint8_t* from, uint32_t length) {
     uint8_t* result;
     GF_NEW(result, uint8_t[length]);
-    memcpy(result, from, length);
+    std::memcpy(result, from, length);
 
     return result;
   }

--- a/src/cppcache/include/geode/Log.hpp
+++ b/src/cppcache/include/geode/Log.hpp
@@ -27,8 +27,8 @@
  */
 
 #include "geode_globals.hpp"
-#include <stdio.h>
-#include <stdarg.h>
+#include <cstdio>
+#include <cstdarg>
 
 /******************************************************************************/
 

--- a/src/cppcache/include/geode/geode_base.hpp
+++ b/src/cppcache/include/geode/geode_base.hpp
@@ -146,16 +146,10 @@
 #endif
 /* end inttypes.h */
 
-#ifndef _INC_WCHAR
-#include <wchar.h>
-#endif
-
 #else
 /* Unix, including both Sparc Solaris and Linux */
 #define __STDC_FORMAT_MACROS
-#ifndef _WCHAR_H
-#include <wchar.h>
-#endif
+
 #endif /* _WIN32*/
 
 /**@namespace geode This namespace contains all the Geode

--- a/src/cppcache/integration-test/BBNamingContext.hpp
+++ b/src/cppcache/integration-test/BBNamingContext.hpp
@@ -24,7 +24,7 @@
 // move them there.
 // This will avoid pulling in a lot of framework headers to cause compilation
 // grieve, especially with the stl stuff.
-#include <stdlib.h>
+#include <cstdlib>
 #include <string>
 class BBNamingContextClientImpl;
 class BBNamingContextClient {

--- a/src/cppcache/integration-test/BuiltinCacheableWrappers.hpp
+++ b/src/cppcache/integration-test/BuiltinCacheableWrappers.hpp
@@ -21,11 +21,9 @@
  */
 
 #include "CacheableWrapper.hpp"
-extern "C" {
 #include <limits.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <wchar.h>
-}
 
 #include <ace/Date_Time.h>
 

--- a/src/cppcache/integration-test/CacheHelper.cpp
+++ b/src/cppcache/integration-test/CacheHelper.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <ace/OS.h>
 #include <ace/INET_Addr.h>
 #include <ace/SOCK_Acceptor.h>

--- a/src/cppcache/integration-test/CacheHelper.hpp
+++ b/src/cppcache/integration-test/CacheHelper.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/GeodeCppCache.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 #include <geode/SystemProperties.hpp>
 #include <ace/OS.h>
 #include <ace/INET_Addr.h>

--- a/src/cppcache/integration-test/CacheImplHelper.hpp
+++ b/src/cppcache/integration-test/CacheImplHelper.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/GeodeCppCache.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 #include <geode/SystemProperties.hpp>
 #include <ace/OS.h>
 #include "testUtils.hpp"

--- a/src/cppcache/integration-test/QueryHelper.hpp
+++ b/src/cppcache/integration-test/QueryHelper.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/GeodeCppCache.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 #include <geode/SystemProperties.hpp>
 #include <ace/OS.h>
 

--- a/src/cppcache/integration-test/fw_helper.hpp
+++ b/src/cppcache/integration-test/fw_helper.hpp
@@ -93,7 +93,7 @@ BEGIN_TEST.
 #include <list>
 #include <string>
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "TimeBomb.hpp"
 

--- a/src/cppcache/integration-test/testEntriesMap.cpp
+++ b/src/cppcache/integration-test/testEntriesMap.cpp
@@ -32,7 +32,7 @@ END_TEST(NotOnWindows)
 #include <LRUEntriesMap.hpp>
 #include <LRUMapEntry.hpp>
 #include <VersionTag.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 
 using namespace apache::geode::client;
 using namespace std;

--- a/src/cppcache/integration-test/testEntriesMapForVersioning.cpp
+++ b/src/cppcache/integration-test/testEntriesMapForVersioning.cpp
@@ -38,7 +38,7 @@ END_MAIN
 #include <LRUMapEntry.hpp>
 #include <LRUExpMapEntry.hpp>
 #include <VersionTag.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 #include <ClientProxyMembershipID.hpp>
 #include <ace/OS.h>
 #include <string>

--- a/src/cppcache/integration-test/testThinClientSecurityMultiUserTest.cpp
+++ b/src/cppcache/integration-test/testThinClientSecurityMultiUserTest.cpp
@@ -16,7 +16,7 @@
  */
 #include "fw_dunit.hpp"
 #include <string>
-#include <stdlib.h>
+#include <cstdlib>
 #include <geode/GeodeCppCache.hpp>
 #include <geode/FunctionService.hpp>
 #include <geode/Execution.hpp>

--- a/src/cppcache/src/AttributesFactory.cpp
+++ b/src/cppcache/src/AttributesFactory.cpp
@@ -27,8 +27,8 @@ class Region;
 #include <geode/ExpirationAttributes.hpp>
 #include <Utils.hpp>
 #include <geode/DistributedSystem.hpp>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <string>
 #include <geode/Pool.hpp>
 #include <geode/PoolManager.hpp>
 using namespace apache::geode::client;

--- a/src/cppcache/src/CacheAttributes.cpp
+++ b/src/cppcache/src/CacheAttributes.cpp
@@ -16,8 +16,8 @@
  */
 
 #include <Utils.hpp>
-#include <string.h>
-#include <stdlib.h>
+#include <string>
+#include <cstdlib>
 #include <geode/GeodeTypeIds.hpp>
 #include <geode/CacheAttributes.hpp>
 

--- a/src/cppcache/src/CacheConfig.hpp
+++ b/src/cppcache/src/CacheConfig.hpp
@@ -32,7 +32,7 @@
 #endif  // _MSC_VER > 1000
 
 #include <geode/geode_globals.hpp>
-#include <string.h>
+#include <string>
 #include <map>
 #include "RegionConfig.hpp"
 #include <geode/ExceptionTypes.hpp>

--- a/src/cppcache/src/CacheImpl.cpp
+++ b/src/cppcache/src/CacheImpl.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "CacheImpl.hpp"
-#include <string.h>
+#include <string>
 #include <geode/CacheStatistics.hpp>
 #include "Utils.hpp"
 #include "LocalRegion.hpp"

--- a/src/cppcache/src/CacheImpl.hpp
+++ b/src/cppcache/src/CacheImpl.hpp
@@ -42,7 +42,7 @@
 #include "PdxTypeRegistry.hpp"
 #include "MemberListForVersionStamp.hpp"
 
-#include <string.h>
+#include <string>
 #include <string>
 #include <map>
 

--- a/src/cppcache/src/CacheableBuiltins.cpp
+++ b/src/cppcache/src/CacheableBuiltins.cpp
@@ -18,9 +18,7 @@
 #include <geode/CacheableBuiltins.hpp>
 
 #include <ace/OS.h>
-extern "C" {
-#include <stdarg.h>
-}
+#include <cstdarg>
 
 namespace apache {
 namespace geode {

--- a/src/cppcache/src/ClientProxyMembershipID.cpp
+++ b/src/cppcache/src/ClientProxyMembershipID.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "ClientProxyMembershipID.hpp"
-#include <time.h>
+#include <ctime>
 #include <ace/OS.h>
 #include <geode/DistributedSystem.hpp>
 #include <geode/GeodeTypeIds.hpp>

--- a/src/cppcache/src/Exception.cpp
+++ b/src/cppcache/src/Exception.cpp
@@ -15,10 +15,7 @@
  * limitations under the License.
  */
 
-extern "C" {
-#include <string.h>
-#include <stdlib.h>
-}
+#include <cstdlib>
 #include <ace/OS.h>
 
 #include <geode/Exception.hpp>

--- a/src/cppcache/src/ExceptionTypes.cpp
+++ b/src/cppcache/src/ExceptionTypes.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 #include <geode/ExceptionTypes.hpp>
 #include <TXState.hpp>

--- a/src/cppcache/src/ExpirationAction.cpp
+++ b/src/cppcache/src/ExpirationAction.cpp
@@ -17,7 +17,7 @@
 
 #include <geode/ExpirationAction.hpp>
 
-#include <string.h>
+#include <string>
 #include <ace/OS.h>
 
 using namespace apache::geode::client;

--- a/src/cppcache/src/ProxyCache.cpp
+++ b/src/cppcache/src/ProxyCache.cpp
@@ -29,7 +29,7 @@
 #include "ProxyRemoteQueryService.hpp"
 #include "FunctionServiceImpl.hpp"
 #include "ProxyCache.hpp"
-#include <string.h>
+#include <string>
 #include <geode/PoolManager.hpp>
 #include "ThinClientPoolDM.hpp"
 #include "PdxInstanceFactoryImpl.hpp"

--- a/src/cppcache/src/RegionAttributes.cpp
+++ b/src/cppcache/src/RegionAttributes.cpp
@@ -18,8 +18,8 @@
 #include <geode/Cache.hpp>
 #include <Utils.hpp>
 #include <geode/DataOutput.hpp>
-#include <string.h>
-#include <stdlib.h>
+#include <string>
+#include <cstdlib>
 #include <geode/GeodeTypeIds.hpp>
 #include <CacheXmlParser.hpp>
 #include <ace/DLL.h>

--- a/src/cppcache/src/RegionConfig.hpp
+++ b/src/cppcache/src/RegionConfig.hpp
@@ -31,7 +31,7 @@
 
 #include <string>
 #include <geode/Properties.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 
 namespace apache {
 namespace geode {

--- a/src/cppcache/src/StackFrame.hpp
+++ b/src/cppcache/src/StackFrame.hpp
@@ -20,9 +20,9 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
 
 #include <ace/OS.h>
 

--- a/src/cppcache/src/StackTrace.cpp
+++ b/src/cppcache/src/StackTrace.cpp
@@ -94,8 +94,8 @@ void StackTrace::addFrame(std::list<std::string>& frames) {
 #elif defined(_LINUX)
 #include <execinfo.h>
 #include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 namespace apache {
 namespace geode {
@@ -116,8 +116,8 @@ StackTrace::StackTrace() {
 
 #elif defined(_SOLARIS)
 #include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <ucontext.h>
 
 namespace apache {

--- a/src/cppcache/src/SystemProperties.cpp
+++ b/src/cppcache/src/SystemProperties.cpp
@@ -18,8 +18,8 @@
 #include <geode/geode_globals.hpp>
 
 #include <string>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <string>
 
 #include <geode/SystemProperties.hpp>
 #include <CppCacheLibrary.hpp>

--- a/src/cppcache/src/Utils.cpp
+++ b/src/cppcache/src/Utils.cpp
@@ -20,10 +20,7 @@
 #include "NanoTimer.hpp"
 #include <ace/Recursive_Thread_Mutex.h>
 #include <ace/INET_Addr.h>
-
-extern "C" {
-#include <stdio.h>
-}
+#include <cstdio>
 
 using namespace apache::geode::client;
 

--- a/src/cppcache/src/dllmain.cpp
+++ b/src/cppcache/src/dllmain.cpp
@@ -18,8 +18,8 @@
  */
 
 #include "CppCacheLibrary.hpp"
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 #include <string>
 #include "Utils.hpp"
 #include <geode/Exception.hpp>

--- a/src/cppcache/src/statistics/HostStatHelperWin.hpp
+++ b/src/cppcache/src/statistics/HostStatHelperWin.hpp
@@ -27,10 +27,9 @@
 #include <Windows.h>
 #include <WinPerf.h>
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <malloc.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
 #include "ProcessStats.hpp"
 
 /** @file

--- a/src/cppcache/test/ByteArray.cpp
+++ b/src/cppcache/test/ByteArray.cpp
@@ -19,11 +19,7 @@
 
 #include "config.h"
 
-#ifdef _MACOSX
-#include <stdlib.h>  // For wcstombs()
-#endif
-#include <wchar.h>
-
+#include <cstdlib>  // For wcstombs()
 #include <cstring>
 
 namespace {

--- a/src/cppcache/test/DataInputTest.cpp
+++ b/src/cppcache/test/DataInputTest.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include <string.h>  // for ::memset()
+#include <string>  // for ::memset()
 
 #include <stdint.h>
 #define NOMINMAX

--- a/src/cryptoimpl/DHImpl.hpp
+++ b/src/cryptoimpl/DHImpl.hpp
@@ -25,7 +25,8 @@
 #include <openssl/x509.h>
 #include <string>
 #include <vector>
-#include <string.h>
+#include <cstring>
+#include <string>
 
 #include <geode/geode_base.hpp>
 
@@ -89,7 +90,7 @@ class DHImpl {
     /* adongre
      * CID 28924: Uninitialized scalar field (UNINIT_CTOR)
      */
-    memset(m_key, 0, sizeof(m_key));
+    std::memset(m_key, 0, sizeof(m_key));
   }
   static bool m_init;
 };

--- a/src/quickstart/cpp/queryobjects/Position.hpp
+++ b/src/quickstart/cpp/queryobjects/Position.hpp
@@ -23,7 +23,7 @@
 #define __POSITION_HPP__
 
 #include <geode/GeodeCppCache.hpp>
-#include <string.h>
+#include <string>
 
 #ifdef _WIN32
 #ifdef BUILD_TESTOBJECT

--- a/src/quickstart/cpp/queryobjects/PositionPdx.hpp
+++ b/src/quickstart/cpp/queryobjects/PositionPdx.hpp
@@ -26,7 +26,7 @@
 #include <geode/PdxSerializable.hpp>
 #include <geode/PdxWriter.hpp>
 #include <geode/PdxReader.hpp>
-#include <string.h>
+#include <string>
 
 #ifdef _WIN32
 #ifdef BUILD_TESTOBJECT

--- a/src/quickstart/cpp/queryobjects/PositionPdxAuto.hpp
+++ b/src/quickstart/cpp/queryobjects/PositionPdxAuto.hpp
@@ -26,7 +26,7 @@
 #include <geode/PdxSerializable.hpp>
 #include <geode/PdxWriter.hpp>
 #include <geode/PdxReader.hpp>
-#include <string.h>
+#include <string>
 
 #ifdef _WIN32
 #ifdef BUILD_TESTOBJECT

--- a/src/templates/security/PkcsAuthInit.cpp
+++ b/src/templates/security/PkcsAuthInit.cpp
@@ -19,7 +19,7 @@
 #include "geode/Properties.hpp"
 #include "geode/CacheableBuiltins.hpp"
 #include "geode/ExceptionTypes.hpp"
-#include "stdio.h"
+#include <cstdio>
 
 namespace apache {
 namespace geode {

--- a/src/templates/security/PkcsAuthInit.hpp
+++ b/src/templates/security/PkcsAuthInit.hpp
@@ -18,8 +18,8 @@
 #ifndef __PKCSAUTHINIT__
 #define __PKCSAUTHINIT__
 #include "geode/AuthInitialize.hpp"
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <openssl/pem.h>
 #include <openssl/err.h>
 #include <openssl/pkcs12.h>

--- a/src/tests/cpp/fwklib/FwkObjects.cpp
+++ b/src/tests/cpp/fwklib/FwkObjects.cpp
@@ -37,7 +37,7 @@
 #include <xercesc/dom/DOMNamedNodeMap.hpp>
 #include <xercesc/dom/DOMAttr.hpp>
 
-#include <ctype.h>
+#include <cctype>
 
 using namespace apache::geode::client;
 using namespace apache::geode::client::testframework;

--- a/src/tests/cpp/fwklib/MersenneTwister.cpp
+++ b/src/tests/cpp/fwklib/MersenneTwister.cpp
@@ -329,7 +329,7 @@ std::istream &operator>>(std::istream &is, MTRand &mtrand) {
 // v0.7 - Fixed operator precedence ambiguity in reload()
 //      - Added access for real numbers in (0,1) and (0,n)
 //
-// v0.8 - Included time.h header to properly support time_t and clock_t
+// v0.8 - Included ctime header to properly support time_t and clock_t
 //
 // v1.0 - Revised seeding to match 26 Jan 2002 update of Nishimura and Matsumoto
 //      - Allowed for seeding with arrays of any length

--- a/src/tests/cpp/fwklib/MersenneTwister.hpp
+++ b/src/tests/cpp/fwklib/MersenneTwister.hpp
@@ -81,8 +81,8 @@
 
 #include <iostream>
 #include <limits.h>
-#include <stdio.h>
-#include <time.h>
+#include <cstdio>
+#include <ctime>
 #include <math.h>
 
 #include "SpinLock.hpp"
@@ -188,7 +188,7 @@ class MTRand {
 // v0.7 - Fixed operator precedence ambiguity in reload()
 //      - Added access for real numbers in (0,1) and (0,n)
 //
-// v0.8 - Included time.h header to properly support time_t and clock_t
+// v0.8 - Included ctime header to properly support time_t and clock_t
 //
 // v1.0 - Revised seeding to match 26 Jan 2002 update of Nishimura and Matsumoto
 //      - Allowed for seeding with arrays of any length

--- a/src/tests/cpp/fwklib/PaceMeter.hpp
+++ b/src/tests/cpp/fwklib/PaceMeter.hpp
@@ -27,8 +27,8 @@
 #ifdef WIN32
 #include <windows.h>
 #else
-#include <sys/time.h>
-#include <sys/types.h>
+#include <ctime>
+#include <cctype>
 #include <unistd.h>
 #endif
 

--- a/src/tests/cpp/fwklib/PoolHelper.hpp
+++ b/src/tests/cpp/fwklib/PoolHelper.hpp
@@ -27,7 +27,7 @@
 #include "fwklib/FwkStrCvt.hpp"
 #include "fwklib/FwkLog.hpp"
 #include <geode/PoolFactory.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <string>
 #include <map>

--- a/src/tests/cpp/fwklib/QueryHelper.hpp
+++ b/src/tests/cpp/fwklib/QueryHelper.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/GeodeCppCache.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 #include <geode/SystemProperties.hpp>
 #include <ace/OS.h>
 

--- a/src/tests/cpp/fwklib/RegionHelper.hpp
+++ b/src/tests/cpp/fwklib/RegionHelper.hpp
@@ -26,7 +26,7 @@
 #include "fwklib/FwkObjects.hpp"
 #include "fwklib/FwkStrCvt.hpp"
 #include "fwklib/FwkLog.hpp"
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <string>
 #include <map>

--- a/src/tests/cpp/fwklib/TaskClient.cpp
+++ b/src/tests/cpp/fwklib/TaskClient.cpp
@@ -20,13 +20,13 @@
 #include "fwklib/FwkLog.hpp"
 #include "fwklib/PerfFwk.hpp"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
-#include <string.h>
-#include <ctype.h>
+#include <string>
+#include <cctype>
 #ifndef WIN32
 #include <unistd.h>
 #endif

--- a/src/tests/cpp/fwklib/TimeSync.cpp
+++ b/src/tests/cpp/fwklib/TimeSync.cpp
@@ -20,9 +20,9 @@
 #include "fwklib/PerfFwk.hpp"
 #include "fwklib/PaceMeter.hpp"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
 #include <memory.h>
 #include <errno.h>
 #include <sys/types.h>

--- a/src/tests/cpp/fwklib/Timer.hpp
+++ b/src/tests/cpp/fwklib/Timer.hpp
@@ -23,14 +23,14 @@
 #include <geode/geode_base.hpp>
 #include "fwklib/FwkLog.hpp"
 
+#include <ctime>
+#include <cstdio>
 #include <ace/Time_Value.h>
 #include <ace/High_Res_Timer.h>
 
 #ifdef _WIN32
 
-#include <time.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <windows.h>
 #include <winbase.h>
 
@@ -38,8 +38,6 @@
 
 #ifdef _SOLARIS
 
-#include <time.h>
-#include <stdio.h>
 #include <strings.h>
 
 #endif

--- a/src/tests/cpp/pdxautoserializerclass/PositionPdx.hpp
+++ b/src/tests/cpp/pdxautoserializerclass/PositionPdx.hpp
@@ -28,7 +28,7 @@
 #include <geode/PdxSerializable.hpp>
 #include <geode/PdxWriter.hpp>
 #include <geode/PdxReader.hpp>
-#include <string.h>
+#include <string>
 
 #ifdef _WIN32
 #ifdef BUILD_TESTOBJECT

--- a/src/tests/cpp/security/PkcsAuthInit.cpp
+++ b/src/tests/cpp/security/PkcsAuthInit.cpp
@@ -19,7 +19,7 @@
 #include <geode/Properties.hpp>
 #include <geode/CacheableBuiltins.hpp>
 #include <geode/ExceptionTypes.hpp>
-#include "stdio.h"
+#include <cstdio>
 #include <string>
 
 namespace apache {

--- a/src/tests/cpp/security/PkcsAuthInit.hpp
+++ b/src/tests/cpp/security/PkcsAuthInit.hpp
@@ -21,8 +21,8 @@
  */
 
 #include <geode/AuthInitialize.hpp>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <openssl/pem.h>
 #include <openssl/err.h>
 #include <openssl/pkcs12.h>

--- a/src/tests/cpp/security/XmlAuthzCredentialGenerator.hpp
+++ b/src/tests/cpp/security/XmlAuthzCredentialGenerator.hpp
@@ -26,8 +26,8 @@
 #include "typedefs.hpp"
 
 #include <algorithm>
-#include <time.h>
-#include <stdlib.h>
+#include <ctime>
+#include <cstdlib>
 
 namespace apache {
 namespace geode {

--- a/src/tests/cpp/testobject/ArrayOfByte.hpp
+++ b/src/tests/cpp/testobject/ArrayOfByte.hpp
@@ -21,7 +21,7 @@
  */
 
 #include <geode/GeodeCppCache.hpp>
-#include <string.h>
+#include <string>
 #include "fwklib/FwkLog.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include <ace/Time_Value.h>

--- a/src/tests/cpp/testobject/BatchObject.hpp
+++ b/src/tests/cpp/testobject/BatchObject.hpp
@@ -25,7 +25,7 @@
  */
 
 #include <geode/GeodeCppCache.hpp>
-#include <string.h>
+#include <string>
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include "TimestampedObject.hpp"

--- a/src/tests/cpp/testobject/DeltaFastAssetAccount.hpp
+++ b/src/tests/cpp/testobject/DeltaFastAssetAccount.hpp
@@ -25,7 +25,7 @@
  */
 
 #include <geode/GeodeCppCache.hpp>
-#include <string.h>
+#include <string>
 #include "fwklib/FrameworkTest.hpp"
 #include <ace/ACE.h>
 #include <ace/OS.h>

--- a/src/tests/cpp/testobject/DeltaPSTObject.hpp
+++ b/src/tests/cpp/testobject/DeltaPSTObject.hpp
@@ -25,7 +25,7 @@
  */
 
 #include <geode/GeodeCppCache.hpp>
-#include <string.h>
+#include <string>
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include "TimestampedObject.hpp"

--- a/src/tests/cpp/testobject/EqStruct.hpp
+++ b/src/tests/cpp/testobject/EqStruct.hpp
@@ -25,7 +25,7 @@
  */
 
 #include <geode/GeodeCppCache.hpp>
-#include <string.h>
+#include <string>
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include "TimestampedObject.hpp"

--- a/src/tests/cpp/testobject/FastAsset.hpp
+++ b/src/tests/cpp/testobject/FastAsset.hpp
@@ -25,7 +25,7 @@
  */
 
 #include <geode/GeodeCppCache.hpp>
-#include <string.h>
+#include <string>
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include "TimestampedObject.hpp"

--- a/src/tests/cpp/testobject/FastAssetAccount.hpp
+++ b/src/tests/cpp/testobject/FastAssetAccount.hpp
@@ -25,7 +25,7 @@
  */
 
 #include <geode/GeodeCppCache.hpp>
-#include <string.h>
+#include <string>
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include "TimestampedObject.hpp"

--- a/src/tests/cpp/testobject/PSTObject.hpp
+++ b/src/tests/cpp/testobject/PSTObject.hpp
@@ -25,7 +25,7 @@
  */
 
 #include <geode/GeodeCppCache.hpp>
-#include <string.h>
+#include <string>
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include "TimestampedObject.hpp"

--- a/src/tests/cpp/testobject/Position.hpp
+++ b/src/tests/cpp/testobject/Position.hpp
@@ -25,7 +25,7 @@
  */
 
 #include <geode/GeodeCppCache.hpp>
-#include <string.h>
+#include <string>
 
 #ifdef _WIN32
 #ifdef BUILD_TESTOBJECT

--- a/src/tests/cpp/testobject/PositionPdx.hpp
+++ b/src/tests/cpp/testobject/PositionPdx.hpp
@@ -28,7 +28,7 @@
 #include <geode/PdxSerializable.hpp>
 #include <geode/PdxWriter.hpp>
 #include <geode/PdxReader.hpp>
-#include <string.h>
+#include <string>
 
 #ifdef _WIN32
 #ifdef BUILD_TESTOBJECT


### PR DESCRIPTION
Purpose is to remove potentially non-portable c headers with the c++ equivalent headers.

Testing - built on OSX