### PR TITLE
GEODE-3457: Linking fails on Solaris SPARC due to -xatomic=none option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,12 @@ add_library(c++11 INTERFACE)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "SunPro")
   # Force linker to error on undefined symbols in shared libraries
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -z defs -xatomic=none")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -z defs")
+  if (PRODUCT_SYSTEM_NAME STREQUAL "solaris-sparc")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -xatomic=studio")
+  elseif(PRODUCT_SYSTEM_NAME STREQUAL "solaris-x86")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -xatomic=none")
+  endif()
   # TODO cmake find a better way to set runtime libraries
   # C++11 requires these libraries, treat -std=c++11 as library
   #TODO look into CMAKE_CXX_STANDARD_LIBRARIES


### PR DESCRIPTION
Fixes Solaris SPARC linking error. For more information: https://docs.oracle.com/cd/E60778_01/html/E60746/gqhbq.html

Testing: built on solaris sparc