### PR TITLE
GEODE-2657: Execute Region Function sends incorrect message format

### DIFF
--- a/src/cppcache/src/TcrMessage.cpp
+++ b/src/cppcache/src/TcrMessage.cpp
@@ -2447,6 +2447,7 @@ TcrMessageExecuteRegionFunction::TcrMessageExecuteRegionFunction(
   m_tcdm = connectionDM;
   m_regionName = region == NULL ? "INVALID_REGION_NAME" : region->getFullPath();
   m_region = region;
+  m_hasResult = getResult;
 
   if (routingObj != NULLPTR && routingObj->size() == 1) {
     LOGDEBUG("setting up key");

--- a/src/cppcache/test/TcrMessage_unittest.cpp
+++ b/src/cppcache/test/TcrMessage_unittest.cpp
@@ -541,6 +541,8 @@ TEST_F(TcrMessageTest, testConstructorEXECUTE_REGION_FUNCTION) {
       "030157000000000001012900000001000A00000004000000000000000004000000000000"
       "000002014200",
       testMessage);
+
+  EXPECT_TRUE(testMessage.hasResult());
 }
 
 TEST_F(TcrMessageTest, testConstructorEXECUTE_FUNCTION) {


### PR DESCRIPTION
`TcrMessageExecuteRegionFunction` is missing a call to set `m_hasResults`. This causes the message response to be parsed synchronously and not asynchronously chunked. The synchronous parser does not support this message type and it barfs.