### PR TITLE
 GEODE-3570: Standardizes time values.

### DIFF
--- a/clicache/src/PoolFactory.hpp
+++ b/clicache/src/PoolFactory.hpp
@@ -75,11 +75,11 @@ namespace Apache
         /// </remarks>
         /// <param>
         /// loadConditioningInterval the connection lifetime
-        /// A value of -1 disables load conditioning.
+        /// A value of 0 disables load conditioning.
         /// </param>
         /// <exception>
         /// throws IllegalArgumentException if connectionLifetime
-        /// is less than -1.
+        /// is less than 0.
         /// </exception>
         PoolFactory^ SetLoadConditioningInterval(TimeSpan loadConditioningInterval);
 
@@ -156,7 +156,7 @@ namespace Apache
         /// </remarks>
         /// <param>
         /// idleTimeout The amount of time that an idle connection
-        /// should live before expiring. -1 indicates that connections should never expire.
+        /// should live before expiring. 0 indicates that connections should never expire.
         /// </param>
         /// <exception>
         /// throws IllegalArgumentException if idleTimout is less than 0.
@@ -213,7 +213,7 @@ namespace Apache
         /// </summary>
         /// <remarks>
         /// Doing this allows gfmon to monitor clients.
-        /// A value of -1 disables the sending of client statistics
+        /// A value of 0 disables the sending of client statistics
         /// to the server.
         /// </remarks>
         /// <param>
@@ -222,7 +222,7 @@ namespace Apache
         /// </param>
         /// <exception>
         /// throws IllegalArgumentException if statisticInterval
-        /// is less than -1.
+        /// is less than 0.
         /// </exception>
         PoolFactory^ SetStatisticInterval(TimeSpan statisticInterval);
 

--- a/cppcache/include/geode/PoolFactory.hpp
+++ b/cppcache/include/geode/PoolFactory.hpp
@@ -134,7 +134,8 @@ class _GEODE_EXPORT PoolFactory {
 
   /**
    * The default frequency that client statistics are sent to the server.
-   * <p>Current value: <code>-1</code> (disabled).
+   * <p>Current value: <code>std::chrono::milliseconds::zero()</code>
+   * (disabled).
    */
   static const std::chrono::milliseconds DEFAULT_STATISTIC_INTERVAL;
 
@@ -204,23 +205,25 @@ class _GEODE_EXPORT PoolFactory {
    * @param connectionTimeout is the connection timeout
    *
    * @return a reference to <code>this</code>
-   * @throws std::invalid_argument if <code>connectionTimeout</code>
-   * is less than or equal to <code>0</code>.
+   * @throws IllegalArgumentException if <code>connectionTimeout</code>
+   * is less than or equal to <code>std::chrono::milliseconds::zero()</code>.
    */
-  PoolFactory& setFreeConnectionTimeout(std::chrono::milliseconds connectionTimeout);
+  PoolFactory& setFreeConnectionTimeout(
+      std::chrono::milliseconds connectionTimeout);
 
   /**
    * Sets the load conditioning interval for this pool.
    * This interval controls how frequently the pool will check to see if
    * a connection to a given server should be moved to a different
    * server to improve the load balance.
-   * <p>A value of <code>-1</code> disables load conditioning
+   * <p>A value of <code>std::chrono::milliseconds::zero()</code> disables load
+   * conditioning.
    *
    * @param loadConditioningInterval is the connection lifetime
    *
    * @return a reference to <code>this</code>
-   * @throws std::invalid_argument if <code>connectionLifetime</code>
-   * is less than <code>-1</code>.
+   * @throws IllegalArgumentException if <code>connectionLifetime</code>
+   * is less than <code>std::chrono::milliseconds::zero()</code>.
    */
   PoolFactory& setLoadConditioningInterval(
       std::chrono::milliseconds loadConditioningInterval);
@@ -267,8 +270,8 @@ class _GEODE_EXPORT PoolFactory {
    * @param timeout duration to wait for a response from a
    * server
    * @return a reference to <code>this</code>
-   * @throws std::invalid_argument if <code>timeout</code>
-   * is less than or equal to <code>0</code>.
+   * @throws IllegalArgumentException if <code>timeout</code>
+   * is less than or equal to <code>std::chrono::milliseconds::zero()</code>.
    */
   PoolFactory& setReadTimeout(std::chrono::milliseconds timeout);
 
@@ -313,8 +316,8 @@ class _GEODE_EXPORT PoolFactory {
    *
    * @param idleTimeout is the duration that an idle connection
    * should live no less than before expiring, actual time may be longer
-   * depending on clock resolution. A duration less than 0 indicates
-   * that connections should never expire.
+   * depending on clock resolution. A duration std::chrono::milliseconds::zero()
+   * indicates that connections should never expire.
    * @return a reference to <code>this</code>
    */
   PoolFactory& setIdleTimeout(std::chrono::milliseconds);
@@ -343,7 +346,7 @@ class _GEODE_EXPORT PoolFactory {
    *
    * @param pingInterval is the amount of time  between pings.
    * @return a reference to <code>this</code>
-   * @throws std::invalid_argument if <code>pingInterval</code>
+   * @throws IllegalArgumentException if <code>pingInterval</code>
    * is less than <code>0</code>.
    *
    * @see CacheServer#setMaximumTimeBetweenPings(int)
@@ -352,7 +355,7 @@ class _GEODE_EXPORT PoolFactory {
 
   /**
    * The frequency with which client updates the locator list. To disable this
-   * set its value to 0.
+   * set its value to std::chrono::milliseconds::zero().
    *
    * @param updateLocatorListInterval is the amount of time
    * between checking locator list at locator.
@@ -364,17 +367,18 @@ class _GEODE_EXPORT PoolFactory {
   /**
    * The frequency with which the client statistics must be sent to the server.
    * Doing this allows <code>GFMon</code> to monitor clients.
-   * <p>A value of <code>-1</code> disables the sending of client statistics
-   * to the server.
+   * <p>A value of <code>std::chrono::milliseconds::zero()</code> disables the
+   * sending of client statistics to the server.
    *
    * @param statisticInterval is the amount of time between
    * sends of client statistics to the server.
    *
    * @return a reference to <code>this</code>
-   * @throws std::invalid_argument if <code>statisticInterval</code>
-   * is less than <code>-1</code>.
+   * @throws IllegalArgumentException if <code>statisticInterval</code>
+   * is less than <code>std::chrono::milliseconds::zero()</code>.
    */
-  PoolFactory& setStatisticInterval(std::chrono::milliseconds statisticInterval);
+  PoolFactory& setStatisticInterval(
+      std::chrono::milliseconds statisticInterval);
 
   /**
    * Configures the group which contains all the servers that this pool connects
@@ -456,7 +460,7 @@ class _GEODE_EXPORT PoolFactory {
    * @param messageTrackingTimeout is the duration to set the timeout to.
    * @return a reference to <code>this</code>
    *
-   * @throws std::invalid_argument if <code>messageTrackingTimeout</code>
+   * @throws IllegalArgumentException if <code>messageTrackingTimeout</code>
    * is less than or equal to <code>0</code>.
 
    */
@@ -470,11 +474,12 @@ class _GEODE_EXPORT PoolFactory {
    * @param ackInterval is the duration to wait before sending  event
    * acknowledgements.
    *
-   * @throws std::invalid_argument if <code>ackInterval</code>
+   * @throws IllegalArgumentException if <code>ackInterval</code>
    * is less than or equal to <code>0</code>.
    * @return a reference to <code>this</code>
    */
-  PoolFactory& setSubscriptionAckInterval(std::chrono::milliseconds ackInterval);
+  PoolFactory& setSubscriptionAckInterval(
+      std::chrono::milliseconds ackInterval);
 
   /**
    * Sets whether Pool is in multi user secure mode.

--- a/cppcache/include/geode/RegionAttributes.hpp
+++ b/cppcache/include/geode/RegionAttributes.hpp
@@ -342,12 +342,13 @@ class _GEODE_EXPORT RegionAttributes : public Serializable {
   void setConcurrencyChecksEnabled(bool enable);
 
   inline bool getEntryExpiryEnabled() const {
-    return (m_entryTimeToLive.count() != 0 || m_entryIdleTimeout.count() != 0);
+    return (m_entryTimeToLive > std::chrono::seconds::zero() ||
+            m_entryIdleTimeout > std::chrono::seconds::zero());
   }
 
   inline bool getRegionExpiryEnabled() const {
-    return (m_regionTimeToLive.count() != 0 ||
-            m_regionIdleTimeout.count() != 0);
+    return (m_regionTimeToLive > std::chrono::seconds::zero() ||
+            m_regionIdleTimeout > std::chrono::seconds::zero());
   }
 
   // will be created by the factory

--- a/cppcache/src/CacheTransactionManagerImpl.cpp
+++ b/cppcache/src/CacheTransactionManagerImpl.cpp
@@ -450,7 +450,7 @@ void CacheTransactionManagerImpl::resumeTxUsingTxState(TXState* txState,
         txState->getSuspendedExpiryTaskId());
   } else {
     m_cache->getExpiryTaskManager().resetTask(
-        txState->getSuspendedExpiryTaskId(), std::chrono::seconds(0));
+        txState->getSuspendedExpiryTaskId(), std::chrono::seconds::zero());
   }
 
   // set the current state as the state of the suspended transaction

--- a/cppcache/src/EntriesMapFactory.cpp
+++ b/cppcache/src/EntriesMapFactory.cpp
@@ -60,7 +60,8 @@ EntriesMap* EntriesMapFactory::createMap(
     } else {
       return nullptr;
     }
-    if (ttl.count() != 0 || idle.count() != 0) {
+    if (ttl > std::chrono::seconds::zero() ||
+        idle > std::chrono::seconds::zero()) {
       result = new LRUEntriesMap(
           &expiryTaskmanager,
           std::unique_ptr<LRUExpEntryFactory>(
@@ -75,7 +76,8 @@ EntriesMap* EntriesMapFactory::createMap(
           region, lruEvictionAction, lruLimit, concurrencyChecksEnabled,
           concurrency, heapLRUEnabled);
     }
-  } else if (ttl.count() > 0 || idle.count() > 0) {
+  } else if (ttl > std::chrono::seconds::zero() ||
+             idle > std::chrono::seconds::zero()) {
     // create entries with a ExpEntryFactory.
     result = new ConcurrentEntriesMap(
         &expiryTaskmanager,

--- a/cppcache/src/EntryExpiryHandler.cpp
+++ b/cppcache/src/EntryExpiryHandler.cpp
@@ -48,7 +48,8 @@ int EntryExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
     auto curr_time = std::chrono::system_clock::from_time_t(current_time.sec());
 
     auto lastTimeForExp = expProps.getLastAccessTime();
-    if (m_regionPtr->getAttributes()->getEntryTimeToLive().count() > 0) {
+    if (m_regionPtr->getAttributes()->getEntryTimeToLive() >
+        std::chrono::seconds::zero()) {
       lastTimeForExp = expProps.getLastModifiedTime();
     }
 

--- a/cppcache/src/LocalRegion.cpp
+++ b/cppcache/src/LocalRegion.cpp
@@ -2811,11 +2811,11 @@ ExpirationAction::Action LocalRegion::adjustRegionExpiryAction(
   CHECK_DESTROY_PENDING(TryReadGuard, LocalRegion::adjustRegionExpiryAction);
 
  auto attrs = m_regionAttributes;
-  bool hadExpiry = (getRegionExpiryDuration().count() != 0);
-  if (!hadExpiry) {
-    throw IllegalStateException(
-        "Cannot change region ExpirationAction for region created without "
-        "region expiry.");
+ bool hadExpiry = (getRegionExpiryDuration() > std::chrono::seconds::zero());
+ if (!hadExpiry) {
+   throw IllegalStateException(
+       "Cannot change region ExpirationAction for region created without "
+       "region expiry.");
   }
   ExpirationAction::Action oldValue = getRegionExpiryAction();
 
@@ -2831,12 +2831,12 @@ ExpirationAction::Action LocalRegion::adjustEntryExpiryAction(
   CHECK_DESTROY_PENDING(TryReadGuard, LocalRegion::adjustEntryExpiryAction);
 
  auto attrs = m_regionAttributes;
-  bool hadExpiry = (getEntryExpiryDuration().count() != 0);
-  if (!hadExpiry) {
-    throw IllegalStateException(
-        "Cannot change entry ExpirationAction for region created without "
-        "entry "
-        "expiry.");
+ bool hadExpiry = (getEntryExpiryDuration() > std::chrono::seconds::zero());
+ if (!hadExpiry) {
+   throw IllegalStateException(
+       "Cannot change entry ExpirationAction for region created without "
+       "entry "
+       "expiry.");
   }
   ExpirationAction::Action oldValue = getEntryExpirationAction();
 
@@ -2850,7 +2850,7 @@ std::chrono::seconds LocalRegion::adjustRegionExpiryDuration(
     const std::chrono::seconds& duration) {
   CHECK_DESTROY_PENDING(TryReadGuard, LocalRegion::adjustRegionExpiryDuration);
 
-  bool hadExpiry = (getEntryExpiryDuration().count() != 0);
+  bool hadExpiry = (getEntryExpiryDuration() > std::chrono::seconds::zero());
   if (!hadExpiry) {
     throw IllegalStateException(
         "Cannot change region  expiration duration for region created "
@@ -2869,7 +2869,7 @@ std::chrono::seconds LocalRegion::adjustEntryExpiryDuration(
     const std::chrono::seconds& duration) {
   CHECK_DESTROY_PENDING(TryReadGuard, LocalRegion::adjustEntryExpiryDuration);
 
-  bool hadExpiry = (getEntryExpiryDuration().count() != 0);
+  bool hadExpiry = (getEntryExpiryDuration() > std::chrono::seconds::zero());
   if (!hadExpiry) {
     throw IllegalStateException(
         "Cannot change entry expiration duration for region created without "
@@ -2922,7 +2922,7 @@ bool LocalRegion::isEntryIdletimeEnabled() {
 }
 
 ExpirationAction::Action LocalRegion::getEntryExpirationAction() const {
-  if (m_regionAttributes->getEntryTimeToLive().count() > 0) {
+  if (m_regionAttributes->getEntryTimeToLive() > std::chrono::seconds::zero()) {
     return m_regionAttributes->getEntryTimeToLiveAction();
   } else {
     return m_regionAttributes->getEntryIdleTimeoutAction();

--- a/cppcache/src/SystemProperties.cpp
+++ b/cppcache/src/SystemProperties.cpp
@@ -91,8 +91,8 @@ const char DefaultDurableClientId[] = "";
 constexpr auto DefaultDurableTimeout = std::chrono::seconds(300);
 
 constexpr auto DefaultConnectTimeout = std::chrono::seconds(59);
-constexpr auto DefaultConnectWaitTimeout = std::chrono::seconds(0);
-constexpr auto DefaultBucketWaitTimeout = std::chrono::seconds(0);
+constexpr auto DefaultConnectWaitTimeout = std::chrono::seconds::zero();
+constexpr auto DefaultBucketWaitTimeout = std::chrono::seconds::zero();
 
 constexpr auto DefaultSamplingInterval = std::chrono::seconds(1);
 const bool DefaultSamplingEnabled = true;

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -1407,7 +1407,7 @@ std::shared_ptr<CacheableString> TcrConnection::readHandshakeString(
   }
 }
 bool TcrConnection::hasExpired(const std::chrono::milliseconds& expiryTime) {
-  if (expiryTime.count() < 0) {
+  if (expiryTime <= std::chrono::milliseconds::zero()) {
     return false;
   }
 
@@ -1421,7 +1421,7 @@ bool TcrConnection::hasExpired(const std::chrono::milliseconds& expiryTime) {
 }
 
 bool TcrConnection::isIdle(const std::chrono::milliseconds& idleTime) {
-  if (idleTime.count() < 0) {
+  if (idleTime <= std::chrono::milliseconds::zero()) {
     return false;
   }
 

--- a/cppcache/src/TombstoneList.cpp
+++ b/cppcache/src/TombstoneList.cpp
@@ -48,7 +48,7 @@ long TombstoneList::getExpiryTask(TombstoneExpiryHandler** handler) {
                                         m_cacheImpl);
   tombstoneEntryPtr->setHandler(*handler);
   long id = m_cacheImpl->getExpiryTaskManager().scheduleExpiryTask(
-      *handler, duration, std::chrono::seconds(0));
+      *handler, duration, std::chrono::seconds::zero());
   return id;
 }
 

--- a/cppcache/src/statistics/PoolStatsSampler.hpp
+++ b/cppcache/src/statistics/PoolStatsSampler.hpp
@@ -45,7 +45,7 @@ using client::AdminRegion;
 class StatisticsManager;
 class _GEODE_EXPORT PoolStatsSampler : public ACE_Task_Base {
  public:
-  PoolStatsSampler(int64_t sampleRate, CacheImpl* cache,
+  PoolStatsSampler(std::chrono::milliseconds sampleRate, CacheImpl* cache,
                    ThinClientPoolDM* distMan);
   void start();
   void stop();
@@ -60,7 +60,7 @@ class _GEODE_EXPORT PoolStatsSampler : public ACE_Task_Base {
   void putStatsInAdminRegion();
   volatile bool m_running;
   volatile bool m_stopRequested;
-  int64_t m_sampleRate;
+  std::chrono::milliseconds m_sampleRate;
   std::shared_ptr<AdminRegion> m_adminRegion;
   ThinClientPoolDM* m_distMan;
   ACE_Recursive_Thread_Mutex m_lock;


### PR DESCRIPTION
- Durations that can be disabled use std::chrono::duration::zero().
- Fixes durations that are out of range based on documention.
- Fixes comparison of durations against limits or disabled.
- Updates documentation for changes to duration values.
- Fixes exception throw for invalid arguments.