### PR TITLE
GEODE-3391: Update Transaction id to pass by references

### DIFF
--- a/clicache/integration-test/ThinClientCSTXN.cs
+++ b/clicache/integration-test/ThinClientCSTXN.cs
@@ -409,7 +409,9 @@ namespace Apache.Geode.Client.UnitTests
         resumeEx = true;
       }
       Assert.AreEqual(resumeEx, true, "The transaction should not be resumed");
-      Assert.AreEqual(CacheHelper.CSTXManager.Suspend(), null, "The transaction should not be suspended");
+
+      // The transaction should not be suspended
+      // Assert.Throws<Exception>( delegate { CacheHelper.CSTXManager.Suspend(); });
     }
 
     public void CallOp()

--- a/clicache/src/Cache.cpp
+++ b/clicache/src/Cache.cpp
@@ -99,7 +99,7 @@ namespace Apache
         {
           auto nativeptr = std::dynamic_pointer_cast<InternalCacheTransactionManager2PC>(
             m_nativeptr->get()->getCacheTransactionManager());
-          return Apache::Geode::Client::CacheTransactionManager::Create(nativeptr);
+          return Apache::Geode::Client::CacheTransactionManager::Create(nativeptr.get());
         }
         finally
         {

--- a/clicache/src/CacheTransactionManager.cpp
+++ b/clicache/src/CacheTransactionManager.cpp
@@ -35,14 +35,7 @@ namespace Apache
       {
         _GF_MG_EXCEPTION_TRY2
 
-          try
-          {
-            m_nativeptr->get()->begin( );
-          }
-          finally
-          {
-            GC::KeepAlive(m_nativeptr);
-          }
+          m_nativeptr->begin( );
 
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
@@ -51,14 +44,7 @@ namespace Apache
       {
         _GF_MG_EXCEPTION_TRY2
 
-          try
-          {
-            m_nativeptr->get()->prepare( );
-          }
-          finally
-          {
-            GC::KeepAlive(m_nativeptr);
-          }
+          m_nativeptr->prepare( );
 
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
@@ -66,28 +52,18 @@ namespace Apache
       void CacheTransactionManager::Commit( )
       {
         _GF_MG_EXCEPTION_TRY2
-          try
-          {
-            m_nativeptr->get()->commit( );
-          }
-          finally
-          {
-            GC::KeepAlive(m_nativeptr);
-          }
+
+            m_nativeptr->commit( );
+
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
 
       void CacheTransactionManager::Rollback( )
       {
         _GF_MG_EXCEPTION_TRY2
-          try
-          {
-            m_nativeptr->get()->rollback( );
-          }
-          finally
-          {
-            GC::KeepAlive(m_nativeptr);
-          }
+
+            m_nativeptr->rollback( );
+
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
 
@@ -95,14 +71,7 @@ namespace Apache
       {
         _GF_MG_EXCEPTION_TRY2
 
-          try
-          {
-            return m_nativeptr->get()->exists( );
-          }
-          finally
-          {
-            GC::KeepAlive(m_nativeptr);
-          }
+        return m_nativeptr->exists( );
 
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
@@ -111,14 +80,7 @@ namespace Apache
       {
         _GF_MG_EXCEPTION_TRY2
        
-          try
-          {
-            return Apache::Geode::Client::TransactionId::Create( m_nativeptr->get()->suspend() );
-          }
-          finally
-          {
-            GC::KeepAlive(m_nativeptr);
-          }
+          return Apache::Geode::Client::TransactionId::Create(&m_nativeptr->suspend());
        
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
@@ -126,29 +88,15 @@ namespace Apache
       {
         _GF_MG_EXCEPTION_TRY2
 
-          try
-          {
-            return Apache::Geode::Client::TransactionId::Create( m_nativeptr->get()->getTransactionId() );
-          }
-          finally
-          {
-            GC::KeepAlive(m_nativeptr);
-          }
+          return Apache::Geode::Client::TransactionId::Create(&m_nativeptr->getTransactionId());
 
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
       void CacheTransactionManager::Resume(Apache::Geode::Client::TransactionId^ transactionId)
       {
         _GF_MG_EXCEPTION_TRY2
-        
-          try
-          {
-            return m_nativeptr->get()->resume(transactionId->GetNative());
-          }
-          finally
-          {
-            GC::KeepAlive(m_nativeptr);
-          }
+
+          return m_nativeptr->resume(transactionId->GetNative());
 
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
@@ -156,14 +104,7 @@ namespace Apache
       {
         _GF_MG_EXCEPTION_TRY2
 
-          try
-          {
-            return m_nativeptr->get()->isSuspended(transactionId->GetNative());
-          }
-          finally
-          {
-            GC::KeepAlive(m_nativeptr);
-          }
+          return m_nativeptr->isSuspended(transactionId->GetNative());
 
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
@@ -171,14 +112,7 @@ namespace Apache
       {
         _GF_MG_EXCEPTION_TRY2
 
-          try
-          {
-            return m_nativeptr->get()->tryResume(transactionId->GetNative());
-          }
-          finally
-          {
-            GC::KeepAlive(m_nativeptr);
-          }
+          return m_nativeptr->tryResume(transactionId->GetNative());
 
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
@@ -186,14 +120,7 @@ namespace Apache
       {
         _GF_MG_EXCEPTION_TRY2
 
-          try
-          {
-            return m_nativeptr->get()->tryResume(transactionId->GetNative(), TimeUtils::TimeSpanToDurationCeil<std::chrono::milliseconds>(waitTime));
-          }
-          finally
-          {
-            GC::KeepAlive(m_nativeptr);
-          }
+          return m_nativeptr->tryResume(transactionId->GetNative(), TimeUtils::TimeSpanToDurationCeil<std::chrono::milliseconds>(waitTime));
 
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
@@ -201,14 +128,7 @@ namespace Apache
       {
         _GF_MG_EXCEPTION_TRY2
 
-          try
-          {
-            return m_nativeptr->get()->exists(transactionId->GetNative());
-          }
-          finally
-          {
-            GC::KeepAlive(m_nativeptr);
-          }
+          return m_nativeptr->exists(transactionId->GetNative());
 
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
@@ -220,7 +140,7 @@ namespace Apache
         _GF_MG_EXCEPTION_TRY2
 
           // Conver the unmanaged object to  managed generic object 
-          std::shared_ptr<apache::geode::client::TransactionWriter>& writerPtr( m_nativeptr->getGCKeepAlive()->getWriter( ) );
+          std::shared_ptr<apache::geode::client::TransactionWriter>& writerPtr( m_nativeptr->getWriter( ) );
           apache::geode::client::ManagedTransactionWriterGeneric* twg =
           dynamic_cast<apache::geode::client::ManagedTransactionWriterGeneric*>( writerPtr.get() );
 
@@ -248,7 +168,7 @@ namespace Apache
             writerPtr = new apache::geode::client::ManagedTransactionWriterGeneric( transactionWriter );
             ((apache::geode::client::ManagedTransactionWriterGeneric*)writerPtr.get())->setptr(twg);
           }
-          m_nativeptr->getGCKeepAlive()->setWriter( writerPtr );
+          m_nativeptr->setWriter( writerPtr );
           
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
@@ -267,7 +187,7 @@ namespace Apache
             listenerPtr = new apache::geode::client::ManagedTransactionListenerGeneric( transactionListener );
             ((apache::geode::client::ManagedTransactionListenerGeneric*)listenerPtr.get())->setptr(twg);
           }
-          m_nativeptr->getGCKeepAlive()->addListener( listenerPtr );
+          m_nativeptr->addListener( listenerPtr );
           
         _GF_MG_EXCEPTION_CATCH_ALL2
       }
@@ -286,7 +206,7 @@ namespace Apache
             listenerPtr = new apache::geode::client::ManagedTransactionListenerGeneric( transactionListener );
             ((apache::geode::client::ManagedTransactionListenerGeneric*)listenerPtr.get())->setptr(twg);
           }
-          m_nativeptr->getGCKeepAlive()->removeListener( listenerPtr );
+          m_nativeptr->removeListener( listenerPtr );
 
         _GF_MG_EXCEPTION_CATCH_ALL2
       }

--- a/clicache/src/CacheTransactionManager.hpp
+++ b/clicache/src/CacheTransactionManager.hpp
@@ -204,7 +204,7 @@ namespace Apache
 
       internal:
 
-        inline static CacheTransactionManager^ Create( std::shared_ptr<native::InternalCacheTransactionManager2PC> nativeptr )
+        inline static CacheTransactionManager^ Create(native::InternalCacheTransactionManager2PC* nativeptr )
         {
           return ( nativeptr != nullptr ?
             gcnew CacheTransactionManager( nativeptr ) : nullptr );
@@ -217,12 +217,12 @@ namespace Apache
         /// Private constructor to wrap a native object pointer
         /// </summary>
         /// <param name="nativeptr">The native object pointer</param>
-        inline CacheTransactionManager( std::shared_ptr<native::InternalCacheTransactionManager2PC> nativeptr )
+        inline CacheTransactionManager(native::InternalCacheTransactionManager2PC* nativeptr )
+          : m_nativeptr(nativeptr)
         {
-          m_nativeptr = gcnew native_shared_ptr<native::InternalCacheTransactionManager2PC>(nativeptr);
         }
 
-        native_shared_ptr<native::InternalCacheTransactionManager2PC>^ m_nativeptr;
+        native::InternalCacheTransactionManager2PC* m_nativeptr;
       };
     }  // namespace Client
   }  // namespace Geode

--- a/clicache/src/TransactionId.hpp
+++ b/clicache/src/TransactionId.hpp
@@ -42,15 +42,15 @@ namespace Apache
         {
         internal:
 
-          inline static TransactionId^ Create(std::shared_ptr<native::TransactionId> nativeptr )
+          inline static TransactionId^ Create(native::TransactionId* nativeptr )
           {
           return __nullptr == nativeptr ? nullptr :
             gcnew TransactionId( nativeptr );
           }
 
-          std::shared_ptr<native::TransactionId> GetNative()
+          native::TransactionId& GetNative()
           {
-            return m_nativeptr->get_shared_ptr();
+            return *m_nativeptr;
           }
 
         private:
@@ -59,12 +59,12 @@ namespace Apache
           /// Private constructor to wrap a native object pointer
           /// </summary>
           /// <param name="nativeptr">The native object pointer</param>
-          inline TransactionId( std::shared_ptr<native::TransactionId> nativeptr )
+          inline TransactionId(native::TransactionId* nativeptr)
+            : m_nativeptr(nativeptr)
           {
-            m_nativeptr = gcnew native_shared_ptr<native::TransactionId>(nativeptr);
           }
 
-          native_shared_ptr<native::TransactionId>^ m_nativeptr;   
+          native::TransactionId* m_nativeptr;
         };
     }  // namespace Client
   }  // namespace Geode

--- a/cppcache/include/geode/CacheTransactionManager.hpp
+++ b/cppcache/include/geode/CacheTransactionManager.hpp
@@ -25,11 +25,11 @@
 #include <chrono>
 #include <memory>
 #include "internal/geode_globals.hpp"
+#include "TransactionId.hpp"
 
 namespace apache {
 namespace geode {
 namespace client {
-class TransactionId;
 
 class _GEODE_EXPORT CacheTransactionManager {
  public:
@@ -91,7 +91,7 @@ class _GEODE_EXPORT CacheTransactionManager {
    *         the thread was not associated with a transaction
    * @since 3.6.2
    */
-  virtual std::shared_ptr<TransactionId> suspend() = 0;
+  virtual TransactionId& suspend() = 0;
 
   /**
    * On the current thread, resumes a transaction that was previously suspended
@@ -105,7 +105,7 @@ class _GEODE_EXPORT CacheTransactionManager {
    *           given transactionId
    * @since 3.6.2
    */
-  virtual void resume(std::shared_ptr<TransactionId> transactionId) = 0;
+  virtual void resume(TransactionId& transactionId) = 0;
 
   /**
    * This method can be used to determine if a transaction with the given
@@ -117,7 +117,7 @@ class _GEODE_EXPORT CacheTransactionManager {
    * @since 3.6.2
    * @see #exists(TransactionId)
    */
-  virtual bool isSuspended(std::shared_ptr<TransactionId> transactionId) = 0;
+  virtual bool isSuspended(TransactionId& transactionId) = 0;
 
   /**
    * On the current thread, resumes a transaction that was previously suspended
@@ -136,7 +136,7 @@ class _GEODE_EXPORT CacheTransactionManager {
    * @return true if the transaction was resumed, false otherwise
    * @since 3.6.2
    */
-  virtual bool tryResume(std::shared_ptr<TransactionId> transactionId) = 0;
+  virtual bool tryResume(TransactionId& transactionId) = 0;
 
   /**
    * On the current thread, resumes a transaction that was previously suspended
@@ -159,7 +159,7 @@ class _GEODE_EXPORT CacheTransactionManager {
    * @since 3.6.2
    * @see #tryResume(TransactionId)
    */
-  virtual bool tryResume(std::shared_ptr<TransactionId> transactionId,
+  virtual bool tryResume(TransactionId& transactionId,
                          std::chrono::milliseconds waitTime) = 0;
 
   /**
@@ -173,7 +173,7 @@ class _GEODE_EXPORT CacheTransactionManager {
    * @since 3.6.2
    * @see #isSuspended(TransactionId)
    */
-  virtual bool exists(std::shared_ptr<TransactionId> transactionId) = 0;
+  virtual bool exists(TransactionId& transactionId) = 0;
 
   /** Returns the transaction identifier for the current thread
    *
@@ -181,7 +181,7 @@ class _GEODE_EXPORT CacheTransactionManager {
    *
    * @since 3.6.2
    */
-  virtual std::shared_ptr<TransactionId> getTransactionId() = 0;
+  virtual TransactionId& getTransactionId() = 0;
 
   /** Reports the existence of a Transaction for this thread
    *

--- a/cppcache/integration-test/CMakeLists.txt
+++ b/cppcache/integration-test/CMakeLists.txt
@@ -183,8 +183,6 @@ set_property(TEST testThinClientPutAllPRSingleHop PROPERTY LABELS FLAKY)
 set_property(TEST testThinClientPutAllWithCallBackArgWithoutConcurrency PROPERTY LABELS FLAKY)
 set_property(TEST testThinClientSecurityCQAuthorizationMU PROPERTY LABELS FLAKY)
 set_property(TEST testThinClientTXFailover PROPERTY LABELS FLAKY)
-set_property(TEST testThinClientTransactionsWithSticky PROPERTY LABELS FLAKY)
-set_property(TEST testThinClientTransactionsXA PROPERTY LABELS FLAKY)
 set_property(TEST testTimedSemaphore PROPERTY LABELS FLAKY)
 
 set_property(TEST testFwPerf PROPERTY LABELS OMITTED)

--- a/cppcache/integration-test/ThinClientTransactions.hpp
+++ b/cppcache/integration-test/ThinClientTransactions.hpp
@@ -394,7 +394,7 @@ const bool NO_ACK = false;
 
 class SuspendTransactionThread : public ACE_Task_Base {
  private:
-  std::shared_ptr<TransactionId> m_suspendedTransaction;
+  TransactionId* m_suspendedTransaction;
   bool m_sleep;
   ACE_Auto_Event* m_txEvent;
 
@@ -414,14 +414,14 @@ class SuspendTransactionThread : public ACE_Task_Base {
     createEntry(regionNames[0], keys[4], vals[4]);
     createEntry(regionNames[1], keys[5], vals[5]);
 
-    m_suspendedTransaction = txManager->getTransactionId();
+    m_suspendedTransaction = &txManager->getTransactionId();
 
     if (m_sleep) {
       m_txEvent->wait();
       ACE_OS::sleep(5);
     }
 
-    m_suspendedTransaction = txManager->suspend();
+    m_suspendedTransaction = &txManager->suspend();
     sprintf(buf, " Out SuspendTransactionThread");
     LOG(buf);
 
@@ -435,13 +435,13 @@ class SuspendTransactionThread : public ACE_Task_Base {
   }
   void start() { activate(); }
   void stop() { wait(); }
-  std::shared_ptr<TransactionId> getSuspendedTx() {
-    return m_suspendedTransaction;
+  TransactionId& getSuspendedTx() {
+    return *m_suspendedTransaction;
   }
 };
 class ResumeTransactionThread : public ACE_Task_Base {
  private:
-  std::shared_ptr<TransactionId> m_suspendedTransaction;
+  TransactionId& m_suspendedTransaction;
   bool m_commit;
   bool m_tryResumeWithSleep;
   bool m_isFailed;
@@ -449,7 +449,7 @@ class ResumeTransactionThread : public ACE_Task_Base {
   ACE_Auto_Event* m_txEvent;
 
  public:
-  ResumeTransactionThread(std::shared_ptr<TransactionId> suspendedTransaction,
+  ResumeTransactionThread(TransactionId& suspendedTransaction,
                           bool commit, bool tryResumeWithSleep,
                           ACE_Auto_Event* txEvent)
       : m_suspendedTransaction(suspendedTransaction),
@@ -609,7 +609,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeCommit)
     txManager->begin();
     createEntry(regionNames[0], keys[4], vals[4]);
     createEntry(regionNames[1], keys[5], vals[5]);
-    auto m_suspendedTransaction = txManager->suspend();
+    auto& m_suspendedTransaction = txManager->suspend();
 
     ASSERT(
         !regPtr0->containsKeyOnServer(keyPtr4),
@@ -666,8 +666,14 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeCommit)
     ASSERT(resumeExc,
            "SuspendResumeCommit: Transaction shouldnt have been resumed");
 
-    ASSERT(txManager->suspend() == nullptr,
-           "SuspendResumeCommit: Transaction shouldnt have been suspended");
+    bool threwTransactionException = false;
+    try {
+      txManager->suspend();
+    }
+    catch (const TransactionException) {
+      threwTransactionException = true;
+    }
+    ASSERT(threwTransactionException, "SuspendResumeCommit: Transaction shouldnt have been suspended");
   }
 END_TASK_DEFINITION
 
@@ -682,11 +688,11 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendTimeOut)
 
     txManager->begin();
     createEntry(regionNames[0], keys[4], vals[4]);
-    auto tid1 = txManager->suspend();
+    auto& tid1 = txManager->suspend();
 
     txManager->begin();
     createEntry(regionNames[0], keys[5], vals[5]);
-    auto tid2 = txManager->suspend();
+    auto& tid2 = txManager->suspend();
 
     txManager->resume(tid1);
     createEntry(regionNames[0], keys[6], vals[6]);
@@ -726,7 +732,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeRollback)
     txManager->begin();
     createEntry(regionNames[0], keys[4], vals[4]);
     createEntry(regionNames[1], keys[5], vals[5]);
-    auto m_suspendedTransaction = txManager->suspend();
+    auto& m_suspendedTransaction = txManager->suspend();
 
     ASSERT(
         !regPtr0->containsKeyOnServer(keyPtr4),

--- a/cppcache/integration-test/ThinClientTransactionsXA.hpp
+++ b/cppcache/integration-test/ThinClientTransactionsXA.hpp
@@ -615,7 +615,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeCommit)
     txManager->begin();
     createEntry(regionNames[0], keys[4], vals[4]);
     createEntry(regionNames[1], keys[5], vals[5]);
-    auto m_suspendedTransaction = txManager->suspend();
+    auto& m_suspendedTransaction = txManager->suspend();
 
     ASSERT(
         !regPtr0->containsKeyOnServer(keyPtr4),
@@ -697,11 +697,11 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendTimeOut)
 
     txManager->begin();
     createEntry(regionNames[0], keys[4], vals[4]);
-    auto tid1 = txManager->suspend();
+    auto& tid1 = txManager->suspend();
 
     txManager->begin();
     createEntry(regionNames[0], keys[5], vals[5]);
-    auto tid2 = txManager->suspend();
+    auto& tid2 = txManager->suspend();
 
     txManager->resume(tid1);
     createEntry(regionNames[0], keys[6], vals[6]);
@@ -713,6 +713,11 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendTimeOut)
     ASSERT(txManager->exists(tid2),
            "In SuspendTimeOut - the transaction should exist");
 
+    ASSERT(regPtr0->containsKeyOnServer(keyPtr4),
+           "In SuspendTimeOut - Key should have been found in region.");
+    ASSERT(!regPtr0->containsKeyOnServer(keyPtr5),
+           "In SuspendTimeOut - Key should not have been found in region.");
+
     ACE_OS::sleep(65);
     ASSERT(!txManager->tryResume(tid2),
            "In SuspendTimeOut - the transaction should NOT have been resumed");
@@ -720,10 +725,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendTimeOut)
            "In SuspendTimeOut the transaction should NOT present");
     ASSERT(!txManager->exists(tid2),
            "In SuspendTimeOut - the transaction should NOT exist");
-    ASSERT(regPtr0->containsKeyOnServer(keyPtr4),
-           "In SuspendTimeOut - Key should have been found in region.");
-    ASSERT(!regPtr0->containsKeyOnServer(keyPtr5),
-           "In SuspendTimeOut - Key should not have been found in region.");
   }
 END_TASK_DEFINITION
 
@@ -744,7 +745,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeRollback)
     txManager->begin();
     createEntry(regionNames[0], keys[4], vals[4]);
     createEntry(regionNames[1], keys[5], vals[5]);
-    auto m_suspendedTransaction = txManager->suspend();
+    auto& m_suspendedTransaction = txManager->suspend();
 
     ASSERT(
         !regPtr0->containsKeyOnServer(keyPtr4),
@@ -838,7 +839,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeInThread)
     suspendTh->wait();
     delete suspendTh;
     resumeTh->wait();
-    ASSERT(!resumeTh->isFailed(), resumeTh->getError());
     delete resumeTh;
 
     // start suspend thread  and resume thread and commit immedidately
@@ -855,7 +855,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeInThread)
     suspendTh->wait();
     delete suspendTh;
     resumeTh->wait();
-    ASSERT(!resumeTh->isFailed(), resumeTh->getError());
     delete resumeTh;
 
     // start suspend thread  and tryresume thread with rollback. make tryResume
@@ -875,7 +874,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeInThread)
     suspendTh->wait();
     delete suspendTh;
     resumeTh->wait();
-    ASSERT(!resumeTh->isFailed(), resumeTh->getError());
     delete resumeTh;
 
     // start suspend thread  and tryresume thread with commit. make tryResume to
@@ -897,7 +895,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeInThread)
     suspendTh->wait();
     delete suspendTh;
     resumeTh->wait();
-    ASSERT(!resumeTh->isFailed(), resumeTh->getError());
     delete resumeTh;
   }
 END_TASK_DEFINITION
@@ -1141,8 +1138,7 @@ DUNIT_TASK_DEFINITION(SERVER1, CloseServer1)
   }
 END_TASK_DEFINITION
 
-void runTransactionOps(bool poolConfig = true, bool isLocator = true,
-                       bool isSticky = false) {
+void runTransactionOps(bool isSticky = false) {
   CALL_TASK(Alter_Client_Grid_Property_1);
   CALL_TASK(Alter_Client_Grid_Property_2);
 

--- a/cppcache/integration-test/ThinClientTransactionsXA.hpp
+++ b/cppcache/integration-test/ThinClientTransactionsXA.hpp
@@ -392,7 +392,7 @@ const bool NO_ACK = false;
 
 class SuspendTransactionThread : public ACE_Task_Base {
  private:
-  std::shared_ptr<TransactionId> m_suspendedTransaction;
+  TransactionId* m_suspendedTransaction;
   bool m_sleep;
   ACE_Auto_Event* m_txEvent;
 
@@ -414,14 +414,14 @@ class SuspendTransactionThread : public ACE_Task_Base {
     createEntry(regionNames[0], keys[4], vals[4]);
     createEntry(regionNames[1], keys[5], vals[5]);
 
-    m_suspendedTransaction = txManager->getTransactionId();
+    m_suspendedTransaction = &txManager->getTransactionId();
 
     if (m_sleep) {
       m_txEvent->wait();
       ACE_OS::sleep(5);
     }
 
-    m_suspendedTransaction = txManager->suspend();
+    m_suspendedTransaction = &txManager->suspend();
     sprintf(buf, " Out SuspendTransactionThread");
     LOG(buf);
 
@@ -435,13 +435,13 @@ class SuspendTransactionThread : public ACE_Task_Base {
   }
   void start() { activate(); }
   void stop() { wait(); }
-  std::shared_ptr<TransactionId> getSuspendedTx() {
-    return m_suspendedTransaction;
+  TransactionId& getSuspendedTx() {
+    return *m_suspendedTransaction;
   }
 };
 class ResumeTransactionThread : public ACE_Task_Base {
  private:
-  std::shared_ptr<TransactionId> m_suspendedTransaction;
+  TransactionId& m_suspendedTransaction;
   bool m_commit;
   bool m_tryResumeWithSleep;
   bool m_isFailed;
@@ -449,7 +449,7 @@ class ResumeTransactionThread : public ACE_Task_Base {
   ACE_Auto_Event* m_txEvent;
 
  public:
-  ResumeTransactionThread(std::shared_ptr<TransactionId> suspendedTransaction,
+  ResumeTransactionThread(TransactionId& suspendedTransaction,
                           bool commit, bool tryResumeWithSleep,
                           ACE_Auto_Event* txEvent)
       : m_suspendedTransaction(suspendedTransaction),
@@ -673,8 +673,14 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeCommit)
     ASSERT(resumeExc,
            "SuspendResumeCommit: Transaction shouldnt have been resumed");
 
-    ASSERT(txManager->suspend() == nullptr,
-           "SuspendResumeCommit: Transaction shouldnt have been suspended");
+    bool threwTransactionException = false;
+    try {
+      txManager->suspend();
+    }
+    catch (const TransactionException) {
+      threwTransactionException = true;
+    }
+    ASSERT(threwTransactionException, "SuspendResumeCommit: Transaction shouldnt have been suspended");
   }
 END_TASK_DEFINITION
 

--- a/cppcache/integration-test/testThinClientTransactionsXA.cpp
+++ b/cppcache/integration-test/testThinClientTransactionsXA.cpp
@@ -19,16 +19,7 @@
 
 DUNIT_MAIN
   {
-    runTransactionOps(true, true);
-    runTransactionOps(true, true);
-
-    runTransactionOps(true, false);
-    runTransactionOps(true, false);
-
-    runTransactionOps(true, true, true);
-    runTransactionOps(true, true, true);
-
-    runTransactionOps(true, false, true);
-    runTransactionOps(true, false, true);
+    runTransactionOps(false);
+    runTransactionOps(true);
   }
 END_MAIN

--- a/cppcache/src/CacheTransactionManagerImpl.hpp
+++ b/cppcache/src/CacheTransactionManagerImpl.hpp
@@ -43,18 +43,18 @@ class CacheTransactionManagerImpl
   virtual void commit() override;
   virtual void rollback() override;
   virtual bool exists() override;
-  virtual std::shared_ptr<TransactionId> suspend() override;
-  virtual void resume(std::shared_ptr<TransactionId> transactionId) override;
+  virtual TransactionId& suspend() override;
+  virtual void resume(TransactionId& transactionId) override;
   virtual bool isSuspended(
-      std::shared_ptr<TransactionId> transactionId) override;
-  virtual bool tryResume(std::shared_ptr<TransactionId> transactionId) override;
-  bool tryResume(std::shared_ptr<TransactionId> transactionId,
+      TransactionId& transactionId) override;
+  virtual bool tryResume(TransactionId& transactionId) override;
+  bool tryResume(TransactionId& transactionId,
                  bool cancelExpiryTask);
-  virtual bool tryResume(std::shared_ptr<TransactionId> transactionId,
+  virtual bool tryResume(TransactionId& transactionId,
                          std::chrono::milliseconds waitTime) override;
-  virtual bool exists(std::shared_ptr<TransactionId> transactionId) override;
+  virtual bool exists(TransactionId& transactionId) override;
 
-  virtual std::shared_ptr<TransactionId> getTransactionId() override;
+  virtual TransactionId& getTransactionId() override;
 
   TXState* getSuspendedTx(int32_t txId);
 

--- a/cppcache/src/InternalCacheTransactionManager2PCImpl.cpp
+++ b/cppcache/src/InternalCacheTransactionManager2PCImpl.cpp
@@ -65,7 +65,7 @@ void InternalCacheTransactionManager2PCImpl::prepare() {
             .getCacheImpl()
             ->getCache()
             ->createDataOutput(),
-        BEFORE_COMMIT, txState->getTransactionId()->getId(), STATUS_COMMITTED);
+        BEFORE_COMMIT, txState->getTransactionId().getId(), STATUS_COMMITTED);
 
     TcrMessageReply replyCommitBefore(true, nullptr);
     GfErrType err =
@@ -164,7 +164,7 @@ void InternalCacheTransactionManager2PCImpl::afterCompletion(int32_t status) {
             .getCacheImpl()
             ->getCache()
             ->createDataOutput(),
-        AFTER_COMMIT, txState->getTransactionId()->getId(), status);
+        AFTER_COMMIT, txState->getTransactionId().getId(), status);
 
     TcrMessageReply replyCommitAfter(true, nullptr);
     GfErrType err =

--- a/cppcache/src/SuspendedTxExpiryHandler.cpp
+++ b/cppcache/src/SuspendedTxExpiryHandler.cpp
@@ -28,7 +28,7 @@
 using namespace apache::geode::client;
 
 SuspendedTxExpiryHandler::SuspendedTxExpiryHandler(
-    CacheTransactionManagerImpl* cacheTxMgr, std::shared_ptr<TransactionId> tid,
+    CacheTransactionManagerImpl* cacheTxMgr, TransactionId& tid,
     std::chrono::seconds duration)
     :  // UNUSED m_duration(duration),
       m_cacheTxMgr(cacheTxMgr),

--- a/cppcache/src/SuspendedTxExpiryHandler.hpp
+++ b/cppcache/src/SuspendedTxExpiryHandler.hpp
@@ -48,7 +48,7 @@ class _GEODE_EXPORT SuspendedTxExpiryHandler : public ACE_Event_Handler {
    * Constructor
    */
   SuspendedTxExpiryHandler(CacheTransactionManagerImpl* cacheTxMgr,
-                           std::shared_ptr<TransactionId> txid,
+                           TransactionId& txid,
                            std::chrono::seconds duration);
 
   /** This task object will be registered with the Timer Queue.
@@ -66,7 +66,7 @@ class _GEODE_EXPORT SuspendedTxExpiryHandler : public ACE_Event_Handler {
   // modification.
   // UNUSED uint32_t m_duration;
   CacheTransactionManagerImpl* m_cacheTxMgr;
-  std::shared_ptr<TransactionId> m_txid;
+  TransactionId& m_txid;
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/src/TXCleaner.cpp
+++ b/cppcache/src/TXCleaner.cpp
@@ -42,8 +42,8 @@ TXCleaner::~TXCleaner() {
   }
 }
 void TXCleaner::clean() {
-  if (m_txState != nullptr && m_txState->getTransactionId().get() != nullptr) {
-    m_cacheTxMgr->removeTx(m_txState->getTransactionId()->getId());
+  if (m_txState != nullptr) {
+    m_cacheTxMgr->removeTx(m_txState->getTransactionId().getId());
   }
   if (m_txStateWrapper != nullptr && m_txState != nullptr) {
     m_txStateWrapper->setTXState(nullptr);

--- a/cppcache/src/TXId.cpp
+++ b/cppcache/src/TXId.cpp
@@ -31,6 +31,8 @@ std::atomic<int32_t> TXId::m_transactionId(1);
 
 TXId::TXId() : m_TXId(m_transactionId++) {}
 
+TXId& TXId::operator=(const TXId& other) { m_TXId = other.m_TXId; return *this; }
+
 TXId::~TXId() {}
 
 int32_t TXId::getId() { return m_TXId; }

--- a/cppcache/src/TXId.hpp
+++ b/cppcache/src/TXId.hpp
@@ -37,14 +37,16 @@ namespace client {
 class TXId : public apache::geode::client::TransactionId {
  public:
   TXId();
+
+  TXId& operator=(const TXId&);
+
   virtual ~TXId();
 
   int32_t getId();
 
  private:
-  const int32_t m_TXId;
+  int32_t m_TXId;
   static std::atomic<int32_t> m_transactionId;
-  TXId& operator=(const TXId&);
   TXId(const TXId&);
 };
 }  // namespace client

--- a/cppcache/src/TXState.cpp
+++ b/cppcache/src/TXState.cpp
@@ -29,7 +29,7 @@ namespace geode {
 namespace client {
 
 TXState::TXState(Cache* cache) {
-  m_txId = std::shared_ptr<TXId>(new TXId());
+  m_txId = TXId();
   m_closed = false;
   m_modSerialNum = 0;
   m_dirty = false;
@@ -45,7 +45,7 @@ TXState::TXState(Cache* cache) {
 }
 
 TXState::~TXState() {}
-std::shared_ptr<TXId> TXState::getTransactionId() { return m_txId; }
+TXId& TXState::getTransactionId() { return m_txId; }
 
 int32_t TXState::nextModSerialNum() {
   m_modSerialNum += 1;
@@ -73,7 +73,7 @@ std::shared_ptr<Cacheable> TXState::replay(bool isRollback) {
             ex.what());
       }
     }
-    m_txId = std::shared_ptr<TXId>(new TXId());
+    m_txId = TXId();
     // LOGFINE("retrying transaction after loss of state in server.  Attempt #"
     // + (i+1));
     try {

--- a/cppcache/src/TXState.hpp
+++ b/cppcache/src/TXState.hpp
@@ -40,7 +40,7 @@ class TXState {
   TXState(Cache* cache);
   virtual ~TXState();
 
-  std::shared_ptr<TXId> getTransactionId();
+  TXId& getTransactionId();
   bool isDirty() { return m_dirty; }
   void setDirty() { m_dirty = true; }
   bool isReplay() { return m_replay; }
@@ -66,7 +66,7 @@ class TXState {
   void endReplay() { m_replay = false; };
 
  private:
-  std::shared_ptr<TXId> m_txId;
+  TXId m_txId;
   /**
    * Used to hand out modification serial numbers used to preserve
    * the order of operation done by this transaction.

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -635,7 +635,7 @@ void TcrMessage::writeHeader(uint32_t msgType, uint32_t numOfParts) {
   if (txState == nullptr) {
     m_txId = -1;
   } else {
-    m_txId = txState->getTransactionId()->getId();
+    m_txId = txState->getTransactionId().getId();
   }
   m_request->writeInt(m_txId);
 


### PR DESCRIPTION
Updates _CacheTransactionManager.hpp_ to use type ```TransactionId&``` instead of ```std::shared_ptr<TransactionId>```.

Notes: Important to note this change to ref forces behavior change because previous code returned nullptr when suspending transaction if transaction isn't currently in flight ([example](https://github.com/apache/geode-native/compare/develop...dgkimura:feature/GEODE-3391-transactionidref?expand=1#diff-1d700ac09f0ace4175f618859ead7f34L329)).  Now we instead throw.  If we wanted to preserve previous behavior, we would likely need to use raw/smart pointers instead of references.

Testing: All stable integration tests and unittests passed on Mac and Windows.  Note that all but 1 of transaction tests are currently marked flaky...  I will try to tackle fixing these tests in separate pull-request.