### PR TITLE
GEODE-2726: Add Packer Build Files for VS 2017

### DIFF
--- a/packer/windows-2012-vs-2017.json
+++ b/packer/windows-2012-vs-2017.json
@@ -1,0 +1,64 @@
+{
+  "variables":{
+    "region":"us-west-2",
+    "source_ami":"ami-ac5395cc",
+    "source_image_name":"X.vmx",
+    "image_name":"windows-2012-vs-2017"
+  },
+  "builders":[
+    {
+      "type":"amazon-ebs",
+      "instance_type":"t2.large",
+      "ami_name":"native-{{user `version`}}-{{user `image_name`}} {{timestamp}}",
+      "access_key":"{{user `aws_access_key`}}",
+      "secret_key":"{{user `aws_secret_key`}}",
+      "region":"{{user `region`}}",
+      "source_ami":"{{user `source_ami`}}",
+      "subnet_id":"{{user `subnet_id`}}",
+      "vpc_id":"{{user `vpc_id`}}",
+      "tags":{
+        "team":"native",
+        "version":"{{user `version`}}",
+        "source_ami":"{{user `source_ami`}}"
+      },
+      "communicator":"winrm",
+      "winrm_username":"Administrator",
+      "launch_block_device_mappings":[
+        {
+          "device_name":"/dev/sda1",
+          "delete_on_termination":true,
+          "volume_size":60
+        }
+      ]
+    }
+  ],
+  "provisioners":[
+    {
+      "pause_before":"30s",
+      "type":"file",
+      "source":"windows/Packer.psm1",
+      "destination":"Documents/WindowsPowerShell/Modules/Packer/Packer.psm1"
+    },
+    {
+      "type":"powershell",
+      "scripts":[
+        "windows/install-vs-2017-community.ps1"
+      ]
+    },
+    {
+      "type":"powershell",
+      "scripts":[
+        "windows/cleanup.ps1"
+      ]
+    },
+    {
+      "type":"powershell",
+      "scripts":[
+        "windows/setup-ec2config.ps1"
+      ],
+      "only":[
+        "amazon-ebs"
+      ]
+    }
+  ]
+}

--- a/packer/windows/install-vs-2017-community.ps1
+++ b/packer/windows/install-vs-2017-community.ps1
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# TODO AdminDeploy.xml
+# vs_community.exe /AdminFile C:\Users\Administrator\AdminDeployment.xml /Log setup.log /Passive
+Set-PSDebug -Trace 2
+
+choco install visualstudio2017community -y --ignore-package-exit-codes
+
+Exit 0


### PR DESCRIPTION
Added new packer files to support building Visual Studio 2017 environments.