### PR TITLE
GEODE-3558: Use TCP IPC channel only.

### DIFF
--- a/tests/cli/DUnitFramework/IClientServerComm.cs
+++ b/tests/cli/DUnitFramework/IClientServerComm.cs
@@ -258,10 +258,7 @@ namespace Apache.Geode.DUnitFramework
   public static class CommConstants
   {
     public const string ClientService = "Client";
-    public const string ClientIPC = "localClientIPCPort";
-
     public const string DriverService = "Driver";
-    public const string ServerIPC = "localServerIPCPort";
     public const string BBService = "BlackBoard";
     public const string BBAddrEnvVar = "CSFWK_BBADDR";
     public const string DriverAddrEnvVar = "CSFWK_DRIVERADDR";

--- a/tests/cli/FwkClient/ClientProcess.cs
+++ b/tests/cli/FwkClient/ClientProcess.cs
@@ -20,7 +20,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Remoting;
 using System.Runtime.Remoting.Channels;
-using System.Runtime.Remoting.Channels.Ipc;
 using System.Runtime.Remoting.Channels.Tcp;
 using System.Runtime.Serialization.Formatters;
 
@@ -58,18 +57,9 @@ namespace Apache.Geode.Client.FwkClient
         #region Create the communication channel to receive commands from server
 
         properties = new Dictionary<string, string>();
-        if (clientPort.GetType() == typeof(int))
-        {
-          properties["port"] = clientPort.ToString();
-          clientChannel = new TcpChannel(properties, clientProvider, serverProvider);
-          //Util.Log("Registering TCP channel: " + clientPort);
-        }
-        else
-        {
-          properties["portName"] = clientPort.ToString();
-          clientChannel = new IpcChannel(properties, clientProvider, serverProvider);
-          //Util.Log("Registering IPC channel: " + clientPort);
-        }
+        properties["port"] = clientPort.ToString();
+        clientChannel = new TcpChannel(properties, clientProvider, serverProvider);
+        //Util.Log("Registering TCP channel: " + clientPort);
         ChannelServices.RegisterChannel(clientChannel, false);
 
         RemotingConfiguration.RegisterWellKnownServiceType(typeof(ClientComm),
@@ -103,7 +93,6 @@ namespace Apache.Geode.Client.FwkClient
       }
       string procName = Util.ProcessName;
       Util.Log("Usage: " + procName + " [OPTION] <client port>");
-      Util.Log("If <client port> is a string then IPC is used else TCP at the given port number");
       Util.Log("Options are:");
       Util.Log("  --id=ID \t\t ID of the client; process ID is used when not provided");
       Util.Log("  --driver=URL \t The URL (e.g. tcp://<host>:<port>/<service>) of the Driver");

--- a/tests/cli/FwkLauncher/LauncherProcess.cs
+++ b/tests/cli/FwkLauncher/LauncherProcess.cs
@@ -20,7 +20,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Remoting;
 using System.Runtime.Remoting.Channels;
-using System.Runtime.Remoting.Channels.Ipc;
 using System.Runtime.Remoting.Channels.Tcp;
 using System.Runtime.Serialization.Formatters;
 


### PR DESCRIPTION
- Removes named pipe IPC channel.