### PR TITLE
GEODE-2741: Adding a warning for 64bit Windows Tools sets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,9 @@ project(nativeclient)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 if(CMAKE_GENERATOR MATCHES Win64*)
+
   if ((CMAKE_GENERATOR MATCHES "Visual Studio") AND (CMAKE_GENERATOR_TOOLSET STREQUAL ""))
-    message(WARNING "GEODE expects that a user must provode -Thost=x64 if you are using a"
+    message(FATAL_ERROR "GEODE expects that a user must provide -Thost=x64 if you are using a"
             " 64-bit toolset, otherwise you may get a linker error when DLLs are larger"
             " than 2GB saying \"Unable to open file apache-geode-static.dll.\" This is due"
             " to the 32bit toolset being used by default.")


### PR DESCRIPTION
- Need to include -Thost=x64 in the configuration step