### PR TITLE
GEODE-3728: Move DataOutput::writeFullUTF to TcrMessage

### DIFF
--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -336,29 +336,6 @@ class CPPCACHE_EXPORT DataOutput {
   }
 
   /**
-   * Writes the given string using java modified UTF-8 encoding
-   * supporting maximum 32-bit unsigned integer.
-   *
-   * @param value the C string to be written
-   *
-   */
-  inline void writeFullUTF(const char* value, uint32_t length = 0) {
-    if (value != nullptr) {
-      int32_t encodedLen = getEncodedLength(value, length);
-      writeInt(encodedLen);
-      ensureCapacity(encodedLen);
-      write(static_cast<int8_t>(0));  // isObject = 0 BYTE_CODE
-      uint8_t* end = m_buf + encodedLen;
-      while (m_buf < end) {
-        encodeChar(*value++);
-      }
-      if (m_buf > end) m_buf = end;
-    } else {
-      writeInt(static_cast<uint16_t>(0));
-    }
-  }
-
-  /**
    * Writes the given given string using java modified UTF-8 encoding
    * supporting maximum encoded length of 64K (i.e. unsigned 16-bit integer).
    * @remarks The string will be truncated if greater than the maximum

--- a/cppcache/test/DataOutputTest.cpp
+++ b/cppcache/test/DataOutputTest.cpp
@@ -239,14 +239,6 @@ TEST_F(DataOutputTest, TestWriteASCIIHuge) {
       dataOutput.getByteArray());
 }
 
-TEST_F(DataOutputTest, TestWriteFullUTF) {
-  TestDataOutput dataOutput(nullptr);
-  dataOutput.writeFullUTF("You had me at meat tornado.");
-  EXPECT_BYTEARRAY_EQ(
-      "0000001B00596F7520686164206D65206174206D65617420746F726E61646F2E",
-      dataOutput.getByteArray());
-}
-
 TEST_F(DataOutputTest, TestWriteUTF) {
   TestDataOutput dataOutput(nullptr);
   dataOutput.writeUTF("You had me at meat tornado.");


### PR DESCRIPTION
Testing: Unittests in TcrMessage that exercise this code all passed