### PR TITLE
GEODE-2766: Only apply patches on Solaris

### DIFF
--- a/src/dependencies/ACE/CMakeLists.txt
+++ b/src/dependencies/ACE/CMakeLists.txt
@@ -136,6 +136,7 @@ if (${WIN32})
   set(CMAKE_STATIC_LIBRARY_SUFFIX s$<${MSVC}:$<$<CONFIG:Debug>:d>>.lib)
 endif()
 
+if ($(CMAKE_HOST_SOLARIS))
 set( PATCH_FILE ${CMAKE_CURRENT_SOURCE_DIR}/patches )
 ExternalProject_Add_Step( ${${PROJECT_NAME}_EXTERN} patches
     ALWAYS 0
@@ -146,6 +147,7 @@ ExternalProject_Add_Step( ${${PROJECT_NAME}_EXTERN} patches
     WORKING_DIRECTORY ${${PROJECT_NAME}_SOURCE_DIR}
     COMMAND ${PATCH} -u -N -p1 < ${PATCH_FILE}
 )
+endif()
 
 configure_file(config.h.in config.h)
 ExternalProject_Add_Step( ${${PROJECT_NAME}_EXTERN} config.h

--- a/src/dependencies/openssl/CMakeLists.txt
+++ b/src/dependencies/openssl/CMakeLists.txt
@@ -100,6 +100,7 @@ else()
   set( CMAKE_LINK_LIBRARY_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
 endif()
 
+if ($(CMAKE_HOST_SOLARIS))
 ExternalProject_Add_Step( ${${PROJECT_NAME}_EXTERN} patches
     BYPRODUCTS ${${PROJECT_NAME}_SOURCE_DIR}/Configure
     ALWAYS 0
@@ -109,6 +110,7 @@ ExternalProject_Add_Step( ${${PROJECT_NAME}_EXTERN} patches
     WORKING_DIRECTORY ${${PROJECT_NAME}_SOURCE_DIR}
     COMMAND ${PATCH} -u -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches
 )
+endif()
 
 add_library(ssl INTERFACE)
 target_include_directories(ssl INTERFACE


### PR DESCRIPTION
- This avoids trying to apply patches on Windows which can break if the source
  wasn't actually checked out by a Windows git.