### PR TITLE
GEODE-3135 Update Geode Client docs OpenSSL version

### DIFF
--- a/docs/geode-native-docs/introduction/client-configurations.html.md.erb
+++ b/docs/geode-native-docs/introduction/client-configurations.html.md.erb
@@ -157,7 +157,7 @@ The following libraries are external dependencies of the client library, `libgfc
 
 If you plan on using SSL in your Geode client and server deployment, you will need to download and install OpenSSL.
 
-The client requires OpenSSL 1.0.1t or later. For Windows platforms, you can use either the regular or the OpenSSL "Light" version.
+The client requires OpenSSL version 1.0.2. For Windows platforms, you can use either the regular or the OpenSSL "Light" version.
 
 In addition, make sure that your system environment variables have been configured to include OpenSSL.
 

--- a/docs/geode-native-docs/introduction/quickstart.html.md.erb
+++ b/docs/geode-native-docs/introduction/quickstart.html.md.erb
@@ -53,8 +53,6 @@ for the latest Java version for your operating system. See the installation info
 Geode User's Guide for the versions of Java that are compatible with Geode. 
 
 - **Security Toolkit** (optional): The QuickStart security examples rely on a security plugin, `securityImpl`, which is based on the OpenSSL toolkit.
-If you plan to run the security examples, download the latest version of release 1.0.1 (must be 1.0.1) from the [OpenSSL website] (http://www.openssl.org/source/).
-Follow the instructions in the README and INSTALL files to install OpenSSL on your system.
 
 ## <a id="ConfiguringQSE_Linux" class="no-quick-link"></a> Configuring QuickStarts - Linux and Solaris
 

--- a/docs/geode-native-docs/security/sslclientserver.html.md.erb
+++ b/docs/geode-native-docs/security/sslclientserver.html.md.erb
@@ -25,49 +25,21 @@ This section describes how to configure OpenSSL, implement SSL-based communicati
 
 The open-source OpenSSL toolkit provides a full-strength general purpose cryptography library to operate along with the PKCS sample implementation for encrypted authentication of native client credentials.
 
-Follow these instructions to download and install OpenSSL for your specific operating system.
-
-The native client requires OpenSSL 1.0.1t or later. For Windows platforms, you can use either the regular or the OpenSSL 1.0.1t "Light" version.
+Download and install OpenSSL 1.0.2 for your specific operating system.
+For Windows platforms, you can use either the regular or the "Light" version.
 
 **Note for Windows users:** If you use Cygwin, do not use the OpenSSL library that comes with
 Cygwin, which is built with `cygwin.dll` as a dependency. Instead, download a fresh copy from
 OpenSSL as described in the following section.
 
-## Step 1. Download and install OpenSSL
-
-To install OpenSSL:
-
-1. Download the OpenSSL archive from the [OpenSSL web site](http://www.openssl.org/source/). 
-
-2. Extract the archive in a directory of your choice. For example:
-
-    ```
-    $ tar xvzf openssl-1.0.1u.tar.gz
-    x openssl-1.0.1u/ACKNOWLEDGMENTS
-    x openssl-1.0.1u/apps/
-    x openssl-1.0.1u/apps/app_rand.c
-    ...
-    ```
-
-3. Look in the top-level directory of the source distribution to identify the installation instructions for your operating system:
-
-    ```
-    $ cd openssl-1.0.1u
-    $ ls INSTALL*
-    INSTALL        INSTALL.DJGPP      INSTALL.MacOS      INSTALL.NW        INSTALL.OS2
-    INSTALL.VMS    INSTALL.W32        INSTALL.W64        INSTALL.WCE
-    ```
-
-4. Build the OpenSSL library by following the instructions for your operating system.
-
-## Step 2. Create keystores
+## Step 1. Create keystores
 
 The Geode server requires keys and keystores in the Java Key Store (JKS) format while the native client requires them in the clear PEM format. Thus you need to be able to generate private/public keypairs in either format and convert between the two using the `keytool` utility and the `openssl` command.
 
 There are public third party free tools and source code available to download such as the "KeyTool IUI" tool.
 
 
-## Step 3. Configure environment variables
+## Step 2. Configure environment variables
 
 Configure your system environment to build and run OpenSSL by adding the appropriate executable and library directories to your paths.
 For example, for Bourne and Korn shells (sh, ksh, bash), environment setup would look something like this:
@@ -93,7 +65,7 @@ For Windows, environment setup might resemble this:
 
 where _jdk-or-jre-path_ is the directory in which Java is installed.
 
-## Step 4. Configure SSL properties in client and server properties files
+## Step 3. Configure SSL properties in client and server properties files
 
 Configure SSL properties. For details on the SSL properties available, see "Managing > Security >
 SSL > Configuring SSL" in the server User Guide.  


### PR DESCRIPTION
@pivotal-jbarrett @joeymcallister @davebarnes97 
Please review.  I have reduced the locations which call out which version of OpenSSL to use, and reworded to specify version 1.0.2 (no references to 'or a later version').  I also eliminated instructions for installing OpenSSL; they provide those, and we should not.