### PR TITLE
 GEODE-4151: Fixes include search paths and statements.

### DIFF
--- a/clicache/src/Log.cpp
+++ b/clicache/src/Log.cpp
@@ -37,7 +37,7 @@ namespace Apache
         _GF_MG_EXCEPTION_TRY2
 
           ManagedString mg_lfname(logFileName);
-        apache::geode::client::Log::init(static_cast<apache::geode::client::Log::LogLevel>(level),
+        apache::geode::client::Log::init(static_cast<apache::geode::client::LogLevel>(level),
                                          mg_lfname.CharPtr);
 
         _GF_MG_EXCEPTION_CATCH_ALL2
@@ -48,7 +48,7 @@ namespace Apache
         _GF_MG_EXCEPTION_TRY2
 
           ManagedString mg_lfname(logFileName);
-        apache::geode::client::Log::init(static_cast<apache::geode::client::Log::LogLevel>(level),
+        apache::geode::client::Log::init(static_cast<apache::geode::client::LogLevel>(level),
                                          mg_lfname.CharPtr, logFileLimit);
 
         _GF_MG_EXCEPTION_CATCH_ALL2
@@ -67,7 +67,7 @@ namespace Apache
       void Log::SetLevel(LogLevel level)
       {
         apache::geode::client::Log::setLogLevel(
-          static_cast<apache::geode::client::Log::LogLevel>(level));
+          static_cast<apache::geode::client::LogLevel>(level));
       }
 
       String^ Log::LogFileName()
@@ -82,7 +82,7 @@ namespace Apache
       bool Log::Enabled(LogLevel level)
       {
         return apache::geode::client::Log::enabled(
-          static_cast<apache::geode::client::Log::LogLevel>(level));
+          static_cast<apache::geode::client::LogLevel>(level));
       }
 
       void Log::Write(LogLevel level, String^ msg)
@@ -90,7 +90,7 @@ namespace Apache
         _GF_MG_EXCEPTION_TRY2
 
           ManagedString mg_msg(msg);
-        apache::geode::client::Log::log(static_cast<apache::geode::client::Log::LogLevel>(level),
+        apache::geode::client::Log::log(static_cast<apache::geode::client::LogLevel>(level),
                                         mg_msg.CharPtr);
 
         _GF_MG_EXCEPTION_CATCH_ALL2

--- a/clicache/src/Log.hpp
+++ b/clicache/src/Log.hpp
@@ -161,7 +161,7 @@ namespace Apache
       ///
       /// </para>
       /// </remarks>
-      public ref class Log STATICCLASS
+      private ref class Log STATICCLASS
       {
       public:
 

--- a/cppcache/include/geode/AttributesMutator.hpp
+++ b/cppcache/include/geode/AttributesMutator.hpp
@@ -21,8 +21,9 @@
 #define GEODE_ATTRIBUTESMUTATOR_H_
 
 #include <chrono>
-#include <string>
+#include <iosfwd>
 #include <memory>
+#include <string>
 
 #include "geode_globals.hpp"
 #include "ExpirationAction.hpp"

--- a/cppcache/include/geode/Cache.hpp
+++ b/cppcache/include/geode/Cache.hpp
@@ -30,9 +30,8 @@
 #include "PoolFactory.hpp"
 #include "RegionShortcut.hpp"
 #include "RegionFactory.hpp"
-#include "InternalCacheTransactionManager2PC.hpp"
-#include "statistics/StatisticsFactory.hpp"
-#include "geode/TypeRegistry.hpp"
+#include "TypeRegistry.hpp"
+
 /**
  * @file
  */
@@ -47,6 +46,9 @@ class CacheRegionHelper;
 class Pool;
 class CacheImpl;
 class AuthInitialize;
+class CacheTransactionManager;
+class RegionFactory;
+
 /**
  * @class Cache Cache.hpp
  *

--- a/cppcache/include/geode/CacheListener.hpp
+++ b/cppcache/include/geode/CacheListener.hpp
@@ -20,8 +20,9 @@
  * limitations under the License.
  */
 
-#include "geode_globals.hpp"
 #include <memory>
+
+#include "geode_globals.hpp"
 
 /**
  * @file
@@ -32,8 +33,9 @@ namespace geode {
 namespace client {
 
 class EntryEvent;
-class RegionEvent;
 class Region;
+class RegionEvent;
+
 /**
  * @class CacheListener CacheListener.hpp
  * An application plug-in that can be installed on a region.

--- a/cppcache/include/geode/Cacheable.hpp
+++ b/cppcache/include/geode/Cacheable.hpp
@@ -21,9 +21,12 @@
 #define GEODE_CACHEABLE_H_
 
 #include <memory>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "geode_globals.hpp"
 #include "Serializable.hpp"
+#include "util/functional.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/include/geode/CacheableEnum.hpp
+++ b/cppcache/include/geode/CacheableEnum.hpp
@@ -20,8 +20,14 @@
 #ifndef GEODE_CACHEABLEENUM_H_
 #define GEODE_CACHEABLEENUM_H_
 
+#include <iosfwd>
+#include <memory>
+#include <string>
+
 #include "CacheableKey.hpp"
 #include "CacheableString.hpp"
+#include "GeodeTypeIds.hpp"
+#include "geode_base.hpp"
 
 namespace apache {
 namespace geode {
@@ -40,6 +46,10 @@ namespace client {
  * @see PdxWriter#writeObject
  * @see PdxReader#readObject
  */
+
+class DataInput;
+class DataOutput;
+class Serializable;
 
 class CPPCACHE_EXPORT CacheableEnum : public CacheableKey {
  private:

--- a/cppcache/include/geode/CacheableFileName.hpp
+++ b/cppcache/include/geode/CacheableFileName.hpp
@@ -20,9 +20,13 @@
 #ifndef GEODE_CACHEABLEFILENAME_H_
 #define GEODE_CACHEABLEFILENAME_H_
 
-#include "geode_globals.hpp"
+
+
+#include <memory>
+
 #include "CacheableKey.hpp"
 #include "CacheableString.hpp"
+#include "geode_globals.hpp"
 
 /** @file
  */
@@ -35,6 +39,10 @@ namespace client {
  * Implement an immutable wrapper for filenames that can serve as a
  * distributable filename object for caching as both key and value.
  */
+class DataInput;
+class DataOutput;
+class Serializable;
+
 class CPPCACHE_EXPORT CacheableFileName : public CacheableString {
  public:
   /**

--- a/cppcache/include/geode/CacheableObjectArray.hpp
+++ b/cppcache/include/geode/CacheableObjectArray.hpp
@@ -37,6 +37,10 @@ namespace client {
  * Implement an immutable Vector of <code>Cacheable</code> objects
  * that can serve as a distributable object for caching.
  */
+class DataInput;
+class DataOutput;
+class Serializable;
+
 class CPPCACHE_EXPORT CacheableObjectArray
     : public Cacheable,
       public std::vector<std::shared_ptr<Cacheable>> {

--- a/cppcache/include/geode/CacheableUndefined.hpp
+++ b/cppcache/include/geode/CacheableUndefined.hpp
@@ -20,6 +20,8 @@
 #ifndef GEODE_CACHEABLEUNDEFINED_H_
 #define GEODE_CACHEABLEUNDEFINED_H_
 
+#include <memory>
+
 #include "geode_globals.hpp"
 #include "Cacheable.hpp"
 
@@ -33,6 +35,10 @@ namespace client {
 /**
  * Encapsulate an undefined query result.
  */
+class DataInput;
+class DataOutput;
+class Serializable;
+
 class CPPCACHE_EXPORT CacheableUndefined : public Cacheable {
  public:
   /**

--- a/cppcache/include/geode/CqAttributesFactory.hpp
+++ b/cppcache/include/geode/CqAttributesFactory.hpp
@@ -20,9 +20,11 @@
  * limitations under the License.
  */
 
-#include "geode_globals.hpp"
+#include <memory>
+
 #include "CqAttributes.hpp"
 #include "CqListener.hpp"
+#include "geode_globals.hpp"
 
 /**
  * @file
@@ -52,6 +54,9 @@ namespace client {
  * @see CqAttributes
  *
  */
+class CqAttributes;
+class CqListener;
+
 class CPPCACHE_EXPORT CqAttributesFactory  {
  public:
   /**

--- a/cppcache/include/geode/CqState.hpp
+++ b/cppcache/include/geode/CqState.hpp
@@ -20,6 +20,8 @@
  * limitations under the License.
  */
 
+#include <iosfwd>
+
 #include "geode_globals.hpp"
 
 /**

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -21,12 +21,28 @@
 #define GEODE_DATAINPUT_H_
 
 #include <cstring>
+#include <iosfwd>
+#include <memory>
 #include <string>
 
-#include "geode_globals.hpp"
+#include "CacheableString.hpp"
 #include "ExceptionTypes.hpp"
 #include "Serializable.hpp"
-#include "CacheableString.hpp"
+#include "GeodeTypeIds.hpp"
+#include "geode_base.hpp"
+#include "ExceptionTypes.hpp"
+#include "geode_globals.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+class Cache;
+class CacheableString;
+class DataInput;
+class Serializable;
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
 
 /**
  * @file
@@ -47,6 +63,7 @@ namespace client {
 class SerializationRegistry;
 class DataInputInternal;
 class CacheImpl;
+class DataInputInternal;
 
 /**
  * Provide operations for reading primitive data values, byte arrays,
@@ -628,7 +645,6 @@ class CPPCACHE_EXPORT DataInput {
           CacheableString::createUTFDeserializableHuge()));
       csPtr->fromData(*this);
     } else {
-      LOGDEBUG("In readNativeString something is wrong while expecting string");
       rewindCursor(1);
       csPtr = nullptr;
     }

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -27,7 +27,6 @@
 
 #include "geode_globals.hpp"
 #include "ExceptionTypes.hpp"
-#include "util/Log.hpp"
 #include "Serializable.hpp"
 #include "CacheableString.hpp"
 

--- a/cppcache/include/geode/Delta.hpp
+++ b/cppcache/include/geode/Delta.hpp
@@ -24,9 +24,12 @@
  * @file
  */
 
+#include <memory>
+
 #include "Cacheable.hpp"
 #include "DataInput.hpp"
 #include "DataOutput.hpp"
+
 namespace apache {
 namespace geode {
 namespace client {
@@ -42,6 +45,10 @@ namespace client {
  * apply a serialized delta to an existing object
  * of the class.
  */
+
+class Cache;
+class DataInput;
+class DataOutput;
 
 class CPPCACHE_EXPORT Delta {
  public:

--- a/cppcache/include/geode/DiskPolicyType.hpp
+++ b/cppcache/include/geode/DiskPolicyType.hpp
@@ -20,6 +20,7 @@
 #ifndef GEODE_DISKPOLICYTYPE_H_
 #define GEODE_DISKPOLICYTYPE_H_
 
+#include <iosfwd>
 #include <string>
 
 #include "geode_globals.hpp"

--- a/cppcache/include/geode/EntryEvent.hpp
+++ b/cppcache/include/geode/EntryEvent.hpp
@@ -1,8 +1,3 @@
-#pragma once
-
-#ifndef GEODE_ENTRYEVENT_H_
-#define GEODE_ENTRYEVENT_H_
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,9 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "geode_globals.hpp"
-#include "Region.hpp"
+
+#pragma once
+
+#ifndef GEODE_ENTRYEVENT_H_
+#define GEODE_ENTRYEVENT_H_
+
+#include <memory>
+
 #include "CacheableKey.hpp"
+#include "Region.hpp"
+#include "geode/Cacheable.hpp"
+#include "geode_globals.hpp"
 
 /** @file
 */
@@ -32,6 +36,10 @@ namespace client {
 
 /** Represents an entry event affecting an entry, including its identity and the
  * the circumstances of the event. */
+class CacheableKey;
+class Region;
+class Serializable;
+
 class CPPCACHE_EXPORT EntryEvent {
  protected:
   std::shared_ptr<Region> m_region;      /**< Region */

--- a/cppcache/include/geode/ExpirationAction.hpp
+++ b/cppcache/include/geode/ExpirationAction.hpp
@@ -20,6 +20,7 @@
 #ifndef GEODE_EXPIRATIONACTION_H_
 #define GEODE_EXPIRATIONACTION_H_
 
+#include <iosfwd>
 #include <string>
 
 #include "geode_globals.hpp"

--- a/cppcache/include/geode/FunctionService.hpp
+++ b/cppcache/include/geode/FunctionService.hpp
@@ -20,6 +20,8 @@
 #ifndef GEODE_FUNCTIONSERVICE_H_
 #define GEODE_FUNCTIONSERVICE_H_
 
+#include <memory>
+
 #include "geode_globals.hpp"
 #include "Execution.hpp"
 
@@ -30,9 +32,11 @@
 namespace apache {
 namespace geode {
 namespace client {
-class Region;
 class Pool;
+class Region;
 class RegionService;
+class Execution;
+
 /**
  * @class FunctionService FunctionService.hpp
  * entry point for function execution

--- a/cppcache/include/geode/PartitionResolver.hpp
+++ b/cppcache/include/geode/PartitionResolver.hpp
@@ -20,17 +20,19 @@
 #ifndef GEODE_PARTITIONRESOLVER_H_
 #define GEODE_PARTITIONRESOLVER_H_
 
+#include <iosfwd>
 #include <memory>
 #include <string>
 
 #include "Cacheable.hpp"
+#include "geode_base.hpp"
 
 namespace apache {
 namespace geode {
 namespace client {
 
-class EntryEvent;
 class CacheableKey;
+class EntryEvent;
 
 /**
  * Implementers of interface <code>PartitionResolver</code> enable custom

--- a/cppcache/include/geode/PdxFieldTypes.hpp
+++ b/cppcache/include/geode/PdxFieldTypes.hpp
@@ -20,6 +20,8 @@
 #ifndef GEODE_PDXFIELDTYPES_H_
 #define GEODE_PDXFIELDTYPES_H_
 
+#include "geode_base.hpp"
+
 namespace apache {
 namespace geode {
 namespace client {

--- a/cppcache/include/geode/PdxSerializable.hpp
+++ b/cppcache/include/geode/PdxSerializable.hpp
@@ -20,14 +20,21 @@
 #ifndef GEODE_PDXSERIALIZABLE_H_
 #define GEODE_PDXSERIALIZABLE_H_
 
+#include <iosfwd>
+#include <memory>
+#include <string>
+
 #include "CacheableKey.hpp"
+#include "geode_base.hpp"
 
 namespace apache {
 namespace geode {
 namespace client {
 
-class PdxWriter;
 class PdxReader;
+class PdxWriter;
+class DataInput;
+class DataOutput;
 
 class CPPCACHE_EXPORT PdxSerializable : public CacheableKey {
  public:

--- a/cppcache/include/geode/PdxWrapper.hpp
+++ b/cppcache/include/geode/PdxWrapper.hpp
@@ -20,12 +20,23 @@
 #ifndef GEODE_PDXWRAPPER_H_
 #define GEODE_PDXWRAPPER_H_
 
-#include "PdxSerializer.hpp"
+#include <iosfwd>
+#include <memory>
+#include <string>
+
 #include "PdxSerializable.hpp"
+#include "PdxSerializer.hpp"
+#include "geode_base.hpp"
 
 namespace apache {
 namespace geode {
 namespace client {
+
+class CacheableKey;
+class DataInput;
+class DataOutput;
+class PdxReader;
+class PdxWriter;
 
 class CPPCACHE_EXPORT PdxWrapper : public PdxSerializable {
   /**

--- a/cppcache/include/geode/PersistenceManager.hpp
+++ b/cppcache/include/geode/PersistenceManager.hpp
@@ -20,11 +20,23 @@
 #ifndef GEODE_PERSISTENCEMANAGER_H_
 #define GEODE_PERSISTENCEMANAGER_H_
 
-#include "geode_globals.hpp"
+#include <memory>
+
+#include "Cacheable.hpp"
+#include "CacheableKey.hpp"
 #include "DistributedSystem.hpp"
 #include "ExceptionTypes.hpp"
-#include "CacheableKey.hpp"
-#include "Cacheable.hpp"
+#include "geode_base.hpp"
+#include "geode_globals.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+class CacheableKey;
+class Properties;
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
 
 /**
  * @file

--- a/cppcache/include/geode/Pool.hpp
+++ b/cppcache/include/geode/Pool.hpp
@@ -21,12 +21,15 @@
 #define GEODE_POOL_H_
 
 #include <chrono>
+#include <iosfwd>
+#include <memory>
 
-#include "geode_globals.hpp"
-#include "util/chrono/duration.hpp"
-#include "CacheableBuiltins.hpp"
 #include "Cache.hpp"
 #include "CacheFactory.hpp"
+#include "CacheableBuiltins.hpp"
+#include "geode_base.hpp"
+#include "geode_globals.hpp"
+#include "util/chrono/duration.hpp"
 
 /**
  * @file
@@ -39,6 +42,11 @@ namespace client {
 class Cache;
 class CacheFactory;
 class PoolAttributes;
+class CacheImpl;
+class CacheableStringArray;
+class Properties;
+class QueryService;
+class RegionService;
 
 /**
  * A pool of connections to connect from a client to a set of Geode Cache

--- a/cppcache/include/geode/PoolManager.hpp
+++ b/cppcache/include/geode/PoolManager.hpp
@@ -20,24 +20,31 @@
 #ifndef GEODE_POOLMANAGER_H_
 #define GEODE_POOLMANAGER_H_
 
-#include <unordered_map>
+#include <iosfwd>
+#include <memory>
 #include <string>
-
-#include "geode_globals.hpp"
+#include <unordered_map>
 
 #include "Cache.hpp"
 #include "Pool.hpp"
 #include "PoolFactory.hpp"
 #include "Region.hpp"
+#include "geode_base.hpp"
+#include "geode_globals.hpp"
 
 namespace apache {
 namespace geode {
 namespace client {
 
-class ThinClientPoolDM;
-class FunctionService;
 class CacheImpl;
+class FunctionService;
 class PoolManagerImpl;
+class ThinClientPoolDM;
+class Cache;
+class Pool;
+class PoolFactory;
+class Region;
+class RegionFactory;
 
 typedef std::unordered_map<std::string, std::shared_ptr<Pool>> HashMapOfPools;
 

--- a/cppcache/include/geode/Region.hpp
+++ b/cppcache/include/geode/Region.hpp
@@ -20,36 +20,43 @@
 #ifndef GEODE_REGION_H_
 #define GEODE_REGION_H_
 
-//#### Warning: DO NOT directly include Region.hpp, include Cache.hpp instead.
+#include <chrono>
+#include <iosfwd>
+#include <memory>
 
 #include "geode_globals.hpp"
-#include "CacheableKey.hpp"
-#include "CacheableString.hpp"
 #include "CacheStatistics.hpp"
-#include "ExceptionTypes.hpp"
-#include "CacheableString.hpp"
 #include "CacheableBuiltins.hpp"
-
-/**
- * @file
- */
-
-#include "RegionEntry.hpp"
-#include "CacheListener.hpp"
-#include "PartitionResolver.hpp"
-#include "CacheWriter.hpp"
-#include "CacheLoader.hpp"
-#include "RegionAttributes.hpp"
-#include "AttributesMutator.hpp"
-#include "AttributesFactory.hpp"
 #include "CacheableKey.hpp"
+#include "CacheableString.hpp"
+#include "CacheableString.hpp"
+#include "ExceptionTypes.hpp"
+#include "Cacheable.hpp"
+#include "AttributesFactory.hpp"
+#include "AttributesMutator.hpp"
+#include "CacheListener.hpp"
+#include "CacheLoader.hpp"
+#include "CacheWriter.hpp"
+#include "CacheableKey.hpp"
+#include "PartitionResolver.hpp"
 #include "Query.hpp"
+#include "RegionAttributes.hpp"
+#include "RegionEntry.hpp"
 
 namespace apache {
 namespace geode {
 namespace client {
 
 class Pool;
+class AttributesMutator;
+class Cache;
+class CacheStatistics;
+class CacheableKey;
+class RegionAttributes;
+class RegionEntry;
+class RegionService;
+class SelectResults;
+class Serializable;
 
 static constexpr std::chrono::milliseconds DEFAULT_RESPONSE_TIMEOUT =
     std::chrono::seconds(15);

--- a/cppcache/include/geode/SelectResultsIterator.hpp
+++ b/cppcache/include/geode/SelectResultsIterator.hpp
@@ -24,11 +24,15 @@
  * @file
  */
 
-#include "geode_globals.hpp"
-#include "ExceptionTypes.hpp"
-#include "Serializable.hpp"
-#include "SelectResults.hpp"
+
+#include <memory>
+
 #include "CacheableBuiltins.hpp"
+#include "ExceptionTypes.hpp"
+#include "SelectResults.hpp"
+#include "Serializable.hpp"
+#include "geode_base.hpp"
+#include "geode_globals.hpp"
 
 namespace apache {
 namespace geode {
@@ -36,6 +40,9 @@ namespace client {
 
 class ResultSetImpl;
 class StructSetImpl;
+class CacheableVector;
+class SelectResults;
+class Serializable;
 
 /**
  * @class SelectResultsIterator SelectResultsIterator.hpp

--- a/cppcache/include/geode/SystemProperties.hpp
+++ b/cppcache/include/geode/SystemProperties.hpp
@@ -21,7 +21,7 @@
 #define GEODE_SYSTEMPROPERTIES_H_
 
 #include "Properties.hpp"
-#include "util/Log.hpp"
+#include "util/LogLevel.hpp"
 
 /** @file
  */
@@ -127,7 +127,7 @@ class CPPCACHE_EXPORT SystemProperties {
   /**
    * Returns the log level at which logging would be done.
    */
-  Log::LogLevel logLevel() const { return m_logLevel; }
+  LogLevel logLevel() const { return m_logLevel; }
 
   /**
    * Returns  a boolean that specifies if heapLRULimit has been enabled for the
@@ -377,7 +377,7 @@ class CPPCACHE_EXPORT SystemProperties {
 
   std::string m_logFilename;
 
-  Log::LogLevel m_logLevel;
+  LogLevel m_logLevel;
 
   int m_sessions;
 

--- a/cppcache/include/geode/TypeRegistry.hpp
+++ b/cppcache/include/geode/TypeRegistry.hpp
@@ -20,8 +20,10 @@
 #ifndef GEODE_TYPEREGISTRY_H_
 #define GEODE_TYPEREGISTRY_H_
 
-#include "geode_globals.hpp"
+#include <memory>
+
 #include "Serializable.hpp"
+#include "geode_globals.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/include/geode/UserFunctionExecutionException.hpp
+++ b/cppcache/include/geode/UserFunctionExecutionException.hpp
@@ -20,14 +20,21 @@
 #ifndef GEODE_USERFUNCTIONEXECUTIONEXCEPTION_H_
 #define GEODE_USERFUNCTIONEXECUTIONEXCEPTION_H_
 
-#include "Serializable.hpp"
+
+
+#include <memory>
+
 #include "CacheableString.hpp"
+#include "Serializable.hpp"
 
 namespace apache {
 namespace geode {
 namespace client {
 
 class UserFunctionExecutionException;
+class CacheableString;
+class DataInput;
+class DataOutput;
 
 /**
  * @brief UserFunctionExecutionException class is used to encapsulate geode

--- a/cppcache/include/geode/geode_globals.hpp
+++ b/cppcache/include/geode/geode_globals.hpp
@@ -122,7 +122,4 @@
 
 #include <cstdint>
 
-#include "util/Log.hpp"
-#include "Assert.hpp"
-
 #endif  // GEODE_GFCPP_GLOBALS_H_

--- a/cppcache/include/geode/util/LogLevel.hpp
+++ b/cppcache/include/geode/util/LogLevel.hpp
@@ -24,7 +24,7 @@ namespace apache {
 namespace geode {
 namespace client {
 
-enum LogLevel {
+enum class LogLevel {
   None,
   Error,
   Warning,

--- a/cppcache/include/geode/util/LogLevel.hpp
+++ b/cppcache/include/geode/util/LogLevel.hpp
@@ -15,32 +15,32 @@
  * limitations under the License.
  */
 
-#include <geode/Cache.hpp>
-#include <geode/CacheableKey.hpp>
+#pragma once
 
-#include "CacheableToken.hpp"
+#ifndef GEODE_UTIL_LOGLEVEL_HPP
+#define GEODE_UTIL_LOGLEVEL_HPP
 
 namespace apache {
 namespace geode {
 namespace client {
 
-RegionEntry::RegionEntry(const std::shared_ptr<Region>& region,
-                         const std::shared_ptr<CacheableKey>& key,
-                         const std::shared_ptr<Cacheable>& value)
-    : m_region(region), m_key(key), m_value(value), m_destroyed(false) {}
-
-RegionEntry::~RegionEntry() {}
-std::shared_ptr<CacheableKey> RegionEntry::getKey() { return m_key; }
-std::shared_ptr<Cacheable> RegionEntry::getValue() {
-  return CacheableToken::isInvalid(m_value) ? nullptr : m_value;
-}
-std::shared_ptr<Region> RegionEntry::getRegion() { return m_region; }
-std::shared_ptr<CacheStatistics> RegionEntry::getStatistics() {
-  return m_statistics;
-}
-
-bool RegionEntry::isDestroyed() const { return m_destroyed; }
+enum LogLevel {
+  None,
+  Error,
+  Warning,
+  Info,
+  Default,
+  Config,
+  Fine,
+  Finer,
+  Finest,
+  Debug,
+  All
+};
 
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
+
+#endif //GEODE_UTIL_LOGLEVEL_HPP
+

--- a/cppcache/include/geode/util/chrono/duration.hpp
+++ b/cppcache/include/geode/util/chrono/duration.hpp
@@ -20,10 +20,12 @@
 #ifndef GEODE_UTIL_CHRONO_DURATION_H_
 #define GEODE_UTIL_CHRONO_DURATION_H_
 
-#include <string>
 #include <chrono>
-#include <type_traits>
+#include <iosfwd>
+#include <ratio>
 #include <stdexcept>
+#include <string>
+#include <type_traits>
 
 namespace apache {
 namespace geode {

--- a/cppcache/include/geode/util/functional.hpp
+++ b/cppcache/include/geode/util/functional.hpp
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_UTIL_FUNCTIONAL_H_
+#define GEODE_UTIL_FUNCTIONAL_H_
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <string>
+#include <codecvt>
+#include <locale>
+
+//#include "string.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+template <class _T>
+struct dereference_hash;
+
+template <class _T>
+struct dereference_hash<std::shared_ptr<_T>>
+    : public std::unary_function<std::shared_ptr<_T>, size_t> {
+  size_t operator()(const std::shared_ptr<_T>& val) const {
+    return std::hash<_T>{}(*val);
+  }
+};
+
+template <class _T>
+struct dereference_hash<_T*> : public std::unary_function<_T*, size_t> {
+  typedef _T* argument_type;
+  size_t operator()(const argument_type& val) const {
+    return std::hash<_T>{}(*val);
+  }
+};
+
+template <class _T>
+struct dereference_equal_to;
+
+template <class _T>
+struct dereference_equal_to<std::shared_ptr<_T>>
+    : public std::binary_function<std::shared_ptr<_T>, std::shared_ptr<_T>,
+                                  bool> {
+  constexpr bool operator()(const std::shared_ptr<_T>& lhs,
+                            const std::shared_ptr<_T>& rhs) const {
+    return std::equal_to<_T>{}(*lhs, *rhs);
+  }
+};
+
+template <class _T>
+struct dereference_equal_to<_T*> : std::equal_to<_T*> {
+  typedef _T* first_argument_type;
+  typedef _T* second_argument_type;
+  constexpr bool operator()(const first_argument_type& lhs,
+                            const second_argument_type& rhs) const {
+    return std::equal_to<_T>{}(*lhs, *rhs);
+  }
+};
+
+/**
+ * Hashes based on the same algorithm used in the Geode server.
+ *
+ * @tparam _T class type to hash.
+ */
+template <class _T>
+struct geode_hash {
+  typedef _T argument_type;
+  int32_t operator()(const argument_type& val);
+};
+
+/**
+ * Hashes like java.lang.String
+ */
+template <>
+struct geode_hash<std::u16string> {
+  inline int32_t operator()(const std::u16string& val) {
+    int32_t hash = 0;
+    for (auto&& c : val) {
+      hash = 31 * hash + c;
+    }
+    return hash;
+  }
+};
+
+/**
+ * Hashes like java.lang.String
+ */
+template <>
+struct geode_hash<std::string> {
+  int32_t operator()(const std::string& val);
+//  {
+//    // TODO string optimize without conversion to UTF-16
+//    return geode_hash<std::u16string>{}(to_utf16(val));
+//  }
+};
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_UTIL_FUNCTIONAL_H_

--- a/cppcache/integration-test/CMakeLists.txt
+++ b/cppcache/integration-test/CMakeLists.txt
@@ -28,6 +28,9 @@ target_compile_definitions(${TEST_UTILS_LIB}
   PRIVATE
     $<MAKE_C_IDENTIFIER:${TEST_UTILS_LIB}>_static=1
 )
+target_include_directories(${TEST_UTILS_LIB} PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src>
+)
 
 add_library(unit_test_callbacks SHARED LibraryCallbacks.cpp)
 target_link_libraries(unit_test_callbacks
@@ -36,6 +39,9 @@ target_link_libraries(unit_test_callbacks
   PUBLIC
     apache-geode
     c++11
+)
+target_include_directories(unit_test_callbacks PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src>
 )
 
 enable_testing()
@@ -77,7 +83,10 @@ foreach(FILE ${SOURCES})
       fwk
       c++11
   )
-  
+  target_include_directories(${TEST} PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src>
+  )
+
   # Some tests depend on these library
   add_dependencies(${TEST} securityImpl cryptoImpl DHImpl SqLiteImpl)
   

--- a/cppcache/integration-test/LibraryCallbacks.cpp
+++ b/cppcache/integration-test/LibraryCallbacks.cpp
@@ -36,6 +36,7 @@ void millisleep(uint32_t x) {
 #include "TallyListener.hpp"
 #include "TallyLoader.hpp"
 #include "TallyWriter.hpp"
+#include <util/Log.hpp>
 
 #ifdef _WIN32
 #define _T_DLL_EXPORT __declspec(dllexport)

--- a/cppcache/integration-test/TallyListener.hpp
+++ b/cppcache/integration-test/TallyListener.hpp
@@ -22,6 +22,7 @@
 
 #include <geode/EntryEvent.hpp>
 #include <string>
+#include <util/Log.hpp>
 
 using namespace apache::geode::client;
 

--- a/cppcache/integration-test/ThinClientPdxSerializer.hpp
+++ b/cppcache/integration-test/ThinClientPdxSerializer.hpp
@@ -32,7 +32,7 @@
 #include <string>
 
 #include "ThinClientHelper.hpp"
-#include <Utils.hpp>
+#include "Utils.hpp"
 #include "testobject/PdxClassV1.hpp"
 #include "testobject/PdxClassV2.hpp"
 #include "testobject/NonPdxType.hpp"

--- a/cppcache/integration-test/ThinClientRemoveAll.hpp
+++ b/cppcache/integration-test/ThinClientRemoveAll.hpp
@@ -31,8 +31,8 @@
 #include <string>
 
 #include "BuiltinCacheableWrappers.hpp"
-#include <Utils.hpp>
-#include <statistics/StatisticsFactory.hpp>
+#include "Utils.hpp"
+#include "statistics/StatisticsFactory.hpp"
 
 #include "CacheHelper.hpp"
 

--- a/cppcache/integration-test/ThinClientTXFailover.hpp
+++ b/cppcache/integration-test/ThinClientTXFailover.hpp
@@ -25,6 +25,7 @@
 
 #include <ace/OS.h>
 #include <string>
+#include <geode/CacheTransactionManager.hpp>
 
 #define ROOT_NAME "ThinClientTXFailover"
 #define ROOT_SCOPE DISTRIBUTED_ACK

--- a/cppcache/integration-test/ThinClientTransactions.hpp
+++ b/cppcache/integration-test/ThinClientTransactions.hpp
@@ -26,6 +26,9 @@
 #include <ace/High_Res_Timer.h>
 
 #include <string>
+#include <geode/TransactionId.hpp>
+#include <geode/CacheTransactionManager.hpp>
+
 
 #define ROOT_NAME "ThinClientTransactions"
 #define ROOT_SCOPE DISTRIBUTED_ACK

--- a/cppcache/integration-test/ThinClientTransactionsXA.hpp
+++ b/cppcache/integration-test/ThinClientTransactionsXA.hpp
@@ -26,6 +26,8 @@
 #include <ace/High_Res_Timer.h>
 
 #include <string>
+#include <geode/TransactionId.hpp>
+#include <InternalCacheTransactionManager2PC.hpp>
 
 #define ROOT_NAME "ThinClientTransactionsXA"
 #define ROOT_SCOPE DISTRIBUTED_ACK

--- a/cppcache/integration-test/ThinClientVersionedOps.hpp
+++ b/cppcache/integration-test/ThinClientVersionedOps.hpp
@@ -23,6 +23,7 @@
 #define ROOT_NAME "testThinClientVersionedOps"
 
 #include "ThinClientSecurityHelper.hpp"
+#include <geode/CacheTransactionManager.hpp>
 
 #define CLIENT1 s1p1
 #define CLIENT2 s1p2

--- a/cppcache/integration-test/fw_helper.hpp
+++ b/cppcache/integration-test/fw_helper.hpp
@@ -82,19 +82,19 @@ BEGIN_TEST.
 #endif
 #endif
 
-#include <ace/ACE.h>
-#include <ace/OS.h>
-
 #include <typeinfo>
-
-#include <CppCacheLibrary.hpp>
-#include <geode/Exception.hpp>
-#include "util/Log.hpp"
-
 #include <list>
 #include <string>
 #include <sstream>
 #include <cstdio>
+
+#include <ace/ACE.h>
+#include <ace/OS.h>
+
+#include <geode/Exception.hpp>
+
+#include <CppCacheLibrary.hpp>
+#include <util/Log.hpp>
 
 #include "TimeBomb.hpp"
 
@@ -133,7 +133,7 @@ class TestException {
   void print() {
     char buf[256];
     apache::geode::client::Log::formatLogLine(
-        buf, apache::geode::client::Log::Error);
+        buf, apache::geode::client::LogLevel::Error);
     fprintf(stdout, "--->%sTestException: %s in %s at line %d<---\n", buf,
             m_message.c_str(), m_filename, m_lineno);
   }

--- a/cppcache/integration-test/testLogger.cpp
+++ b/cppcache/integration-test/testLogger.cpp
@@ -49,32 +49,32 @@ int numOfLinesInFile(const char* fname) {
 }
 
 void testLogFnError() {
-  LogFn logFn("TestLogger::testLogFnError", Log::Error);
+  LogFn logFn("TestLogger::testLogFnError", LogLevel::Error);
   Log::error("...");
 }
 
 void testLogFnWarning() {
-  LogFn logFn("TestLogger::testLogFnWarning", Log::Warning);
+  LogFn logFn("TestLogger::testLogFnWarning", LogLevel::Warning);
   Log::warning("...");
 }
 
 void testLogFnInfo() {
-  LogFn logFn("TestLogger::testLogFnInfo", Log::Info);
+  LogFn logFn("TestLogger::testLogFnInfo", LogLevel::Info);
   Log::info("...");
 }
 
 void testLogFnConfig() {
-  LogFn logFn("TestLogger::testLogFnConfig", Log::Config);
+  LogFn logFn("TestLogger::testLogFnConfig", LogLevel::Config);
   Log::config("...");
 }
 
 void testLogFnFine() {
-  LogFn logFn("TestLogger::testLogFnFine", Log::Fine);
+  LogFn logFn("TestLogger::testLogFnFine", LogLevel::Fine);
   Log::fine("...");
 }
 
 void testLogFnFiner() {
-  LogFn logFn("TestLogger::testLogFnFiner", Log::Finer);
+  LogFn logFn("TestLogger::testLogFnFiner", LogLevel::Finer);
   Log::finer("...");
 }
 
@@ -84,16 +84,16 @@ void testLogFnFinest() {
 }
 
 void testLogFnDebug() {
-  LogFn logFn("TestLogger::testLogFnDebug", Log::Debug);
+  LogFn logFn("TestLogger::testLogFnDebug", LogLevel::Debug);
   Log::debug("...");
 }
 
 int expected(int level) {
   int expected = level;
-  if (level != Log::None) {
+  if (level != LogLevel::None) {
     expected += LENGTH_OF_BANNER;
   }
-  if (level >= Log::Default) {
+  if (level >= LogLevel::Default) {
     expected--;
   }
   return expected;
@@ -103,9 +103,9 @@ BEGIN_TEST(REINIT)
   {
     LOGINFO("Started logging");
     int exceptiongot = 0;
-    Log::init(Log::Debug, "logfile");
+    Log::init(LogLevel::Debug, "logfile");
     try {
-      Log::init(Log::Debug, "logfile1");
+      Log::init(LogLevel::Debug, "logfile1");
     } catch (IllegalStateException& ex) {
       printf("Got Illegal state exception while calling init again\n");
       printf("Exception mesage = %s\n", ex.what());
@@ -119,8 +119,8 @@ END_TEST(REINIT)
 
 BEGIN_TEST(ALL_LEVEL)
   {
-    for (Log::LogLevel level = Log::Error; level <= Log::Debug;
-         level = Log::LogLevel(level + 1)) {
+    for (LogLevel level = Error; level <= Debug;
+         level = LogLevel(level + 1)) {
       Log::init(level, "all_logfile");
 
       Log::error("Error Message");
@@ -146,8 +146,8 @@ END_TEST(ALL_LEVEL)
 
 BEGIN_TEST(ALL_LEVEL_MACRO)
   {
-    for (Log::LogLevel level = Log::Error; level <= Log::Debug;
-         level = Log::LogLevel(level + 1)) {
+    for (LogLevel level = Error; level <= Debug;
+         level = LogLevel(level + 1)) {
       Log::init(level, "all_logfile");
 
       LOGERROR("Error Message");
@@ -177,9 +177,9 @@ BEGIN_TEST(FILE_LIMIT)
 #ifdef _WIN32
 // Fail to roll file over to timestamp file on windows.
 #else
-    for (Log::LogLevel level = Log::Error; level <= Log::Debug;
-         level = Log::LogLevel(level + 1)) {
-      if (level == Log::Default) continue;
+    for (LogLevel level = Error; level <= Debug;
+         level = LogLevel(level + 1)) {
+      if (level == Default) continue;
       Log::init(level, "logfile", 1);
 
       Log::error("Error Message");
@@ -193,7 +193,7 @@ BEGIN_TEST(FILE_LIMIT)
 
       int lines = numOfLinesInFile("logfile.log");
       int expectedLines =
-          level + LENGTH_OF_BANNER - (level >= Log::Default ? 1 : 0);
+          level + LENGTH_OF_BANNER - (level >= Default ? 1 : 0);
       printf("lines = %d expectedLines = %d level = %d\n", lines, expectedLines,
              level);
 
@@ -208,7 +208,7 @@ END_TEST(FILE_LIMIT)
 
 BEGIN_TEST(CONFIG_ONWARDS)
   {
-    Log::init(Log::Config, "logfile");
+    Log::init(LogLevel::Config, "logfile");
 
     Log::debug("Debug Message");
     Log::config("Config Message");
@@ -228,7 +228,7 @@ END_TEST(CONFIG_ONWARDS)
 
 BEGIN_TEST(INFO_ONWARDS)
   {
-    Log::init(Log::Info, "logfile");
+    Log::init(LogLevel::Info, "logfile");
 
     Log::debug("Debug Message");
     Log::config("Config Message");
@@ -248,7 +248,7 @@ END_TEST(INFO_ONWARDS)
 
 BEGIN_TEST(WARNING_ONWARDS)
   {
-    Log::init(Log::Warning, "logfile");
+    Log::init(LogLevel::Warning, "logfile");
 
     Log::debug("Debug Message");
     Log::config("Config Message");
@@ -268,7 +268,7 @@ END_TEST(WARNING_ONWARDS)
 
 BEGIN_TEST(ERROR_LEVEL)
   {
-    Log::init(Log::Error, "logfile");
+    Log::init(LogLevel::Error, "logfile");
 
     Log::debug("Debug Message");
     Log::config("Config Message");
@@ -287,7 +287,7 @@ END_TEST(ERROR_LEVEL)
 
 BEGIN_TEST(NO_LOG)
   {
-    Log::init(Log::None, "logfile");
+    Log::init(LogLevel::None, "logfile");
 
     Log::debug("Debug Message");
     Log::config("Config Message");
@@ -307,8 +307,8 @@ END_TEST(NO_LOG)
 
 BEGIN_TEST(LOGFN)
   {
-    for (Log::LogLevel level = Log::Error; level <= Log::Debug;
-         level = Log::LogLevel(level + 1)) {
+    for (LogLevel level = Error; level <= Debug;
+         level = LogLevel(level + 1)) {
       Log::init(level, "logfile");
 
       testLogFnError();

--- a/cppcache/integration-test/testLogger.cpp
+++ b/cppcache/integration-test/testLogger.cpp
@@ -88,8 +88,8 @@ void testLogFnDebug() {
   Log::debug("...");
 }
 
-int expected(int level) {
-  int expected = level;
+int expected(LogLevel level) {
+  int expected = static_cast<int>(level);
   if (level != LogLevel::None) {
     expected += LENGTH_OF_BANNER;
   }
@@ -119,8 +119,11 @@ END_TEST(REINIT)
 
 BEGIN_TEST(ALL_LEVEL)
   {
-    for (LogLevel level = Error; level <= Debug;
-         level = LogLevel(level + 1)) {
+    for (LogLevel level : {
+        LogLevel::Error, LogLevel::Warning, LogLevel::Info,
+        LogLevel::Default, LogLevel::Config, LogLevel::Fine,
+        LogLevel::Finer, LogLevel::Finest, LogLevel::Debug,
+    }) {
       Log::init(level, "all_logfile");
 
       Log::error("Error Message");
@@ -146,8 +149,11 @@ END_TEST(ALL_LEVEL)
 
 BEGIN_TEST(ALL_LEVEL_MACRO)
   {
-    for (LogLevel level = Error; level <= Debug;
-         level = LogLevel(level + 1)) {
+    for (LogLevel level : {
+        LogLevel::Error, LogLevel::Warning, LogLevel::Info,
+        LogLevel::Default, LogLevel::Config, LogLevel::Fine,
+        LogLevel::Finer, LogLevel::Finest, LogLevel::Debug,
+    }) {
       Log::init(level, "all_logfile");
 
       LOGERROR("Error Message");
@@ -177,9 +183,12 @@ BEGIN_TEST(FILE_LIMIT)
 #ifdef _WIN32
 // Fail to roll file over to timestamp file on windows.
 #else
-    for (LogLevel level = Error; level <= Debug;
-         level = LogLevel(level + 1)) {
-      if (level == Default) continue;
+      for (LogLevel level : {
+          LogLevel::Error, LogLevel::Warning, LogLevel::Info,
+          LogLevel::Default, LogLevel::Config, LogLevel::Fine,
+          LogLevel::Finer, LogLevel::Finest, LogLevel::Debug,
+      }) {
+        if (level == LogLevel::Default) continue;
       Log::init(level, "logfile", 1);
 
       Log::error("Error Message");
@@ -192,8 +201,8 @@ BEGIN_TEST(FILE_LIMIT)
       Log::debug("Debug Message");
 
       int lines = numOfLinesInFile("logfile.log");
-      int expectedLines =
-          level + LENGTH_OF_BANNER - (level >= Default ? 1 : 0);
+        int expectedLines = static_cast<int>(level) + LENGTH_OF_BANNER -
+            (level >= LogLevel::Default ? 1 : 0);
       printf("lines = %d expectedLines = %d level = %d\n", lines, expectedLines,
              level);
 
@@ -307,8 +316,11 @@ END_TEST(NO_LOG)
 
 BEGIN_TEST(LOGFN)
   {
-    for (LogLevel level = Error; level <= Debug;
-         level = LogLevel(level + 1)) {
+    for (LogLevel level : {
+        LogLevel::Error, LogLevel::Warning, LogLevel::Info,
+        LogLevel::Default, LogLevel::Config, LogLevel::Fine,
+        LogLevel::Finer, LogLevel::Finest, LogLevel::Debug,
+    }) {
       Log::init(level, "logfile");
 
       testLogFnError();

--- a/cppcache/integration-test/testSerialization.cpp
+++ b/cppcache/integration-test/testSerialization.cpp
@@ -22,10 +22,10 @@
 
 #define ROOT_SCOPE DISTRIBUTED_ACK
 
-#include <SerializationRegistry.hpp>
+#include "SerializationRegistry.hpp"
 #include <geode/CacheableString.hpp>
 #include <geode/GeodeTypeIds.hpp>
-#include <GeodeTypeIdsImpl.hpp>
+#include "GeodeTypeIdsImpl.hpp"
 
 // Use to init lib when testing components.
 #include <CppCacheLibrary.hpp>

--- a/cppcache/integration-test/testSystemProperties.cpp
+++ b/cppcache/integration-test/testSystemProperties.cpp
@@ -66,7 +66,7 @@ BEGIN_TEST(NEW_CONFIG)
     std::string filePath = testsrc + "/resources/system.properties";
 
     // Make sure product can at least log to stdout.
-    Log::init(Log::Config, nullptr, 0);
+    Log::init(Config, nullptr, 0);
 
     SystemProperties* sp = new SystemProperties(nullptr, filePath.c_str());
 

--- a/cppcache/integration-test/testSystemProperties.cpp
+++ b/cppcache/integration-test/testSystemProperties.cpp
@@ -66,7 +66,7 @@ BEGIN_TEST(NEW_CONFIG)
     std::string filePath = testsrc + "/resources/system.properties";
 
     // Make sure product can at least log to stdout.
-    Log::init(Config, nullptr, 0);
+    Log::init(LogLevel::Config, nullptr, 0);
 
     SystemProperties* sp = new SystemProperties(nullptr, filePath.c_str());
 

--- a/cppcache/integration-test/testThinClientCacheables.cpp
+++ b/cppcache/integration-test/testThinClientCacheables.cpp
@@ -20,7 +20,7 @@
 
 #include "fw_dunit.hpp"
 #include "BuiltinCacheableWrappers.hpp"
-#include <Utils.hpp>
+#include "Utils.hpp"
 
 #include <ace/OS.h>
 #include <ace/High_Res_Timer.h>

--- a/cppcache/integration-test/testThinClientFixedPartitionResolver.cpp
+++ b/cppcache/integration-test/testThinClientFixedPartitionResolver.cpp
@@ -16,7 +16,7 @@
  */
 #include "fw_dunit.hpp"
 #include "BuiltinCacheableWrappers.hpp"
-#include <Utils.hpp>
+#include "Utils.hpp"
 #include <geode/FixedPartitionResolver.hpp>
 #include <ace/OS.h>
 #include <ace/High_Res_Timer.h>

--- a/cppcache/integration-test/testThinClientPRPutAllFailover.cpp
+++ b/cppcache/integration-test/testThinClientPRPutAllFailover.cpp
@@ -20,7 +20,7 @@
 
 #include "fw_dunit.hpp"
 #include "BuiltinCacheableWrappers.hpp"
-#include <Utils.hpp>
+#include "Utils.hpp"
 
 #include <ace/OS.h>
 #include <ace/High_Res_Timer.h>

--- a/cppcache/integration-test/testThinClientPartitionResolver.cpp
+++ b/cppcache/integration-test/testThinClientPartitionResolver.cpp
@@ -20,7 +20,7 @@
 
 #include "fw_dunit.hpp"
 #include "BuiltinCacheableWrappers.hpp"
-#include <Utils.hpp>
+#include "Utils.hpp"
 #include <geode/PartitionResolver.hpp>
 #include <ace/OS.h>
 #include <ace/High_Res_Timer.h>

--- a/cppcache/integration-test/testThinClientPdxTests.cpp
+++ b/cppcache/integration-test/testThinClientPdxTests.cpp
@@ -49,7 +49,7 @@ END_MAIN*/
 #include "testobject/InvalidPdxUsage.hpp"
 #include "QueryStrings.hpp"
 #include "QueryHelper.hpp"
-#include <Utils.hpp>
+#include "Utils.hpp"
 #include <geode/Query.hpp>
 #include <geode/QueryService.hpp>
 #include "CachePerfStats.hpp"

--- a/cppcache/integration-test/testThinClientSecurityAuthentication.cpp
+++ b/cppcache/integration-test/testThinClientSecurityAuthentication.cpp
@@ -20,6 +20,7 @@
 #include <ace/High_Res_Timer.h>
 
 #include "ThinClientSecurity.hpp"
+#include <geode/CacheTransactionManager.hpp>
 
 using namespace apache::geode::client;
 using namespace test;

--- a/cppcache/integration-test/testThinClientSecurityAuthenticationMU.cpp
+++ b/cppcache/integration-test/testThinClientSecurityAuthenticationMU.cpp
@@ -23,6 +23,7 @@
 #include <ace/High_Res_Timer.h>
 
 #include "ThinClientSecurity.hpp"
+#include <geode/CacheTransactionManager.hpp>
 
 using namespace apache::geode::client;
 using namespace test;

--- a/cppcache/src/AttributesFactory.cpp
+++ b/cppcache/src/AttributesFactory.cpp
@@ -15,14 +15,16 @@
  * limitations under the License.
  */
 
-#include <geode/Cache.hpp>
-#include <geode/ExpirationAttributes.hpp>
-#include <Utils.hpp>
-#include <geode/DistributedSystem.hpp>
 #include <cstdlib>
 #include <string>
+
+#include <geode/Cache.hpp>
+#include <geode/ExpirationAttributes.hpp>
+#include <geode/DistributedSystem.hpp>
 #include <geode/Pool.hpp>
 #include <geode/PoolManager.hpp>
+
+#include "Utils.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/AttributesMutator.cpp
+++ b/cppcache/src/AttributesMutator.cpp
@@ -16,7 +16,8 @@
  */
 
 #include <geode/AttributesMutator.hpp>
-#include <RegionInternal.hpp>
+
+#include "RegionInternal.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/CMakeLists.txt
+++ b/cppcache/src/CMakeLists.txt
@@ -101,7 +101,6 @@ target_compile_definitions(_apache-geode INTERFACE
 )
 target_include_directories(_apache-geode INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )
 add_dependencies(_apache-geode version-header)

--- a/cppcache/src/Cache.cpp
+++ b/cppcache/src/Cache.cpp
@@ -15,28 +15,29 @@
  * limitations under the License.
  */
 
-#include <geode/geode_globals.hpp>
 #include <memory>
 
-#include <geode/DistributedSystem.hpp>
-#include <DistributedSystemImpl.hpp>
-#include <CacheXmlParser.hpp>
-#include <CacheRegionHelper.hpp>
-#include <geode/Cache.hpp>
-#include <CacheImpl.hpp>
-#include <UserAttributes.hpp>
-#include <ProxyRegion.hpp>
+#include <geode/geode_globals.hpp>
 #include <geode/FunctionService.hpp>
 #include <geode/PoolManager.hpp>
-#include <PdxInstanceFactoryImpl.hpp>
+#include <geode/DistributedSystem.hpp>
+#include <geode/Cache.hpp>
 
-extern ACE_Recursive_Thread_Mutex* g_disconnectLock;
+#include "DistributedSystemImpl.hpp"
+#include "CacheXmlParser.hpp"
+#include "CacheRegionHelper.hpp"
+#include "CacheImpl.hpp"
+#include "UserAttributes.hpp"
+#include "ProxyRegion.hpp"
+#include "PdxInstanceFactoryImpl.hpp"
 
 #define DEFAULT_DS_NAME "default_GeodeDS"
 
 namespace apache {
 namespace geode {
 namespace client {
+
+extern ACE_Recursive_Thread_Mutex* g_disconnectLock;
 
 /** Returns the name of this cache.
  * This method does not throw

--- a/cppcache/src/CacheFactory.cpp
+++ b/cppcache/src/CacheFactory.cpp
@@ -33,7 +33,6 @@
 #include "CacheImpl.hpp"
 #include "CppCacheLibrary.hpp"
 #include "PoolAttributes.hpp"
-
 #include "CacheConfig.hpp"
 #include "DistributedSystemImpl.hpp"
 #include "SerializationRegistry.hpp"
@@ -45,11 +44,11 @@
 
 #define DEFAULT_CACHE_NAME "default_GeodeCache"
 
-extern ACE_Recursive_Thread_Mutex* g_disconnectLock;
-
 namespace apache {
 namespace geode {
 namespace client {
+
+extern ACE_Recursive_Thread_Mutex* g_disconnectLock;
 
 std::shared_ptr<CacheFactory> CacheFactory::createCacheFactory(
     const std::shared_ptr<Properties>& configPtr) {

--- a/cppcache/src/CacheLoader.cpp
+++ b/cppcache/src/CacheLoader.cpp
@@ -16,9 +16,9 @@
  */
 
 #include <geode/Region.hpp>
-#include <CacheRegionHelper.hpp>
-#include <RegionInternal.hpp>
-#include <MapEntry.hpp>
+#include "CacheRegionHelper.hpp"
+#include "RegionInternal.hpp"
+#include "MapEntry.hpp"
 
 using namespace apache::geode::client;
 

--- a/cppcache/src/CachePerfStats.hpp
+++ b/cppcache/src/CachePerfStats.hpp
@@ -25,6 +25,7 @@
 #include "statistics/Statistics.hpp"
 #include "statistics/StatisticsFactory.hpp"
 #include "statistics/StatisticsManager.hpp"
+#include "Assert.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/CacheableObjectArray.cpp
+++ b/cppcache/src/CacheableObjectArray.cpp
@@ -19,7 +19,7 @@
 #include <geode/DataInput.hpp>
 #include <geode/ExceptionTypes.hpp>
 #include <geode/GeodeTypeIds.hpp>
-#include <GeodeTypeIdsImpl.hpp>
+#include "GeodeTypeIdsImpl.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/CacheableString.cpp
+++ b/cppcache/src/CacheableString.cpp
@@ -32,6 +32,7 @@
 #include "DataOutputInternal.hpp"
 #include "SerializationRegistry.hpp"
 #include "Utils.hpp"
+#include "util/string.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/CacheableUndefined.cpp
+++ b/cppcache/src/CacheableUndefined.cpp
@@ -18,7 +18,8 @@
 #include <geode/DataOutput.hpp>
 #include <geode/DataInput.hpp>
 #include <geode/GeodeTypeIds.hpp>
-#include <GeodeTypeIdsImpl.hpp>
+
+#include "GeodeTypeIdsImpl.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/ClientProxyMembershipIDFactory.cpp
+++ b/cppcache/src/ClientProxyMembershipIDFactory.cpp
@@ -1,8 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <algorithm>
 #include <iterator>
 #include <random>
 
 #include "ClientProxyMembershipIDFactory.hpp"
+#include "util/Log.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/CqAttributesFactory.cpp
+++ b/cppcache/src/CqAttributesFactory.cpp
@@ -14,11 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <geode/CqAttributesFactory.hpp>
-#include <CqAttributesImpl.hpp>
 #include <geode/ExceptionTypes.hpp>
 
-using namespace apache::geode::client;
+#include "CqAttributesImpl.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
 
 CqAttributesFactory::CqAttributesFactory() {
   m_cqAttributes = std::make_shared<CqAttributesImpl>();
@@ -45,7 +49,12 @@ void CqAttributesFactory::initCqListeners(
   std::static_pointer_cast<CqAttributesImpl>(m_cqAttributes)
       ->setCqListeners(cqListeners);
 }
+
 std::shared_ptr<CqAttributes> CqAttributesFactory::create() {
   return std::shared_ptr<CqAttributes>(
       std::static_pointer_cast<CqAttributesImpl>(m_cqAttributes)->clone());
 }
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/CqAttributesImpl.cpp
+++ b/cppcache/src/CqAttributesImpl.cpp
@@ -15,8 +15,10 @@
  * limitations under the License.
  */
 
-#include "CqAttributesImpl.hpp"
 #include <geode/ExceptionTypes.hpp>
+
+#include "CqAttributesImpl.hpp"
+#include "util/Log.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/DataOutput.cpp
+++ b/cppcache/src/DataOutput.cpp
@@ -22,8 +22,8 @@
 
 #include <geode/DataOutput.hpp>
 #include <geode/SystemProperties.hpp>
-#include <SerializationRegistry.hpp>
 
+#include "SerializationRegistry.hpp"
 #include "CacheImpl.hpp"
 #include "CacheRegionHelper.hpp"
 #include "util/Log.hpp"

--- a/cppcache/src/DistributedSystem.cpp
+++ b/cppcache/src/DistributedSystem.cpp
@@ -14,25 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "config.h"
-#include <geode/geode_globals.hpp>
 
-#include <geode/DistributedSystem.hpp>
-#include "statistics/StatisticsManager.hpp"
-#include <geode/SystemProperties.hpp>
-
-#include <CppCacheLibrary.hpp>
-#include <Utils.hpp>
-#include "util/Log.hpp"
-#include <geode/CacheFactory.hpp>
 #include <ace/OS.h>
-
 #include <ace/Guard_T.h>
 #include <ace/Recursive_Thread_Mutex.h>
 
+#include <geode/geode_globals.hpp>
+#include <geode/DistributedSystem.hpp>
+#include <geode/CacheFactory.hpp>
+#include <geode/SystemProperties.hpp>
+#include <geode/DataOutput.hpp>
+
+#include "config.h"
+#include "version.h"
+
+#include "CppCacheLibrary.hpp"
+#include "Utils.hpp"
+#include "util/Log.hpp"
+#include "statistics/StatisticsManager.hpp"
 #include "ExpiryTaskManager.hpp"
 #include "CacheImpl.hpp"
-#include "geode/DataOutput.hpp"
 #include "TcrMessage.hpp"
 #include "DistributedSystemImpl.hpp"
 #include "RegionStats.hpp"
@@ -40,9 +41,10 @@
 #include "CacheRegionHelper.hpp"
 #include "DiffieHellman.hpp"
 
-#include "version.h"
+namespace apache {
+namespace geode {
+namespace client {
 
-using namespace apache::geode::client;
 using namespace apache::geode::statistics;
 
 ACE_Recursive_Thread_Mutex* g_disconnectLock = new ACE_Recursive_Thread_Mutex();
@@ -231,3 +233,7 @@ SystemProperties& DistributedSystem::getSystemProperties() const {
 }
 
 const std::string& DistributedSystem::getName() const { return m_name; }
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/DistributedSystemImpl.cpp
+++ b/cppcache/src/DistributedSystemImpl.cpp
@@ -15,10 +15,14 @@
  * limitations under the License.
  */
 
-#include "DistributedSystemImpl.hpp"
 #include <geode/SystemProperties.hpp>
 
-using namespace apache::geode::client;
+#include "DistributedSystemImpl.hpp"
+#include "util/Log.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
 
 // guard for connect/disconnect
 extern ACE_Recursive_Thread_Mutex* g_disconnectLock;
@@ -105,3 +109,7 @@ void DistributedSystemImpl::unregisterCliCallback(int appdomainId) {
     LOGFINE("Removing cliCallback %d", appdomainId);
   }
 }
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/EntryEvent.cpp
+++ b/cppcache/src/EntryEvent.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 #include <geode/EntryEvent.hpp>
-#include <CacheableToken.hpp>
+#include "CacheableToken.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/Exception.cpp
+++ b/cppcache/src/Exception.cpp
@@ -18,11 +18,14 @@
 #include <cstdlib>
 
 #include <ace/OS.h>
+#include <ace/TSS_T.h>
+
+#include <boost/core/demangle.hpp>
+
 #include <geode/Exception.hpp>
 #include <geode/CacheableString.hpp>
-#include <StackTrace.hpp>
-#include <ace/TSS_T.h>
-#include <boost/core/demangle.hpp>
+
+#include "StackTrace.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/ExceptionTypes.cpp
+++ b/cppcache/src/ExceptionTypes.cpp
@@ -18,13 +18,17 @@
 #include <cstdio>
 #include <string>
 #include <sstream>
+
 #include <geode/ExceptionTypes.hpp>
-#include <TXState.hpp>
-#include <TSSTXStateWrapper.hpp>
+
+#include "TXState.hpp"
+#include "TSSTXStateWrapper.hpp"
+#include "util/Log.hpp"
 
 namespace apache {
 namespace geode {
 namespace client {
+
 void setTSSExceptionMessage(const char* exMsg);
 const char* getTSSExceptionMessage();
 

--- a/cppcache/src/FairQueue.hpp
+++ b/cppcache/src/FairQueue.hpp
@@ -1,8 +1,3 @@
-#pragma once
-
-#ifndef GEODE_FAIRQUEUE_H_
-#define GEODE_FAIRQUEUE_H_
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -20,13 +15,22 @@
  * limitations under the License.
  */
 
+#pragma once
+
+#ifndef GEODE_FAIRQUEUE_H_
+#define GEODE_FAIRQUEUE_H_
+
 #include <deque>
+
 #include <ace/ACE.h>
 #include <ace/Thread_Mutex.h>
 #include <ace/Token.h>
 #include <ace/Condition_T.h>
 #include <ace/Time_Value.h>
 #include <ace/Guard_T.h>
+
+#include "util/Log.hpp"
+#include "Assert.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/LRUList.cpp
+++ b/cppcache/src/LRUList.cpp
@@ -14,10 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "LRUList.hpp"
-#include "util/concurrent/spinlock_mutex.hpp"
 
 #include <mutex>
+
+#include "LRUList.hpp"
+#include "util/concurrent/spinlock_mutex.hpp"
+#include "Assert.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/Log.cpp
+++ b/cppcache/src/Log.cpp
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-#include <geode/geode_globals.hpp>
-
 #include <cctype>
 #include <string>
 #include <utility>
@@ -36,9 +34,13 @@
 #include <ace/Dirent_Selector.h>
 #include <ace/OS_NS_sys_stat.h>
 
-#include "util/Log.hpp"
+#include <geode/geode_globals.hpp>
 #include <geode/ExceptionTypes.hpp>
-#include <geodeBanner.hpp>
+#include <geode/util/LogLevel.hpp>
+
+#include "util/Log.hpp"
+#include "geodeBanner.hpp"
+#include "Assert.hpp"
 
 #if defined(_WIN32)
 #include <io.h>
@@ -50,15 +52,11 @@
 
 /*****************************************************************************/
 
-using namespace apache::geode::client;
-
 /**
  * The implementation of the Log class
  *
  *
  */
-
-Log::LogLevel Log::s_logLevel = Default;
 
 /*****************************************************************************/
 
@@ -150,6 +148,12 @@ static int comparator(const dirent** d1, const dirent** d2) {
   }
 }
 }
+
+namespace apache {
+namespace geode {
+namespace client {
+
+LogLevel Log::s_logLevel = Default;
 
 using namespace apache::geode::log::globals;
 
@@ -423,7 +427,7 @@ void Log::writeBanner() {
     g_isLogFileOpened = true;
   }
 
-  if (s_logLevel == Log::None) {
+  if (s_logLevel == None) {
     return;
   }
   std::string bannertext = geodeBanner::getBanner();
@@ -452,39 +456,39 @@ void Log::writeBanner() {
   fflush(g_log);
 }
 
-const char* Log::levelToChars(Log::LogLevel level) {
+const char* Log::levelToChars(LogLevel level) {
   switch (level) {
-    case Log::None:
+    case None:
       return "none";
 
-    case Log::Error:
+    case Error:
       return "error";
 
-    case Log::Warning:
+    case Warning:
       return "warning";
 
-    case Log::Info:
+    case Info:
       return "info";
 
-    case Log::Default:
+    case Default:
       return "default";
 
-    case Log::Config:
+    case Config:
       return "config";
 
-    case Log::Fine:
+    case Fine:
       return "fine";
 
-    case Log::Finer:
+    case Finer:
       return "finer";
 
-    case Log::Finest:
+    case Finest:
       return "finest";
 
-    case Log::Debug:
+    case Debug:
       return "debug";
 
-    case Log::All:
+    case All:
       return "all";
 
     default: {
@@ -495,43 +499,43 @@ const char* Log::levelToChars(Log::LogLevel level) {
   }
 }
 
-Log::LogLevel Log::charsToLevel(const std::string& chars) {
+LogLevel Log::charsToLevel(const std::string& chars) {
   std::string level = chars;
 
-  if (level.empty()) return Log::None;
+  if (level.empty()) return None;
 
   for (uint32_t i = 0; i < level.size(); i++) {
     if (isupper(level[i])) level[i] = tolower(level[i]);
   }
 
   if (level == "none") {
-    return Log::None;
+    return None;
   } else if (level == "error") {
-    return Log::Error;
+    return Error;
   } else if (level == "warning") {
-    return Log::Warning;
+    return Warning;
   } else if (level == "info") {
-    return Log::Info;
+    return Info;
   } else if (level == "default") {
-    return Log::Default;
+    return Default;
   } else if (level == "config") {
-    return Log::Config;
+    return Config;
   } else if (level == "fine") {
-    return Log::Fine;
+    return Fine;
   } else if (level == "finer") {
-    return Log::Finer;
+    return Finer;
   } else if (level == "finest") {
-    return Log::Finest;
+    return Finest;
   } else if (level == "debug") {
-    return Log::Debug;
+    return Debug;
   } else if (level == "all") {
-    return Log::All;
+    return All;
   } else {
     throw IllegalArgumentException(("Unexpected log level: " + level).c_str());
   }
 }
 
-char* Log::formatLogLine(char* buf, Log::LogLevel level) {
+char* Log::formatLogLine(char* buf, LogLevel level) {
   if (g_pid == 0) {
     g_pid = ACE_OS::getpid();
     ACE_OS::uname(&g_uname);
@@ -752,7 +756,7 @@ void LogVarargs::debug(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Log::Debug, msg);
+  Log::put(Debug, msg);
   va_end(argp);
 }
 
@@ -762,7 +766,7 @@ void LogVarargs::error(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Log::Error, msg);
+  Log::put(Error, msg);
   va_end(argp);
 }
 
@@ -772,7 +776,7 @@ void LogVarargs::warn(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Log::Warning, msg);
+  Log::put(Warning, msg);
   va_end(argp);
 }
 
@@ -782,7 +786,7 @@ void LogVarargs::info(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Log::Info, msg);
+  Log::put(Info, msg);
   va_end(argp);
 }
 
@@ -792,7 +796,7 @@ void LogVarargs::config(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Log::Config, msg);
+  Log::put(Config, msg);
   va_end(argp);
 }
 
@@ -802,7 +806,7 @@ void LogVarargs::fine(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Log::Fine, msg);
+  Log::put(Fine, msg);
   va_end(argp);
 }
 
@@ -812,7 +816,7 @@ void LogVarargs::finer(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Log::Finer, msg);
+  Log::put(Finer, msg);
   va_end(argp);
 }
 
@@ -822,6 +826,10 @@ void LogVarargs::finest(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Log::Finest, msg);
+  Log::put(Finest, msg);
   va_end(argp);
 }
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/Log.cpp
+++ b/cppcache/src/Log.cpp
@@ -153,7 +153,7 @@ namespace apache {
 namespace geode {
 namespace client {
 
-LogLevel Log::s_logLevel = Default;
+LogLevel Log::s_logLevel = LogLevel::Default;
 
 using namespace apache::geode::log::globals;
 
@@ -427,7 +427,7 @@ void Log::writeBanner() {
     g_isLogFileOpened = true;
   }
 
-  if (s_logLevel == None) {
+  if (s_logLevel == LogLevel::None) {
     return;
   }
   std::string bannertext = geodeBanner::getBanner();
@@ -458,37 +458,37 @@ void Log::writeBanner() {
 
 const char* Log::levelToChars(LogLevel level) {
   switch (level) {
-    case None:
+    case LogLevel::None:
       return "none";
 
-    case Error:
+    case LogLevel::Error:
       return "error";
 
-    case Warning:
+    case LogLevel::Warning:
       return "warning";
 
-    case Info:
+    case LogLevel::Info:
       return "info";
 
-    case Default:
+    case LogLevel::Default:
       return "default";
 
-    case Config:
+    case LogLevel::Config:
       return "config";
 
-    case Fine:
+    case LogLevel::Fine:
       return "fine";
 
-    case Finer:
+    case LogLevel::Finer:
       return "finer";
 
-    case Finest:
+    case LogLevel::Finest:
       return "finest";
 
-    case Debug:
+    case LogLevel::Debug:
       return "debug";
 
-    case All:
+    case LogLevel::All:
       return "all";
 
     default: {
@@ -502,34 +502,32 @@ const char* Log::levelToChars(LogLevel level) {
 LogLevel Log::charsToLevel(const std::string& chars) {
   std::string level = chars;
 
-  if (level.empty()) return None;
+  if (level.empty()) return LogLevel::None;
 
-  for (uint32_t i = 0; i < level.size(); i++) {
-    if (isupper(level[i])) level[i] = tolower(level[i]);
-  }
+  std::transform(level.begin(), level.end(), level.begin(), ::tolower);
 
   if (level == "none") {
-    return None;
+    return LogLevel::None;
   } else if (level == "error") {
-    return Error;
+    return LogLevel::Error;
   } else if (level == "warning") {
-    return Warning;
+    return LogLevel::Warning;
   } else if (level == "info") {
-    return Info;
+    return LogLevel::Info;
   } else if (level == "default") {
-    return Default;
+    return LogLevel::Default;
   } else if (level == "config") {
-    return Config;
+    return LogLevel::Config;
   } else if (level == "fine") {
-    return Fine;
+    return LogLevel::Fine;
   } else if (level == "finer") {
-    return Finer;
+    return LogLevel::Finer;
   } else if (level == "finest") {
-    return Finest;
+    return LogLevel::Finest;
   } else if (level == "debug") {
-    return Debug;
+    return LogLevel::Debug;
   } else if (level == "all") {
-    return All;
+    return LogLevel::All;
   } else {
     throw IllegalArgumentException(("Unexpected log level: " + level).c_str());
   }
@@ -756,7 +754,7 @@ void LogVarargs::debug(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Debug, msg);
+  Log::put(LogLevel::Debug, msg);
   va_end(argp);
 }
 
@@ -766,7 +764,7 @@ void LogVarargs::error(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Error, msg);
+  Log::put(LogLevel::Error, msg);
   va_end(argp);
 }
 
@@ -776,7 +774,7 @@ void LogVarargs::warn(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Warning, msg);
+  Log::put(LogLevel::Warning, msg);
   va_end(argp);
 }
 
@@ -786,7 +784,7 @@ void LogVarargs::info(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Info, msg);
+  Log::put(LogLevel::Info, msg);
   va_end(argp);
 }
 
@@ -796,7 +794,7 @@ void LogVarargs::config(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Config, msg);
+  Log::put(LogLevel::Config, msg);
   va_end(argp);
 }
 
@@ -806,7 +804,7 @@ void LogVarargs::fine(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Fine, msg);
+  Log::put(LogLevel::Fine, msg);
   va_end(argp);
 }
 
@@ -816,7 +814,7 @@ void LogVarargs::finer(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Finer, msg);
+  Log::put(LogLevel::Finer, msg);
   va_end(argp);
 }
 
@@ -826,7 +824,7 @@ void LogVarargs::finest(const char* fmt, ...) {
   va_start(argp, fmt);
   vsnprintf(msg, _GF_MSG_LIMIT, fmt, argp);
   /* win doesn't guarantee termination */ msg[_GF_MSG_LIMIT - 1] = '\0';
-  Log::put(Finest, msg);
+  Log::put(LogLevel::Finest, msg);
   va_end(argp);
 }
 

--- a/cppcache/src/PdxSerializable.cpp
+++ b/cppcache/src/PdxSerializable.cpp
@@ -22,10 +22,11 @@
  */
 
 #include <geode/PdxSerializable.hpp>
-#include <GeodeTypeIdsImpl.hpp>
 #include <geode/CacheableString.hpp>
-#include <PdxHelper.hpp>
 #include <geode/CacheableKeys.hpp>
+
+#include "GeodeTypeIdsImpl.hpp"
+#include "PdxHelper.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/PdxWrapper.cpp
+++ b/cppcache/src/PdxWrapper.cpp
@@ -14,17 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * PdxWrapper.cpp
- *
- *  Created on: Apr 17, 2012
- *      Author: vrao
- */
 
 #include <geode/PdxWrapper.hpp>
-#include <Utils.hpp>
-#include <PdxHelper.hpp>
-#include <SerializationRegistry.hpp>
+
+#include "Utils.hpp"
+#include "PdxHelper.hpp"
+#include "SerializationRegistry.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/Pool.cpp
+++ b/cppcache/src/Pool.cpp
@@ -16,11 +16,13 @@
  */
 
 #include <geode/Pool.hpp>
-#include <PoolAttributes.hpp>
 #include <geode/Cache.hpp>
 #include <geode/CacheFactory.hpp>
-#include <ProxyCache.hpp>
-#include <ThinClientPoolHADM.hpp>
+
+#include "PoolAttributes.hpp"
+#include "ProxyCache.hpp"
+#include "ThinClientPoolHADM.hpp"
+
 /**
  * @file
  */

--- a/cppcache/src/RegionAttributes.cpp
+++ b/cppcache/src/RegionAttributes.cpp
@@ -15,17 +15,20 @@
  * limitations under the License.
  */
 
-#include <geode/Cache.hpp>
-#include <Utils.hpp>
-#include <geode/DataOutput.hpp>
 #include <string>
 #include <cstdlib>
-#include <geode/GeodeTypeIds.hpp>
-#include <CacheXmlParser.hpp>
+
 #include <ace/DLL.h>
 #include <ace/OS.h>
+
+#include <geode/Cache.hpp>
+#include <geode/DataOutput.hpp>
+#include <geode/GeodeTypeIds.hpp>
 #include <geode/DataInput.hpp>
 #include <geode/Properties.hpp>
+
+#include "Utils.hpp"
+#include "CacheXmlParser.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/RegionFactory.cpp
+++ b/cppcache/src/RegionFactory.cpp
@@ -15,25 +15,28 @@
  * limitations under the License.
  */
 
-#include <geode/CacheFactory.hpp>
-#include <geode/RegionFactory.hpp>
-#include <CppCacheLibrary.hpp>
-#include <geode/Cache.hpp>
-#include <CacheImpl.hpp>
-#include <geode/SystemProperties.hpp>
-#include <geode/PoolManager.hpp>
-#include <CacheConfig.hpp>
-#include <CacheRegionHelper.hpp>
-#include <ace/Recursive_Thread_Mutex.h>
-#include <ace/Guard_T.h>
 #include <map>
 #include <string>
 
-extern ACE_Recursive_Thread_Mutex* g_disconnectLock;
+#include <ace/Recursive_Thread_Mutex.h>
+#include <ace/Guard_T.h>
+
+#include <geode/CacheFactory.hpp>
+#include <geode/RegionFactory.hpp>
+#include <geode/Cache.hpp>
+#include <geode/SystemProperties.hpp>
+#include <geode/PoolManager.hpp>
+
+#include "CppCacheLibrary.hpp"
+#include "CacheImpl.hpp"
+#include "CacheConfig.hpp"
+#include "CacheRegionHelper.hpp"
 
 namespace apache {
 namespace geode {
 namespace client {
+
+extern ACE_Recursive_Thread_Mutex* g_disconnectLock;
 
 RegionFactory::RegionFactory(RegionShortcut preDefinedRegion,
                              CacheImpl* cacheImpl)

--- a/cppcache/src/RegionStats.cpp
+++ b/cppcache/src/RegionStats.cpp
@@ -19,9 +19,9 @@
 #include <ace/Singleton.h>
 
 #include <geode/geode_globals.hpp>
-#include <util/concurrent/spinlock_mutex.hpp>
 
 #include "RegionStats.hpp"
+#include "util/concurrent/spinlock_mutex.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/RegionXmlCreation.cpp
+++ b/cppcache/src/RegionXmlCreation.cpp
@@ -16,10 +16,14 @@
  */
 
 #include <geode/Cache.hpp>
-#include <CacheRegionHelper.hpp>
+
+#include "CacheRegionHelper.hpp"
 #include "RegionXmlCreation.hpp"
 #include "CacheImpl.hpp"
-using namespace apache::geode::client;
+
+namespace apache {
+namespace geode {
+namespace client {
 
 void RegionXmlCreation::addSubregion(
     std::shared_ptr<RegionXmlCreation> regionPtr) {
@@ -70,3 +74,7 @@ std::string RegionXmlCreation::getAttrId() const { return attrId; }
 void RegionXmlCreation::setAttrId(const std::string& pattrId) {
   this->attrId = pattrId;
 }
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/Serializable.cpp
+++ b/cppcache/src/Serializable.cpp
@@ -16,10 +16,11 @@
  */
 #include <geode/geode_globals.hpp>
 #include <geode/Serializable.hpp>
-#include <GeodeTypeIdsImpl.hpp>
-#include <SerializationRegistry.hpp>
-#include <Utils.hpp>
 #include <geode/CacheableString.hpp>
+
+#include "GeodeTypeIdsImpl.hpp"
+#include "SerializationRegistry.hpp"
+#include "Utils.hpp"
 #include "CacheImpl.hpp"
 
 namespace apache {

--- a/cppcache/src/SslSockStream.cpp
+++ b/cppcache/src/SslSockStream.cpp
@@ -14,11 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "SslSockStream.hpp"
-#include <geode/ExceptionTypes.hpp>
+
 #include <ace/OS_NS_stdio.h>
 
-using namespace apache::geode::client;
+#include <geode/ExceptionTypes.hpp>
+
+#include "SslSockStream.hpp"
+#include "util/Log.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/Struct.cpp
+++ b/cppcache/src/Struct.cpp
@@ -18,7 +18,7 @@
 #include <string>
 
 #include <geode/Struct.hpp>
-#include <GeodeTypeIdsImpl.hpp>
+#include "GeodeTypeIdsImpl.hpp"
 #include <geode/DataInput.hpp>
 
 namespace apache {

--- a/cppcache/src/StructSetImpl.cpp
+++ b/cppcache/src/StructSetImpl.cpp
@@ -19,8 +19,11 @@
 #include <stdexcept>
 
 #include "StructSetImpl.hpp"
+#include "util/Log.hpp"
 
-using namespace apache::geode::client;
+namespace apache {
+namespace geode {
+namespace client {
 
 StructSetImpl::StructSetImpl(
     const std::shared_ptr<CacheableVector>& response,
@@ -94,3 +97,7 @@ SelectResults::Iterator StructSetImpl::end() const {
 }
 
 StructSetImpl::~StructSetImpl() {}
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/SystemProperties.cpp
+++ b/cppcache/src/SystemProperties.cpp
@@ -43,7 +43,7 @@ const char StatisticsEnabled[] = "statistic-sampling-enabled";
 const char AppDomainEnabled[] = "appdomain-enabled";
 const char StatisticsArchiveFile[] = "statistic-archive-file";
 const char LogFilename[] = "log-file";
-const char LogLevel[] = "log-level";
+const char LogLevelProperty[] = "log-level";
 
 const char Name[] = "name";
 const char JavaConnectionPoolSize[] = "connection-pool-size";
@@ -101,8 +101,8 @@ const bool DefaultAppDomainEnabled = false;
 const char DefaultStatArchive[] = "statArchive.gfs";
 const char DefaultLogFilename[] = "";  // stdout...
 
-const apache::geode::client::Log::LogLevel DefaultLogLevel =
-    apache::geode::client::Log::Config;
+const apache::geode::client::LogLevel DefaultLogLevel =
+    apache::geode::client::LogLevel::Config;
 
 const int DefaultJavaConnectionPoolSize = 5;
 
@@ -337,11 +337,9 @@ void SystemProperties::processProperty(const std::string& property,
     m_statisticsArchiveFile = value;
   } else if (property == LogFilename) {
     m_logFilename = value;
-  } else if (property == LogLevel) {
+  } else if (property == LogLevelProperty) {
     try {
-      Log::LogLevel level = Log::charsToLevel(value);
-      m_logLevel = level;
-
+      m_logLevel = Log::charsToLevel(value);
     } catch (IllegalArgumentException&) {
       throwError(
           ("SystemProperties: unknown log level " + property + "=" + value)

--- a/cppcache/src/TXState.cpp
+++ b/cppcache/src/TXState.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <geode/Cache.hpp>
+#include <geode/CacheTransactionManager.hpp>
 
 #include "TXState.hpp"
 #include "TransactionalOperation.hpp"

--- a/cppcache/src/TcpConn.hpp
+++ b/cppcache/src/TcpConn.hpp
@@ -21,11 +21,13 @@
 #define GEODE_TCPCONN_H_
 
 #include <geode/geode_globals.hpp>
-#include "util/Log.hpp"
-#include "Connector.hpp"
 
 #include <ace/SOCK_Stream.h>
 #include <ace/OS.h>
+
+#include "util/Log.hpp"
+#include "Connector.hpp"
+#include "Assert.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/Utils.hpp
+++ b/cppcache/src/Utils.hpp
@@ -43,6 +43,8 @@
 #include <geode/DistributedSystem.hpp>
 
 #include "statistics/Statistics.hpp"
+#include "util/Log.hpp"
+#include "Assert.hpp"
 
 #ifdef __GNUC__
 extern "C" {

--- a/cppcache/src/VersionedCacheableObjectPartList.hpp
+++ b/cppcache/src/VersionedCacheableObjectPartList.hpp
@@ -20,10 +20,13 @@
 #ifndef GEODE_VERSIONEDCACHEABLEOBJECTPARTLIST_H_
 #define GEODE_VERSIONEDCACHEABLEOBJECTPARTLIST_H_
 
+#include <vector>
+
+#include <ace/Task.h>
+
 #include "CacheableObjectPartList.hpp"
 #include "VersionTag.hpp"
-#include <ace/Task.h>
-#include <vector>
+#include "util/Log.hpp"
 
 /** @file
  */

--- a/cppcache/src/statistics/AtomicStatisticsImpl.cpp
+++ b/cppcache/src/statistics/AtomicStatisticsImpl.cpp
@@ -15,24 +15,21 @@
  * limitations under the License.
  */
 
-#include <geode/geode_globals.hpp>
 
 #include <atomic>
 
 #include <ace/OS_NS_stdio.h>
+
+#include <geode/geode_globals.hpp>
+
 #include "AtomicStatisticsImpl.hpp"
 #include "StatisticsTypeImpl.hpp"
 #include "StatisticDescriptorImpl.hpp"
+#include "../Assert.hpp"
 
 namespace apache {
 namespace geode {
 namespace statistics {
-/**
- * An implementation of {@link Statistics} that stores its statistics
- * in local  memory and supports atomic operations.
- *
- */
-//////////////////////  Static Methods  //////////////////////
 
 int64_t AtomicStatisticsImpl::calcNumericId(StatisticsFactory* system,
                                             int64_t userValue) {
@@ -58,23 +55,6 @@ std::string AtomicStatisticsImpl::calcTextId(StatisticsFactory* system,
   }
 }
 
-///////////////////////  Constructors  ///////////////////////
-
-/**
- * Creates a new statistics instance of the given type
- *
- * @param type
- *        A description of the statistics
- * @param textId
- *        Text that identifies this statistic when it is monitored
- * @param numericId
- *        A number that displayed when this statistic is monitored
- * @param uniqueId
- *        A number that uniquely identifies this instance
- * @param system
- *        The distributed system that determines whether or not these
- *        statistics are stored (and collected) in local memory
- */
 AtomicStatisticsImpl::AtomicStatisticsImpl(StatisticsType* typeArg,
                                            const std::string& textIdArg,
                                            int64_t numericIdArg,
@@ -143,8 +123,6 @@ AtomicStatisticsImpl::~AtomicStatisticsImpl() {
   }
 }
 
-//////////////////////  Instance Methods  //////////////////////
-
 bool AtomicStatisticsImpl::isShared() const { return false; }
 
 bool AtomicStatisticsImpl::isAtomic() const {
@@ -156,8 +134,6 @@ void AtomicStatisticsImpl::close() {
   // file.
   closed = true;
 }
-
-////////////////////////  store() Methods  ///////////////////////
 
 void AtomicStatisticsImpl::_setInt(int32_t offset, int32_t value) {
   if (offset >= statsType->getIntStatCount()) {
@@ -195,8 +171,6 @@ void AtomicStatisticsImpl::_setDouble(int32_t offset, double value) {
 
   doubleStorage[offset] = value;
 }
-
-///////////////////////  get() Methods  ///////////////////////
 
 int32_t AtomicStatisticsImpl::_getInt(int32_t offset) const {
   if (offset >= statsType->getIntStatCount()) {
@@ -264,8 +238,6 @@ int64_t AtomicStatisticsImpl::getRawBits(
   }
 }
 
-////////////////////////  inc() Methods  ////////////////////////
-
 int32_t AtomicStatisticsImpl::_incInt(int32_t offset, int32_t delta) {
   if (offset >= statsType->getIntStatCount()) {
     char s[128] = {'\0'};
@@ -322,10 +294,6 @@ double AtomicStatisticsImpl::_incDouble(int32_t offset, double delta) {
   return value;
 }
 
-/**************************Base class methods ********************/
-
-//////////////////////  Instance Methods  //////////////////////
-
 int32_t AtomicStatisticsImpl::nameToId(const std::string& name) const {
   return statsType->nameToId(name);
 }
@@ -339,20 +307,13 @@ bool AtomicStatisticsImpl::isClosed() const { return closed; }
 
 bool AtomicStatisticsImpl::isOpen() const { return !closed; }
 
-////////////////////////  attribute Methods  ///////////////////////
-
 StatisticsType* AtomicStatisticsImpl::getType() const { return statsType; }
 
 const std::string& AtomicStatisticsImpl::getTextId() const { return textIdStr; }
 
 int64_t AtomicStatisticsImpl::getNumericId() const { return numericId; }
 
-/**
- * Gets the unique id for this resource
- */
 int64_t AtomicStatisticsImpl::getUniqueId() const { return uniqueId; }
-
-////////////////////////  set() Methods  ///////////////////////
 
 void AtomicStatisticsImpl::setInt(const std::string& name, int32_t value) {
   int32_t id = getIntId(nameToDescriptor(name));
@@ -370,7 +331,6 @@ void AtomicStatisticsImpl::setInt(int32_t id, int32_t value) {
     _setInt(id, value);
   }
 }
-////////////////////////////////LONG METHODS/////////////////////////////
 
 void AtomicStatisticsImpl::setLong(const std::string& name, int64_t value) {
   setLong(nameToDescriptor(name), value);
@@ -386,7 +346,6 @@ void AtomicStatisticsImpl::setLong(int32_t id, int64_t value) {
     _setLong(id, value);
   }
 }
-////////////////////////////////////////DOUBLE METHODS////////////////////
 
 void AtomicStatisticsImpl::setDouble(const std::string& name, double value) {
   setDouble(nameToDescriptor(name), value);
@@ -456,9 +415,6 @@ double AtomicStatisticsImpl::getDouble(int32_t id) const {
   }
 }
 
-/*
- *Increment the value of the int32_t decriptor by delta
- */
 int32_t AtomicStatisticsImpl::incInt(const std::string& name, int32_t delta) {
   int32_t id = getIntId(nameToDescriptor(name));
   return incInt(id, delta);
@@ -478,10 +434,6 @@ int32_t AtomicStatisticsImpl::incInt(int32_t id, int32_t delta) {
   }
 }
 
-/*
- *Increment the value of the int64_t decriptor by delta
- */
-
 int64_t AtomicStatisticsImpl::incLong(const std::string& name, int64_t delta) {
   return incLong(nameToDescriptor(name), delta);
 }
@@ -498,10 +450,6 @@ int64_t AtomicStatisticsImpl::incLong(int32_t id, int64_t delta) {
     return 0;
   }
 }
-
-/*
- *Increment the value of the double decriptor by delta
- */
 
 double AtomicStatisticsImpl::incDouble(const std::string& name, double delta) {
   return incDouble(nameToDescriptor(name), delta);

--- a/cppcache/src/statistics/AtomicStatisticsImpl.hpp
+++ b/cppcache/src/statistics/AtomicStatisticsImpl.hpp
@@ -1,8 +1,3 @@
-#pragma once
-
-#ifndef GEODE_STATISTICS_ATOMICSTATISTICSIMPL_H_
-#define GEODE_STATISTICS_ATOMICSTATISTICSIMPL_H_
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -20,18 +15,21 @@
  * limitations under the License.
  */
 
-#include <geode/geode_globals.hpp>
+#pragma once
+
+#ifndef GEODE_STATISTICS_ATOMICSTATISTICSIMPL_H_
+#define GEODE_STATISTICS_ATOMICSTATISTICSIMPL_H_
 
 #include <atomic>
 #include <string>
+
+#include <geode/geode_globals.hpp>
 
 #include "Statistics.hpp"
 #include "StatisticsTypeImpl.hpp"
 #include "StatisticsFactory.hpp"
 
-#include <NonCopyable.hpp>
-
-using namespace apache::geode::client;
+#include "../NonCopyable.hpp"
 
 /** @file
  */
@@ -40,12 +38,13 @@ namespace apache {
 namespace geode {
 namespace statistics {
 
+using namespace apache::geode::client;
+
 /**
  * An implementation of {@link Statistics} that stores its statistics
  * in local memory and support atomic operations
  *
  */
-
 class AtomicStatisticsImpl : public Statistics, private NonCopyable {
  private:
   /**********varbs originally kept in statisticsimpl class*****************/

--- a/cppcache/src/statistics/GeodeStatisticsFactory.cpp
+++ b/cppcache/src/statistics/GeodeStatisticsFactory.cpp
@@ -16,22 +16,27 @@
  * limitations under the License.
  */
 
-#include <geode/geode_globals.hpp>
+#include <string>
 
 #include <ace/Recursive_Thread_Mutex.h>
 #include <ace/OS.h>
 #include <ace/Thread_Mutex.h>
 #include <ace/Guard_T.h>
+
+#include <geode/geode_globals.hpp>
 #include <geode/Exception.hpp>
+
 #include "GeodeStatisticsFactory.hpp"
-#include "util/Log.hpp"
-#include <string>
+#include "../util/Log.hpp"
 #include "AtomicStatisticsImpl.hpp"
 #include "OsStatisticsImpl.hpp"
 #include "HostStatHelper.hpp"
 
+namespace apache {
+namespace geode {
+namespace statistics {
+
 using namespace apache::geode::client;
-using namespace apache::geode::statistics;
 
 GeodeStatisticsFactory::GeodeStatisticsFactory(StatisticsManager* statMngr) {
   m_name = "GeodeStatisticsFactory";
@@ -238,3 +243,7 @@ StatisticDescriptor* GeodeStatisticsFactory::createDoubleGauge(
   return StatisticDescriptorImpl::createDoubleGauge(name, description, units,
                                                     largerBetter);
 }
+
+}  // namespace statistics
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/statistics/HostStatHelper.cpp
+++ b/cppcache/src/statistics/HostStatHelper.cpp
@@ -15,19 +15,18 @@
  * limitations under the License.
  */
 
-#include <geode/geode_globals.hpp>
-#include "config.h"
 #include <ace/OS_NS_sys_utsname.h>
+
+#include <geode/geode_globals.hpp>
+
+#include "config.h"
 #include "HostStatHelper.hpp"
 #include "GeodeStatisticsFactory.hpp"
+#include "../Assert.hpp"
 
-using namespace apache::geode::statistics;
-
-/**
- * Provides native methods which fetch operating system statistics.
- * accessed by calling {@link #getInstance()}.
- *
- */
+namespace apache {
+namespace geode {
+namespace statistics {
 
 int32_t HostStatHelper::PROCESS_STAT_FLAG = 1;
 int32_t HostStatHelper::SYSTEM_STAT_FLAG = 2;
@@ -35,9 +34,6 @@ GFS_OSTYPES HostStatHelper::osCode =
     static_cast<GFS_OSTYPES>(0);  // Default OS is Linux
 ProcessStats* HostStatHelper::processStats = nullptr;
 
-/**
- * Determine the OS and creates Process Statistics Type for that OS
- */
 void HostStatHelper::initOSCode() {
   ACE_utsname u;
   ACE_OS::uname(&u);
@@ -60,9 +56,6 @@ void HostStatHelper::initOSCode() {
   }
 }
 
-/**
- * Refresh statistics of the process through operating system specific calls
- */
 void HostStatHelper::refresh() {
   if (processStats != nullptr) {
 #if defined(_WIN32)
@@ -79,10 +72,6 @@ void HostStatHelper::refresh() {
   }
 }
 
-/**
- * Creates and returns a {@link Statistics} with
- * the given pid and name.
- */
 void HostStatHelper::newProcessStats(GeodeStatisticsFactory* statisticsFactory,
                                      int64_t pid, const char* name) {
   // Init OsCode
@@ -141,9 +130,14 @@ int64_t HostStatHelper::getCpuTime() {
   }
   return 0;
 }
+
 int32_t HostStatHelper::getNumThreads() {
   if (HostStatHelper::processStats != nullptr) {
     return HostStatHelper::processStats->getNumThreads();
   }
   return 0;
 }
+
+}  // namespace statistics
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/statistics/HostStatSampler.cpp
+++ b/cppcache/src/statistics/HostStatSampler.cpp
@@ -36,11 +36,11 @@
 #include "HostStatSampler.hpp"
 #include "HostStatHelper.hpp"
 #include "StatArchiveWriter.hpp"
-#include "util/Log.hpp"
 #include "GeodeStatisticsFactory.hpp"
-#include "ClientHealthStats.hpp"
-#include "ClientProxyMembershipID.hpp"
-#include "CacheImpl.hpp"
+#include "../util/Log.hpp"
+#include "../ClientHealthStats.hpp"
+#include "../ClientProxyMembershipID.hpp"
+#include "../CacheImpl.hpp"
 
 namespace apache {
 namespace geode {
@@ -61,6 +61,8 @@ typedef std::vector<std::pair<std::string, int64_t> > g_fileInfo;
 }  // namespace statistics
 }  // namespace geode
 }  // namespace apache
+
+namespace {
 
 using namespace apache::geode::statistics::globals;
 
@@ -116,7 +118,8 @@ int comparator(const dirent** d1, const dirent** d2) {
     return 0;
   }
 }
-//}
+
+}
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/statistics/HostStatSampler.hpp
+++ b/cppcache/src/statistics/HostStatSampler.hpp
@@ -37,7 +37,7 @@
 #include "StatArchiveWriter.hpp"
 #include <geode/ExceptionTypes.hpp>
 
-#include <NonCopyable.hpp>
+#include "../NonCopyable.hpp"
 
 using namespace apache::geode::client;
 

--- a/cppcache/src/statistics/LinuxProcessStats.cpp
+++ b/cppcache/src/statistics/LinuxProcessStats.cpp
@@ -14,19 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <geode/geode_globals.hpp>
+
 #include <ace/Thread_Mutex.h>
 #include <ace/Singleton.h>
+
+#include <geode/geode_globals.hpp>
+
 #include "LinuxProcessStats.hpp"
 #include "HostStatHelperLinux.hpp"
+#include "../Assert.hpp"
 
-using namespace apache::geode::statistics;
-
-/**
- * <P>This class provides the interface for statistics about a
- * Linux operating system process that is using a Geode system.
- *
- */
+namespace apache {
+namespace geode {
+namespace statistics {
 
 LinuxProcessStats::LinuxProcessStats(GeodeStatisticsFactory* statFactory,
                                      int64_t pid, const char* name) {
@@ -43,11 +43,6 @@ LinuxProcessStats::LinuxProcessStats(GeodeStatisticsFactory* statFactory,
 #endif  // if defined(_LINUX)
 }
 
-/**
- * Creates the StatisticsType for collecting the Stats of a Linux process
- * This function is called by the class HostStatHelper before objects of
- * LinuxProcessStatistics are created by it.
- */
 void LinuxProcessStats::createType(StatisticsFactory* statFactory) {
   try {
     StatisticDescriptor** statDescriptorArr = new StatisticDescriptor*[6];
@@ -104,8 +99,11 @@ int64_t LinuxProcessStats::getProcessSize() {
 int32_t LinuxProcessStats::getCpuUsage() {
   return stats->getInt(hostCpuUsageINT);
 }
+
 int64_t LinuxProcessStats::getCPUTime() { return stats->getInt(userTimeINT); }
+
 int32_t LinuxProcessStats::getNumThreads() { return stats->getInt(threadsINT); }
+
 int64_t LinuxProcessStats::getAllCpuTime() {
   return ((stats->getInt(userTimeINT)) + (stats->getInt(systemTimeINT)));
 }
@@ -120,3 +118,7 @@ LinuxProcessStats::~LinuxProcessStats() {
   m_statsType = nullptr;
   stats = nullptr;
 }
+
+}  // namespace statistics
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/statistics/OsStatisticsImpl.cpp
+++ b/cppcache/src/statistics/OsStatisticsImpl.cpp
@@ -20,6 +20,7 @@
 #include "OsStatisticsImpl.hpp"
 #include "StatisticsTypeImpl.hpp"
 #include "StatisticDescriptorImpl.hpp"
+#include "../util/Log.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/statistics/OsStatisticsImpl.hpp
+++ b/cppcache/src/statistics/OsStatisticsImpl.hpp
@@ -23,7 +23,7 @@
 #include "Statistics.hpp"
 #include "StatisticsFactory.hpp"
 #include "StatisticsTypeImpl.hpp"
-#include "NonCopyable.hpp"
+#include "../NonCopyable.hpp"
 
 /** @file
  */
@@ -39,22 +39,6 @@ using namespace apache::geode::client;
  * in local memory and does not support atomic operations.
  *
  */
-
-/* adongre
- * CID 28734: Other violation (MISSING_COPY)
- * Class "apache::geode::statistics::OsStatisticsImpl" owns resources that are
- * managed in its constructor and destructor but has no user-written copy
- * constructor.
- *
- * CID 28720: Other violation (MISSING_ASSIGN)
- * Class "apache::geode::statistics::OsStatisticsImpl" owns resources that are
- * managed
- * in its constructor and destructor but has no user-written assignment
- * operator.
- *
- * FIX : Make the class Non-Copyable
- */
-
 class OsStatisticsImpl : public Statistics,
                          private NonCopyable,
                          private NonAssignable {

--- a/cppcache/src/statistics/PoolStatsSampler.cpp
+++ b/cppcache/src/statistics/PoolStatsSampler.cpp
@@ -20,12 +20,12 @@
 #include <thread>
 
 #include "PoolStatsSampler.hpp"
-#include "ReadWriteLock.hpp"
-#include "CacheImpl.hpp"
-#include "ThinClientPoolDM.hpp"
 #include "GeodeStatisticsFactory.hpp"
-#include "ClientHealthStats.hpp"
 #include "HostStatHelper.hpp"
+#include "../ReadWriteLock.hpp"
+#include "../CacheImpl.hpp"
+#include "../ThinClientPoolDM.hpp"
+#include "../ClientHealthStats.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/statistics/PoolStatsSampler.hpp
+++ b/cppcache/src/statistics/PoolStatsSampler.hpp
@@ -21,9 +21,10 @@
 #define GEODE_STATISTICS_POOLSTATSSAMPLER_H_
 
 #include <ace/Task.h>
+
 #include <geode/geode_globals.hpp>
 
-#include "statistics/GeodeStatisticsFactory.hpp"
+#include "GeodeStatisticsFactory.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/statistics/SolarisProcessStats.cpp
+++ b/cppcache/src/statistics/SolarisProcessStats.cpp
@@ -14,19 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <geode/geode_globals.hpp>
+
 #include <ace/Thread_Mutex.h>
 #include <ace/Singleton.h>
+
+#include <geode/geode_globals.hpp>
+
 #include "SolarisProcessStats.hpp"
 #include "HostStatHelperSolaris.hpp"
+#include "../Assert.hpp"
 
-using namespace apache::geode::statistics;
-
-/**
- * <P>This class provides the interface for statistics about a
- * Solaris operating system process that is using a Geode system.
- *
- */
+namespace apache {
+namespace geode {
+namespace statistics {
 
 SolarisProcessStats::SolarisProcessStats(GeodeStatisticsFactory* statFactory,
                                          int64_t pid, const char* name) {
@@ -43,11 +43,6 @@ SolarisProcessStats::SolarisProcessStats(GeodeStatisticsFactory* statFactory,
 #endif  // if def(_SOLARIS)
 }
 
-/**
- * Creates the StatisticsType for collecting the Stats of a Solaris process
- * This function is called by the class HostStatHelper before objects of
- * SolarisProcessStatistics are created by it.
- */
 void SolarisProcessStats::createType(StatisticsFactory* statFactory) {
   try {
     StatisticDescriptor** statDescriptorArr = new StatisticDescriptor*[7];
@@ -110,10 +105,13 @@ int64_t SolarisProcessStats::getProcessSize() {
 int32_t SolarisProcessStats::getCpuUsage() {
   return stats->getInt(hostCpuUsageINT);
 }
+
 int64_t SolarisProcessStats::getCPUTime() { return stats->getInt(userTimeINT); }
+
 int32_t SolarisProcessStats::getNumThreads() {
   return stats->getInt(threadsINT);
 }
+
 int64_t SolarisProcessStats::getAllCpuTime() {
   return ((stats->getInt(userTimeINT)) + (stats->getInt(systemTimeINT)));
 }
@@ -128,3 +126,7 @@ SolarisProcessStats::~SolarisProcessStats() {
   m_statsType = nullptr;
   stats = nullptr;
 }
+
+}  // namespace statistics
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/statistics/StatArchiveWriter.cpp
+++ b/cppcache/src/statistics/StatArchiveWriter.cpp
@@ -26,7 +26,7 @@
 
 #include "StatArchiveWriter.hpp"
 #include "GeodeStatisticsFactory.hpp"
-#include "CacheImpl.hpp"
+#include "../CacheImpl.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/statistics/StatArchiveWriter.hpp
+++ b/cppcache/src/statistics/StatArchiveWriter.hpp
@@ -37,7 +37,7 @@
 #include "HostStatSampler.hpp"
 #include "../util/Log.hpp"
 #include "../NonCopyable.hpp"
-#include "SerializationRegistry.hpp"
+#include "../SerializationRegistry.hpp"
 
 using namespace apache::geode::client;
 /**

--- a/cppcache/src/statistics/StatSamplerStats.cpp
+++ b/cppcache/src/statistics/StatSamplerStats.cpp
@@ -16,12 +16,11 @@
  */
 
 #include "StatSamplerStats.hpp"
-#include "statistics/StatisticsManager.hpp"
-using namespace apache::geode::statistics;
+#include "StatisticsManager.hpp"
 
-/**
- * Statistics related to the statistic sampler.
- */
+namespace apache {
+namespace geode {
+namespace statistics {
 
 StatSamplerStats::StatSamplerStats(StatisticsFactory* statFactory) {
   statDescriptorArr = new StatisticDescriptor*[2];
@@ -42,10 +41,6 @@ StatSamplerStats::StatSamplerStats(StatisticsFactory* statFactory) {
                                                      statFactory->getId());
 }
 
-/**
- * The default values of the individual Stats descriptors are zero.
- * This function can be used to set initial values to the descriptors.
- */
 void StatSamplerStats::setInitialValues() {
   if (samplerStats) {
     samplerStats->setInt(sampleCountId, 0);
@@ -53,10 +48,6 @@ void StatSamplerStats::setInitialValues() {
   }
 }
 
-/**
- * This function is called to refresh the values
- * of the individual Stats descriptors.
- */
 void StatSamplerStats::tookSample(int64_t nanosSpentWorking) {
   if (samplerStats) {
     samplerStats->incInt(sampleCountId, 1);
@@ -64,25 +55,12 @@ void StatSamplerStats::tookSample(int64_t nanosSpentWorking) {
   }
 }
 
-/**
- * Calls the destroyStatistics() function of the factory
- * which deletes the Stats object
- * It is mandatory to call this function for proper deletion of stats objects.
- */
 void StatSamplerStats::close() {
   if (samplerStats) {
     samplerStats->close();
   }
 }
 
-/**
- * All objects are created by factory, and the reference is passed to this class
- * Factory takes the responsibility of deleting the objetcs.
- * Hence they can be simply set to nullptr here.
- * But it is mandatory that StatSamplerStats::close() be called
- * before this destructor gets called,
- * otherwise samplerStats will not get deleted and a memory leak will occur.
- */
 StatSamplerStats::~StatSamplerStats() {
   samplerType = nullptr;
   for (int32_t i = 0; i < 2; i++) {
@@ -90,3 +68,7 @@ StatSamplerStats::~StatSamplerStats() {
   }
   samplerStats = nullptr;
 }
+
+}  // namespace statistics
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/statistics/StatisticsManager.cpp
+++ b/cppcache/src/statistics/StatisticsManager.cpp
@@ -26,7 +26,7 @@
 #include <geode/Exception.hpp>
 
 #include "StatisticsManager.hpp"
-#include "util/Log.hpp"
+#include "../util/Log.hpp"
 #include "GeodeStatisticsFactory.hpp"
 #include "AtomicStatisticsImpl.hpp"
 #include "OsStatisticsImpl.hpp"
@@ -36,10 +36,6 @@ namespace geode {
 namespace statistics {
 
 using namespace apache::geode::client;
-
-/**
- * static member initialization
- */
 
 StatisticsManager::StatisticsManager(
     const char* filePath, const std::chrono::milliseconds sampleInterval,
@@ -69,8 +65,6 @@ StatisticsManager::StatisticsManager(
 void StatisticsManager::forceSample() {
   if (m_sampler) m_sampler->forceSample();
 }
-
-/**************************Dtor*******************************************/
 
 StatisticsManager::~StatisticsManager() {
   try {
@@ -126,6 +120,7 @@ void StatisticsManager::closeSampler() {
     m_sampler = nullptr;
   }
 }
+
 void StatisticsManager::addStatisticsToList(Statistics* stat) {
   if (stat) {
     ACE_Guard<ACE_Recursive_Thread_Mutex> guard(m_statsListLock);

--- a/cppcache/src/statistics/StatisticsManager.hpp
+++ b/cppcache/src/statistics/StatisticsManager.hpp
@@ -29,7 +29,7 @@
 #include "Statistics.hpp"
 #include "HostStatSampler.hpp"
 #include "StatisticsTypeImpl.hpp"
-#include "AdminRegion.hpp"
+#include "../AdminRegion.hpp"
 #include "GeodeStatisticsFactory.hpp"
 
 namespace apache {

--- a/cppcache/src/statistics/StatisticsTypeImpl.cpp
+++ b/cppcache/src/statistics/StatisticsTypeImpl.cpp
@@ -15,37 +15,17 @@
  * limitations under the License.
  */
 
+#include <string>
+
+#include <ace/OS.h>
+
 #include "StatisticsTypeImpl.hpp"
 #include "StatisticDescriptorImpl.hpp"
-#include <string>
-#include <ace/OS.h>
-using namespace apache::geode::statistics;
+#include "../util/Log.hpp"
 
-/**
- * Gathers together a number of {@link StatisticDescriptor statistics}
- * into one logical type.
- *
- */
-
-/**
- * Creates a new <code>StatisticsType</code> with the given name,
- * description, and statistics.
- *
- * @param name
- *        The name of this statistics type (for example,
- *        <code>"DatabaseStatistics"</code>)
- * @param description
- *        A description of this statistics type (for example,
- *        "Information about the application's use of the
- *        database").
- * @param stats
- *        Descriptions of the individual statistics grouped together
- *        in this statistics type{@link StatisticDescriptor}.
- *
- * @throws NullPointerException
- *         If either <code>name</code> or <code>stats</code> is
- *         <code>null</code>.
- */
+namespace apache {
+namespace geode {
+namespace statistics {
 
 StatisticsTypeImpl::StatisticsTypeImpl(std::string nameArg,
                                        std::string descriptionArg,
@@ -118,8 +98,6 @@ StatisticsTypeImpl::StatisticsTypeImpl(std::string nameArg,
   this->doubleStatCount = doubleCount;
 }
 
-///////////////////////////////Dtor/////////////////////////
-
 StatisticsTypeImpl::~StatisticsTypeImpl() {
   try {
     // Delete the descriptor pointers from the array
@@ -137,8 +115,6 @@ StatisticsTypeImpl::~StatisticsTypeImpl() {
   } catch (...) {
   }
 }
-
-//////////////////////  StatisticsType Methods  //////////////////////
 
 const std::string& StatisticsTypeImpl::getName() const { return name; }
 
@@ -166,26 +142,17 @@ StatisticDescriptor* StatisticsTypeImpl::nameToDescriptor(
     return iterFind->second;
   }
 }
-//////////////////////  Instance Methods  //////////////////////
 
-/**
- * Gets the number of statistics in this type that are ints.
- */
 int32_t StatisticsTypeImpl::getIntStatCount() const { return intStatCount; }
 
-/**
- * Gets the number of statistics in this type that are longs.
- */
 int32_t StatisticsTypeImpl::getLongStatCount() const { return longStatCount; }
 
-/**
- * Gets the number of statistics that are doubles.
- */
 int32_t StatisticsTypeImpl::getDoubleStatCount() const {
   return doubleStatCount;
 }
 
-/**
- * Gets the total number of statistic descriptors.
- */
 int32_t StatisticsTypeImpl::getDescriptorsCount() const { return statsLength; }
+
+}  // namespace statistics
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/statistics/WindowsProcessStats.cpp
+++ b/cppcache/src/statistics/WindowsProcessStats.cpp
@@ -23,6 +23,7 @@
 #include "WindowsProcessStats.hpp"
 #include "HostStatHelperWin.hpp"
 #include "HostStatHelper.hpp"
+#include "../Assert.hpp"
 
 namespace apache {
 namespace geode {

--- a/cppcache/src/statistics/WindowsProcessStats.hpp
+++ b/cppcache/src/statistics/WindowsProcessStats.hpp
@@ -21,12 +21,12 @@
 #define GEODE_STATISTICS_WINDOWSPROCESSSTATS_H_
 
 #include <geode/geode_globals.hpp>
-#include "statistics/Statistics.hpp"
-#include "statistics/StatisticsType.hpp"
-#include "statistics/StatisticDescriptor.hpp"
-#include "statistics/StatisticsFactory.hpp"
 #include <geode/ExceptionTypes.hpp>
 
+#include "Statistics.hpp"
+#include "StatisticsType.hpp"
+#include "StatisticDescriptor.hpp"
+#include "StatisticsFactory.hpp"
 #include "ProcessStats.hpp"
 #include "GeodeStatisticsFactory.hpp"
 
@@ -43,7 +43,6 @@ using namespace apache::geode::client;
  * <P>This class provides the interface for statistics about a
  * Windows operating system process that is using a Geode system.
  */
-
 class CPPCACHE_EXPORT WindowsProcessStats : public ProcessStats {
  private:
   /** The Static Type for Windows Process Stats */

--- a/cppcache/src/util/Log.hpp
+++ b/cppcache/src/util/Log.hpp
@@ -25,6 +25,7 @@
 #include <string>
 
 #include <geode/geode_globals.hpp>
+#include <geode/util/LogLevel.hpp>
 
 /******************************************************************************/
 
@@ -143,31 +144,6 @@ class CPPCACHE_EXPORT Log {
  public:
   /******/
 
-  enum LogLevel {
-
-    // NOTE: if you change this enum declaration at all, be sure to
-    // change levelToChars and charsToLevel functions!
-
-    None,
-
-    Error,
-    Warning,
-    Info,
-
-    Default,
-
-    Config,
-
-    Fine,
-    Finer,
-    Finest,
-
-    Debug,
-
-    All
-
-  };
-
   /******/
 
   /**
@@ -209,7 +185,7 @@ class CPPCACHE_EXPORT Log {
    * lower case. Out of range values will throw
    * IllegalArgumentException.
    */
-  static const char* levelToChars(Log::LogLevel level);
+  static const char* levelToChars(LogLevel level);
 
   /**
    * returns log level specified by "chars", or throws
@@ -570,10 +546,10 @@ class CPPCACHE_EXPORT Log {
 
 class LogFn {
   const char* m_functionName;
-  Log::LogLevel m_level;
+  LogLevel m_level;
 
  public:
-  LogFn(const char* functionName, Log::LogLevel level = Log::Finest)
+  LogFn(const char* functionName, LogLevel level = Finest)
       : m_functionName(functionName), m_level(level) {
     if (Log::enabled(m_level)) Log::enterFn(m_level, m_functionName);
   }
@@ -606,35 +582,35 @@ class CPPCACHE_EXPORT LogVarargs {
   static void finest(const char* fmt, ...);
 
   inline static void debug(const std::string& message) {
-    Log::put(Log::Debug, message.c_str());
+    Log::put(Debug, message.c_str());
   }
 
   inline static void error(const std::string& message) {
-    Log::put(Log::Error, message.c_str());
+    Log::put(Error, message.c_str());
   }
 
   inline static void warn(const std::string& message) {
-    Log::put(Log::Warning, message.c_str());
+    Log::put(Warning, message.c_str());
   }
 
   inline static void info(const std::string& message) {
-    Log::put(Log::Info, message.c_str());
+    Log::put(Info, message.c_str());
   }
 
   inline static void config(const std::string& message) {
-    Log::put(Log::Config, message.c_str());
+    Log::put(Config, message.c_str());
   }
 
   inline static void fine(const std::string& message) {
-    Log::put(Log::Fine, message.c_str());
+    Log::put(Fine, message.c_str());
   }
 
   inline static void finer(const std::string& message) {
-    Log::put(Log::Finer, message.c_str());
+    Log::put(Finer, message.c_str());
   }
 
   inline static void finest(const std::string& message) {
-    Log::put(Log::Finest, message.c_str());
+    Log::put(Finest, message.c_str());
   }
 };
 }  // namespace client
@@ -644,56 +620,56 @@ class CPPCACHE_EXPORT LogVarargs {
 /************************ LOGDEBUG ***********************************/
 
 #define LOGDEBUG                              \
-  if (apache::geode::client::Log::Debug <=    \
+  if (apache::geode::client::LogLevel::Debug <=    \
       apache::geode::client::Log::logLevel()) \
   apache::geode::client::LogVarargs::debug
 
 /************************ LOGERROR ***********************************/
 
 #define LOGERROR                              \
-  if (apache::geode::client::Log::Error <=    \
+  if (apache::geode::client::LogLevel::Error <=    \
       apache::geode::client::Log::logLevel()) \
   apache::geode::client::LogVarargs::error
 
 /************************ LOGWARN ***********************************/
 
 #define LOGWARN                               \
-  if (apache::geode::client::Log::Warning <=  \
+  if (apache::geode::client::LogLevel::Warning <=  \
       apache::geode::client::Log::logLevel()) \
   apache::geode::client::LogVarargs::warn
 
 /************************ LOGINFO ***********************************/
 
 #define LOGINFO                               \
-  if (apache::geode::client::Log::Info <=     \
+  if (apache::geode::client::LogLevel::Info <=     \
       apache::geode::client::Log::logLevel()) \
   apache::geode::client::LogVarargs::info
 
 /************************ LOGCONFIG ***********************************/
 
 #define LOGCONFIG                             \
-  if (apache::geode::client::Log::Config <=   \
+  if (apache::geode::client::LogLevel::Config <=   \
       apache::geode::client::Log::logLevel()) \
   apache::geode::client::LogVarargs::config
 
 /************************ LOGFINE ***********************************/
 
 #define LOGFINE                               \
-  if (apache::geode::client::Log::Fine <=     \
+  if (apache::geode::client::LogLevel::Fine <=     \
       apache::geode::client::Log::logLevel()) \
   apache::geode::client::LogVarargs::fine
 
 /************************ LOGFINER ***********************************/
 
 #define LOGFINER                              \
-  if (apache::geode::client::Log::Finer <=    \
+  if (apache::geode::client::LogLevel::Finer <=    \
       apache::geode::client::Log::logLevel()) \
   apache::geode::client::LogVarargs::finer
 
 /************************ LOGFINEST ***********************************/
 
 #define LOGFINEST                             \
-  if (apache::geode::client::Log::Finest <=   \
+  if (apache::geode::client::LogLevel::Finest <=   \
       apache::geode::client::Log::logLevel()) \
   apache::geode::client::LogVarargs::finest
 

--- a/cppcache/src/util/Log.hpp
+++ b/cppcache/src/util/Log.hpp
@@ -30,7 +30,7 @@
 /******************************************************************************/
 
 #ifndef GEODE_HIGHEST_LOG_LEVEL
-#define GEODE_HIGHEST_LOG_LEVEL All
+#define GEODE_HIGHEST_LOG_LEVEL LogLevel::All
 #endif
 
 #ifndef GEODE_MAX_LOG_FILE_LIMIT
@@ -216,7 +216,7 @@ class CPPCACHE_EXPORT Log {
    * Returns whether log messages at given level are enabled.
    */
   static bool enabled(LogLevel level) {
-    return (((s_doingDebug && level == Debug) ||
+    return (((s_doingDebug && level == LogLevel::Debug) ||
              GEODE_HIGHEST_LOG_LEVEL >= level) &&
             s_logLevel >= level);
   }
@@ -248,7 +248,8 @@ class CPPCACHE_EXPORT Log {
    * Returns whether "error" log messages are enabled.
    */
   static bool errorEnabled() {
-    return GEODE_HIGHEST_LOG_LEVEL >= Error && s_logLevel >= Error;
+    return GEODE_HIGHEST_LOG_LEVEL >= LogLevel::Error
+        && s_logLevel >= LogLevel::Error;
   }
 
   /**
@@ -256,7 +257,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "error".
    */
   static void error(const char* msg) {
-    if (errorEnabled()) put(Error, msg);
+    if (errorEnabled()) put(LogLevel::Error, msg);
   }
 
   /**
@@ -264,7 +265,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "error".
    */
   static void errorThrow(const char* msg, const Exception& ex) {
-    if (errorEnabled()) putThrow(Error, msg, ex);
+    if (errorEnabled()) putThrow(LogLevel::Error, msg, ex);
   }
 
   /**
@@ -272,7 +273,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "error".
    */
   static void errorCatch(const char* msg, const Exception& ex) {
-    if (errorEnabled()) putCatch(Error, msg, ex);
+    if (errorEnabled()) putCatch(LogLevel::Error, msg, ex);
   }
 
   /******/
@@ -281,7 +282,8 @@ class CPPCACHE_EXPORT Log {
    * Returns whether "warning" log messages are enabled.
    */
   static bool warningEnabled() {
-    return GEODE_HIGHEST_LOG_LEVEL >= Warning && s_logLevel >= Warning;
+    return GEODE_HIGHEST_LOG_LEVEL >= LogLevel::Warning
+        && s_logLevel >= LogLevel::Warning;
   }
 
   /**
@@ -289,7 +291,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "warning".
    */
   static void warning(const char* msg) {
-    if (warningEnabled()) put(Warning, msg);
+    if (warningEnabled()) put(LogLevel::Warning, msg);
   }
 
   /**
@@ -297,7 +299,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "warning".
    */
   static void warningThrow(const char* msg, const Exception& ex) {
-    if (warningEnabled()) putThrow(Warning, msg, ex);
+    if (warningEnabled()) putThrow(LogLevel::Warning, msg, ex);
   }
 
   /**
@@ -305,7 +307,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "warning".
    */
   static void warningCatch(const char* msg, const Exception& ex) {
-    if (warningEnabled()) putCatch(Warning, msg, ex);
+    if (warningEnabled()) putCatch(LogLevel::Warning, msg, ex);
   }
 
   /******/
@@ -314,7 +316,8 @@ class CPPCACHE_EXPORT Log {
    * Returns whether "info" log messages are enabled.
    */
   static bool infoEnabled() {
-    return GEODE_HIGHEST_LOG_LEVEL >= Info && s_logLevel >= Info;
+    return GEODE_HIGHEST_LOG_LEVEL >= LogLevel::Info
+        && s_logLevel >= LogLevel::Info;
   }
 
   /**
@@ -322,7 +325,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "info".
    */
   static void info(const char* msg) {
-    if (infoEnabled()) put(Info, msg);
+    if (infoEnabled()) put(LogLevel::Info, msg);
   }
 
   /**
@@ -330,7 +333,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "info".
    */
   static void infoThrow(const char* msg, const Exception& ex) {
-    if (infoEnabled()) putThrow(Info, msg, ex);
+    if (infoEnabled()) putThrow(LogLevel::Info, msg, ex);
   }
 
   /**
@@ -338,7 +341,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "info".
    */
   static void infoCatch(const char* msg, const Exception& ex) {
-    if (infoEnabled()) putCatch(Info, msg, ex);
+    if (infoEnabled()) putCatch(LogLevel::Info, msg, ex);
   }
 
   /******/
@@ -347,7 +350,8 @@ class CPPCACHE_EXPORT Log {
    * Returns whether "config" log messages are enabled.
    */
   static bool configEnabled() {
-    return GEODE_HIGHEST_LOG_LEVEL >= Config && s_logLevel >= Config;
+    return GEODE_HIGHEST_LOG_LEVEL >= LogLevel::Config
+        && s_logLevel >= LogLevel::Config;
   }
 
   /**
@@ -355,7 +359,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "config".
    */
   static void config(const char* msg) {
-    if (configEnabled()) put(Config, msg);
+    if (configEnabled()) put(LogLevel::Config, msg);
   }
 
   /**
@@ -363,7 +367,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "config".
    */
   static void configThrow(const char* msg, const Exception& ex) {
-    if (configEnabled()) putThrow(Config, msg, ex);
+    if (configEnabled()) putThrow(LogLevel::Config, msg, ex);
   }
 
   /**
@@ -371,7 +375,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "config".
    */
   static void configCatch(const char* msg, const Exception& ex) {
-    if (configEnabled()) putCatch(Config, msg, ex);
+    if (configEnabled()) putCatch(LogLevel::Config, msg, ex);
   }
 
   /******/
@@ -380,7 +384,8 @@ class CPPCACHE_EXPORT Log {
    * Returns whether "fine" log messages are enabled.
    */
   static bool fineEnabled() {
-    return GEODE_HIGHEST_LOG_LEVEL >= Fine && s_logLevel >= Fine;
+    return GEODE_HIGHEST_LOG_LEVEL >= LogLevel::Fine
+        && s_logLevel >= LogLevel::Fine;
   }
 
   /**
@@ -388,7 +393,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "fine".
    */
   static void fine(const char* msg) {
-    if (fineEnabled()) put(Fine, msg);
+    if (fineEnabled()) put(LogLevel::Fine, msg);
   }
 
   /**
@@ -396,7 +401,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "fine".
    */
   static void fineThrow(const char* msg, const Exception& ex) {
-    if (fineEnabled()) putThrow(Fine, msg, ex);
+    if (fineEnabled()) putThrow(LogLevel::Fine, msg, ex);
   }
 
   /**
@@ -404,7 +409,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "fine".
    */
   static void fineCatch(const char* msg, const Exception& ex) {
-    if (fineEnabled()) putCatch(Fine, msg, ex);
+    if (fineEnabled()) putCatch(LogLevel::Fine, msg, ex);
   }
 
   /******/
@@ -413,7 +418,8 @@ class CPPCACHE_EXPORT Log {
    * Returns whether "finer" log messages are enabled.
    */
   static bool finerEnabled() {
-    return GEODE_HIGHEST_LOG_LEVEL >= Finer && s_logLevel >= Finer;
+    return GEODE_HIGHEST_LOG_LEVEL >= LogLevel::Finer
+        && s_logLevel >= LogLevel::Finer;
   }
 
   /**
@@ -421,7 +427,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "finer".
    */
   static void finer(const char* msg) {
-    if (finerEnabled()) put(Finer, msg);
+    if (finerEnabled()) put(LogLevel::Finer, msg);
   }
 
   /**
@@ -429,7 +435,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "finer".
    */
   static void finerThrow(const char* msg, const Exception& ex) {
-    if (finerEnabled()) putThrow(Finer, msg, ex);
+    if (finerEnabled()) putThrow(LogLevel::Finer, msg, ex);
   }
 
   /**
@@ -437,7 +443,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "finer".
    */
   static void finerCatch(const char* msg, const Exception& ex) {
-    if (finerEnabled()) putCatch(Finer, msg, ex);
+    if (finerEnabled()) putCatch(LogLevel::Finer, msg, ex);
   }
 
   /******/
@@ -446,7 +452,8 @@ class CPPCACHE_EXPORT Log {
    * Returns whether "finest" log messages are enabled.
    */
   static bool finestEnabled() {
-    return GEODE_HIGHEST_LOG_LEVEL >= Finest && s_logLevel >= Finest;
+    return GEODE_HIGHEST_LOG_LEVEL >= LogLevel::Finest
+        && s_logLevel >= LogLevel::Finest;
   }
 
   /**
@@ -454,7 +461,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "finest".
    */
   static void finest(const char* msg) {
-    if (finestEnabled()) put(Finest, msg);
+    if (finestEnabled()) put(LogLevel::Finest, msg);
   }
 
   /**
@@ -462,7 +469,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "finest".
    */
   static void finestThrow(const char* msg, const Exception& ex) {
-    if (finestEnabled()) putThrow(Finest, msg, ex);
+    if (finestEnabled()) putThrow(LogLevel::Finest, msg, ex);
   }
 
   /**
@@ -470,7 +477,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "finest".
    */
   static void finestCatch(const char* msg, const Exception& ex) {
-    if (finestEnabled()) putCatch(Finest, msg, ex);
+    if (finestEnabled()) putCatch(LogLevel::Finest, msg, ex);
   }
 
   /******/
@@ -479,8 +486,8 @@ class CPPCACHE_EXPORT Log {
    * Returns whether "debug" log messages are enabled.
    */
   static bool debugEnabled() {
-    return (s_doingDebug || GEODE_HIGHEST_LOG_LEVEL >= Debug) &&
-           s_logLevel >= Debug;
+    return (s_doingDebug || GEODE_HIGHEST_LOG_LEVEL >= LogLevel::Debug) &&
+        s_logLevel >= LogLevel::Debug;
   }
 
   /**
@@ -488,7 +495,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "debug".
    */
   static void debug(const char* msg) {
-    if (debugEnabled()) put(Debug, msg);
+    if (debugEnabled()) put(LogLevel::Debug, msg);
   }
 
   /**
@@ -496,7 +503,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "debug".
    */
   static void debugThrow(const char* msg, const Exception& ex) {
-    if (debugEnabled()) putThrow(Debug, msg, ex);
+    if (debugEnabled()) putThrow(LogLevel::Debug, msg, ex);
   }
 
   /**
@@ -504,7 +511,7 @@ class CPPCACHE_EXPORT Log {
    * The message level is "debug".
    */
   static void debugCatch(const char* msg, const Exception& ex) {
-    if (debugEnabled()) putCatch(Debug, msg, ex);
+    if (debugEnabled()) putCatch(LogLevel::Debug, msg, ex);
   }
 
   /******/
@@ -549,7 +556,7 @@ class LogFn {
   LogLevel m_level;
 
  public:
-  LogFn(const char* functionName, LogLevel level = Finest)
+  LogFn(const char *functionName, LogLevel level = LogLevel::Finest)
       : m_functionName(functionName), m_level(level) {
     if (Log::enabled(m_level)) Log::enterFn(m_level, m_functionName);
   }
@@ -582,35 +589,35 @@ class CPPCACHE_EXPORT LogVarargs {
   static void finest(const char* fmt, ...);
 
   inline static void debug(const std::string& message) {
-    Log::put(Debug, message.c_str());
+    Log::put(LogLevel::Debug, message.c_str());
   }
 
   inline static void error(const std::string& message) {
-    Log::put(Error, message.c_str());
+    Log::put(LogLevel::Error, message.c_str());
   }
 
   inline static void warn(const std::string& message) {
-    Log::put(Warning, message.c_str());
+    Log::put(LogLevel::Warning, message.c_str());
   }
 
   inline static void info(const std::string& message) {
-    Log::put(Info, message.c_str());
+    Log::put(LogLevel::Info, message.c_str());
   }
 
   inline static void config(const std::string& message) {
-    Log::put(Config, message.c_str());
+    Log::put(LogLevel::Config, message.c_str());
   }
 
   inline static void fine(const std::string& message) {
-    Log::put(Fine, message.c_str());
+    Log::put(LogLevel::Fine, message.c_str());
   }
 
   inline static void finer(const std::string& message) {
-    Log::put(Finer, message.c_str());
+    Log::put(LogLevel::Finer, message.c_str());
   }
 
   inline static void finest(const std::string& message) {
-    Log::put(Finest, message.c_str());
+    Log::put(LogLevel::Finest, message.c_str());
   }
 };
 }  // namespace client

--- a/cppcache/src/util/functional.cpp
+++ b/cppcache/src/util/functional.cpp
@@ -15,31 +15,22 @@
  * limitations under the License.
  */
 
-#include <geode/Cache.hpp>
-#include <geode/CacheableKey.hpp>
+#include <string>
+#include <codecvt>
+#include <locale>
 
-#include "CacheableToken.hpp"
+#include <geode/util/functional.hpp>
+
+#include "string.hpp"
 
 namespace apache {
 namespace geode {
 namespace client {
 
-RegionEntry::RegionEntry(const std::shared_ptr<Region>& region,
-                         const std::shared_ptr<CacheableKey>& key,
-                         const std::shared_ptr<Cacheable>& value)
-    : m_region(region), m_key(key), m_value(value), m_destroyed(false) {}
-
-RegionEntry::~RegionEntry() {}
-std::shared_ptr<CacheableKey> RegionEntry::getKey() { return m_key; }
-std::shared_ptr<Cacheable> RegionEntry::getValue() {
-  return CacheableToken::isInvalid(m_value) ? nullptr : m_value;
+int32_t geode_hash<std::string>::operator()(const std::string& val) {
+  // TODO string optimize without conversion to UTF-16
+  return geode_hash<std::u16string>{}(to_utf16(val));
 }
-std::shared_ptr<Region> RegionEntry::getRegion() { return m_region; }
-std::shared_ptr<CacheStatistics> RegionEntry::getStatistics() {
-  return m_statistics;
-}
-
-bool RegionEntry::isDestroyed() const { return m_destroyed; }
 
 }  // namespace client
 }  // namespace geode

--- a/cppcache/test/CMakeLists.txt
+++ b/cppcache/test/CMakeLists.txt
@@ -28,6 +28,9 @@ target_link_libraries(${UNITTEST}
   boost
   c++11
 )
+target_include_directories(${UNITTEST} PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src>
+)
 
 enable_testing()
 

--- a/cppcache/test/CacheableStringEqualityTest.cpp
+++ b/cppcache/test/CacheableStringEqualityTest.cpp
@@ -22,8 +22,7 @@
 #include <unordered_map>
 
 #include <geode/CacheableString.hpp>
-
-#include "util/functional.hpp"
+#include <geode/util/functional.hpp>
 
 using namespace apache::geode::client;
 

--- a/cppcache/test/util/functionalTests.cpp
+++ b/cppcache/test/util/functionalTests.cpp
@@ -19,7 +19,7 @@
 
 #include <gtest/gtest.h>
 
-#include "util/functional.hpp"
+#include <geode/util/functional.hpp>
 
 using namespace apache::geode::client;
 

--- a/plugins/SQLiteCLI/SqLiteImpl.cs
+++ b/plugins/SQLiteCLI/SqLiteImpl.cs
@@ -57,7 +57,6 @@ namespace Apache.Geode.Plugins.SQLite
           pageSize = string.IsNullOrEmpty(diskProperties.Find(PageSize)) ? DefaultPageSize : diskProperties.Find(PageSize);
           maxPageCount = string.IsNullOrEmpty(diskProperties.Find(MaxPageCount)) ? DefaultMaxPageCount : diskProperties.Find(MaxPageCount);
         }
-        Log.Debug("InitalizeSqLite called with MaxPageCount:{0} PageSize:{1} PersistenceDir:{2}", maxPageCount, pageSize, persistenceDir);
 
         // create region db file
         m_persistenceDir = Path.Combine(Directory.GetCurrentDirectory(), persistenceDir);
@@ -67,12 +66,10 @@ namespace Apache.Geode.Plugins.SQLite
         //create sqlite connection string
         m_connectionString = string.Format("Data Source={0};Version=3;Page Size={1};Max Page Count={2};",
           Path.Combine(m_regionDir, m_tableName + ".db"), pageSize, maxPageCount);
-        Log.Debug("Created connection string : {0}", m_connectionString);
         SqliteHelper.InitalizeSqLite(m_tableName, m_connectionString);
       }
       catch (Exception ex)
       {
-        Log.Error("Exception in SqLiteImpl.Init: {0}", ex);
         throw;
       }
 
@@ -86,7 +83,6 @@ namespace Apache.Geode.Plugins.SQLite
       }
       catch (Exception ex)
       {
-        Log.Error("Exceptn in SqLiteImpl.Init: {0}", ex);
         throw;
       }
     }
@@ -99,7 +95,6 @@ namespace Apache.Geode.Plugins.SQLite
       }
       catch (Exception ex)
       {
-        Log.Error("Exceptn in SqLiteImpl.Init: {0}", ex);
         throw;
       }
     }
@@ -122,7 +117,6 @@ namespace Apache.Geode.Plugins.SQLite
       }
       catch (Exception ex)
       {
-        Log.Error("Exceptn in SqLiteImpl.Init: {0}", ex);
         throw;
       }
     }
@@ -137,7 +131,6 @@ namespace Apache.Geode.Plugins.SQLite
       }
       catch (Exception ex)
       {
-        Log.Error("Exceptn in SqLiteImpl.Init: {0}", ex);
       }
     }
 
@@ -189,11 +182,9 @@ namespace Apache.Geode.Plugins.SQLite
         conn.Open();
         using (SQLiteCommand command = new SQLiteCommand(query, conn))
         {
-          Log.Debug("Executing query:{0} ", command.CommandText);
           command.ExecuteNonQuery();
         }
       }
-      Log.Debug("Initialization Completed");
     }
 
     public static void ExecutePragma(string pragmaName, string pragmaValue, string connectionString)
@@ -204,7 +195,6 @@ namespace Apache.Geode.Plugins.SQLite
         conn.Open();
         using (SQLiteCommand command = new SQLiteCommand(pragmaQuery, conn))
         {
-          Log.Debug("Executing query:{0} ", command.CommandText);
           command.ExecuteNonQuery();
         }
       }
@@ -221,7 +211,6 @@ namespace Apache.Geode.Plugins.SQLite
         {
           command.Parameters.Add(new SQLiteParameter("@key", key));
           command.Parameters.Add(new SQLiteParameter("@value", GetBytes(value)));
-          Log.Debug("Executing query:{0} ", command.CommandText);
           command.ExecuteNonQuery();
         }
       }
@@ -239,7 +228,6 @@ namespace Apache.Geode.Plugins.SQLite
         {
           // create parameters and execute
           command.Parameters.Add(new SQLiteParameter("@key", key));
-          Log.Debug("Executing query:{0} ", command.CommandText);
           retValue = SqliteHelper.GetObject((byte[])command.ExecuteScalar());
         }
       }
@@ -257,7 +245,6 @@ namespace Apache.Geode.Plugins.SQLite
         {
           // create parameters and execute
           command.Parameters.Add(new SQLiteParameter("@key", key));
-          Log.Debug("Executing query:{0} ", command.CommandText);
           command.ExecuteNonQuery();
         }
       }

--- a/sqliteimpl/CMakeLists.txt
+++ b/sqliteimpl/CMakeLists.txt
@@ -12,13 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.4)
-project(sqliteimpl)
+
+project(SqLiteImpl)
 
 file(GLOB_RECURSE SOURCES "*.cpp")
 
-add_library(SqLiteImpl SHARED ${SOURCES})
-target_link_libraries(SqLiteImpl
+add_library(${PROJECT_NAME} SHARED ${SOURCES})
+target_link_libraries(${PROJECT_NAME}
   PUBLIC
     apache-geode
     sqlite

--- a/sqliteimpl/SqLiteHelper.cpp
+++ b/sqliteimpl/SqLiteHelper.cpp
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "SqLiteHelper.hpp"
+
 #define QUERY_SIZE 512
+
 int SqLiteHelper::initDB(const char *regionName, int maxPageCount, int pageSize,
                          const char *regionDBfile, int busy_timeout_ms) {
-  LOGDEBUG(
-      "SqLiteHelper::initDB Initializing SqLite with region name:%s, max page "
-      "count : %d, page size:%d and region db file :%s",
-      regionName, maxPageCount, pageSize, regionDBfile);
+
   // open the database
   int retCode = sqlite3_open(regionDBfile, &m_dbHandle);
   if (retCode == SQLITE_OK) {
@@ -53,8 +53,6 @@ int SqLiteHelper::createTable() {
            m_tableName);
   sqlite3_stmt *stmt;
 
-  LOGDEBUG("SqLiteHelper::createTable Creating table with query:%s", query);
-
   // prepare statement
   int retCode;
   retCode = sqlite3_prepare_v2(m_dbHandle, query, -1, &stmt, 0);
@@ -70,9 +68,6 @@ int SqLiteHelper::insertKeyValue(void *keyData, uint32_t keyDataSize,
   // construct query
   char query[QUERY_SIZE];
   SNPRINTF(query, QUERY_SIZE, "REPLACE INTO %s VALUES(?,?);", m_tableName);
-
-  LOGDEBUG("SqLiteHelper::insertKeyValue Inserting key value with query:%s",
-           query);
 
   // prepare statement
   sqlite3_stmt *stmt;
@@ -92,8 +87,6 @@ int SqLiteHelper::removeKey(void *keyData, uint32_t keyDataSize) {
   // construct query
   char query[QUERY_SIZE];
   SNPRINTF(query, QUERY_SIZE, "DELETE FROM %s WHERE key=?;", m_tableName);
-
-  LOGDEBUG("SqLiteHelper::removeKey Removing key with query:%s", query);
 
   // prepare statement
   sqlite3_stmt *stmt;
@@ -115,8 +108,6 @@ int SqLiteHelper::getValue(void *keyData, uint32_t keyDataSize,
   SNPRINTF(query, QUERY_SIZE,
            "SELECT value, length(value) AS valLength FROM %s WHERE key=?;",
            m_tableName);
-
-  LOGDEBUG("SqLiteHelper::getValue Getting value with query:%s", query);
 
   // prepare statement
   sqlite3_stmt *stmt;
@@ -145,7 +136,6 @@ int SqLiteHelper::dropTable() {
   char query[QUERY_SIZE];
   SNPRINTF(query, QUERY_SIZE, "DROP TABLE %s;", m_tableName);
 
-  LOGDEBUG("SqLiteHelper::dropTable Dropping table with query:%s", query);
   // prepare statement
   sqlite3_stmt *stmt;
   int retCode;
@@ -159,8 +149,6 @@ int SqLiteHelper::dropTable() {
 }
 
 int SqLiteHelper::closeDB() {
-  LOGDEBUG("SqLiteHelper::closeDB closing the database for region %s",
-           m_tableName);
   int retCode = dropTable();
   if (retCode == SQLITE_OK) retCode = sqlite3_close(m_dbHandle);
 
@@ -173,8 +161,6 @@ int SqLiteHelper::executePragma(const char *pragmaName, int pragmaValue) {
   char strVal[50];
   SNPRINTF(strVal, 50, "%d", pragmaValue);
   SNPRINTF(query, QUERY_SIZE, "PRAGMA %s = %s;", pragmaName, strVal);
-
-  LOGDEBUG("SqLiteHelper::executePragma Executing pragma query:%s", query);
 
   // prepare statement
   sqlite3_stmt *stmt;

--- a/sqliteimpl/SqLiteImpl.cpp
+++ b/sqliteimpl/SqLiteImpl.cpp
@@ -84,12 +84,7 @@ void SqLiteImpl::init(const std::shared_ptr<Region>& region,
     m_persistanceDir = std::string(currWDPath) + "/" + m_persistanceDir;
   }
 
-  LOGINFO("SqLiteImpl::init absolute path for persistence directory: %s",
-          m_persistanceDir.c_str());
-
   // Create persistence directory
-  LOGFINE("SqLiteImpl::init creating persistence directory: %s",
-          m_persistanceDir.c_str());
   CreateDirectory(m_persistanceDir.c_str(), NULL);
 
   // Create region directory
@@ -97,8 +92,6 @@ void SqLiteImpl::init(const std::shared_ptr<Region>& region,
   CreateDirectory(regionDirectory.c_str(), NULL);
   m_regionDBFile = regionDirectory + "/" + regionName + ".db";
 
-  LOGFINE("SqLiteImpl::init creating persistence region file: %s",
-          m_regionDBFile.c_str());
 #endif
 
   if (m_sqliteHelper->initDB(region->getName().c_str(), maxPageCount, pageSize,

--- a/sqliteimpl/SqLiteImpl.cpp
+++ b/sqliteimpl/SqLiteImpl.cpp
@@ -14,10 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <geode/Region.hpp>
 #include <geode/Cache.hpp>
 
 #include "SqLiteImpl.hpp"
+
 #ifdef _WIN32
 #include <Windows.h>
 #endif
@@ -64,16 +66,12 @@ void SqLiteImpl::init(const std::shared_ptr<Region>& region,
   }
 
   // Create persistence directory
-  LOGFINE("SqLiteImpl::init creating persistence directory: %s",
-          m_persistanceDir.c_str());
   ::mkdir(m_persistanceDir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 
   // Create region directory
   std::string regionDirectory = m_persistanceDir + "/" + regionName;
   ::mkdir(regionDirectory.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
   m_regionDBFile = regionDirectory + "/" + regionName + ".db";
-  LOGFINE("SqLiteImpl::init creating persistence region file: %s",
-          m_regionDBFile.c_str());
 
 #else
   char currWDPath[512];

--- a/sqliteimpl/SqLiteImpl.hpp
+++ b/sqliteimpl/SqLiteImpl.hpp
@@ -120,7 +120,7 @@ class SqLiteImpl : public PersistenceManager {
   /**
    * @brief destructor
    */
-  ~SqLiteImpl() { LOGDEBUG("SqLiteImpl::~SqLiteImpl calling  ~SqLiteImpl"); }
+  ~SqLiteImpl() {}
 
   /**
    * @brief constructor

--- a/templates/security/PkcsAuthInit.cpp
+++ b/templates/security/PkcsAuthInit.cpp
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "SerializationRegistry.hpp"
+
 #include "PkcsAuthInit.hpp"
 #include "geode/Properties.hpp"
 #include "geode/CacheableBuiltins.hpp"

--- a/templates/security/UserPasswordAuthInit.cpp
+++ b/templates/security/UserPasswordAuthInit.cpp
@@ -18,7 +18,6 @@
 #include "UserPasswordAuthInit.hpp"
 #include "geode/Properties.hpp"
 #include "geode/ExceptionTypes.hpp"
-#include "util/Log.hpp"
 
 #define SECURITY_USERNAME "security-username"
 #define SECURITY_PASSWORD "security-password"

--- a/tests/cli/NewFwkLib/FwkTest.cs
+++ b/tests/cli/NewFwkLib/FwkTest.cs
@@ -1335,8 +1335,6 @@ namespace Apache.Geode.Client.FwkLib
             FwkInfo("Region attributes for {0}: {1}", rootRegionName,
               CacheHelper<TKey, TVal>.RegionAttributesToString(regAttr));
           }
-          Log.Info("<ExpectedException action=add>NotAuthorizedException" +
-            "</ExpectedException>");
           return region;
         }
       }

--- a/tests/cpp/fwk/CMakeLists.txt
+++ b/tests/cpp/fwk/CMakeLists.txt
@@ -27,6 +27,9 @@ target_link_libraries(fwk
     framework
     c++11
 )
+target_include_directories(fwk PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/cppcache/src>
+)
 
 #TODO very bad we include root of tests
 include_directories(${CMAKE_SOURCE_DIR}/tests/cpp)

--- a/tests/cpp/fwklib/CMakeLists.txt
+++ b/tests/cpp/fwklib/CMakeLists.txt
@@ -27,6 +27,9 @@ target_link_libraries(framework
     apache-geode
     xerces-c
 )
+target_include_directories(framework PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/cppcache/src>
+)
 
 # Add PIC flags to link later with shared library
 add_definitions(${CMAKE_CXX_COMPILE_OPTIONS_PIC})

--- a/tests/cpp/security/CMakeLists.txt
+++ b/tests/cpp/security/CMakeLists.txt
@@ -31,5 +31,9 @@ target_link_libraries(security
 
 set_target_properties(security PROPERTIES FOLDER test)
 
+target_include_directories(security PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/cppcache/src>
+)
+
 # TODO fix includes
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/tests/cpp/security/PkcsAuthInit.cpp
+++ b/tests/cpp/security/PkcsAuthInit.cpp
@@ -14,13 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "SerializationRegistry.hpp"
-#include "PkcsAuthInit.hpp"
+
+#include <cstdio>
+#include <string>
+
 #include <geode/Properties.hpp>
 #include <geode/CacheableBuiltins.hpp>
 #include <geode/ExceptionTypes.hpp>
-#include <cstdio>
-#include <string>
+
+#include <util/Log.hpp>
+
+#include "SerializationRegistry.hpp"
+#include "PkcsAuthInit.hpp"
 
 namespace apache {
 namespace geode {

--- a/tests/cpp/testobject/CMakeLists.txt
+++ b/tests/cpp/testobject/CMakeLists.txt
@@ -38,6 +38,9 @@ target_link_libraries(testobject
   PRIVATE
     ACE
 )
+target_include_directories(testobject PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/cppcache/src>
+)
 
 
 #TODO very bad we include root of tests

--- a/tests/cpp/testobject/InvalidPdxUsage.hpp
+++ b/tests/cpp/testobject/InvalidPdxUsage.hpp
@@ -31,6 +31,7 @@
 #include <geode/CacheableObjectArray.hpp>
 #include <geode/PdxWriter.hpp>
 #include <geode/PdxReader.hpp>
+#include <util/Log.hpp>
 
 #ifdef _WIN32
 #ifdef BUILD_TESTOBJECT

--- a/tests/cpp/testobject/NestedPdxObject.hpp
+++ b/tests/cpp/testobject/NestedPdxObject.hpp
@@ -28,6 +28,7 @@
 #include <geode/CacheableEnum.hpp>
 #include <geode/PdxWriter.hpp>
 #include <geode/PdxReader.hpp>
+#include <util/Log.hpp>
 
 #ifdef _WIN32
 #ifdef BUILD_TESTOBJECT

--- a/tests/cpp/testobject/NonPdxType.hpp
+++ b/tests/cpp/testobject/NonPdxType.hpp
@@ -30,6 +30,8 @@
 #include <geode/CacheableEnum.hpp>
 #include <geode/CacheableObjectArray.hpp>
 #include <geode/PdxWrapper.hpp>
+#include <util/Log.hpp>
+
 #ifdef _WIN32
 #ifdef BUILD_TESTOBJECT
 #define TESTOBJECT_EXPORT LIBEXP

--- a/tests/cpp/testobject/NoopAuthInit.cpp
+++ b/tests/cpp/testobject/NoopAuthInit.cpp
@@ -18,7 +18,7 @@
 #include "NoopAuthInit.hpp"
 #include "geode/Properties.hpp"
 #include "geode/ExceptionTypes.hpp"
-#include "util/Log.hpp"
+#include <util/Log.hpp>
 
 namespace apache {
 namespace geode {

--- a/tests/cpp/testobject/PdxClassV1.hpp
+++ b/tests/cpp/testobject/PdxClassV1.hpp
@@ -30,6 +30,9 @@
 #include <geode/PdxWriter.hpp>
 #include <geode/PdxReader.hpp>
 #include <geode/PdxSerializer.hpp>
+#include <util/Log.hpp>
+#include <util/Log.hpp>
+
 #ifdef _WIN32
 #ifdef BUILD_TESTOBJECT
 #define TESTOBJECT_EXPORT LIBEXP

--- a/tests/cpp/testobject/PdxClassV2.hpp
+++ b/tests/cpp/testobject/PdxClassV2.hpp
@@ -30,6 +30,8 @@
 #include <geode/PdxSerializer.hpp>
 #include <geode/PdxWriter.hpp>
 #include <geode/PdxReader.hpp>
+#include <util/Log.hpp>
+#include <util/Log.hpp>
 
 #ifdef _WIN32
 #ifdef BUILD_TESTOBJECT

--- a/tests/cpp/testobject/PdxType.hpp
+++ b/tests/cpp/testobject/PdxType.hpp
@@ -31,6 +31,7 @@
 #include <geode/PdxWriter.hpp>
 #include <geode/PdxReader.hpp>
 #include <geode/CacheableObjectArray.hpp>
+#include <util/Log.hpp>
 
 #ifdef _WIN32
 #ifdef BUILD_TESTOBJECT

--- a/tests/cpp/testobject/PdxVersioned1.cpp
+++ b/tests/cpp/testobject/PdxVersioned1.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "PdxVersioned1.hpp"
+#include <util/Log.hpp>
 
 using namespace apache::geode::client;
 using namespace PdxTests;

--- a/tests/cpp/testobject/PdxVersioned2.cpp
+++ b/tests/cpp/testobject/PdxVersioned2.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "PdxVersioned2.hpp"
+#include <util/Log.hpp>
 
 using namespace apache::geode::client;
 using namespace PdxTests;

--- a/tests/cpp/testobject/Portfolio.hpp
+++ b/tests/cpp/testobject/Portfolio.hpp
@@ -27,6 +27,7 @@
 #include <geode/CacheableBuiltins.hpp>
 #include <geode/CacheableDate.hpp>
 #include "Position.hpp"
+#include <util/Log.hpp>
 
 using namespace apache::geode::client;
 

--- a/tests/cpp/testobject/PortfolioPdx.cpp
+++ b/tests/cpp/testobject/PortfolioPdx.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "PortfolioPdx.hpp"
+#include <util/Log.hpp>
 
 using namespace apache::geode::client;
 using namespace testobject;

--- a/tests/cpp/testobject/VariousPdxTypes.cpp
+++ b/tests/cpp/testobject/VariousPdxTypes.cpp
@@ -23,6 +23,8 @@
 
 #include "VariousPdxTypes.hpp"
 #include <geode/CacheableEnum.hpp>
+#include <util/Log.hpp>
+
 namespace PdxTests {
 
 /************************************************************


### PR DESCRIPTION
I found that early on we had mixed up the include paths in the CMake project so we were able to include private headers from the public headers. This will cause anyone trying to build a client to have a frustrating time since public won't be able to find private headers. I found this while experimenting with include what you use. The results here are a correction in the includes and forward declarations on the public headers and minimal include changes on the internal side. A more extensive include what you use run will need to be done on the internal sources later. 