### PR TITLE
 GEODE-4071: Stabilizes CLI integration tests, ThinClientFunctionExecutionTestsN

### DIFF
--- a/clicache/integration-test/CacheHelperN.cs
+++ b/clicache/integration-test/CacheHelperN.cs
@@ -2168,7 +2168,14 @@ namespace Apache.Geode.Client.UnitTests
         outSr.Close();
         if (!started)
         {
-          javaProc.Kill();
+          try
+          {
+            javaProc.Kill();
+          }
+          catch
+          {
+            //ignore
+          }
         }
         Assert.IsTrue(started, "Timed out waiting for " +
           "Java cacheserver to start.{0}Please check the server logs.",
@@ -2224,7 +2231,14 @@ namespace Apache.Geode.Client.UnitTests
           outSr.Close();
           if (!stopped)
           {
-            javaStopProc.Kill();
+            try
+            {
+              javaStopProc.Kill();
+            }
+            catch
+            {
+              //ignore
+            }
           }
           if (ssl)
           {
@@ -2279,7 +2293,14 @@ namespace Apache.Geode.Client.UnitTests
           outSr.Close();
           if (!stopped)
           {
-            javaStopProc.Kill();
+            try
+            {
+              javaStopProc.Kill();
+            }
+            catch
+            {
+              //ignore
+            }
           }
           Assert.IsTrue(stopped, "Timed out waiting for " +
             "Java cacheserver to stop.{0}Please check the server logs.",
@@ -2354,8 +2375,15 @@ namespace Apache.Geode.Client.UnitTests
           {
             Util.Log("Killing geode process with id {0}", processId);
             Process proc = Process.GetProcessById(processId);
-            proc.Kill();
-            proc.WaitForExit();
+            try
+            {
+              proc.Kill();
+            }
+            catch
+            {
+              //ignore
+            }
+            proc.WaitForExit(MaxWaitMillis);
           }
           else
           {

--- a/clicache/integration-test/ThinClientFunctionExecutionTestsN.cs
+++ b/clicache/integration-test/ThinClientFunctionExecutionTestsN.cs
@@ -1814,6 +1814,11 @@ namespace Apache.Geode.Client.UnitTests
     public void ExecuteFunctionOnRegionMultiFilterKey()
     {
       runExecuteFunctionOnRegionMultiFilterKey(false);
+    }
+
+    [Test]
+    public void ExecuteFunctionOnRegionMultiFilterKeySingleHop()
+    {
       runExecuteFunctionOnRegionMultiFilterKey(true);
     }
 
@@ -1821,6 +1826,11 @@ namespace Apache.Geode.Client.UnitTests
     public void ExecuteFunctionTimeOut()
     {
       runExecuteFunctionTimeOut(false);
+    }
+
+    [Test]
+    public void ExecuteFunctionTimeOutSingleHop()
+    {
       runExecuteFunctionTimeOut(true);
     }
 
@@ -1833,8 +1843,13 @@ namespace Apache.Geode.Client.UnitTests
     [Test]
     public void TestFEOnRegionTransaction()
     {
-      runFEOnRegionTx(true);
       runFEOnRegionTx(false);
+    }
+    
+    [Test]
+    public void TestFEOnRegionTransactionSingleHop()
+    {
+      runFEOnRegionTx(true);
     }
   }
 }

--- a/clicache/src/Cache.cpp
+++ b/clicache/src/Cache.cpp
@@ -116,8 +116,6 @@ namespace Apache
       {
         _GF_MG_EXCEPTION_TRY2
 
-          Apache::Geode::Client::DistributedSystem::acquireDisconnectLock();
-
           m_nativeptr->get()->close( keepalive );
           Apache::Geode::Client::DistributedSystem::UnregisterBuiltinManagedTypes(this);
 
@@ -126,7 +124,6 @@ namespace Apache
         {
 					CacheRegionHelper::getCacheImpl(m_nativeptr->get())->getPdxTypeRegistry()->clear();
           Serializable::Clear();
-          Apache::Geode::Client::DistributedSystem::releaseDisconnectLock();
           Apache::Geode::Client::DistributedSystem::unregisterCliCallback();
           GC::KeepAlive(m_nativeptr);
         }

--- a/clicache/src/CacheFactory.cpp
+++ b/clicache/src/CacheFactory.cpp
@@ -62,7 +62,6 @@ namespace Apache
         bool pdxReadSerialized = false;
         _GF_MG_EXCEPTION_TRY2
           //msclr::lock lockInstance(m_singletonSync);
-          DistributedSystem::acquireDisconnectLock();
           auto nativeCache = std::make_shared<native::Cache>(m_nativeptr->get()->create( ));
 
           auto cache = Cache::Create( nativeCache );
@@ -88,7 +87,6 @@ namespace Apache
         _GF_MG_EXCEPTION_CATCH_ALL2
         finally {
           GC::KeepAlive(m_nativeptr);
-           DistributedSystem::releaseDisconnectLock();
         }
       }
    

--- a/clicache/src/DistributedSystem.cpp
+++ b/clicache/src/DistributedSystem.cpp
@@ -133,8 +133,6 @@ namespace Apache
       DistributedSystem^ DistributedSystem::Connect(String^ name, Properties<String^, String^>^ config, Cache ^ cache)
       {
         // TODO AppDomain should we be able to create a DS directly?
-        native::DistributedSystemImpl::acquireDisconnectLock();
-
         _GF_MG_EXCEPTION_TRY2
 
         auto nativeptr = native::DistributedSystem::create(marshal_as<std::string>(name),
@@ -146,16 +144,10 @@ namespace Apache
         return gcnew DistributedSystem(std::move(nativeptr));
 
         _GF_MG_EXCEPTION_CATCH_ALL2
-
-          finally {
-          native::DistributedSystemImpl::releaseDisconnectLock();
-        }
       }
 
       void DistributedSystem::Disconnect(Cache^ cache)
       {
-        native::DistributedSystemImpl::acquireDisconnectLock();
-
         _GF_MG_EXCEPTION_TRY2
 
 
@@ -165,10 +157,6 @@ namespace Apache
         GC::KeepAlive(m_nativeptr);
 
         _GF_MG_EXCEPTION_CATCH_ALL2
-
-          finally {
-          native::DistributedSystemImpl::releaseDisconnectLock();
-        }
       }
 
       void DistributedSystem::AppDomainInstanceInitialization(Cache^ cache)
@@ -418,8 +406,6 @@ namespace Apache
       {
         _GF_MG_EXCEPTION_TRY2
 
-          native::DistributedSystemImpl::acquireDisconnectLock();
-
           Serializable::UnregisterNativesGeneric();
 
           Serializable::UnregisterTypeGeneric(
@@ -446,10 +432,6 @@ namespace Apache
             GeodeClassIds::CacheableManagedObjectXml - 0x80000000, cache);
 
         _GF_MG_EXCEPTION_CATCH_ALL2
-
-          finally {
-          native::DistributedSystemImpl::releaseDisconnectLock();
-        }
       }
 
       Apache::Geode::Client::SystemProperties^ DistributedSystem::SystemProperties::get()
@@ -501,16 +483,6 @@ namespace Apache
       DistributedSystem::~DistributedSystem()
       {
         m_memoryPressureHandler->Dispose(nullptr);
-      }
-
-      void DistributedSystem::acquireDisconnectLock()
-      {
-        native::DistributedSystemImpl::acquireDisconnectLock();
-      }
-
-      void DistributedSystem::releaseDisconnectLock()
-      {
-        native::DistributedSystemImpl::releaseDisconnectLock();
       }
 
       void DistributedSystem::registerCliCallback()

--- a/clicache/src/DistributedSystem.hpp
+++ b/clicache/src/DistributedSystem.hpp
@@ -124,10 +124,6 @@ namespace Apache
 
         DistributedSystem(std::unique_ptr<native::DistributedSystem> nativeptr);
 
-        static void acquireDisconnectLock();
-
-        static void releaseDisconnectLock();
-
         delegate void cliCallback(apache::geode::client::Cache& cache);
 
         static void registerCliCallback();

--- a/cppcache/src/Cache.cpp
+++ b/cppcache/src/Cache.cpp
@@ -37,8 +37,6 @@ namespace apache {
 namespace geode {
 namespace client {
 
-extern ACE_Recursive_Thread_Mutex* g_disconnectLock;
-
 /** Returns the name of this cache.
  * This method does not throw
  * <code>CacheClosedException</code> if the cache is closed.
@@ -76,7 +74,6 @@ void Cache::close() { close(false); }
  * @throws CacheClosedException,  if the cache is already closed.
  */
 void Cache::close(bool keepalive) {
-  ACE_Guard<ACE_Recursive_Thread_Mutex> connectGuard(*g_disconnectLock);
   m_cacheImpl->close(keepalive);
 
   try {

--- a/cppcache/src/CacheFactory.cpp
+++ b/cppcache/src/CacheFactory.cpp
@@ -48,8 +48,6 @@ namespace apache {
 namespace geode {
 namespace client {
 
-extern ACE_Recursive_Thread_Mutex* g_disconnectLock;
-
 std::shared_ptr<CacheFactory> CacheFactory::createCacheFactory(
     const std::shared_ptr<Properties>& configPtr) {
   return std::make_shared<CacheFactory>(configPtr);
@@ -77,8 +75,6 @@ CacheFactory::CacheFactory(const std::shared_ptr<Properties> dsProps) {
 }
 
 Cache CacheFactory::create() const {
-  ACE_Guard<ACE_Recursive_Thread_Mutex> connectGuard(*g_disconnectLock);
-
   LOGFINE("CacheFactory called DistributedSystem::connect");
   auto cache = create(DEFAULT_CACHE_NAME, nullptr);
 
@@ -116,8 +112,6 @@ Cache CacheFactory::create() const {
 Cache CacheFactory::create(
     std::string name,
     const std::shared_ptr<CacheAttributes>& attrs /*= nullptr*/) const {
-  ACE_Guard<ACE_Recursive_Thread_Mutex> connectGuard(*g_disconnectLock);
-
   auto cache = Cache(std::move(name), dsProp, ignorePdxUnreadFields,
                      pdxReadSerialized, authInitialize);
   cache.m_cacheImpl->setAttributes(attrs);

--- a/cppcache/src/DistributedSystem.cpp
+++ b/cppcache/src/DistributedSystem.cpp
@@ -47,8 +47,6 @@ namespace client {
 
 using namespace apache::geode::statistics;
 
-ACE_Recursive_Thread_Mutex* g_disconnectLock = new ACE_Recursive_Thread_Mutex();
-
 DistributedSystem::DistributedSystem(
     const std::string& name,
     std::unique_ptr<SystemProperties> sysProps)
@@ -157,7 +155,6 @@ std::unique_ptr<DistributedSystem> DistributedSystem::create(
 }
 
 void DistributedSystem::connect(Cache* cache) {
-  ACE_Guard<ACE_Recursive_Thread_Mutex> disconnectGuard(*g_disconnectLock);
   if (m_connected == true) {
     throw AlreadyConnectedException(
         "DistributedSystem::connect: already connected, call getInstance to "
@@ -204,8 +201,6 @@ void DistributedSystem::connect(Cache* cache) {
 }
 
 void DistributedSystem::disconnect() {
-  ACE_Guard<ACE_Recursive_Thread_Mutex> disconnectGuard(*g_disconnectLock);
-
   if (!m_connected) {
     throw NotConnectedException(
         "DistributedSystem::disconnect: connect "

--- a/cppcache/src/DistributedSystemImpl.cpp
+++ b/cppcache/src/DistributedSystemImpl.cpp
@@ -24,9 +24,6 @@ namespace apache {
 namespace geode {
 namespace client {
 
-// guard for connect/disconnect
-extern ACE_Recursive_Thread_Mutex* g_disconnectLock;
-
 volatile bool DistributedSystemImpl::m_isCliCallbackSet = false;
 std::map<int, CliCallbackMethod> DistributedSystemImpl::m_cliCallbackMap;
 ACE_Recursive_Thread_Mutex DistributedSystemImpl::m_cliCallbackLock;
@@ -50,14 +47,6 @@ void DistributedSystemImpl::connect() {}
 
 void DistributedSystemImpl::disconnect() {
   LOGFINE("DistributedSystemImpl::disconnect done");
-}
-
-void DistributedSystemImpl::acquireDisconnectLock() {
-  g_disconnectLock->acquire();
-}
-
-void DistributedSystemImpl::releaseDisconnectLock() {
-  g_disconnectLock->release();
 }
 
 void DistributedSystemImpl::CallCliCallBack(Cache& cache) {

--- a/cppcache/src/DistributedSystemImpl.hpp
+++ b/cppcache/src/DistributedSystemImpl.hpp
@@ -95,10 +95,6 @@ class CPPCACHE_EXPORT DistributedSystemImpl {
 
   // acquire/release locks
 
-  static void acquireDisconnectLock();
-
-  static void releaseDisconnectLock();
-
   static void registerCliCallback(int appdomainId,
                                   CliCallbackMethod clicallback);
 

--- a/cppcache/src/MapEntry.cpp
+++ b/cppcache/src/MapEntry.cpp
@@ -21,8 +21,6 @@
 namespace apache {
 namespace geode {
 namespace client {
-std::shared_ptr<MapEntry> MapEntry::MapEntry_NullPointer(nullptr);
-
 void EntryFactory::newMapEntry(ExpiryTaskManager* expiryTaskManager,
                                const std::shared_ptr<CacheableKey>& key,
                                std::shared_ptr<MapEntryImpl>& result) const {

--- a/cppcache/src/MapEntry.hpp
+++ b/cppcache/src/MapEntry.hpp
@@ -111,8 +111,6 @@ class CPPCACHE_EXPORT ExpEntryProperties {
  */
 class CPPCACHE_EXPORT MapEntry {
  public:
-  static std::shared_ptr<MapEntry> MapEntry_NullPointer;
-
   virtual ~MapEntry() {}
 
   virtual void getKey(std::shared_ptr<CacheableKey>& result) const = 0;

--- a/cppcache/src/RegionFactory.cpp
+++ b/cppcache/src/RegionFactory.cpp
@@ -36,8 +36,6 @@ namespace apache {
 namespace geode {
 namespace client {
 
-extern ACE_Recursive_Thread_Mutex* g_disconnectLock;
-
 RegionFactory::RegionFactory(RegionShortcut preDefinedRegion,
                              CacheImpl* cacheImpl)
     : m_preDefinedRegion(preDefinedRegion),

--- a/cppcache/src/statistics/HostStatHelper.cpp
+++ b/cppcache/src/statistics/HostStatHelper.cpp
@@ -58,16 +58,12 @@ void HostStatHelper::initOSCode() {
 
 void HostStatHelper::refresh() {
   if (processStats != nullptr) {
-#if defined(_WIN32)
-    HostStatHelperWin::refreshProcess(processStats);
-#elif defined(_SOLARIS)
+#if defined(_SOLARIS)
     HostStatHelperSolaris::refreshProcess(processStats);
 #elif defined(_LINUX)
     HostStatHelperLinux::refreshProcess(processStats);
-#elif defined(_MACOSX)
-    HostStatHelperNull::refreshProcess(processStats);
 #else
-#error missing stats helper
+    HostStatHelperNull::refreshProcess(processStats);
 #endif
   }
 }
@@ -105,9 +101,6 @@ void HostStatHelper::close() {
 }
 
 void HostStatHelper::cleanup() {
-#if defined(_WIN32)
-  HostStatHelperWin::closeHostStatHelperWin();  // close registry structures
-#endif
 #if defined(_SOLARIS)
   HostStatHelperSolaris::closeHostStatHelperSolaris();  // close kstats
 #endif


### PR DESCRIPTION
There are a couple of seemingly unrelated issues here but they relate. The unused code was just unused code and cleaning up make sense. The static lock around DS was left over form the app domain refcounting and since this test was creating and destroying lots of caches it made sense to eliminate it as a cause. Ultimately it came down to this test being long running and the windows stats collector being very buggy. Eventually the stats collector would cause a segfault and the test would either hang or fail.