### PR TITLE
GEODE-4314: Removes std::enable_shared_from_this.

### DIFF
--- a/cppcache/include/geode/PdxSerializable.hpp
+++ b/cppcache/include/geode/PdxSerializable.hpp
@@ -36,7 +36,9 @@ class PdxWriter;
 class DataInput;
 class DataOutput;
 
-class _GEODE_EXPORT PdxSerializable : public CacheableKey {
+class _GEODE_EXPORT PdxSerializable
+    : public CacheableKey,
+      public std::enable_shared_from_this<PdxSerializable> {
  public:
   PdxSerializable();
   virtual ~PdxSerializable();

--- a/cppcache/include/geode/Serializable.hpp
+++ b/cppcache/include/geode/Serializable.hpp
@@ -56,8 +56,7 @@ typedef PdxSerializable* (*TypeFactoryMethodPdx)();
  * This abstract base class is the superclass of all user objects
  * in the cache that can be serialized.
  */
-class _GEODE_EXPORT Serializable
-    : public std::enable_shared_from_this<Serializable> {
+class _GEODE_EXPORT Serializable {
  public:
   /**
    *@brief serialize this object

--- a/cppcache/integration-test/DeltaEx.hpp
+++ b/cppcache/integration-test/DeltaEx.hpp
@@ -31,11 +31,6 @@
 #include "CacheHelper.hpp"
 
 class DeltaEx : public Cacheable, public Delta {
- private:
-  std::shared_ptr<DeltaEx> shared_from_this() {
-    return std::static_pointer_cast<DeltaEx>(Serializable::shared_from_this());
-  }
-
  public:
   int counter;
   bool isDelta;
@@ -87,12 +82,6 @@ class DeltaEx : public Cacheable, public Delta {
 };
 
 class PdxDeltaEx : public PdxSerializable, public Delta {
- private:
-  std::shared_ptr<PdxDeltaEx> shared_from_this() {
-    return std::static_pointer_cast<PdxDeltaEx>(
-        Serializable::shared_from_this());
-  }
-
  public:
   int m_counter;
   bool m_isDelta;

--- a/cppcache/src/PdxHelper.cpp
+++ b/cppcache/src/PdxHelper.cpp
@@ -14,12 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * PdxHelper.cpp
- *
- *  Created on: Dec 13, 2011
- *      Author: npatel
- */
 
 #include <geode/Cache.hpp>
 #include <geode/DataInput.hpp>
@@ -53,10 +47,8 @@ PdxHelper::~PdxHelper() {}
 
 void PdxHelper::serializePdx(DataOutput& output,
                              const PdxSerializable& pdxObject) {
-  serializePdx(
-      output,
-      std::static_pointer_cast<PdxSerializable>(
-          std::const_pointer_cast<Serializable>(pdxObject.shared_from_this())));
+  serializePdx(output, std::const_pointer_cast<PdxSerializable>(
+                           pdxObject.shared_from_this()));
 }
 
 void PdxHelper::serializePdx(

--- a/cppcache/src/PdxHelper.hpp
+++ b/cppcache/src/PdxHelper.hpp
@@ -1,8 +1,3 @@
-#pragma once
-
-#ifndef GEODE_PDXHELPER_H_
-#define GEODE_PDXHELPER_H_
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * PdxHelper.hpp
- *
- *  Created on: Dec 13, 2011
- *      Author: npatel
- */
+
+#pragma once
+
+#ifndef GEODE_PDXHELPER_H_
+#define GEODE_PDXHELPER_H_
 
 #include <geode/DataOutput.hpp>
+
 #include "EnumInfo.hpp"
 #include "PdxType.hpp"
 #include "CacheImpl.hpp"

--- a/cppcache/src/PdxType.hpp
+++ b/cppcache/src/PdxType.hpp
@@ -20,17 +20,19 @@
 #ifndef GEODE_PDXTYPE_H_
 #define GEODE_PDXTYPE_H_
 
-#include <geode/Serializable.hpp>
-#include "PdxFieldType.hpp"
-#include <geode/CacheableBuiltins.hpp>
 #include <map>
 #include <vector>
 #include <list>
 #include <string>
+
 #include <ace/ACE.h>
 #include <ace/Recursive_Thread_Mutex.h>
-#include "ReadWriteLock.hpp"
 
+#include <geode/Serializable.hpp>
+#include <geode/CacheableBuiltins.hpp>
+
+#include "PdxFieldType.hpp"
+#include "ReadWriteLock.hpp"
 #include "NonCopyable.hpp"
 
 namespace apache {
@@ -42,6 +44,7 @@ class PdxType;
 class PdxTypeRegistry;
 
 class PdxType : public Serializable,
+                public std::enable_shared_from_this<PdxType>,
                 private NonCopyable,
                 private NonAssignable {
  private:
@@ -95,10 +98,6 @@ class PdxType : public Serializable,
       std::shared_ptr<PdxType> otherType);
   std::shared_ptr<PdxType> isRemoteTypeContains(
       std::shared_ptr<PdxType> localType);
-
-  std::shared_ptr<PdxType> shared_from_this() {
-    return std::static_pointer_cast<PdxType>(Serializable::shared_from_this());
-  }
 
  public:
   PdxType(std::shared_ptr<PdxTypeRegistry> pdxTypeRegistryPtr,

--- a/tests/cpp/testobject/DeltaPSTObject.hpp
+++ b/tests/cpp/testobject/DeltaPSTObject.hpp
@@ -52,10 +52,6 @@ class TESTOBJECT_EXPORT DeltaPSTObject : public Cacheable, public Delta {
   int32_t field1;
   int8_t field2;
   std::shared_ptr<CacheableBytes> valueData;
-  std::shared_ptr<DeltaPSTObject> shared_from_this() {
-    return std::static_pointer_cast<DeltaPSTObject>(
-        Serializable::shared_from_this());
-  }
 
  public:
   DeltaPSTObject() : Delta(nullptr), timestamp(0), valueData(nullptr) {}


### PR DESCRIPTION
- Adds std::enable_shared_from_this to PdxSerializable to satisfy some
  strange serialization behavior. See GEODE-4359