### PR TITLE
GEODE-2513 Rebrand Setting System Properties section

### DIFF
--- a/docs/geode-native-book/master_middleman/source/subnavs/geode-nc-nav.erb
+++ b/docs/geode-native-book/master_middleman/source/subnavs/geode-nc-nav.erb
@@ -89,10 +89,10 @@ limitations under the License.
                         <a href="/docs/guide-native/11/setting-properties/chapter-overview.html">Setting System Properties</a>
                         <ul>
                             <li class="has_submenu">
-                                <a href="/docs/guide-native/11/setting-properties/config-overview.html">Configuring the Native Client and Cache Server</a>
+                                <a href="/docs/guide-native/11/setting-properties/config-overview.html">Configuring the Client and Cache Server</a>
                                 <ul>
                                     <li>
-                                        <a href="/docs/guide-native/11/setting-properties/native-client-config.html">Native Client Configuration</a>
+                                        <a href="/docs/guide-native/11/setting-properties/native-client-config.html">Client Configuration</a>
                                     </li>
                                     <li>
                                         <a href="/docs/guide-native/11/setting-properties/cache-server-config.html">Cache Server Configuration</a>

--- a/docs/geode-native-docs/gfcpp.properties/chapter_overview.html.md.erb
+++ b/docs/geode-native-docs/gfcpp.properties/chapter_overview.html.md.erb
@@ -19,7 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-Use the gfcpp.properties file to configure distributed system connections for the Apache Geode native client.
+Use the gfcpp.properties file to configure distributed system connections for the client.
 
 The following example shows the format of a gfcpp.properties file. The first two attributes in this example should be set by programmers during application development, while other attributes are set on-site during system integration. The properties and their default settings that can be set in this file are described in detail in [Attributes in gfcpp.properties](../setting-properties/attributes-gfcpp.html#attributes-gfcpp).
 

--- a/docs/geode-native-docs/gfcpp.properties/gfcpp.properties_search_path.html.md.erb
+++ b/docs/geode-native-docs/gfcpp.properties/gfcpp.properties_search_path.html.md.erb
@@ -19,7 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-The native client and cache server processes first look for their properties file in the <code>_product-dir_/defaultSystem</code> directory, then in the working directory.
+The client and cache server processes first look for their properties file in the <code>_product-dir_/defaultSystem</code> directory, then in the working directory.
 
 Any properties set in the working directory override settings in the `defaultSystem/gfcpp.properties` file.
 

--- a/docs/geode-native-docs/setting-properties/attribute-def-priority.html.md.erb
+++ b/docs/geode-native-docs/setting-properties/attribute-def-priority.html.md.erb
@@ -21,18 +21,14 @@ limitations under the License.
 
 You can specify attributes in different ways, which can cause conflicting definitions. Applications can be configured programmatically, and that has priority over other settings.
 
-Check your application documentation to see whether this applies in your case.
+In case an attribute is defined in more than one place, the first source in this list is used:
 
 -   Programmatic configuration
 -   Properties set at the command line
 -   <code>_current-working-directory_/gfcpp.properties</code> file
 -   <code>_product-dir_/defaultSystem/gfcpp.properties</code> file
--   Geode defaults
+-   defaults
 
-In case an attribute is defined in more than one place, the first source in this list is used:
 
 The `gfcpp.properties` files and programmatic configuration are optional. If they are not present, no warnings or errors occur. For details on programmatic configuration through the `Properties` object, see [Defining Properties Programmatically](define-programmatically.html#define-programmatically).
-
-For information on the cache server configuration, see the *User's Guide*.
-
 

--- a/docs/geode-native-docs/setting-properties/attributes-gfcpp.html.md.erb
+++ b/docs/geode-native-docs/setting-properties/attributes-gfcpp.html.md.erb
@@ -19,7 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-A variety of `gfcpp.properties` settings can be used when a native client connects to a distributed system.
+A variety of `gfcpp.properties` settings can be used when a client connects to a distributed system.
 
 The following settings can be configured:
 
@@ -31,7 +31,7 @@ The following settings can be configured:
 
 ## <a id="attributes-gfcpp__section_655789BCC46642789F91CDA8AE03CD9B" class="no-quick-link"></a>Attribute Definitions
 
-The following tables list Geode configuration attributes that can be stored in the `gfcpp.properties` file to be read by a native client.
+The following tables list attributes that can be stored in the `gfcpp.properties` file to be read by a client.
 
 For the system properties that relate to high availability, see [Sending Periodic Acknowledgement](../preserving-data/sending-periodic-ack.html#concept_868B8082463846DE9F35BBEA56105C82). For a list of security-related system properties and their descriptions, see the table [System Properties for Client Authentication and Authorization](../security/security-systemprops.html#security__table_92A6A66523764199A19BCD66BA189921).
 
@@ -54,12 +54,12 @@ For the system properties that relate to high availability, see [Sending Periodi
 <tbody>
 <tr class="odd">
 <td>appdomain-enabled</td>
-<td>If <code class="ph codeph">true</code>, allows native client to work when multiple .NET appdomains are in use.</td>
+<td>If <code class="ph codeph">true</code>, allows client to work when multiple .NET appdomains are in use.</td>
 <td>false</td>
 </tr>
 <tr class="even">
 <td>cache-xml-file</td>
-<td>Name and path of the file whose contents are used by default to initialize a cache if one is created. If not specified, the native client starts with an empty cache, which is populated at runtime.
+<td>Name and path of the file whose contents are used by default to initialize a cache if one is created. If not specified, the client starts with an empty cache, which is populated at run time.
 <p>See <a href="../cache-init-file/chapter-overview.html#chapter-overview">Cache Initialization File</a> for more information on the cache initialization file.</p></td>
 <td>no default</td>
 </tr>
@@ -115,7 +115,7 @@ For the system properties that relate to high availability, see [Sending Periodi
 </tr>
 <tr class="odd">
 <td>max-socket-buffer-size</td>
-<td>Maximum size of the socket buffers, in bytes, that the native client will try to set for client-server connections.</td>
+<td>Maximum size of the socket buffers, in bytes, that the client will try to set for client-server connections.</td>
 <td>65 * 1024</td>
 </tr>
 <tr class="even">
@@ -146,10 +146,7 @@ For the system properties that relate to high availability, see [Sending Periodi
 <tr class="odd">
 <td>tombstone-timeout</td>
 <td>Time in milliseconds used to timeout tombstone entries when region consistency checking is enabled.
-<div class="note note">
-**Note:**
-<p>Do not modify this property unless instructed by technical support.</p>
-</div></td>
+</td>
 <td>480000</td>
 </tr>
 </tbody>
@@ -229,7 +226,7 @@ For the system properties that relate to high availability, see [Sending Periodi
 </tr>
 <tr class="even">
 <td>statistic-archive-file</td>
-<td>Name and full path of the file where a running system member writes archives statistics. If <code class="ph codeph">archive-disk-space-limit</code> is not set, the native client appends the process ID to the configured file name, like <code class="ph codeph">statArchive-PID.gfs</code>. If the space limit is set, the process ID is not appended but each rolled file name is renamed to statArchive-ID.gfs, where ID is the rolled number of the file.</td>
+<td>Name and full path of the file where a running system member writes archives statistics. If <code class="ph codeph">archive-disk-space-limit</code> is not set, the client appends the process ID to the configured file name, like <code class="ph codeph">statArchive-PID.gfs</code>. If the space limit is set, the process ID is not appended but each rolled file name is renamed to statArchive-ID.gfs, where ID is the rolled number of the file.</td>
 <td>./statArchive.gfs</td>
 </tr>
 <tr class="odd">
@@ -246,7 +243,7 @@ For the system properties that relate to high availability, see [Sending Periodi
 <td>statistic-sample-rate</td>
 <td>Rate, in seconds, that statistics are sampled. Operating system statistics are updated only when a sample is taken. If statistic archival is enabled, then these samples are written to the archive.
 <p>Lowering the sample rate for statistics reduces system resource use while still providing some statistics for system tuning and failure analysis.</p>
-<p>You can view archived statistics with the optional VSD utility.</p></td>
+</td>
 <td>1</td>
 </tr>
 <tr class="even">

--- a/docs/geode-native-docs/setting-properties/cache-server-config.html.md.erb
+++ b/docs/geode-native-docs/setting-properties/cache-server-config.html.md.erb
@@ -21,16 +21,14 @@ limitations under the License.
 
 You configure the cache server in two files: `gemfire.properties` for server system-level configuration and `cache.xml` for cache-level configuration.
 
-The configuration of the caches is part of the application development process. See [Cache Initialization File](../cache-init-file/chapter-overview.html#chapter-overview). (The cache-level configuration file is generally referred to as `cache.xml`, but you can use any name.)
+The configuration of the caches is part of the application development process. See [Cache Initialization File](../cache-init-file/chapter-overview.html#chapter-overview). The cache-level configuration file is generally referred to as `cache.xml`, but you can use any name.
 
 ## <a id="cache-server-config__section_FED30097F6C246DE843EBD8B5292D86C" class="no-quick-link"></a>Configuration File Locations
 
-For the GemFire cache server, the `gemfire.properties` file is usually stored in the current working directory. For more information, see the *User's Guide*.
+For the cache server, the `gemfire.properties` file is usually stored in the current working directory.
 
-For the `cache.xml` cache configuration file, a native client looks for the path specified by the `cache-xml-file` attribute in `gfcpp.properties` (see [Attributes in gfcpp.properties](attributes-gfcpp.html#attributes-gfcpp)). If the `cache.xml` is not found, the process starts with an unconfigured cache.
+For the `cache.xml` configuration file, a client looks for the path specified by the `cache-xml-file` attribute in `gfcpp.properties` (see [Attributes in gfcpp.properties](attributes-gfcpp.html#attributes-gfcpp)). If the `cache.xml` is not found, the process starts with an unconfigured cache.
 
 ## <a id="cache-server-config__section_F47DE4D858B04244956B91360AD8967E" class="no-quick-link"></a>Modifying Attributes Outside the gemfire.properties File
 
 In addition to the `gemfire.properties file`, you can pass attributes to the cache server on the gfsh command line. These override any settings found in the `gemfire.properties` file when starting the cache server.
-
-For more information, see *Configuring a Cluster* in the *User's Guide*.

--- a/docs/geode-native-docs/setting-properties/chapter-overview.html.md.erb
+++ b/docs/geode-native-docs/setting-properties/chapter-overview.html.md.erb
@@ -19,18 +19,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-*Setting System Properties* describes how to configure Apache Geode native clients and cache servers to participate in a distributed system.
+This section describes how to configure clients and cache servers to participate in a distributed system.
 
--   **[Configuring the Native Client and Cache Server](config-overview.html)**
+-   **[Configuring the Client and Server](config-overview.html)**
 
     You can configure clients through files and API calls. The servers are configured through command-line input and configuration files.
 
 -   **[Attributes in gfcpp.properties](attributes-gfcpp.html)**
 
-    A variety of `gfcpp.properties` settings can be used when a native client connects to a distributed system.
+    A variety of `gfcpp.properties` settings can be used when a client connects to a distributed system.
 
 -   **[gfcpp.properties Example File](../gfcpp.properties/chapter_overview.html)**
 
-    Use the gfcpp.properties file to configure distributed system connections for the Apache Geode native client.
+    Use the gfcpp.properties file to configure distributed system connections for the client.
 
 

--- a/docs/geode-native-docs/setting-properties/config-overview.html.md.erb
+++ b/docs/geode-native-docs/setting-properties/config-overview.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  Configuring the Native Client and Cache Server
+title:  Configuring the Client and Server
 ---
 
 <!--
@@ -21,9 +21,9 @@ limitations under the License.
 
 You can configure clients through files and API calls. The servers are configured through command-line input and configuration files.
 
--   **[Native Client Configuration](native-client-config.html)**
+-   **[Client Configuration](native-client-config.html)**
 
-    You configure the native client in two files: `gfcpp.properties` for native client system-level configuration and `cache.xml` for cache-level configuration.
+    You configure the client in two files: `gfcpp.properties` for system-level configuration and `cache.xml` for cache-level configuration.
 
 -   **[Cache Server Configuration](cache-server-config.html)**
 
@@ -35,7 +35,7 @@ You can configure clients through files and API calls. The servers are configure
 
 -   **[Search Path for Multiple gfcpp.properties Files](../gfcpp.properties/gfcpp.properties_search_path.html)**
 
-    The native client and cache server processes first look for their properties file in the <code>_product-dir_/defaultSystem</code> directory, then in the working directory.
+    The client and server processes first look for their properties file in the <code>_product-dir_/defaultSystem</code> directory, then in the working directory.
 
 -   **[Overriding gfcpp.properties Settings](../gfcpp.properties/overriding_gfcpp.properties.html)**
 

--- a/docs/geode-native-docs/setting-properties/native-client-config.html.md.erb
+++ b/docs/geode-native-docs/setting-properties/native-client-config.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  Native Client Configuration
+title:  Client Configuration
 ---
 
 <!--
@@ -19,7 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-You configure the native client in two files: `gfcpp.properties` for native client system-level configuration and `cache.xml` for cache-level configuration.
+You configure the client in two files: `gfcpp.properties` for system-level configuration and `cache.xml` for cache-level configuration.
 
 The configuration of the caches is part of the application development process. See [Cache Initialization File](../cache-init-file/chapter-overview.html#chapter-overview). (The cache-level configuration file is generally referred to as `cache.xml`, but you can use any name.)
 
@@ -33,20 +33,20 @@ If you do not have `gfcpp.properties` files, use any text editor to create them.
 
 ## <a id="native-client-config__section_88780874FD6C4BBD9B1B993758A985BB" class="no-quick-link"></a>Configuration File Locations
 
-A native client looks for `gfcpp.properties` first in the working directory where the process runs, then in <code>_product-dir_/defaultSystem</code>.
+A client looks for a `gfcpp.properties` file first in the working directory where the process runs, then in <code>_product-dir_/defaultSystem</code>.
 Use the `defaultSystem` directory to group configuration files or to share them among processes for more convenient administration. If `gfcpp.properties` is not found, the process starts up with the default settings.
 
-For the `cache.xml` cache configuration file, a native client looks for the path specified by the `cache-xml-file` attribute in `gfcpp.properties` (see [Attributes in gfcpp.properties](attributes-gfcpp.html#attributes-gfcpp)). If the `cache.xml` is not found, the process starts with an unconfigured cache.
+For the `cache.xml` cache configuration file, a client looks for the path specified by the `cache-xml-file` attribute in `gfcpp.properties` (see [Attributes in gfcpp.properties](attributes-gfcpp.html#attributes-gfcpp)). If the `cache.xml` is not found, the process starts with an unconfigured cache.
 
-## <a id="native-client-config__section_6EBE269F15A1497BB4ABBF659F978DA1" class="no-quick-link"></a>Configuring System Properties for the Native Client
+## <a id="native-client-config__section_6EBE269F15A1497BB4ABBF659F978DA1" class="no-quick-link"></a>Configuring System Properties for the Client
 
-The typical configuration procedure for a native client includes the high-level steps listed below. The rest of this chapter provides the details.
+The typical configuration procedure for a client includes the high-level steps listed below. The rest of this chapter provides the details.
 
 1.  Place the `gfcpp.properties` file for the application in the working directory or in <code>_product-dir_/defaultSystem</code>.
 Use the configuration file that came with the application software if there is one, or create your own. See [gfcpp.properties Example File](../gfcpp.properties/chapter_overview.html#concept_41DADD6F4E41495A89CCBB8A790ED9DF) for a sample of the file format and contents.
 2.  Place the `cache.xml` file for the application in the desired location and specify its path in the `gfcpp.properties` file.
 3.  Add other attributes to the `gfcpp.properties` file as needed for the local system architecture. See [Attributes in gfcpp.properties](attributes-gfcpp.html#attributes-gfcpp) for the configurable attributes, and [gfcpp.properties Example File](../gfcpp.properties/chapter_overview.html#concept_41DADD6F4E41495A89CCBB8A790ED9DF) for a sample of the file format.
 
-## <a id="native-client-config__section_7F09E85DD0144972AAA7028D81780129" class="no-quick-link"></a>Running a Native Client Out of the Box
+## <a id="native-client-config__section_7F09E85DD0144972AAA7028D81780129" class="no-quick-link"></a>Running a Client Out of the Box
 
-If you start a native client without any configurations, it uses any attributes set programmatically plus any hard-coded defaults (listed in [Attributes in gfcpp.properties](attributes-gfcpp.html#attributes-gfcpp)). Running with the defaults is a convenient way to learn the operation of the distributed system and to test which attributes need to be reconfigured for your environment.
+If you start a client without any configuration, it uses any attributes set programmatically plus any hard-coded defaults (listed in [Attributes in gfcpp.properties](attributes-gfcpp.html#attributes-gfcpp)). Running with the defaults is a convenient way to learn the operation of the distributed system and to test which attributes need to be reconfigured for your environment.


### PR DESCRIPTION
of Geode Native documentation

- Removed references to Pivotal GemFire and related commercial products
- Changed 'native client' to 'client.'
- Cosmetic wording changes

@davebarnes97 @joeymcallister @echobravopapa @PivotalSarge @dgkimura @mmartell    Can you please review these changes?