### PR TITLE
GEODE-2691: Fix function execution attributes mismatch

### DIFF
--- a/src/cppcache/src/ExecutionImpl.hpp
+++ b/src/cppcache/src/ExecutionImpl.hpp
@@ -69,8 +69,6 @@ class ExecutionImpl : public Execution {
                          const CacheableVectorPtr& results);
 
  private:
-  ResultCollectorPtr execute(const char* func, uint32_t timeout,
-                             bool verifyFuncArgs);
   ExecutionImpl(const ExecutionImpl& rhs)
       : m_routingObj(rhs.m_routingObj),
         m_args(rhs.m_args),


### PR DESCRIPTION
Fixes function execution invocation which previously passed in attributes that
function execute would compare to the server's view of the registered function
attributes. Since the previously passed in attributes were deprecated there is
nothing to compare. Instead we should accept the attributes that the server
returns.

Testing: Function execution tests pass