### PR TITLE
GEODE-2636: Fix C# quickstarts.

### DIFF
--- a/src/quickstart/csharp/CMakeLists.txt
+++ b/src/quickstart/csharp/CMakeLists.txt
@@ -23,6 +23,9 @@ set (GFCPP CACHE ${NATIVECLIENT_DIR} PATH REQUIRED)
 # Set the .NET Target Framework (Note: This should match the build for Apache.Geode.)
 set (DOTNET_TARGET_FRAMEWORK_VERSION "v4.5.2")
 
+set(PRODUCT_LIB_NAME "apache-geode" CACHE STRING "Binary name")
+set(PRODUCT_DLL_NAME "Apache.Geode" CACHE STRING ".Net Binary name")
+
 file(GLOB_RECURSE CSPROJECTS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.csproj.in")
 
 foreach(FILE ${CSPROJECTS})

--- a/src/quickstart/csharp/app.config.in
+++ b/src/quickstart/csharp/app.config.in
@@ -22,11 +22,11 @@ limitations under the License.
    <assemblyBinding
       xmlns="urn:schemas-microsoft-com:asm.v1">
      <dependentAssembly>
-       <assemblyIdentity name="Apache.Geode.Client"
+       <assemblyIdentity name="${PRODUCT_DLL_NAME}.Client"
           publicKeyToken="126e6338d9f55e0c"
           culture="neutral" />
        <codeBase version="9.0.0.0"
-          href="${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll"/>
+          href="${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll"/>
      </dependentAssembly> 
    </assemblyBinding>  
  </runtime>

--- a/src/quickstart/csharp/app.config.in
+++ b/src/quickstart/csharp/app.config.in
@@ -22,7 +22,7 @@ limitations under the License.
    <assemblyBinding
       xmlns="urn:schemas-microsoft-com:asm.v1">
      <dependentAssembly>
-       <assemblyIdentity name="${PRODUCT_DLL_NAME}.Client"
+       <assemblyIdentity name="Apache.Geode.Client"
           publicKeyToken="126e6338d9f55e0c"
           culture="neutral" />
        <codeBase version="9.0.0.0"

--- a/src/quickstart/csharp/vsprojects/BasicOperations/BasicOperations.csproj.in
+++ b/src/quickstart/csharp/vsprojects/BasicOperations/BasicOperations.csproj.in
@@ -91,7 +91,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>     
     </Reference>

--- a/src/quickstart/csharp/vsprojects/BasicOperations/BasicOperations.csproj.in
+++ b/src/quickstart/csharp/vsprojects/BasicOperations/BasicOperations.csproj.in
@@ -91,9 +91,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>     
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>     
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/CqQuery/CqQuery.csproj.in
+++ b/src/quickstart/csharp/vsprojects/CqQuery/CqQuery.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/CqQuery/CqQuery.csproj.in
+++ b/src/quickstart/csharp/vsprojects/CqQuery/CqQuery.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/DataExpiration/DataExpiration.csproj.in
+++ b/src/quickstart/csharp/vsprojects/DataExpiration/DataExpiration.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=8.1.0.1, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=8.1.0.1, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/DataExpiration/DataExpiration.csproj.in
+++ b/src/quickstart/csharp/vsprojects/DataExpiration/DataExpiration.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=8.1.0.1, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=8.1.0.1, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/Delta/Delta.csproj.in
+++ b/src/quickstart/csharp/vsprojects/Delta/Delta.csproj.in
@@ -88,9 +88,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/quickstart/csharp/vsprojects/Delta/Delta.csproj.in
+++ b/src/quickstart/csharp/vsprojects/Delta/Delta.csproj.in
@@ -88,7 +88,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/DistributedSystem/DistributedSystem.csproj.in
+++ b/src/quickstart/csharp/vsprojects/DistributedSystem/DistributedSystem.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/DistributedSystem/DistributedSystem.csproj.in
+++ b/src/quickstart/csharp/vsprojects/DistributedSystem/DistributedSystem.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/DurableClient/DurableClient.csproj.in
+++ b/src/quickstart/csharp/vsprojects/DurableClient/DurableClient.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/DurableClient/DurableClient.csproj.in
+++ b/src/quickstart/csharp/vsprojects/DurableClient/DurableClient.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/Exceptions/Exceptions.csproj.in
+++ b/src/quickstart/csharp/vsprojects/Exceptions/Exceptions.csproj.in
@@ -92,9 +92,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/Exceptions/Exceptions.csproj.in
+++ b/src/quickstart/csharp/vsprojects/Exceptions/Exceptions.csproj.in
@@ -92,7 +92,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/ExecuteFunctions/ExecuteFunctions.csproj.in
+++ b/src/quickstart/csharp/vsprojects/ExecuteFunctions/ExecuteFunctions.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/ExecuteFunctions/ExecuteFunctions.csproj.in
+++ b/src/quickstart/csharp/vsprojects/ExecuteFunctions/ExecuteFunctions.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/HACache/HACache.csproj.in
+++ b/src/quickstart/csharp/vsprojects/HACache/HACache.csproj.in
@@ -92,9 +92,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/HACache/HACache.csproj.in
+++ b/src/quickstart/csharp/vsprojects/HACache/HACache.csproj.in
@@ -92,7 +92,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/LoaderListenerWriter/LoaderListenerWriter.csproj.in
+++ b/src/quickstart/csharp/vsprojects/LoaderListenerWriter/LoaderListenerWriter.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/LoaderListenerWriter/LoaderListenerWriter.csproj.in
+++ b/src/quickstart/csharp/vsprojects/LoaderListenerWriter/LoaderListenerWriter.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/MultiuserSecurity/MultiuserSecurity.csproj.in
+++ b/src/quickstart/csharp/vsprojects/MultiuserSecurity/MultiuserSecurity.csproj.in
@@ -91,9 +91,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/MultiuserSecurity/MultiuserSecurity.csproj.in
+++ b/src/quickstart/csharp/vsprojects/MultiuserSecurity/MultiuserSecurity.csproj.in
@@ -91,7 +91,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/PdxInstance/PdxInstance.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PdxInstance/PdxInstance.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/PdxInstance/PdxInstance.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PdxInstance/PdxInstance.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/PdxRemoteQuery/PdxRemoteQuery.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PdxRemoteQuery/PdxRemoteQuery.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/PdxRemoteQuery/PdxRemoteQuery.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PdxRemoteQuery/PdxRemoteQuery.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/PdxSerializer/PdxSerializer.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PdxSerializer/PdxSerializer.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/PdxSerializer/PdxSerializer.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PdxSerializer/PdxSerializer.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/PoolCqQuery/PoolCqQuery.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PoolCqQuery/PoolCqQuery.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/PoolCqQuery/PoolCqQuery.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PoolCqQuery/PoolCqQuery.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/PoolRemoteQuery/PoolRemoteQuery.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PoolRemoteQuery/PoolRemoteQuery.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/PoolRemoteQuery/PoolRemoteQuery.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PoolRemoteQuery/PoolRemoteQuery.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/PoolWithEndpoints/PoolWithEndpoints.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PoolWithEndpoints/PoolWithEndpoints.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/PoolWithEndpoints/PoolWithEndpoints.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PoolWithEndpoints/PoolWithEndpoints.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/PutAllGetAllOperations/PutAllGetAllOperations.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PutAllGetAllOperations/PutAllGetAllOperations.csproj.in
@@ -91,9 +91,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/PutAllGetAllOperations/PutAllGetAllOperations.csproj.in
+++ b/src/quickstart/csharp/vsprojects/PutAllGetAllOperations/PutAllGetAllOperations.csproj.in
@@ -91,7 +91,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/RefIDExample/RefIDExample.csproj.in
+++ b/src/quickstart/csharp/vsprojects/RefIDExample/RefIDExample.csproj.in
@@ -88,9 +88,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/RefIDExample/RefIDExample.csproj.in
+++ b/src/quickstart/csharp/vsprojects/RefIDExample/RefIDExample.csproj.in
@@ -88,7 +88,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/RegisterInterest/RegisterInterest.csproj.in
+++ b/src/quickstart/csharp/vsprojects/RegisterInterest/RegisterInterest.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/RegisterInterest/RegisterInterest.csproj.in
+++ b/src/quickstart/csharp/vsprojects/RegisterInterest/RegisterInterest.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/RemoteQuery/RemoteQuery.csproj.in
+++ b/src/quickstart/csharp/vsprojects/RemoteQuery/RemoteQuery.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/RemoteQuery/RemoteQuery.csproj.in
+++ b/src/quickstart/csharp/vsprojects/RemoteQuery/RemoteQuery.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/Security/Security.csproj.in
+++ b/src/quickstart/csharp/vsprojects/Security/Security.csproj.in
@@ -91,9 +91,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/Security/Security.csproj.in
+++ b/src/quickstart/csharp/vsprojects/Security/Security.csproj.in
@@ -91,7 +91,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/SimplePlugins/SimplePlugins.csproj.in
+++ b/src/quickstart/csharp/vsprojects/SimplePlugins/SimplePlugins.csproj.in
@@ -100,7 +100,7 @@
   </Target>
   -->
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral&#xD;&#xA; PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral&#xD;&#xA; PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/SimplePlugins/SimplePlugins.csproj.in
+++ b/src/quickstart/csharp/vsprojects/SimplePlugins/SimplePlugins.csproj.in
@@ -100,9 +100,9 @@
   </Target>
   -->
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral&#xD;&#xA; PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral&#xD;&#xA; PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/quickstart/csharp/vsprojects/Transactions/Transactions.csproj.in
+++ b/src/quickstart/csharp/vsprojects/Transactions/Transactions.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>

--- a/src/quickstart/csharp/vsprojects/Transactions/Transactions.csproj.in
+++ b/src/quickstart/csharp/vsprojects/Transactions/Transactions.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=9.0.0.0, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/TransactionsXA/TransactionsXA.csproj.in
+++ b/src/quickstart/csharp/vsprojects/TransactionsXA/TransactionsXA.csproj.in
@@ -90,9 +90,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Apache.Geode.Client, Version=8.2.0.3, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=8.2.0.3, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>${NATIVECLIENT_BINARIES_DIR}/Apache.Geode.dll</HintPath>
+      <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/quickstart/csharp/vsprojects/TransactionsXA/TransactionsXA.csproj.in
+++ b/src/quickstart/csharp/vsprojects/TransactionsXA/TransactionsXA.csproj.in
@@ -90,7 +90,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="${PRODUCT_DLL_NAME}.Client, Version=8.2.0.3, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
+    <Reference Include="Apache.Geode.Client, Version=8.2.0.3, Culture=neutral, PublicKeyToken=126e6338d9f55e0c, processorArchitecture=x64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>${NATIVECLIENT_BINARIES_DIR}/${PRODUCT_DLL_NAME}.dll</HintPath>
     </Reference>


### PR DESCRIPTION
The C# quickstarts do not use CMake so the Visual Studio project files also needed to be updated with the product DLL name.