### PR TITLE
GEODE-2439: Fix build breaking merge from merge conflict

### DIFF
--- a/src/clicache/src/impl/ManagedCacheableDelta.cpp
+++ b/src/clicache/src/impl/ManagedCacheableDelta.cpp
@@ -252,7 +252,7 @@ namespace apache
 
       }
 
-      System::UInt32 ManagedCacheableDeltaGeneric::hashcode() const
+      System::Int32 ManagedCacheableDeltaGeneric::hashcode() const
       {
         throw gcnew System::NotSupportedException;
       }

--- a/src/clicache/src/impl/ManagedCacheableDelta.hpp
+++ b/src/clicache/src/impl/ManagedCacheableDelta.hpp
@@ -136,7 +136,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual System::UInt32 hashcode() const;
+        virtual System::Int32 hashcode() const;
 
         /// <summary>
         /// return true if this key matches other CacheableKey

--- a/src/clicache/src/impl/ManagedCacheableDeltaBytes.cpp
+++ b/src/clicache/src/impl/ManagedCacheableDeltaBytes.cpp
@@ -303,7 +303,7 @@ namespace apache
         return false;
       }
 
-      System::UInt32 ManagedCacheableDeltaBytesGeneric::hashcode() const
+      System::Int32 ManagedCacheableDeltaBytesGeneric::hashcode() const
       {
         throw gcnew System::NotSupportedException;
       }

--- a/src/clicache/src/impl/ManagedCacheableDeltaBytes.hpp
+++ b/src/clicache/src/impl/ManagedCacheableDeltaBytes.hpp
@@ -175,7 +175,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual System::UInt32 hashcode() const;
+        virtual System::Int32 hashcode() const;
 
         /// <summary>
         /// return true if this key matches other CacheableKey

--- a/src/clicache/src/impl/ManagedCacheableKey.cpp
+++ b/src/clicache/src/impl/ManagedCacheableKey.cpp
@@ -202,7 +202,7 @@ namespace apache
         return false;
       }
 
-      System::UInt32 ManagedCacheableKeyGeneric::hashcode() const
+      System::Int32 ManagedCacheableKeyGeneric::hashcode() const
       {
         if (m_hashcode != 0)
           return m_hashcode;

--- a/src/clicache/src/impl/ManagedCacheableKey.hpp
+++ b/src/clicache/src/impl/ManagedCacheableKey.hpp
@@ -125,7 +125,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual System::UInt32 hashcode() const;
+        virtual System::Int32 hashcode() const;
 
         /// <summary>
         /// Copy the string form of a key into a char* buffer for logging purposes.

--- a/src/clicache/src/impl/ManagedCacheableKeyBytes.cpp
+++ b/src/clicache/src/impl/ManagedCacheableKeyBytes.cpp
@@ -229,7 +229,7 @@ namespace apache
         return false;
       }
 
-      System::UInt32 ManagedCacheableKeyBytesGeneric::hashcode() const
+      System::Int32 ManagedCacheableKeyBytesGeneric::hashcode() const
       {
         return m_hashCode;
       }

--- a/src/clicache/src/impl/ManagedCacheableKeyBytes.hpp
+++ b/src/clicache/src/impl/ManagedCacheableKeyBytes.hpp
@@ -150,7 +150,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual System::UInt32 hashcode() const;
+        virtual System::Int32 hashcode() const;
 
         /// <summary>
         /// Copy the string form of a key into a char* buffer for logging purposes.

--- a/src/clicache/src/impl/PdxManagedCacheableKey.cpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKey.cpp
@@ -191,7 +191,7 @@ namespace apache
         return false;
       }
 
-      System::UInt32 PdxManagedCacheableKey::hashcode() const
+      System::Int32 PdxManagedCacheableKey::hashcode() const
       {
         if (m_hashcode != 0)
           return m_hashcode;

--- a/src/clicache/src/impl/PdxManagedCacheableKey.hpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKey.hpp
@@ -148,7 +148,7 @@ namespace apache
         /// <summary>
         /// return the hashcode for this key.
         /// </summary>
-        virtual System::UInt32 hashcode() const;
+        virtual System::Int32 hashcode() const;
 
         /// <summary>
         /// Copy the string form of a key into a char* buffer for logging purposes.

--- a/src/clicache/src/impl/PdxManagedCacheableKeyBytes.cpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKeyBytes.cpp
@@ -234,7 +234,7 @@ namespace apache
         return false;
       }
 
-      System::UInt32 PdxManagedCacheableKeyBytes::hashcode() const
+      System::Int32 PdxManagedCacheableKeyBytes::hashcode() const
       {
         return m_hashCode;
       }

--- a/src/clicache/src/impl/PdxManagedCacheableKeyBytes.hpp
+++ b/src/clicache/src/impl/PdxManagedCacheableKeyBytes.hpp
@@ -175,7 +175,7 @@ namespace apache
     /// <summary>
     /// return the hashcode for this key.
     /// </summary>
-    virtual System::UInt32 hashcode( ) const;
+    virtual System::Int32 hashcode( ) const;
 
     /// <summary>
     /// Copy the string form of a key into a char* buffer for logging purposes.


### PR DESCRIPTION
Build broke after bad merge with commits: GEODE-2439 and GEODE-2440.

Conflict was resolved incorrectly by accidentally removing the signed-ness.