### PR TITLE
GEODE-2733: Fix integration test errors on xcode 8.3.3

### DIFF
--- a/cppcache/src/CacheFactory.cpp
+++ b/cppcache/src/CacheFactory.cpp
@@ -55,8 +55,6 @@ CacheFactoryPtr CacheFactory::createCacheFactory(
 void CacheFactory::create_(const char* name,
                            const char* id_data, CachePtr& cptr,
                            bool readPdxSerialized) {
-  CppCacheLibrary::initLib();
-
   cptr = nullptr;
   if (name == nullptr) {
     throw IllegalArgumentException("CacheFactory::create: name is nullptr");

--- a/cppcache/src/CppCacheLibrary.cpp
+++ b/cppcache/src/CppCacheLibrary.cpp
@@ -49,39 +49,12 @@ namespace apache {
 namespace geode {
 namespace client {
 
-void gf_log_libinit();
-
-CppCacheLibrary::CppCacheLibrary() {
-  // TODO: This should catch any exceptions, log it, and bail out..
-  // Put initialization code for statics and other such things here.
-  try {
-    gf_log_libinit();
-    // PdxTypeRegistry::init();
-    // log( "Finished initializing CppCacheLibrary." );
-  } catch (apache::geode::client::Exception& ge) {
-    ge.printStackTrace();
-    throw;
-  }
-}
-
-CppCacheLibrary::~CppCacheLibrary() {
-  // Put any global clean up code here.
-  //  PdxTypeRegistry::cleanup();
-
-  ACE::fini();
-}
-
-//---------------------------------------------------------------------
-
-typedef ACE_Singleton<CppCacheLibrary, ACE_Recursive_Thread_Mutex> TheLibrary;
-
 // expect this to be called from key Library entry points, or automatically
 // if we can... Probably safest to call from DistributedSystem factory method.
 // impl type Unit tests may need to call this themselves to ensure the
 // internals are prepared. fw_helper framework will handle this.
-CppCacheLibrary* CppCacheLibrary::initLib(void) {
+void CppCacheLibrary::initLib(void) {
   ACE::init();
-  return TheLibrary::instance();
 }
 
 // this closes ace and triggers the cleanup of the singleton CppCacheLibrary.

--- a/cppcache/src/CppCacheLibrary.hpp
+++ b/cppcache/src/CppCacheLibrary.hpp
@@ -30,13 +30,8 @@ namespace client {
 // initialize GEMFIRE runtime if it has not already been initialized.
 class CPPCACHE_EXPORT CppCacheLibrary {
  public:
-  // All real initialization happens here.
-  CppCacheLibrary();
-  // All cleanup goes here.
-  virtual ~CppCacheLibrary();
-
   // Call to this to trigger initialization.
-  static CppCacheLibrary* initLib(void);
+  static void initLib(void);
   // Call to this to trigger cleanup.  initLib and closeLib calls must be in
   // pairs.
   static void closeLib(void);

--- a/cppcache/src/Log.cpp
+++ b/cppcache/src/Log.cpp
@@ -78,7 +78,7 @@ size_t g_diskSpaceLimit = GEODE_MAX_LOG_DISK_LIMIT;
 
 char g_logFileNameBuffer[2048] = {0};
 
-ACE_Thread_Mutex* g_logMutex = nullptr;
+ACE_Thread_Mutex* g_logMutex = new ACE_Thread_Mutex("Log::logMutex");
 
 int g_rollIndex = 0;
 size_t g_spaceUsed = 0;
@@ -152,29 +152,6 @@ static int comparator(const dirent** d1, const dirent** d2) {
 }
 
 using namespace apache::geode::log::globals;
-
-namespace apache {
-namespace geode {
-namespace client {
-// this method is not thread-safe and expected to be invoked once
-// during initialization
-void gf_log_libinit() {
-  if (g_logMutex == nullptr) {
-    g_logFile = nullptr;
-    g_bytesWritten = 0;
-    g_fileSizeLimit = 0;
-    g_diskSpaceLimit = 0;
-    g_rollIndex = 0;
-    g_spaceUsed = 0;
-    g_logMutex = new ACE_Thread_Mutex("Log::logMutex");
-  }
-  if (g_logMutex == nullptr) {
-    throw IllegalStateException("Log not initialized successfully");
-  }
-}
-}  // namespace client
-}  // namespace geode
-}  // namespace apache
 
 /*****************************************************************************/
 


### PR DESCRIPTION
Issue is that ACE_Singleton::instance call causes SEGV with xcode 8.3.3 developer toolset.  This change removes the offending usage of ACE_Singleton.

Testing: unit tests and integration tests passed