### PR TITLE
GEODE-2407: Update native docs with product name that’s consistent wi…

### DIFF
--- a/docs/geode-native-book/config.yml
+++ b/docs/geode-native-book/config.yml
@@ -30,15 +30,15 @@ template_variables:
   product_version: 1.3
   support_url: http://geode.apache.org/community
   product_url: http://geode.apache.org
-  book_title: Apache Geode Client Documentation
+  book_title: Apache Geode Native Documentation
   book_header_img: /images/Apache_Geode_logo_symbol_white.png
   support_link: <a href="http://geode.apache.org/community" target="_blank">Community</a>
   support_call_to_action: <a href="http://geode.apache.org/community" target="_blank">Need Help?</a>
   changelog_href: https://cwiki.apache.org/confluence/display/GEODE/Release+Notes
   product_link: <div class="header-item"><a href="http://geode.apache.org">Back to Product Page</a></div>
   domain_name: apache.org
-  book_title_short: Geode Client Docs
-  local_header_title: Apache Geode Client
+  book_title_short: Geode Native Docs
+  local_header_title: Apache Geode Native
   local_header_img: /images/Apache_Geode_logo_symbol.png
 
 broken_link_exclusions: iefix|using_custom_classes|arrowhead|cppdocs|dotnetdocs|#

--- a/docs/geode-native-book/master_middleman/source/subnavs/geode-nc-nav.erb
+++ b/docs/geode-native-book/master_middleman/source/subnavs/geode-nc-nav.erb
@@ -20,7 +20,7 @@ limitations under the License.
     <div class="nav-content">
         <ul>
             <li>
-                <a href="/docs/guide-native/11/about-client-users-guide.html">Apache Geode Client Documentation</a>
+                <a href="/docs/guide-native/11/about-client-users-guide.html">Apache Geode Native Documentation</a>
             </li>
         </ul>
         <ul>

--- a/docs/geode-native-docs/about-client-users-guide.html.md.erb
+++ b/docs/geode-native-docs/about-client-users-guide.html.md.erb
@@ -1,4 +1,4 @@
-<% set_title(product_name_long, "Client", product_version, "Documentation") %>
+<% set_title(product_name_long, "Native", product_version, "Documentation") %>
 
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more


### PR DESCRIPTION
…th repo name

"Geode Native Client" should be "Geode Native".
This applies only to text that directly references the Apache project name or repo. Other occurrences can remain as-is.