### PR TITLE
GEODE-2513 Unbranding docs: security

### DIFF
--- a/docs/geode-native-book/master_middleman/source/subnavs/geode-nc-nav.erb
+++ b/docs/geode-native-book/master_middleman/source/subnavs/geode-nc-nav.erb
@@ -596,7 +596,7 @@ limitations under the License.
                                 </ul>
                             </li>
                             <li>
-                                <a href="/docs/guide-native/11/security/security-systemprops.html">Security-Related System Properties (gfcpp.properties)</a>
+                                <a href="/docs/guide-native/11/security/security-systemprops.html">Security-Related System Properties (geode.properties)</a>
                             </li>
                             <li>
                                 <a href="/docs/guide-native/11/security/sslclientserver.html">SSL Client/Server Communication</a>

--- a/docs/geode-native-docs/security/LDAPserverauth.html.md.erb
+++ b/docs/geode-native-docs/security/LDAPserverauth.html.md.erb
@@ -19,9 +19,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-An LDAP server can be used by a Geode cache server using the sample LDAP implementation provided in Geode server product.
+An LDAP server can be used by a Geode cache server using the sample LDAP implementation provided in the server distribution.
 
-See the [Security](../../managing/security/chapter_overview.html#security) to verify authentication credentials for native clients attempting to connect to the Geode servers and sending user name and passwords using the sample UserPassword scheme.
+See the [Security](../../managing/security/chapter_overview.html#security) to verify authentication credentials for clients attempting to connect to the cache servers and sending user name and passwords using the sample UserPassword scheme.
 
 **Note:**
 The user name and password with this sample implementation is sent out in plaintext. For better security, either turn on credential encryption using Diffie-Hellman key exchange, or use a scheme like PKCS.
@@ -39,6 +39,4 @@ security-username=<username>
 security-password=<password>
 ```
 
-For server side settings and LDAP server configuration, see [Security](../../managing/security/chapter_overview.html#security).
-
-
+For server side settings and LDAP server configuration, see the server's security documentation.

--- a/docs/geode-native-docs/security/PKCS.html.md.erb
+++ b/docs/geode-native-docs/security/PKCS.html.md.erb
@@ -28,7 +28,7 @@ With PKCS, clients send encrypted authentication credentials in the form of stan
 
 When clients require authentication to connect to a cache server, they use the `PKCSAuthInit` class implementing the `AuthInitialize` interface to obtain their credentials. For the PKCS sample provided by Geode, the credentials consist of an alias and an encrypted byte array. The private key is obtained from the PKCS\#12 keystore file. To accomplish this,` PKCSAuthInit` gets the alias retrieved from the `security-alias `property, and the keystore path from the `security-keystorepath` property. `PKCSAuthInit` also gets the password for the password-protected keystore file from the `security-keystorepass` property so the keystore can be opened.
 
-**Building the securityImpl Library**
+**The securityImpl Library**
 
 To use the PKCS sample implementation, you need to build OpenSSL and then build the securityImpl library. In the `geode.properties `file for the client, specify the `PKCSAuthInit` callback, the keystore path, the security alias, and the keystore password, like this:
 
@@ -40,6 +40,4 @@ security-alias=<alias>
 security-keystorepass=<keystore password>
 ```
 
-For server side settings, see the description of PKCS sample in [Security](../../managing/security/chapter_overview.html#security).
-
-
+For server side settings and PKCS configuration, see the server's security documentation.

--- a/docs/geode-native-docs/security/createsecureconnregionservice.html.md.erb
+++ b/docs/geode-native-docs/security/createsecureconnregionservice.html.md.erb
@@ -21,7 +21,7 @@ limitations under the License.
 
 To create multiple, secure connections to your servers from a single client, so the client can service different user types, you create an authenticated `RegionService` for each user.
 
-Typically, a Geode client embedded in an application server supports data requests from many users. Each user can be authorized to access a subset of data on the servers. For example, customer users are allowed only to see and update their own orders and shipments.
+Typically, a Geode client embedded in an application server supports data requests from many users. Each user can be authorized to access a subset of data on the servers. For example, customer users are allowed to see and update only their own orders and shipments.
 
 The authenticated users all access the same Cache through instances of the `RegionService` interface. See [RegionService](../client-cache/caching-apis.html#caching-apis__section_8F81996678B64BBE94EF352527F7F006).
 

--- a/docs/geode-native-docs/security/overviewclientauthorization.html.md.erb
+++ b/docs/geode-native-docs/security/overviewclientauthorization.html.md.erb
@@ -25,7 +25,7 @@ The callback can also modify or even disallow the data being provided by the cli
 
 -   **[Configuring Client Authorization](config-clientauthorization.html)**
 
-    You can configure authorization on a per-client basis for various cache operations such as create, get, put, query invalidations, interest registration, and region destroys. On the server side, the `securityclient-accessor` system property in the server’s `gemfire.properties` file specifies the authorization callback.
+    You can configure authorization on a per-client basis for various cache operations such as create, get, put, query invalidations, interest registration, and region destroys. On the server side, the `securityclient-accessor` system property in the server’s `geode.properties` file specifies the authorization callback.
 
 -   **[Post-Operative Authorization](postopauthorization.html)**
 

--- a/docs/geode-native-docs/security/overviewencryptcred.html.md.erb
+++ b/docs/geode-native-docs/security/overviewencryptcred.html.md.erb
@@ -19,7 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-For secure transmission of sensitive credentials like passwords, encrypt credentials using the Diffie-Hellman key exchange algorithm. With Diffie-Hellman enabled, you can have your client authenticate its servers.
+For secure transmission of sensitive credentials such as passwords, encrypt credentials using the Diffie-Hellman key exchange algorithm. With Diffie-Hellman enabled, you can have your client authenticate its servers.
 
 ## <a id="security__section_1BB8F13C7ACB44668FF337F59A3BA5AE" class="no-quick-link"></a>Enabling Diffe-Hellman
 

--- a/docs/geode-native-docs/security/overviewsecurity.html.md.erb
+++ b/docs/geode-native-docs/security/overviewsecurity.html.md.erb
@@ -21,7 +21,7 @@ limitations under the License.
 
 *Security* describes how to implement the security framework for the Geode native client, including authentication, authorization, encryption, and SSL client/server communication.
 
-The security framework authenticates clients that attempt to connect to a Geode cache server, and authorizes client cache operations. You can also configure it for client authentication of servers, and you can plug in your own implementations for authentication and authorization.
+The security framework authenticates clients that attempt to connect to a Geode cache server and authorizes client cache operations. You can also configure it for client authentication of servers, and you can plug in your own implementations for authentication and authorization.
 
 -   **[Authentication](overviewauthentication.html)**
 

--- a/docs/geode-native-docs/security/sslclientserver.html.md.erb
+++ b/docs/geode-native-docs/security/sslclientserver.html.md.erb
@@ -69,35 +69,36 @@ There are public third party free tools and source code available to download su
 
 ## Step 3. Configure environment variables
 
-Configure your system environment to build and run OpenSSL. Follow the environment setup that applies to your operating system.
-
-### <a id="security__section_6C173D0D8C8343EA92961C954032E2CA" class="no-quick-link"></a>Bourne and Korn shells (sh, ksh, bash)
-
+Configure your system environment to build and run OpenSSL by adding the appropriate executable and library directories to your paths.
+For example, for Bourne and Korn shells (sh, ksh, bash), environment setup would look something like this:
 <code>
-% OPENSSL=_parent-folder-for-openssl-binaries_; export OPENSSL<br />
-% GFCPP=_product-dir_; export GFCPP<br />
-% LD\_LIBRARY\_PATH=$LD\_LIBRARY\_PATH:$GFCPP/lib:$GFCPP/ssl\_libs:$OPENSSL/lib<br />
+% LD\_LIBRARY\_PATH=$LD\_LIBRARY\_PATH:_client-install-dir_/lib:_client-install-dir_/ssl\_libs:_openssl-install-dir_/lib<br />
 % export LD\_LIBRARY\_PATH<br />
-% CLASSPATH=$GEMFIRE/lib/gfSecurityImpl.jar:$CLASSPATH
+% CLASSPATH=_server-install-dir_/lib/securityImpl.jar:$CLASSPATH
 </code>
 
-### <a id="security__section_76CF86EDC2234BA6BF7DA6E253C71F61" class="no-quick-link"></a>Windows
+where:
 
+  _client-install-dir_ is the directory in which you installed your client.
+
+  _openssl-install-dir_ is the directory in which you installed OpenSSL.
+
+  _server-install-dir_ is the directory in which you installed your server.
+
+For Windows, environment setup might resemble this:
 <code>
-\> set GFCPP=_product-dir_<br />
-\> set OPENSSL=_path-to-installed-openssl_<br />
-\> set PATH=_jdk-or-jre-path_\bin;%GFCPP%\bin;%GFCPP%\ssl\_libs;%OPENSSL%\bin;%PATH%<br />
-\> set CLASSPATH=_path-to-gemfire-installation_\lib\gfSecurityImpl.jar;%CLASSPATH%
+\> set PATH=_jdk-or-jre-path_\bin;_client-install-dir_\bin;_client-install-dir_\ssl\_libs;_openssl-install-dir_\bin;%PATH%<br />
+\> set CLASSPATH=_server-installdir_\lib\securityImpl.jar;%CLASSPATH%
 </code>
 
-where <code>_path-to-installed-openssl_</code> is typically `C:\OpenSSL>`.
+where _jdk-or-jre-path_ is the directory in which Java is installed.
 
-## Step 4. Configure SSL properties in geode.properties and gemfire.properties
+## Step 4. Configure SSL properties in client and server properties files
 
 Configure SSL properties.
 
-1.  In `geode.properties`, set `ssl-enabled` to true and set `ssl-keystore` and `ssl-truststore` to point to your keystore files. See [Security-Related System Properties (geode.properties)](security-systemprops.html#security) for a description of these properties.
-2.  On each locator, enable SSL and set the following SSL properties in the locator’s `gemfire.properties` file:
+1.  In your client properties file (usually `geode.properties`), set `ssl-enabled` to true and set `ssl-keystore` and `ssl-truststore` to point to your keystore files. See [Security-Related System Properties (geode.properties)](security-systemprops.html#security) for a description of these properties.
+2.  On each locator, enable SSL and set the following SSL properties in the locator’s properties file (usually `geode.properties`, but on the locator's host):
 
     ```
     ssl-enabled-components=server,locator
@@ -121,28 +122,28 @@ For details on stopping and starting locators and cache servers with SSL, see [S
 
 **Example locator start command**
 
-Ensure that all required SSL properties are configured in your server's `gfsecurity.properties` file. Then start your locator as follows:
+Ensure that all required SSL properties are configured in your server's `geode.properties` file. Then start your locator as follows:
 
 ``` pre
 gfsh>start locator --name=my_locator --port=12345 --dir=. \
---security-properties-file=/path/to/your/gfsecurity.properties
+--security-properties-file=/path/to/your/geode.properties
 ```
 
 **Example locator stop command**
 
 ``` pre
 gfsh>stop locator --port=12345 \
---security-properties-file=/path/to/your/gfsecurity.properties
+--security-properties-file=/path/to/your/geode.properties
 ```
 
 **Example server start command**
 
-Again, ensure that all required SSL properties are configured in `gfsecurity.properties`. Then start the server with:
+Again, ensure that all required SSL properties are configured in `geode.properties`. Then start the server with:
 
 ``` pre
 gfsh>start server --name=my_server --locators=hostname[12345] \
 --cache-xml-file=server.xml --log-level=fine \
---security-properties-file=/path/to/your/gfsecurity.properties
+--security-properties-file=/path/to/your/geode.properties
 ```
 
 **Example server stop command**

--- a/docs/geode-native-docs/security/systempropsforauth.html.md.erb
+++ b/docs/geode-native-docs/security/systempropsforauth.html.md.erb
@@ -19,7 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-The native client uses system properties to acquire valid credentials for authentication by the server. You define these properties in the `geode.properties` file, which the native client accesses during startup.
+The client uses system properties to acquire valid credentials for authentication by the server. You define these properties in the `geode.properties` file, which the client accesses during startup.
 
 ## <a id="security__section_E1835A3B22D44D47A4C9DB54A3590B71" class="no-quick-link"></a>security-client-auth-factory
 
@@ -57,7 +57,7 @@ public static IAuthInitialize Create()
 
 Implementations of the factory method are user-provided. Credentials in the form of properties returned by this function are sent by the client to the server for authentication during the client’s handshake process with the server.
 
-The Geode native client installation provides sample security implementations in its `templates/security` folder.
+The client installation provides sample security implementations in its `templates/security` folder.
 
 ## <a id="security__section_9DEC6B55C76D446FB0821AF3B3922BD6" class="no-quick-link"></a>Acquiring Credentials Programmatically (C++ and .NET)
 
@@ -67,9 +67,9 @@ This example shows a C++ client connecting with credentials.
 PropertiesPtr secProp = Properties::create();
 secProp->insert("security-client-auth-factory", "createPKCSAuthInitInstance");
 secProp->insert("security-client-auth-library", "securityImpl");
-secProp->insert("security-keystorepath", "keystore/gemfire6.keystore");
-secProp->insert("security-alias", "gemfire6");
-secProp->insert("security-zkeystorepass", "gemfire");
+secProp->insert("security-keystorepath", "keystore/geode.keystore");
+secProp->insert("security-alias", "geode");
+secProp->insert("security-keystorepass", "geodepass");
 CacheFactoryPtr cacheFactoryPtr = CacheFactory::createCacheFactory(secProp);
 ```
 
@@ -78,8 +78,8 @@ This example shows a .NET client.
 ``` pre
 Properties secProp = Properties.Create();
 secProp.Insert("security-client-auth-factory", 
-   "GemStone.GemFire.Templates.Cache.Security.UserPasswordAuthInit.Create");
+   "Apache.Geode.Templates.Cache.Security.UserPasswordAuthInit.Create");
 secProp.Insert("security-client-auth-library", "securityImpl");
-secProp.Insert("security-username"," gemfire6");
-secProp.Insert("security-password"," gemfire6Pass);
+secProp.Insert("security-username"," geode");
+secProp.Insert("security-password"," geodePass);
 ```


### PR DESCRIPTION
The scope of this pull request is to eliminate occurrences of `gemfire` and `native` from the terminology, along with proprietary-ish names such as `GFCPP`.
The actual procedures in this section may be out-of-date, but updating them is a separate task.