### PR TITLE
GEODE-3019: Refactor Struct class

### DIFF
--- a/src/cppcache/include/geode/Struct.hpp
+++ b/src/cppcache/include/geode/Struct.hpp
@@ -76,7 +76,7 @@ class CPPCACHE_EXPORT Struct : public Serializable {
    * @returns A smart pointer to the field value.
    * @throws IllegalArgumentException if the field name is not found.
    */
-  const SerializablePtr operator[](const char* fieldName) const;
+  const SerializablePtr operator[](const std::string& fieldName) const;
 
   /**
    * Get the parent StructSet of this Struct.
@@ -137,8 +137,9 @@ class CPPCACHE_EXPORT Struct : public Serializable {
   /**
    * Returns the name of the field corresponding to the index number in the
    * Struct
+   * @throws std::out_of_range if index is not found
    */
-  virtual const char* getFieldName(const int32_t index) const;
+  virtual const std::string& getFieldName(const int32_t index) const;
 
   /**
    * always returns 0
@@ -152,9 +153,7 @@ class CPPCACHE_EXPORT Struct : public Serializable {
 
   Struct();
 
-  typedef std::unordered_map<CacheableStringPtr, CacheableInt32Ptr,
-                             dereference_hash<CacheableStringPtr>,
-                             dereference_equal_to<CacheableStringPtr>>
+  typedef std::unordered_map<std::string, int32_t>
       FieldNames;
   FieldNames m_fieldNames;
   std::vector<SerializablePtr> m_fieldValues;

--- a/src/cppcache/include/geode/StructSet.hpp
+++ b/src/cppcache/include/geode/StructSet.hpp
@@ -72,9 +72,9 @@ class CPPCACHE_EXPORT StructSet : public CqResults {
    *
    * @param fieldname the field name for which the index is required.
    * @returns the index number of the specified field name.
-   * @throws IllegalArgumentException if the field name is not found.
+   * @throws std::invalid_argument if the field name is not found.
    */
-  virtual int32_t getFieldIndex(const char* fieldname) = 0;
+  virtual const int32_t getFieldIndex(const std::string& fieldname) = 0;
 
   /**
    * Get the field name of the StructSet from the specified index number.
@@ -82,8 +82,9 @@ class CPPCACHE_EXPORT StructSet : public CqResults {
    * @param index the index number of the field name to get.
    * @returns the field name from the specified index number or nullptr if not
    * found.
+   * @throws std::out_of_range if index is not found
    */
-  virtual const char* getFieldName(int32_t index) = 0;
+  virtual const std::string& getFieldName(int32_t index) = 0;
 
   /**
    * Get a SelectResultsIterator with which to iterate over the items in the

--- a/src/cppcache/src/StructSetImpl.cpp
+++ b/src/cppcache/src/StructSetImpl.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <vector>
+#include <stdexcept>
 
 #include "StructSetImpl.hpp"
 
@@ -38,7 +39,6 @@ StructSetImpl::StructSetImpl(
   int32_t numOfValues = response->size();
   int32_t valStoredCnt = 0;
 
-  // LOGDEBUG("FieldNames = %d and Values = %d", numOfFields, numOfValues);
   m_structVector = CacheableVector::create();
   while (valStoredCnt < numOfValues) {
     std::vector<SerializablePtr> tmpVec;
@@ -66,25 +66,22 @@ SelectResultsIterator StructSetImpl::getIterator() {
   return SelectResultsIterator(m_structVector, shared_from_this());
 }
 
-int32_t StructSetImpl::getFieldIndex(const char* fieldname) {
-  std::map<std::string, int32_t>::iterator iter =
+const int32_t StructSetImpl::getFieldIndex(const std::string& fieldname) {
+  const auto& iter =
       m_fieldNameIndexMap.find(fieldname);
   if (iter != m_fieldNameIndexMap.end()) {
     return iter->second;
   } else {
-    // std::string tmp = "fieldname ";
-    // tmp += fieldname + " not found";
-    throw IllegalArgumentException("fieldname not found");
+    throw std::invalid_argument("fieldname not found");
   }
 }
 
-const char* StructSetImpl::getFieldName(int32_t index) {
-  for (std::map<std::string, int32_t>::iterator iter =
-           m_fieldNameIndexMap.begin();
-       iter != m_fieldNameIndexMap.end(); ++iter) {
-    if (iter->second == index) return iter->first.c_str();
+const std::string& StructSetImpl::getFieldName(int32_t index) {
+  for (const auto& iter : m_fieldNameIndexMap) {
+    if (iter.second == index) return (iter.first);
   }
-  return nullptr;
+
+  throw std::out_of_range("Struct: fieldName not found.");
 }
 
 SelectResults::Iterator StructSetImpl::begin() const {

--- a/src/cppcache/src/StructSetImpl.hpp
+++ b/src/cppcache/src/StructSetImpl.hpp
@@ -53,9 +53,9 @@ class CPPCACHE_EXPORT StructSetImpl
 
   const SerializablePtr operator[](int32_t index) const;
 
-  int32_t getFieldIndex(const char* fieldname);
+  const int32_t getFieldIndex(const std::string& fieldname);
 
-  const char* getFieldName(int32_t index);
+  const std::string& getFieldName(int32_t index);
 
   SelectResultsIterator getIterator();
 

--- a/src/cppcache/test/StructSetTest.cpp
+++ b/src/cppcache/test/StructSetTest.cpp
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <stdexcept>
+
+#include <StructSetImpl.hpp>
+
+using namespace apache::geode::client;
+
+TEST(StructSetTest, Basic) {
+  CacheableVectorPtr values = CacheableVector::create();
+  std::vector<CacheableStringPtr> fieldNames;
+  
+  size_t numOfFields = 10;
+  
+  for (size_t i = 0; i < numOfFields; i++) {
+    std::string value = "value";
+    value += i;
+    std::string field = "field";
+    field += i;
+    values->push_back(CacheableString::create(value.c_str()));
+    fieldNames.push_back(CacheableString::create(field.c_str()));
+  }
+  
+  StructSet* ss = new StructSetImpl(values, fieldNames);
+  
+  ss->size();
+
+}
+TEST(StructSetTest, MissingFieldIndex) {
+  CacheableVectorPtr values = CacheableVector::create();
+  std::vector<CacheableStringPtr> fieldNames;
+  
+  size_t numOfFields = 10;
+  
+  for (size_t i = 0; i < numOfFields; i++) {
+    std::string value = "value";
+    value += i;
+    std::string field = "field";
+    field += i;
+    values->push_back(CacheableString::create(value.c_str()));
+    fieldNames.push_back(CacheableString::create(field.c_str()));
+  }
+  
+  StructSet* ss = new StructSetImpl(values, fieldNames);
+  
+  try {
+    ss->getFieldIndex("test");
+  } catch (const std::invalid_argument& e) {
+    printf("Caught expected exception: %s", e.what());
+  }
+
+}
+TEST(StructSetTest, MissingFieldName) {
+  CacheableVectorPtr values = CacheableVector::create();
+  std::vector<CacheableStringPtr> fieldNames;
+  
+  size_t numOfFields = 10;
+  
+  for (size_t i = 0; i < numOfFields; i++) {
+    std::string value = "value";
+    value += i;
+    std::string field = "field";
+    field += i;
+    values->push_back(CacheableString::create(value.c_str()));
+    fieldNames.push_back(CacheableString::create(field.c_str()));
+  }
+  
+  StructSet* ss = new StructSetImpl(values, fieldNames);
+  
+  try {
+    ss->getFieldName(100);
+  } catch (const std::out_of_range& e) {
+    printf("Caught expected exception: %s", e.what());
+  }
+}


### PR DESCRIPTION
- Using std::string now

- this also addresses GEODE-3020, the map now used standard types