### PR TITLE
GEODE-4186: Replace decayed array paremeters with std::vector

### DIFF
--- a/clicache/src/CacheableBuiltins.hpp
+++ b/clicache/src/CacheableBuiltins.hpp
@@ -549,6 +549,89 @@ namespace Apache
 
       // Built-in Cacheable array types
 
+      template <typename NativeArray, typename ManagedType, System::UInt32 GeodeClassId>
+      ref class CacheableArray : public CacheableBuiltinArray<
+          NativeArray, NativeArray, ManagedType, GeodeClassId> {
+      public:
+          /** <summary>
+          *  Static function to create a new instance copying
+          *  from the given array.
+          *  </summary>
+          *  <remarks>
+          *  Providing a null or zero size array will return a null object.
+          *  </remarks>
+          *  <param name="value">the array to create the new instance</param>
+          */
+          inline static CacheableArray^ Create(array<ManagedType>^ value)
+          {
+              return (value != nullptr /*&& value->Length > 0*/ ?
+                  gcnew CacheableArray(value) : nullptr);
+          }
+          /** <summary>
+          *  Static function to create a new instance copying
+          *  from the given array.
+          *  </summary>
+          *  <remarks>
+          *  Providing a null or zero size array will return a null object.
+          *  </remarks>
+          *  <param name="value">the array to create the new instance</param>
+          */
+          inline static CacheableArray^ Create(array<ManagedType>^ value, System::Int32 length)
+          {
+              return (value != nullptr && value->Length > 0 ?
+                  gcnew CacheableArray(value, length) : nullptr);
+          }
+          /** <summary>
+          * Explicit conversion operator to contained array type.
+          * </summary>
+          */
+          inline static explicit operator array<ManagedType> ^ (CacheableArray^ value)
+          {
+              return (value != nullptr ? value->Value : nullptr);
+          }
+          /** <summary>
+          * Factory function to register this class.
+          * </summary>
+          */
+          static IGeodeSerializable^ CreateDeserializable()
+          {
+              return gcnew CacheableArray();
+          }
+        internal:
+          static IGeodeSerializable^ Create(std::shared_ptr<native::Serializable> obj)
+          {
+              return (obj != nullptr ? gcnew CacheableArray(obj) : nullptr);
+          }
+        private:
+          /** <summary>
+          * Allocates a new instance
+          *  </summary>
+          */
+          inline CacheableArray() : CacheableBuiltinArray() { }
+          /** <summary>
+          * Allocates a new instance copying from the given array.
+          *  </summary>
+          *  <remarks>
+          *  Providing a null or zero size array will return a null object.
+          *  </remarks>
+          *  <param name="value">the array to create the new instance</param>
+          */
+          inline CacheableArray(array<ManagedType>^ value) : CacheableBuiltinArray(value) { }
+          /** <summary>
+          * Allocates a new instance copying given length from the
+          * start of given array.
+          *  </summary>
+          *  <remarks>
+          *  Providing a null or zero size array will return a null object.
+          *  </remarks>
+          *  <param name="value">the array to create the new instance</param>
+          */
+          inline CacheableArray(array<ManagedType>^ value, System::Int32 length)
+            : CacheableBuiltinArray(value, length) { }
+          inline CacheableArray(std::shared_ptr<native::Serializable> nativeptr)
+            : CacheableBuiltinArray(nativeptr) { }
+      };
+
       /// <summary>
       /// An immutable wrapper for byte arrays that can serve
       /// as a distributable object for caching.
@@ -559,43 +642,43 @@ namespace Apache
       /// An immutable wrapper for array of doubles that can serve
       /// as a distributable object for caching.
       /// </summary>
-      _GFCLI_CACHEABLE_ARRAY_DEF_NEW(CacheableDoubleArray, Double);
+      using CacheableDoubleArray = CacheableArray<native::CacheableArray<double>, Double, GeodeClassIds::CacheableDoubleArray>;
 
       /// <summary>
       /// An immutable wrapper for array of floats that can serve
       /// as a distributable object for caching.
       /// </summary>
-      _GFCLI_CACHEABLE_ARRAY_DEF_NEW(CacheableFloatArray, Single);
+      using CacheableFloatArray = CacheableArray<native::CacheableArray<float>, Single, GeodeClassIds::CacheableFloatArray>;
 
       /// <summary>
       /// An immutable wrapper for array of 16-bit integers that can serve
       /// as a distributable object for caching.
       /// </summary>
-      _GFCLI_CACHEABLE_ARRAY_DEF_NEW(CacheableInt16Array, System::Int16);
+      using CacheableInt16Array = CacheableArray<native::CacheableArray<int16_t>, System::Int16, GeodeClassIds::CacheableInt16Array>;
 
       /// <summary>
       /// An immutable wrapper for array of 32-bit integers that can serve
       /// as a distributable object for caching.
       /// </summary>
-      _GFCLI_CACHEABLE_ARRAY_DEF_NEW(CacheableInt32Array, System::Int32);
+      using CacheableInt32Array = CacheableArray<native::CacheableArray<int32_t>, System::Int32, GeodeClassIds::CacheableInt32Array>;
 
       /// <summary>
       /// An immutable wrapper for array of 64-bit integers that can serve
       /// as a distributable object for caching.
       /// </summary>
-      _GFCLI_CACHEABLE_ARRAY_DEF_NEW(CacheableInt64Array, System::Int64);
+      using CacheableInt64Array = CacheableArray<native::CacheableArray<int64_t>, System::Int64, GeodeClassIds::CacheableInt64Array>;
 
       /// <summary>
       /// An immutable wrapper for array of booleans that can serve
       /// as a distributable object for caching.
       /// </summary>
-      _GFCLI_CACHEABLE_ARRAY_DEF_NEW(BooleanArray, bool);
+      using BooleanArray = CacheableArray<native::CacheableArray<bool>, bool, GeodeClassIds::BooleanArray>;
 
       /// <summary>
       /// An immutable wrapper for array of 16-bit characters that can serve
       /// as a distributable object for caching.
       /// </summary>
-      _GFCLI_CACHEABLE_ARRAY_DEF_NEW(CharArray, Char);
+      using CharArray = CacheableArray<native::CacheableArray<char16_t>, Char, GeodeClassIds::CharArray>;
     }  // namespace Client
   }  // namespace Geode
 }  // namespace Apache

--- a/clicache/src/CacheableBuiltins.hpp
+++ b/clicache/src/CacheableBuiltins.hpp
@@ -642,43 +642,43 @@ namespace Apache
       /// An immutable wrapper for array of doubles that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using CacheableDoubleArray = CacheableArray<native::CacheableArray<double>, Double, GeodeClassIds::CacheableDoubleArray>;
+      using CacheableDoubleArray = CacheableArray<native::CacheableArray<double, native::GeodeTypeIds::CacheableDoubleArray>, Double, GeodeClassIds::CacheableDoubleArray>;
 
       /// <summary>
       /// An immutable wrapper for array of floats that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using CacheableFloatArray = CacheableArray<native::CacheableArray<float>, Single, GeodeClassIds::CacheableFloatArray>;
+      using CacheableFloatArray = CacheableArray<native::CacheableArray<float, native::GeodeTypeIds::CacheableFloatArray>, Single, GeodeClassIds::CacheableFloatArray>;
 
       /// <summary>
       /// An immutable wrapper for array of 16-bit integers that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using CacheableInt16Array = CacheableArray<native::CacheableArray<int16_t>, System::Int16, GeodeClassIds::CacheableInt16Array>;
+      using CacheableInt16Array = CacheableArray<native::CacheableArray<int16_t, native::GeodeTypeIds::CacheableInt16Array>, System::Int16, GeodeClassIds::CacheableInt16Array>;
 
       /// <summary>
       /// An immutable wrapper for array of 32-bit integers that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using CacheableInt32Array = CacheableArray<native::CacheableArray<int32_t>, System::Int32, GeodeClassIds::CacheableInt32Array>;
+      using CacheableInt32Array = CacheableArray<native::CacheableArray<int32_t, native::GeodeTypeIds::CacheableInt32Array>, System::Int32, GeodeClassIds::CacheableInt32Array>;
 
       /// <summary>
       /// An immutable wrapper for array of 64-bit integers that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using CacheableInt64Array = CacheableArray<native::CacheableArray<int64_t>, System::Int64, GeodeClassIds::CacheableInt64Array>;
+      using CacheableInt64Array = CacheableArray<native::CacheableArray<int64_t, native::GeodeTypeIds::CacheableInt64Array>, System::Int64, GeodeClassIds::CacheableInt64Array>;
 
       /// <summary>
       /// An immutable wrapper for array of booleans that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using BooleanArray = CacheableArray<native::CacheableArray<bool>, bool, GeodeClassIds::BooleanArray>;
+      using BooleanArray = CacheableArray<native::CacheableArray<bool, native::GeodeTypeIds::BooleanArray>, bool, GeodeClassIds::BooleanArray>;
 
       /// <summary>
       /// An immutable wrapper for array of 16-bit characters that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using CharArray = CacheableArray<native::CacheableArray<char16_t>, Char, GeodeClassIds::CharArray>;
+      using CharArray = CacheableArray<native::CacheableArray<char16_t, native::GeodeTypeIds::CharArray>, Char, GeodeClassIds::CharArray>;
     }  // namespace Client
   }  // namespace Geode
 }  // namespace Apache

--- a/cppcache/include/geode/CacheableBuiltins.hpp
+++ b/cppcache/include/geode/CacheableBuiltins.hpp
@@ -562,6 +562,14 @@ class _GEODE_EXPORT CacheableArray : public Cacheable {
   }
 };
 
+using BooleanArray = CacheableArray<bool>;
+using CharArray = CacheableArray<char16_t>;
+using CacheableDoubleArray = CacheableArray<double>;
+using CacheableFloatArray = CacheableArray<float>;
+using CacheableInt16Array = CacheableArray<int16_t>;
+using CacheableInt32Array = CacheableArray<int32_t>;
+using CacheableInt64Array = CacheableArray<int64_t>;
+
 _GEODE_CACHEABLE_ARRAY_TYPE_DEF_(std::shared_ptr<CacheableString>,
                                  CacheableStringArray);
 /**

--- a/cppcache/include/geode/CacheableBuiltins.hpp
+++ b/cppcache/include/geode/CacheableBuiltins.hpp
@@ -491,11 +491,11 @@ _GEODE_CACHEABLE_ARRAY_TYPE_DEF_(int8_t, CacheableBytes);
  */
 _GEODE_CACHEABLE_ARRAY_TYPE_(int8_t, CacheableBytes);
 
-template <typename T>
+template <typename T, GeodeTypeIds::IdValues GeodeTypeId>
 class _GEODE_EXPORT CacheableArray : public Cacheable {
  protected:
 
-  inline double operator[](uint32_t index) const {
+  inline T operator[](uint32_t index) const {
     if (static_cast<int32_t>(index) >= m_value.size()) {
       throw OutOfRangeException(
           "CacheableArray::operator[]: Index out of range.");
@@ -514,23 +514,7 @@ class _GEODE_EXPORT CacheableArray : public Cacheable {
   virtual int32_t classId() const override { return 0; }
 
   virtual int8_t typeId() const override {
-    if (std::is_same<T, double>::value) {
-      return GeodeTypeIds::CacheableDoubleArray;
-    } else if (std::is_same<T, float>::value) {
-      return GeodeTypeIds::CacheableFloatArray;
-    } else if (std::is_same<T, int64_t>::value) {
-      return GeodeTypeIds::CacheableInt64Array;
-    } else if (std::is_same<T, int32_t>::value) {
-      return GeodeTypeIds::CacheableInt32Array;
-    } else if (std::is_same<T, int16_t>::value) {
-      return GeodeTypeIds::CacheableInt16Array;
-    } else if (std::is_same<T, char16_t>::value) {
-      return GeodeTypeIds::CharArray;
-    } else if (std::is_same<T, bool>::value) {
-      return GeodeTypeIds::BooleanArray;
-    }
-
-    return GeodeTypeIds::NullObj;
+    return GeodeTypeId;
   }
 
   virtual size_t objectSize() const override {
@@ -550,15 +534,19 @@ class _GEODE_EXPORT CacheableArray : public Cacheable {
 
   inline const std::vector<T> value() const { return m_value; }
   inline int32_t length() const { return m_value.size(); }
-  static Serializable* createDeserializable() { return new CacheableArray<T>(); }
-  inline static std::shared_ptr<CacheableArray<T>> create() {
-    return std::make_shared<CacheableArray<T>>();
+  static Serializable* createDeserializable() {
+    return new CacheableArray<T, GeodeTypeId>();
   }
-  inline static std::shared_ptr<CacheableArray<T>> create(int32_t length) {
-    return std::make_shared<CacheableArray<T>>(length);
+  inline static std::shared_ptr<CacheableArray<T, GeodeTypeId>> create() {
+    return std::make_shared<CacheableArray<T, GeodeTypeId>>();
   }
-  inline static std::shared_ptr<CacheableArray<T>> create(const std::vector<T> value) {
-    return std::make_shared<CacheableArray<T>>(value);
+  inline static std::shared_ptr<CacheableArray<T, GeodeTypeId>> create(
+      int32_t length) {
+    return std::make_shared<CacheableArray<T, GeodeTypeId>>(length);
+  }
+  inline static std::shared_ptr<CacheableArray<T, GeodeTypeId>> create(
+      const std::vector<T> value) {
+    return std::make_shared<CacheableArray<T, GeodeTypeId>>(value);
   }
 };
 
@@ -566,43 +554,43 @@ class _GEODE_EXPORT CacheableArray : public Cacheable {
  * An immutable wrapper for array of booleans that can serve as
  * a distributable object for caching.
  */
-using BooleanArray = CacheableArray<bool>;
+using BooleanArray = CacheableArray<bool, GeodeTypeIds::BooleanArray>;
 
 /**
  * An immutable wrapper for array of wide-characters that can serve as
  * a distributable object for caching.
  */
-using CharArray = CacheableArray<char16_t>;
+using CharArray = CacheableArray<char16_t, GeodeTypeIds::CharArray>;
 
 /**
  * An immutable wrapper for array of doubles that can serve as
  * a distributable object for caching.
  */
-using CacheableDoubleArray = CacheableArray<double>;
+using CacheableDoubleArray = CacheableArray<double, GeodeTypeIds::CacheableDoubleArray>;
 
 /**
  * An immutable wrapper for array of floats that can serve as
  * a distributable object for caching.
  */
-using CacheableFloatArray = CacheableArray<float>;
+using CacheableFloatArray = CacheableArray<float, GeodeTypeIds::CacheableFloatArray>;
 
 /**
  * An immutable wrapper for array of 16-bit integers that can serve as
  * a distributable object for caching.
  */
-using CacheableInt16Array = CacheableArray<int16_t>;
+using CacheableInt16Array = CacheableArray<int16_t, GeodeTypeIds::CacheableInt16Array>;
 
 /**
  * An immutable wrapper for array of 32-bit integers that can serve as
  * a distributable object for caching.
  */
-using CacheableInt32Array = CacheableArray<int32_t>;
+using CacheableInt32Array = CacheableArray<int32_t, GeodeTypeIds::CacheableInt32Array>;
 
 /**
  * An immutable wrapper for array of 64-bit integers that can serve as
  * a distributable object for caching.
  */
-using CacheableInt64Array = CacheableArray<int64_t>;
+using CacheableInt64Array = CacheableArray<int64_t, GeodeTypeIds::CacheableInt64Array>;
 
 _GEODE_CACHEABLE_ARRAY_TYPE_DEF_(std::shared_ptr<CacheableString>,
                                  CacheableStringArray);

--- a/cppcache/include/geode/CacheableBuiltins.hpp
+++ b/cppcache/include/geode/CacheableBuiltins.hpp
@@ -433,13 +433,6 @@ _GEODE_CACHEABLE_KEY_TYPE_DEF_(bool, CacheableBoolean, 3);
  */
 _GEODE_CACHEABLE_KEY_TYPE_(bool, CacheableBoolean, 3);
 
-_GEODE_CACHEABLE_ARRAY_TYPE_DEF_(bool, BooleanArray);
-/**
- * An immutable wrapper for array of booleans that can serve as
- * a distributable object for caching.
- */
-_GEODE_CACHEABLE_ARRAY_TYPE_(bool, BooleanArray);
-
 _GEODE_CACHEABLE_KEY_TYPE_DEF_(uint8_t, CacheableByte, 15);
 /**
  * An immutable wrapper for bytes that can serve as
@@ -489,13 +482,6 @@ _GEODE_CACHEABLE_KEY_TYPE_DEF_(char16_t, CacheableCharacter, 3);
  */
 _GEODE_CACHEABLE_KEY_TYPE_(char16_t, CacheableCharacter, 3);
 
-_GEODE_CACHEABLE_ARRAY_TYPE_DEF_(char16_t, CharArray);
-/**
- * An immutable wrapper for array of wide-characters that can serve as
- * a distributable object for caching.
- */
-_GEODE_CACHEABLE_ARRAY_TYPE_(char16_t, CharArray);
-
 // Instantiations for array built-in Cacheables
 
 _GEODE_CACHEABLE_ARRAY_TYPE_DEF_(int8_t, CacheableBytes);
@@ -505,40 +491,76 @@ _GEODE_CACHEABLE_ARRAY_TYPE_DEF_(int8_t, CacheableBytes);
  */
 _GEODE_CACHEABLE_ARRAY_TYPE_(int8_t, CacheableBytes);
 
-_GEODE_CACHEABLE_ARRAY_TYPE_DEF_(double, CacheableDoubleArray);
-/**
- * An immutable wrapper for array of doubles that can serve as
- * a distributable object for caching.
- */
-_GEODE_CACHEABLE_ARRAY_TYPE_(double, CacheableDoubleArray);
+template <typename T>
+class _GEODE_EXPORT CacheableArray : public Cacheable {
+ protected:
 
-_GEODE_CACHEABLE_ARRAY_TYPE_DEF_(float, CacheableFloatArray);
-/**
- * An immutable wrapper for array of floats that can serve as
- * a distributable object for caching.
- */
-_GEODE_CACHEABLE_ARRAY_TYPE_(float, CacheableFloatArray);
+  inline double operator[](uint32_t index) const {
+    if (static_cast<int32_t>(index) >= m_value.size()) {
+      throw OutOfRangeException(
+          "CacheableArray::operator[]: Index out of range.");
+    }
+    return m_value[index];
+  }
 
-_GEODE_CACHEABLE_ARRAY_TYPE_DEF_(int16_t, CacheableInt16Array);
-/**
- * An immutable wrapper for array of 16-bit integers that can serve as
- * a distributable object for caching.
- */
-_GEODE_CACHEABLE_ARRAY_TYPE_(int16_t, CacheableInt16Array);
+  virtual void toData(DataOutput& output) const override {
+    apache::geode::client::serializer::writeArrayObject(output, m_value);
+  }
 
-_GEODE_CACHEABLE_ARRAY_TYPE_DEF_(int32_t, CacheableInt32Array);
-/**
- * An immutable wrapper for array of 32-bit integers that can serve as
- * a distributable object for caching.
- */
-_GEODE_CACHEABLE_ARRAY_TYPE_(int32_t, CacheableInt32Array);
+  virtual void fromData(DataInput& input) override {
+    m_value = apache::geode::client::serializer::readArrayObject<T>(input);
+  }
 
-_GEODE_CACHEABLE_ARRAY_TYPE_DEF_(int64_t, CacheableInt64Array);
-/**
- * An immutable wrapper for array of 64-bit integers that can serve as
- * a distributable object for caching.
- */
-_GEODE_CACHEABLE_ARRAY_TYPE_(int64_t, CacheableInt64Array);
+  virtual int32_t classId() const override { return 0; }
+
+  virtual int8_t typeId() const override {
+    if (std::is_same<T, double>::value) {
+      return GeodeTypeIds::CacheableDoubleArray;
+    } else if (std::is_same<T, float>::value) {
+      return GeodeTypeIds::CacheableFloatArray;
+    } else if (std::is_same<T, int64_t>::value) {
+      return GeodeTypeIds::CacheableInt64Array;
+    } else if (std::is_same<T, int32_t>::value) {
+      return GeodeTypeIds::CacheableInt32Array;
+    } else if (std::is_same<T, int16_t>::value) {
+      return GeodeTypeIds::CacheableInt16Array;
+    } else if (std::is_same<T, char16_t>::value) {
+      return GeodeTypeIds::CharArray;
+    } else if (std::is_same<T, bool>::value) {
+      return GeodeTypeIds::BooleanArray;
+    }
+
+    return GeodeTypeIds::NullObj;
+  }
+
+  virtual size_t objectSize() const override {
+    return static_cast<uint32_t>(
+        apache::geode::client::serializer::objectArraySize(m_value));
+  }
+
+ private:
+  CacheableArray(const CacheableArray& other) = delete;
+  CacheableArray& operator=(const CacheableArray& other) = delete;
+  std::vector<T> m_value;
+
+ public:
+  inline CacheableArray() {}
+  inline CacheableArray(int32_t length) : m_value(length) {}
+  inline CacheableArray(std::vector<T> value) : m_value(value) {}
+
+  inline const std::vector<T> value() const { return m_value; }
+  inline int32_t length() const { return m_value.size(); }
+  static Serializable* createDeserializable() { return new CacheableArray<T>(); }
+  inline static std::shared_ptr<CacheableArray<T>> create() {
+    return std::make_shared<CacheableArray<T>>();
+  }
+  inline static std::shared_ptr<CacheableArray<T>> create(int32_t length) {
+    return std::make_shared<CacheableArray<T>>(length);
+  }
+  inline static std::shared_ptr<CacheableArray<T>> create(const std::vector<T> value) {
+    return std::make_shared<CacheableArray<T>>(value);
+  }
+};
 
 _GEODE_CACHEABLE_ARRAY_TYPE_DEF_(std::shared_ptr<CacheableString>,
                                  CacheableStringArray);

--- a/cppcache/include/geode/CacheableBuiltins.hpp
+++ b/cppcache/include/geode/CacheableBuiltins.hpp
@@ -562,12 +562,46 @@ class _GEODE_EXPORT CacheableArray : public Cacheable {
   }
 };
 
+/**
+ * An immutable wrapper for array of booleans that can serve as
+ * a distributable object for caching.
+ */
 using BooleanArray = CacheableArray<bool>;
+
+/**
+ * An immutable wrapper for array of wide-characters that can serve as
+ * a distributable object for caching.
+ */
 using CharArray = CacheableArray<char16_t>;
+
+/**
+ * An immutable wrapper for array of doubles that can serve as
+ * a distributable object for caching.
+ */
 using CacheableDoubleArray = CacheableArray<double>;
+
+/**
+ * An immutable wrapper for array of floats that can serve as
+ * a distributable object for caching.
+ */
 using CacheableFloatArray = CacheableArray<float>;
+
+/**
+ * An immutable wrapper for array of 16-bit integers that can serve as
+ * a distributable object for caching.
+ */
 using CacheableInt16Array = CacheableArray<int16_t>;
+
+/**
+ * An immutable wrapper for array of 32-bit integers that can serve as
+ * a distributable object for caching.
+ */
 using CacheableInt32Array = CacheableArray<int32_t>;
+
+/**
+ * An immutable wrapper for array of 64-bit integers that can serve as
+ * a distributable object for caching.
+ */
 using CacheableInt64Array = CacheableArray<int64_t>;
 
 _GEODE_CACHEABLE_ARRAY_TYPE_DEF_(std::shared_ptr<CacheableString>,

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -581,12 +581,12 @@ class _GEODE_EXPORT DataInput {
     int arrayLen = readArrayLen();
     std::vector<T> objArray;
     if (arrayLen >= 0) {
-      objArray.resize(arrayLen);
+      objArray.reserve(arrayLen);
       int i = 0;
       for (i = 0; i < arrayLen; i++) {
         T tmp = 0;
         readObject(&tmp);
-        objArray[i] = tmp;
+        objArray.push_back(tmp);
       }
     }
     return objArray;

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -579,9 +579,9 @@ class _GEODE_EXPORT DataInput {
   template <typename T>
   std::vector<T> readArray() {
     int arrayLen = readArrayLen();
-    std::vector<T> objArray(0);
+    std::vector<T> objArray;
     if (arrayLen >= 0) {
-      objArray.reserve(arrayLen);
+      objArray.resize(arrayLen);
       int i = 0;
       for (i = 0; i < arrayLen; i++) {
         T tmp = 0;

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -379,36 +379,36 @@ class _GEODE_EXPORT DataInput {
 
   inline void readObject(double* value) { *value = readDouble(); }
 
-  inline void readCharArray(char16_t** value, int32_t& length) {
-    readObject(value, length);
+  inline std::vector<char16_t> readCharArray() {
+    return readArray<char16_t>();
   }
 
-  inline void readBooleanArray(bool** value, int32_t& length) {
-    readObject(value, length);
+  inline std::vector<bool> readBooleanArray() {
+    return readArray<bool>();
   }
 
-  inline void readByteArray(int8_t** value, int32_t& length) {
-    readObject(value, length);
+  inline std::vector<int8_t> readByteArray() {
+    return readArray<int8_t>();
   }
 
-  inline void readShortArray(int16_t** value, int32_t& length) {
-    readObject(value, length);
+  inline std::vector<int16_t> readShortArray() {
+    return readArray<int16_t>();
   }
 
-  inline void readIntArray(int32_t** value, int32_t& length) {
-    readObject(value, length);
+  inline std::vector<int32_t> readIntArray() {
+    return readArray<int32_t>();
   }
 
-  inline void readLongArray(int64_t** value, int32_t& length) {
-    readObject(value, length);
+  inline std::vector<int64_t> readLongArray() {
+    return readArray<int64_t>();
   }
 
-  inline void readFloatArray(float** value, int32_t& length) {
-    readObject(value, length);
+  inline std::vector<float> readFloatArray() {
+    return readArray<float>();
   }
 
-  inline void readDoubleArray(double** value, int32_t& length) {
-    readObject(value, length);
+  inline std::vector<double> readDoubleArray() {
+    return readArray<double>();
   }
 
   inline std::vector<std::string> readStringArray() {
@@ -574,6 +574,24 @@ class _GEODE_EXPORT DataInput {
       }
       *value = objArray;
     }
+  }
+
+  template <typename T>
+  std::vector<T> readArray() {
+    int arrayLen = readArrayLen();
+    if (arrayLen < 0) {
+      return std::vector<T>(0);
+    }
+    std::vector<T> objArray(arrayLen);
+    if (arrayLen > 0) {
+      int i = 0;
+      for (i = 0; i < arrayLen; i++) {
+        T tmp = 0;
+        readObject(&tmp);
+        objArray[i] = tmp;
+      }
+    }
+    return objArray;
   }
 
   inline char readPdxChar() { return static_cast<char>(readInt16()); }

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -579,11 +579,9 @@ class _GEODE_EXPORT DataInput {
   template <typename T>
   std::vector<T> readArray() {
     int arrayLen = readArrayLen();
-    if (arrayLen < 0) {
-      return std::vector<T>(0);
-    }
-    std::vector<T> objArray(arrayLen);
-    if (arrayLen > 0) {
+    std::vector<T> objArray(0);
+    if (arrayLen >= 0) {
+      objArray.reserve(arrayLen);
       int i = 0;
       for (i = 0; i < arrayLen; i++) {
         T tmp = 0;

--- a/cppcache/include/geode/PdxInstance.hpp
+++ b/cppcache/include/geode/PdxInstance.hpp
@@ -199,8 +199,8 @@ class _GEODE_EXPORT PdxInstance : public PdxSerializable {
    *
    * @see PdxInstance#hasField
    */
-  virtual void getField(const std::string& fieldname, bool** value,
-                        int32_t& length) const = 0;
+  virtual std::vector<bool> getBooleanArrayField(
+      const std::string& fieldname) const = 0;
 
   /**
    * Reads the named field and set its value in signed char array type out
@@ -212,8 +212,8 @@ class _GEODE_EXPORT PdxInstance : public PdxSerializable {
    *
    * @see PdxInstance#hasField
    */
-  virtual void getField(const std::string& fieldname, int8_t** value,
-                        int32_t& length) const = 0;
+  virtual std::vector<int8_t> getByteArrayField(
+      const std::string& fieldname) const = 0;
 
   /**
    * Reads the named field and set its value in int16_t array type out param.
@@ -225,8 +225,8 @@ class _GEODE_EXPORT PdxInstance : public PdxSerializable {
    *
    * @see PdxInstance#hasField
    */
-  virtual void getField(const std::string& fieldname, int16_t** value,
-                        int32_t& length) const = 0;
+  virtual std::vector<int16_t> getShortArrayField(
+      const std::string& fieldname) const = 0;
 
   /**
    * Reads the named field and set its value in int32_t array type out param.
@@ -238,8 +238,8 @@ class _GEODE_EXPORT PdxInstance : public PdxSerializable {
    *
    * @see PdxInstance#hasField
    */
-  virtual void getField(const std::string& fieldname, int32_t** value,
-                        int32_t& length) const = 0;
+  virtual std::vector<int32_t> getIntArrayField(
+      const std::string& fieldname) const = 0;
 
   /**
    * Reads the named field and set its value in int64_t array type out param.
@@ -251,8 +251,8 @@ class _GEODE_EXPORT PdxInstance : public PdxSerializable {
    *
    * @see PdxInstance#hasField
    */
-  virtual void getField(const std::string& fieldname, int64_t** value,
-                        int32_t& length) const = 0;
+  virtual std::vector<int64_t> getLongArrayField(
+      const std::string& fieldname) const = 0;
 
   /**
    * Reads the named field and set its value in float array type out param.
@@ -264,8 +264,8 @@ class _GEODE_EXPORT PdxInstance : public PdxSerializable {
    *
    * @see PdxInstance#hasField
    */
-  virtual void getField(const std::string& fieldname, float** value,
-                        int32_t& length) const = 0;
+  virtual std::vector<float> getFloatArrayField(
+      const std::string& fieldname) const = 0;
 
   /**
    * Reads the named field and set its value in double array type out param.
@@ -277,8 +277,8 @@ class _GEODE_EXPORT PdxInstance : public PdxSerializable {
    *
    * @see PdxInstance#hasField
    */
-  virtual void getField(const std::string& fieldname, double** value,
-                        int32_t& length) const = 0;
+  virtual std::vector<double> getDoubleArrayField(
+      const std::string& fieldname) const = 0;
 
   // charArray
   /**
@@ -291,8 +291,8 @@ class _GEODE_EXPORT PdxInstance : public PdxSerializable {
    *
    * @see PdxInstance#hasField
    */
-  virtual void getField(const std::string& fieldName, char16_t** value,
-                        int32_t& length) const = 0;
+  virtual std::vector<char16_t> getCharArrayField(
+      const std::string& fieldName) const = 0;
 
   /**
    * Reads the named field as a string array.

--- a/cppcache/include/geode/PdxInstanceFactory.hpp
+++ b/cppcache/include/geode/PdxInstanceFactory.hpp
@@ -247,7 +247,7 @@ class _GEODE_EXPORT PdxInstanceFactory {
    * or fieldName is nullptr or empty.
    */
   virtual std::shared_ptr<PdxInstanceFactory> writeBooleanArray(
-      const std::string& fieldName, bool* value, int32_t length) = 0;
+      const std::string& fieldName, const std::vector<bool>& value) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -261,7 +261,7 @@ class _GEODE_EXPORT PdxInstanceFactory {
    * or fieldName is nullptr or empty.
    */
   virtual std::shared_ptr<PdxInstanceFactory> writeCharArray(
-      const std::string& fieldName, char16_t* value, int32_t length) = 0;
+      const std::string& fieldName, const std::vector<char16_t>& value) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -275,7 +275,7 @@ class _GEODE_EXPORT PdxInstanceFactory {
    * or fieldName is nullptr or empty.
    */
   virtual std::shared_ptr<PdxInstanceFactory> writeByteArray(
-      const std::string& fieldName, int8_t* value, int32_t length) = 0;
+      const std::string& fieldName, const std::vector<int8_t>& value) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -289,7 +289,7 @@ class _GEODE_EXPORT PdxInstanceFactory {
    * or fieldName is nullptr or empty.
    */
   virtual std::shared_ptr<PdxInstanceFactory> writeShortArray(
-      const std::string& fieldName, int16_t* value, int32_t length) = 0;
+      const std::string& fieldName, const std::vector<int16_t>& value) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -303,7 +303,7 @@ class _GEODE_EXPORT PdxInstanceFactory {
    * or fieldName is nullptr or empty.
    */
   virtual std::shared_ptr<PdxInstanceFactory> writeIntArray(
-      const std::string& fieldName, int32_t* value, int32_t length) = 0;
+      const std::string& fieldName, const std::vector<int32_t>& value) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -317,7 +317,7 @@ class _GEODE_EXPORT PdxInstanceFactory {
    * or fieldName is nullptr or empty.
    */
   virtual std::shared_ptr<PdxInstanceFactory> writeLongArray(
-      const std::string& fieldName, int64_t* value, int32_t length) = 0;
+      const std::string& fieldName, const std::vector<int64_t>& value) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -331,7 +331,7 @@ class _GEODE_EXPORT PdxInstanceFactory {
    * or fieldName is nullptr or empty.
    */
   virtual std::shared_ptr<PdxInstanceFactory> writeFloatArray(
-      const std::string& fieldName, float* value, int32_t length) = 0;
+      const std::string& fieldName, const std::vector<float>& value) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -345,7 +345,7 @@ class _GEODE_EXPORT PdxInstanceFactory {
    * or fieldName is nullptr or empty.
    */
   virtual std::shared_ptr<PdxInstanceFactory> writeDoubleArray(
-      const std::string& fieldName, double* value, int32_t length) = 0;
+      const std::string& fieldName, const std::vector<double>& value) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.

--- a/cppcache/include/geode/PdxReader.hpp
+++ b/cppcache/include/geode/PdxReader.hpp
@@ -188,8 +188,7 @@ class _GEODE_EXPORT PdxReader {
    *
    * @see PdxReader#hasField
    */
-  virtual char16_t* readCharArray(const std::string& fieldName,
-                                  int32_t& length) = 0;
+  virtual std::vector<char16_t> readCharArray(const std::string& fieldName) = 0;
 
   /**
    * Read a bool* value from the <code>PdxReader</code> and sets array length.
@@ -200,8 +199,7 @@ class _GEODE_EXPORT PdxReader {
    *
    * @see PdxReader#hasField
    */
-  virtual bool* readBooleanArray(const std::string& fieldName,
-                                 int32_t& length) = 0;
+  virtual std::vector<bool> readBooleanArray(const std::string& fieldName) = 0;
 
   /**
    * Read a int8_t* value from the <code>PdxReader</code> and sets array length.
@@ -213,8 +211,7 @@ class _GEODE_EXPORT PdxReader {
    *
    * @see PdxReader#hasField
    */
-  virtual int8_t* readByteArray(const std::string& fieldName,
-                                int32_t& length) = 0;
+  virtual std::vector<int8_t> readByteArray(const std::string& fieldName) = 0;
 
   /**
    * Read a int16_t* value from the <code>PdxReader</code> and sets array
@@ -227,8 +224,7 @@ class _GEODE_EXPORT PdxReader {
    *
    * @see PdxReader#hasField
    */
-  virtual int16_t* readShortArray(const std::string& fieldName,
-                                  int32_t& length) = 0;
+  virtual std::vector<int16_t> readShortArray(const std::string& fieldName) = 0;
 
   /**
    * Read a int32_t* value from the <code>PdxReader</code> and sets array
@@ -241,8 +237,7 @@ class _GEODE_EXPORT PdxReader {
    *
    * @see PdxReader#hasField
    */
-  virtual int32_t* readIntArray(const std::string& fieldName,
-                                int32_t& length) = 0;
+  virtual std::vector<int32_t> readIntArray(const std::string& fieldName) = 0;
 
   /**
    * Read a int64_t* value from the <code>PdxReader</code> and sets array
@@ -255,8 +250,7 @@ class _GEODE_EXPORT PdxReader {
    *
    * @see PdxReader#hasField
    */
-  virtual int64_t* readLongArray(const std::string& fieldName,
-                                 int32_t& length) = 0;
+  virtual std::vector<int64_t> readLongArray(const std::string& fieldName) = 0;
 
   /**
    * Read a float* value from the <code>PdxReader</code> and sets array length.
@@ -268,8 +262,7 @@ class _GEODE_EXPORT PdxReader {
    *
    * @see PdxReader#hasField
    */
-  virtual float* readFloatArray(const std::string& fieldName,
-                                int32_t& length) = 0;
+  virtual std::vector<float> readFloatArray(const std::string& fieldName) = 0;
 
   /**
    * Read a double* value from the <code>PdxReader</code> and sets array length.
@@ -281,8 +274,7 @@ class _GEODE_EXPORT PdxReader {
    *
    * @see PdxReader#hasField
    */
-  virtual double* readDoubleArray(const std::string& fieldName,
-                                  int32_t& length) = 0;
+  virtual std::vector<double> readDoubleArray(const std::string& fieldName) = 0;
 
   /**
    * Read a array of strings from the <code>PdxReader</code>.

--- a/cppcache/include/geode/PdxWriter.hpp
+++ b/cppcache/include/geode/PdxWriter.hpp
@@ -207,7 +207,7 @@ class _GEODE_EXPORT PdxWriter {
    * or fieldName is nullptr or empty.
    */
   virtual PdxWriter& writeBooleanArray(const std::string& fieldName,
-                                       bool* array, int length) = 0;
+                                       std::vector<bool> array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -221,7 +221,7 @@ class _GEODE_EXPORT PdxWriter {
    * or fieldName is nullptr or empty.
    */
   virtual PdxWriter& writeCharArray(
-      const std::string& fieldName, char16_t* array, int length) = 0;
+      const std::string& fieldName, std::vector<char16_t> array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -234,8 +234,8 @@ class _GEODE_EXPORT PdxWriter {
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
    */
-  virtual PdxWriter& writeByteArray(const std::string& fieldName, int8_t* array,
-                                    int length) = 0;
+  virtual PdxWriter& writeByteArray(const std::string& fieldName,
+                                    std::vector<int8_t> array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -249,7 +249,7 @@ class _GEODE_EXPORT PdxWriter {
    * or fieldName is nullptr or empty.
    */
   virtual PdxWriter& writeShortArray(const std::string& fieldName,
-                                     int16_t* array, int length) = 0;
+                                     std::vector<int16_t> array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -262,8 +262,8 @@ class _GEODE_EXPORT PdxWriter {
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
    */
-  virtual PdxWriter& writeIntArray(const std::string& fieldName, int32_t* array,
-                                   int length) = 0;
+  virtual PdxWriter& writeIntArray(const std::string& fieldName,
+                                   std::vector<int32_t> array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -277,7 +277,7 @@ class _GEODE_EXPORT PdxWriter {
    * or fieldName is nullptr or empty.
    */
   virtual PdxWriter& writeLongArray(const std::string& fieldName,
-                                    int64_t* array, int length) = 0;
+                                    std::vector<int64_t> array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -290,8 +290,8 @@ class _GEODE_EXPORT PdxWriter {
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
    */
-  virtual PdxWriter& writeFloatArray(const std::string& fieldName, float* array,
-                                     int length) = 0;
+  virtual PdxWriter& writeFloatArray(const std::string& fieldName,
+                                     std::vector<float> array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -305,7 +305,7 @@ class _GEODE_EXPORT PdxWriter {
    * or fieldName is nullptr or empty.
    */
   virtual PdxWriter& writeDoubleArray(const std::string& fieldName,
-                                      double* array, int length) = 0;
+                                      std::vector<double> array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.

--- a/cppcache/include/geode/PdxWriter.hpp
+++ b/cppcache/include/geode/PdxWriter.hpp
@@ -207,7 +207,7 @@ class _GEODE_EXPORT PdxWriter {
    * or fieldName is nullptr or empty.
    */
   virtual PdxWriter& writeBooleanArray(const std::string& fieldName,
-                                       std::vector<bool> array) = 0;
+                                       const std::vector<bool>& array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -221,7 +221,7 @@ class _GEODE_EXPORT PdxWriter {
    * or fieldName is nullptr or empty.
    */
   virtual PdxWriter& writeCharArray(
-      const std::string& fieldName, std::vector<char16_t> array) = 0;
+      const std::string& fieldName, const std::vector<char16_t>& array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -235,7 +235,7 @@ class _GEODE_EXPORT PdxWriter {
    * or fieldName is nullptr or empty.
    */
   virtual PdxWriter& writeByteArray(const std::string& fieldName,
-                                    std::vector<int8_t> array) = 0;
+                                    const std::vector<int8_t>& array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -249,7 +249,7 @@ class _GEODE_EXPORT PdxWriter {
    * or fieldName is nullptr or empty.
    */
   virtual PdxWriter& writeShortArray(const std::string& fieldName,
-                                     std::vector<int16_t> array) = 0;
+                                     const std::vector<int16_t>& array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -263,7 +263,7 @@ class _GEODE_EXPORT PdxWriter {
    * or fieldName is nullptr or empty.
    */
   virtual PdxWriter& writeIntArray(const std::string& fieldName,
-                                   std::vector<int32_t> array) = 0;
+                                   const std::vector<int32_t>& array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -277,7 +277,7 @@ class _GEODE_EXPORT PdxWriter {
    * or fieldName is nullptr or empty.
    */
   virtual PdxWriter& writeLongArray(const std::string& fieldName,
-                                    std::vector<int64_t> array) = 0;
+                                    const std::vector<int64_t>& array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -291,7 +291,7 @@ class _GEODE_EXPORT PdxWriter {
    * or fieldName is nullptr or empty.
    */
   virtual PdxWriter& writeFloatArray(const std::string& fieldName,
-                                     std::vector<float> array) = 0;
+                                     const std::vector<float>& array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.
@@ -305,7 +305,7 @@ class _GEODE_EXPORT PdxWriter {
    * or fieldName is nullptr or empty.
    */
   virtual PdxWriter& writeDoubleArray(const std::string& fieldName,
-                                      std::vector<double> array) = 0;
+                                      const std::vector<double>& array) = 0;
 
   /**
    * Writes the named field with the given value to the serialized form.

--- a/cppcache/include/geode/Serializer.hpp
+++ b/cppcache/include/geode/Serializer.hpp
@@ -234,7 +234,7 @@ inline std::vector<TObj> readArrayObject(apache::geode::client::DataInput& input
   std::vector<TObj> array;
   int len = input.readArrayLen();
   if (len >= 0) {
-    array.reserve(len);
+    array.resize(len);
     for (auto&& obj : array) {
       readObject(input, obj);
     }

--- a/cppcache/include/geode/Serializer.hpp
+++ b/cppcache/include/geode/Serializer.hpp
@@ -222,22 +222,22 @@ inline void writeObject(apache::geode::client::DataOutput& output,
 
 template <typename TObj>
 inline void writeArrayObject(apache::geode::client::DataOutput& output,
-                             const std::vector<TObj> array) {
+                             const std::vector<TObj>& array) {
   output.writeArrayLen(array.size());
-  for (int i = 0; i < array.size(); i++) {
-    writeObject(output, array[i]);
+  for (auto&& obj : array) {
+    writeObject(output, obj);
   }
 }
 
 template <typename TObj>
 inline std::vector<TObj> readArrayObject(apache::geode::client::DataInput& input) {
+  std::vector<TObj> array;
   int len = input.readArrayLen();
-  if (len < 0) {
-    return std::vector<TObj>{};
-  }
-  std::vector<TObj> array(len);
-  for (int i = 0; i < len; i++) {
-    readObject(input, array[i]);
+  if (len >= 0) {
+    array.reserve(len);
+    for (auto&& obj : array) {
+      readObject(input, obj);
+    }
   }
   return array;
 }
@@ -261,14 +261,14 @@ inline void readObject(apache::geode::client::DataInput& input, TObj*& array,
 template <typename TObj,
           typename std::enable_if<!std::is_base_of<Serializable, TObj>::value,
                                   Serializable>::type* = nullptr>
-inline uint32_t objectArraySize(const std::vector<TObj> array) {
+inline uint32_t objectArraySize(const std::vector<TObj>& array) {
   return (uint32_t)(sizeof(TObj) * array.size());
 }
 
 template <typename TObj,
           typename std::enable_if<std::is_base_of<Serializable, TObj>::value,
                                   Serializable>::type* = nullptr>
-inline uint32_t objectArraySize(const std::vector<TObj> array) {
+inline uint32_t objectArraySize(const std::vector<TObj>& array) {
   uint32_t size = 0;
   for (auto obj : array) {
     size += obj.objectArraySize();

--- a/cppcache/include/geode/WritablePdxInstance.hpp
+++ b/cppcache/include/geode/WritablePdxInstance.hpp
@@ -256,7 +256,7 @@ class _GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    * or if the type of the value is not compatible with the field.
    */
   virtual void setField(const std::string& fieldName,
-                        std::vector<int8_t> value) = 0;
+                        const std::vector<int8_t>& value) = 0;
 
   /**
    * Set the existing named field to the given value.

--- a/cppcache/include/geode/WritablePdxInstance.hpp
+++ b/cppcache/include/geode/WritablePdxInstance.hpp
@@ -237,8 +237,8 @@ class _GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
-  virtual void setField(const std::string& fieldName, bool* value,
-                        int32_t length) = 0;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<bool>& value) = 0;
 
   /**
    * Set the existing named field to the given value.
@@ -255,8 +255,8 @@ class _GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
-  virtual void setField(const std::string& fieldName, int8_t* value,
-                        int32_t length) = 0;
+  virtual void setField(const std::string& fieldName,
+                        std::vector<int8_t> value) = 0;
 
   /**
    * Set the existing named field to the given value.
@@ -273,8 +273,8 @@ class _GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
-  virtual void setField(const std::string& fieldName, int16_t* value,
-                        int32_t length) = 0;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<int16_t>& value) = 0;
 
   /**
    * Set the existing named field to the given value.
@@ -291,8 +291,8 @@ class _GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
-  virtual void setField(const std::string& fieldName, int32_t* value,
-                        int32_t length) = 0;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<int32_t>& value) = 0;
 
   /**
    * Set the existing named field to the given value.
@@ -309,8 +309,8 @@ class _GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
-  virtual void setField(const std::string& fieldName, int64_t* value,
-                        int32_t length) = 0;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<int64_t>& value) = 0;
 
   /**
    * Set the existing named field to the given value.
@@ -327,8 +327,8 @@ class _GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
-  virtual void setField(const std::string& fieldName, float* value,
-                        int32_t length) = 0;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<float>& value) = 0;
 
   /**
    * Set the existing named field to the given value.
@@ -345,8 +345,8 @@ class _GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
-  virtual void setField(const std::string& fieldName, double* value,
-                        int32_t length) = 0;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<double>& value) = 0;
 
   /**
    * Set the existing named field to the given value.
@@ -379,8 +379,8 @@ class _GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
-  virtual void setField(const std::string& fieldName, char16_t* value,
-                        int32_t length) = 0;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<char16_t>& value) = 0;
 
   /**
    * Set the existing named field to the given value.

--- a/cppcache/integration-test/BuiltinCacheableWrappers.hpp
+++ b/cppcache/integration-test/BuiltinCacheableWrappers.hpp
@@ -97,9 +97,9 @@ inline TPRIM random(TPRIM maxValue) {
 // This returns an array allocated on heap
 // which should be freed by the user.
 template <typename TPRIM>
-inline TPRIM* randomArray(int32_t size, TPRIM maxValue) {
+inline std::vector<TPRIM> randomArray(int32_t size, TPRIM maxValue) {
   ASSERT(size > 0, "The size of the array should be greater than zero.");
-  TPRIM* array = new TPRIM[size];
+  std::vector<TPRIM> array(size);
 
   for (int32_t index = 0; index < size; index++) {
     array[index] = random(maxValue);
@@ -166,10 +166,10 @@ inline uint32_t crc32(TPRIM value) {
 }
 
 template <typename TPRIM>
-inline uint32_t crc32Array(const TPRIM* arr, uint32_t len) {
+inline uint32_t crc32Array(const std::vector<TPRIM> arr) {
   auto output = CacheHelper::getHelper().getCache()->createDataOutput();
-  for (uint32_t index = 0; index < len; index++) {
-    apache::geode::client::serializer::writeObject(*output, arr[index]);
+  for (auto obj : arr) {
+    apache::geode::client::serializer::writeObject(*output, obj);
   }
   return crc32(output->getBuffer(), output->getBufferLength());
 }
@@ -837,11 +837,10 @@ class CacheableBytesWrapper : public CacheableWrapper {
   // CacheableWrapper members
 
   virtual void initRandomValue(int32_t maxSize) {
-    uint8_t* randArr =
+    auto randArr =
         CacheableHelper::randomArray<uint8_t>(maxSize, UCHAR_MAX);
     m_cacheableObject = CacheableBytes::create(
-        reinterpret_cast<const int8_t*>(randArr), maxSize);
-    delete[] randArr;
+        reinterpret_cast<const int8_t*>(randArr.data()), maxSize);
   }
 
   virtual uint32_t getCheckSum(const std::shared_ptr<Cacheable> object) const {
@@ -866,17 +865,16 @@ class CacheableDoubleArrayWrapper : public CacheableWrapper {
 
   virtual void initRandomValue(int32_t maxSize) {
     maxSize = maxSize / sizeof(double) + 1;
-    double* randArr =
+    auto randArr =
         CacheableHelper::randomArray(maxSize, static_cast<double>(INT_MAX));
-    m_cacheableObject = CacheableDoubleArray::create(randArr, maxSize);
-    delete[] randArr;
+    m_cacheableObject = CacheableArray<double>::create(randArr);
   }
 
   virtual uint32_t getCheckSum(const std::shared_ptr<Cacheable> object) const {
-    const CacheableDoubleArray* obj =
-        dynamic_cast<const CacheableDoubleArray*>(object.get());
+    const CacheableArray<double>* obj =
+        dynamic_cast<const CacheableArray<double>*>(object.get());
     ASSERT(obj != nullptr, "getCheckSum: null object.");
-    return CacheableHelper::crc32Array(obj->value(), obj->length());
+    return CacheableHelper::crc32Array(obj->value());
   }
 };
 
@@ -892,17 +890,16 @@ class CacheableFloatArrayWrapper : public CacheableWrapper {
 
   virtual void initRandomValue(int32_t maxSize) {
     maxSize = maxSize / sizeof(float) + 1;
-    float* randArr =
+    auto randArr =
         CacheableHelper::randomArray(maxSize, static_cast<float>(INT_MAX));
-    m_cacheableObject = CacheableFloatArray::create(randArr, maxSize);
-    delete[] randArr;
+    m_cacheableObject = CacheableArray<float>::create(randArr);
   }
 
   virtual uint32_t getCheckSum(const std::shared_ptr<Cacheable> object) const {
-    const CacheableFloatArray* obj =
-        dynamic_cast<const CacheableFloatArray*>(object.get());
+    const CacheableArray<float>* obj =
+        dynamic_cast<const CacheableArray<float>*>(object.get());
     ASSERT(obj != nullptr, "getCheckSum: null object.");
-    return CacheableHelper::crc32Array(obj->value(), obj->length());
+    return CacheableHelper::crc32Array(obj->value());
   }
 };
 
@@ -918,16 +915,15 @@ class CacheableInt16ArrayWrapper : public CacheableWrapper {
 
   virtual void initRandomValue(int32_t maxSize) {
     maxSize = maxSize / sizeof(int16_t) + 1;
-    int16_t* randArr = CacheableHelper::randomArray<int16_t>(maxSize, SHRT_MAX);
-    m_cacheableObject = CacheableInt16Array::create(randArr, maxSize);
-    delete[] randArr;
+    auto randArr = CacheableHelper::randomArray<int16_t>(maxSize, SHRT_MAX);
+    m_cacheableObject = CacheableArray<int16_t>::create(randArr);
   }
 
   virtual uint32_t getCheckSum(const std::shared_ptr<Cacheable> object) const {
-    const CacheableInt16Array* obj =
-        dynamic_cast<const CacheableInt16Array*>(object.get());
+    const CacheableArray<int16_t>* obj =
+        dynamic_cast<const CacheableArray<int16_t>*>(object.get());
     ASSERT(obj != nullptr, "getCheckSum: null object.");
-    return CacheableHelper::crc32Array(obj->value(), obj->length());
+    return CacheableHelper::crc32Array(obj->value());
   }
 };
 
@@ -943,16 +939,15 @@ class CacheableInt32ArrayWrapper : public CacheableWrapper {
 
   virtual void initRandomValue(int32_t maxSize) {
     maxSize = maxSize / sizeof(int32_t) + 1;
-    int32_t* randArr = CacheableHelper::randomArray<int32_t>(maxSize, INT_MAX);
-    m_cacheableObject = CacheableInt32Array::create(randArr, maxSize);
-    delete[] randArr;
+    auto randArr = CacheableHelper::randomArray<int32_t>(maxSize, INT_MAX);
+    m_cacheableObject = CacheableArray<int32_t>::create(randArr);
   }
 
   virtual uint32_t getCheckSum(const std::shared_ptr<Cacheable> object) const {
-    const CacheableInt32Array* obj =
-        dynamic_cast<const CacheableInt32Array*>(object.get());
+    const CacheableArray<int32_t>* obj =
+        dynamic_cast<const CacheableArray<int32_t>*>(object.get());
     ASSERT(obj != nullptr, "getCheckSum: null object.");
-    return CacheableHelper::crc32Array(obj->value(), obj->length());
+    return CacheableHelper::crc32Array(obj->value());
   }
 };
 
@@ -968,16 +963,15 @@ class CacheableInt64ArrayWrapper : public CacheableWrapper {
 
   virtual void initRandomValue(int32_t maxSize) {
     maxSize = maxSize / sizeof(int64_t) + 1;
-    int64_t* randArr = CacheableHelper::randomArray<int64_t>(maxSize, INT_MAX);
-    m_cacheableObject = CacheableInt64Array::create(randArr, maxSize);
-    delete[] randArr;
+    auto randArr = CacheableHelper::randomArray<int64_t>(maxSize, INT_MAX);
+    m_cacheableObject = CacheableArray<int64_t>::create(randArr);
   }
 
   virtual uint32_t getCheckSum(const std::shared_ptr<Cacheable> object) const {
-    const CacheableInt64Array* obj =
-        dynamic_cast<const CacheableInt64Array*>(object.get());
+    const CacheableArray<int64_t>* obj =
+        dynamic_cast<const CacheableArray<int64_t>*>(object.get());
     ASSERT(obj != nullptr, "getCheckSum: null object.");
-    return CacheableHelper::crc32Array(obj->value(), obj->length());
+    return CacheableHelper::crc32Array(obj->value());
   }
 };
 

--- a/cppcache/integration-test/BuiltinCacheableWrappers.hpp
+++ b/cppcache/integration-test/BuiltinCacheableWrappers.hpp
@@ -99,7 +99,8 @@ inline TPRIM random(TPRIM maxValue) {
 template <typename TPRIM>
 inline std::vector<TPRIM> randomArray(int32_t size, TPRIM maxValue) {
   ASSERT(size > 0, "The size of the array should be greater than zero.");
-  std::vector<TPRIM> array(size);
+  std::vector<TPRIM> array;
+  array.reserve(size);
 
   for (int32_t index = 0; index < size; index++) {
     array[index] = random(maxValue);
@@ -867,12 +868,12 @@ class CacheableDoubleArrayWrapper : public CacheableWrapper {
     maxSize = maxSize / sizeof(double) + 1;
     auto randArr =
         CacheableHelper::randomArray(maxSize, static_cast<double>(INT_MAX));
-    m_cacheableObject = CacheableArray<double>::create(randArr);
+    m_cacheableObject = CacheableDoubleArray::create(randArr);
   }
 
   virtual uint32_t getCheckSum(const std::shared_ptr<Cacheable> object) const {
-    const CacheableArray<double>* obj =
-        dynamic_cast<const CacheableArray<double>*>(object.get());
+    const auto obj =
+        std::dynamic_pointer_cast<const CacheableDoubleArray>(object);
     ASSERT(obj != nullptr, "getCheckSum: null object.");
     return CacheableHelper::crc32Array(obj->value());
   }
@@ -892,12 +893,12 @@ class CacheableFloatArrayWrapper : public CacheableWrapper {
     maxSize = maxSize / sizeof(float) + 1;
     auto randArr =
         CacheableHelper::randomArray(maxSize, static_cast<float>(INT_MAX));
-    m_cacheableObject = CacheableArray<float>::create(randArr);
+    m_cacheableObject = CacheableFloatArray::create(randArr);
   }
 
   virtual uint32_t getCheckSum(const std::shared_ptr<Cacheable> object) const {
-    const CacheableArray<float>* obj =
-        dynamic_cast<const CacheableArray<float>*>(object.get());
+    const auto obj =
+        std::dynamic_pointer_cast<const CacheableFloatArray>(object);
     ASSERT(obj != nullptr, "getCheckSum: null object.");
     return CacheableHelper::crc32Array(obj->value());
   }
@@ -916,12 +917,12 @@ class CacheableInt16ArrayWrapper : public CacheableWrapper {
   virtual void initRandomValue(int32_t maxSize) {
     maxSize = maxSize / sizeof(int16_t) + 1;
     auto randArr = CacheableHelper::randomArray<int16_t>(maxSize, SHRT_MAX);
-    m_cacheableObject = CacheableArray<int16_t>::create(randArr);
+    m_cacheableObject = CacheableInt16Array::create(randArr);
   }
 
   virtual uint32_t getCheckSum(const std::shared_ptr<Cacheable> object) const {
-    const CacheableArray<int16_t>* obj =
-        dynamic_cast<const CacheableArray<int16_t>*>(object.get());
+    const auto obj =
+        std::dynamic_pointer_cast<const CacheableInt16Array>(object);
     ASSERT(obj != nullptr, "getCheckSum: null object.");
     return CacheableHelper::crc32Array(obj->value());
   }
@@ -940,12 +941,12 @@ class CacheableInt32ArrayWrapper : public CacheableWrapper {
   virtual void initRandomValue(int32_t maxSize) {
     maxSize = maxSize / sizeof(int32_t) + 1;
     auto randArr = CacheableHelper::randomArray<int32_t>(maxSize, INT_MAX);
-    m_cacheableObject = CacheableArray<int32_t>::create(randArr);
+    m_cacheableObject = CacheableInt32Array::create(randArr);
   }
 
   virtual uint32_t getCheckSum(const std::shared_ptr<Cacheable> object) const {
-    const CacheableArray<int32_t>* obj =
-        dynamic_cast<const CacheableArray<int32_t>*>(object.get());
+    const auto obj =
+        std::dynamic_pointer_cast<const CacheableInt32Array>(object);
     ASSERT(obj != nullptr, "getCheckSum: null object.");
     return CacheableHelper::crc32Array(obj->value());
   }
@@ -964,12 +965,12 @@ class CacheableInt64ArrayWrapper : public CacheableWrapper {
   virtual void initRandomValue(int32_t maxSize) {
     maxSize = maxSize / sizeof(int64_t) + 1;
     auto randArr = CacheableHelper::randomArray<int64_t>(maxSize, INT_MAX);
-    m_cacheableObject = CacheableArray<int64_t>::create(randArr);
+    m_cacheableObject = CacheableInt64Array::create(randArr);
   }
 
   virtual uint32_t getCheckSum(const std::shared_ptr<Cacheable> object) const {
-    const CacheableArray<int64_t>* obj =
-        dynamic_cast<const CacheableArray<int64_t>*>(object.get());
+    const auto obj =
+        std::dynamic_pointer_cast<const CacheableInt64Array>(object);
     ASSERT(obj != nullptr, "getCheckSum: null object.");
     return CacheableHelper::crc32Array(obj->value());
   }

--- a/cppcache/integration-test/BuiltinCacheableWrappers.hpp
+++ b/cppcache/integration-test/BuiltinCacheableWrappers.hpp
@@ -103,7 +103,7 @@ inline std::vector<TPRIM> randomArray(int32_t size, TPRIM maxValue) {
   array.reserve(size);
 
   for (int32_t index = 0; index < size; index++) {
-    array[index] = random(maxValue);
+    array.push_back(random(maxValue));
   }
   return array;
 }

--- a/cppcache/integration-test/ThinClientPdxSerializers.hpp
+++ b/cppcache/integration-test/ThinClientPdxSerializers.hpp
@@ -152,8 +152,7 @@ class TestPdxSerializer : public PdxSerializer {
       npt->m_ulong = pr.readLong("m_ulong");
       npt->m_uint32Array = pr.readIntArray("m_uint32Array");
       npt->m_ulongArray = pr.readLongArray("m_ulongArray");
-      npt->m_uint16Array =
-          pr.readShortArray("m_uint16Array");
+      npt->m_uint16Array = pr.readShortArray("m_uint16Array");
       // LOGINFO("PdxType::readInt() start...");
 
       npt->m_byte252 = pr.readByteArray("m_byte252");

--- a/cppcache/integration-test/ThinClientPdxSerializers.hpp
+++ b/cppcache/integration-test/ThinClientPdxSerializers.hpp
@@ -98,11 +98,11 @@ class TestPdxSerializer : public PdxSerializer {
 
       npt->m_bool = pr.readBoolean("m_bool");
       // GenericValCompare
-      npt->m_boolArray = pr.readBooleanArray("m_boolArray", npt->boolArrayLen);
+      npt->m_boolArray = pr.readBooleanArray("m_boolArray");
 
       npt->m_byte = pr.readByte("m_byte");
-      npt->m_byteArray = pr.readByteArray("m_byteArray", npt->byteArrayLen);
-      npt->m_charArray = pr.readCharArray("m_charArray", npt->charArrayLen);
+      npt->m_byteArray = pr.readByteArray("m_byteArray");
+      npt->m_charArray = pr.readCharArray("m_charArray");
 
       npt->m_arraylist = std::dynamic_pointer_cast<CacheableArrayList>(
           pr.readObject("m_arraylist"));
@@ -133,33 +133,33 @@ class TestPdxSerializer : public PdxSerializer {
       npt->m_double = pr.readDouble("m_double");
 
       npt->m_doubleArray =
-          pr.readDoubleArray("m_doubleArray", npt->doubleArrayLen);
+          pr.readDoubleArray("m_doubleArray");
       npt->m_float = pr.readFloat("m_float");
       npt->m_floatArray =
-          pr.readFloatArray("m_floatArray", npt->floatArrayLen);
+          pr.readFloatArray("m_floatArray");
       npt->m_int16 = pr.readShort("m_int16");
       npt->m_int32 = pr.readInt("m_int32");
       npt->m_long = pr.readLong("m_long");
-      npt->m_int32Array = pr.readIntArray("m_int32Array", npt->intArrayLen);
-      npt->m_longArray = pr.readLongArray("m_longArray", npt->longArrayLen);
+      npt->m_int32Array = pr.readIntArray("m_int32Array");
+      npt->m_longArray = pr.readLongArray("m_longArray");
       npt->m_int16Array =
-          pr.readShortArray("m_int16Array", npt->shortArrayLen);
+          pr.readShortArray("m_int16Array");
       npt->m_sbyte = pr.readByte("m_sbyte");
-      npt->m_sbyteArray = pr.readByteArray("m_sbyteArray", npt->byteArrayLen);
+      npt->m_sbyteArray = pr.readByteArray("m_sbyteArray");
       npt->m_stringArray = pr.readStringArray("m_stringArray");
       npt->m_uint16 = pr.readShort("m_uint16");
       npt->m_uint32 = pr.readInt("m_uint32");
       npt->m_ulong = pr.readLong("m_ulong");
-      npt->m_uint32Array = pr.readIntArray("m_uint32Array", npt->intArrayLen);
-      npt->m_ulongArray = pr.readLongArray("m_ulongArray", npt->longArrayLen);
+      npt->m_uint32Array = pr.readIntArray("m_uint32Array");
+      npt->m_ulongArray = pr.readLongArray("m_ulongArray");
       npt->m_uint16Array =
-          pr.readShortArray("m_uint16Array", npt->shortArrayLen);
+          pr.readShortArray("m_uint16Array");
       // LOGINFO("PdxType::readInt() start...");
 
-      npt->m_byte252 = pr.readByteArray("m_byte252", npt->m_byte252Len);
-      npt->m_byte253 = pr.readByteArray("m_byte253", npt->m_byte253Len);
-      npt->m_byte65535 = pr.readByteArray("m_byte65535", npt->m_byte65535Len);
-      npt->m_byte65536 = pr.readByteArray("m_byte65536", npt->m_byte65536Len);
+      npt->m_byte252 = pr.readByteArray("m_byte252");
+      npt->m_byte253 = pr.readByteArray("m_byte253");
+      npt->m_byte65535 = pr.readByteArray("m_byte65535");
+      npt->m_byte65536 = pr.readByteArray("m_byte65536");
 
       npt->m_pdxEnum = pr.readObject("m_pdxEnum");
 
@@ -210,13 +210,13 @@ class TestPdxSerializer : public PdxSerializer {
       pw.markIdentityField("m_char");
       pw.writeBoolean("m_bool", npt->m_bool);  // 1
       pw.markIdentityField("m_bool");
-      pw.writeBooleanArray("m_boolArray", npt->m_boolArray, 3);
+      pw.writeBooleanArray("m_boolArray", npt->m_boolArray);
       pw.markIdentityField("m_boolArray");
       pw.writeByte("m_byte", npt->m_byte);
       pw.markIdentityField("m_byte");
-      pw.writeByteArray("m_byteArray", npt->m_byteArray, 2);
+      pw.writeByteArray("m_byteArray", npt->m_byteArray);
       pw.markIdentityField("m_byteArray");
-      pw.writeCharArray("m_charArray", npt->m_charArray, 2);
+      pw.writeCharArray("m_charArray", npt->m_charArray);
       pw.markIdentityField("m_charArray");
       pw.writeObject("m_arraylist", npt->m_arraylist);
       pw.markIdentityField("m_arraylist");
@@ -236,11 +236,11 @@ class TestPdxSerializer : public PdxSerializer {
       pw.markIdentityField("m_dateTime");
       pw.writeDouble("m_double", npt->m_double);
       pw.markIdentityField("m_double");
-      pw.writeDoubleArray("m_doubleArray", npt->m_doubleArray, 2);
+      pw.writeDoubleArray("m_doubleArray", npt->m_doubleArray);
       pw.markIdentityField("m_doubleArray");
       pw.writeFloat("m_float", npt->m_float);
       pw.markIdentityField("m_float");
-      pw.writeFloatArray("m_floatArray", npt->m_floatArray, 2);
+      pw.writeFloatArray("m_floatArray", npt->m_floatArray);
       pw.markIdentityField("m_floatArray");
       pw.writeShort("m_int16", npt->m_int16);
       pw.markIdentityField("m_int16");
@@ -248,15 +248,15 @@ class TestPdxSerializer : public PdxSerializer {
       pw.markIdentityField("m_int32");
       pw.writeLong("m_long", npt->m_long);
       pw.markIdentityField("m_long");
-      pw.writeIntArray("m_int32Array", npt->m_int32Array, 4);
+      pw.writeIntArray("m_int32Array", npt->m_int32Array);
       pw.markIdentityField("m_int32Array");
-      pw.writeLongArray("m_longArray", npt->m_longArray, 2);
+      pw.writeLongArray("m_longArray", npt->m_longArray);
       pw.markIdentityField("m_longArray");
-      pw.writeShortArray("m_int16Array", npt->m_int16Array, 2);
+      pw.writeShortArray("m_int16Array", npt->m_int16Array);
       pw.markIdentityField("m_int16Array");
       pw.writeByte("m_sbyte", npt->m_sbyte);
       pw.markIdentityField("m_sbyte");
-      pw.writeByteArray("m_sbyteArray", npt->m_sbyteArray, 2);
+      pw.writeByteArray("m_sbyteArray", npt->m_sbyteArray);
       pw.markIdentityField("m_sbyteArray");
 
       int *strlengthArr = new int[2];
@@ -271,20 +271,20 @@ class TestPdxSerializer : public PdxSerializer {
       pw.markIdentityField("m_uint32");
       pw.writeLong("m_ulong", npt->m_ulong);
       pw.markIdentityField("m_ulong");
-      pw.writeIntArray("m_uint32Array", npt->m_uint32Array, 4);
+      pw.writeIntArray("m_uint32Array", npt->m_uint32Array);
       pw.markIdentityField("m_uint32Array");
-      pw.writeLongArray("m_ulongArray", npt->m_ulongArray, 2);
+      pw.writeLongArray("m_ulongArray", npt->m_ulongArray);
       pw.markIdentityField("m_ulongArray");
-      pw.writeShortArray("m_uint16Array", npt->m_uint16Array, 2);
+      pw.writeShortArray("m_uint16Array", npt->m_uint16Array);
       pw.markIdentityField("m_uint16Array");
 
-      pw.writeByteArray("m_byte252", npt->m_byte252, 252);
+      pw.writeByteArray("m_byte252", npt->m_byte252);
       pw.markIdentityField("m_byte252");
-      pw.writeByteArray("m_byte253", npt->m_byte253, 253);
+      pw.writeByteArray("m_byte253", npt->m_byte253);
       pw.markIdentityField("m_byte253");
-      pw.writeByteArray("m_byte65535", npt->m_byte65535, 65535);
+      pw.writeByteArray("m_byte65535", npt->m_byte65535);
       pw.markIdentityField("m_byte65535");
-      pw.writeByteArray("m_byte65536", npt->m_byte65536, 65536);
+      pw.writeByteArray("m_byte65536", npt->m_byte65536);
       pw.markIdentityField("m_byte65536");
 
       pw.writeObject("m_pdxEnum", npt->m_pdxEnum);

--- a/cppcache/integration-test/testThinClientPdxInstance.cpp
+++ b/cppcache/integration-test/testThinClientPdxInstance.cpp
@@ -65,7 +65,7 @@ bool genericValCompare(T1 value1, T2 value2) /*const*/
 }
 
 template <typename T1, typename T2>
-bool genericCompare(T1* value1, T2* value2, int length) /*const*/
+bool genericCompare(std::vector<T1> value1, std::vector<T2> value2, int length) /*const*/
 {
   int i = 0;
   while (i < length) {
@@ -905,43 +905,38 @@ DUNIT_TASK_DEFINITION(CLIENT2, accessPdxInstance)
              "All stringVals should be equal");
     }
 
-    int8_t* byteArray = nullptr;
-    int32_t byteArrayLength = 0;
-    pIPtr->getField("m_byteArray", &byteArray, byteArrayLength);
+    auto byteArray = pIPtr->getByteArrayField("m_byteArray");
     ASSERT(genericValCompare(pdxobjPtr->getByteArrayLength(),
-                             byteArrayLength) == true,
+                             byteArray.size()) == true,
            "byteArrayLength should be equal");
     ASSERT(genericCompare(pdxobjPtr->getByteArray(), byteArray,
-                          byteArrayLength) == true,
+                          byteArray.size()) == true,
            "byteArray should be equal");
     ASSERT(pIPtr->getFieldType("m_byteArray") == PdxFieldTypes::BYTE_ARRAY,
            "Type Value BYTE_ARRAY Mismatch");
 
-    char16_t* charArray = nullptr;
-    int32_t charArrayLength = 0;
-    pIPtr->getField("m_charArray", &charArray, charArrayLength);
+    auto charArray = pIPtr->getCharArrayField("m_charArray");
     ASSERT(genericValCompare(pdxobjPtr->getCharArrayLength(),
-                             charArrayLength) == true,
+                             charArray.size()) == true,
            "charArrayLength should be equal");
     ASSERT(genericCompare(pdxobjPtr->getCharArray(), charArray,
-                          charArrayLength) == true,
+                          charArray.size()) == true,
            "charArray should be equal");
     ASSERT(pIPtr->getFieldType("m_charArray") == PdxFieldTypes::CHAR_ARRAY,
            "Type Value CHAR_ARRAY Mismatch");
 
-    pIPtr->getField("m_sbyteArray", &byteArray, byteArrayLength);
+    byteArray = pIPtr->getByteArrayField("m_sbyteArray");
     ASSERT(genericValCompare(pdxobjPtr->getByteArrayLength(),
-                             byteArrayLength) == true,
+                             byteArray.size()) == true,
            "sbyteArrayLength should be equal");
     ASSERT(genericCompare(pdxobjPtr->getSByteArray(), byteArray,
-                          byteArrayLength) == true,
+                          byteArray.size()) == true,
            "m_sbyteArray should be equal");
     ASSERT(pIPtr->getFieldType("m_sbyteArray") == PdxFieldTypes::BYTE_ARRAY,
            "Type Value BYTE_ARRAY Mismatch");
 
-    bool* boolArray = nullptr;
-    int32_t boolArrayLength = 0;
-    pIPtr->getField("m_boolArray", &boolArray, boolArrayLength);
+    auto boolArray = pIPtr->getBooleanArrayField("m_boolArray");
+    int32_t boolArrayLength = boolArray.size();
     ASSERT(genericValCompare(pdxobjPtr->getBoolArrayLength(),
                              boolArrayLength) == true,
            "boolArrayLength should be equal");
@@ -951,9 +946,8 @@ DUNIT_TASK_DEFINITION(CLIENT2, accessPdxInstance)
     ASSERT(pIPtr->getFieldType("m_boolArray") == PdxFieldTypes::BOOLEAN_ARRAY,
            "Type Value BOOLEAN_ARRAY Mismatch");
 
-    int16_t* shortArray = nullptr;
-    int32_t shortArrayLength = 0;
-    pIPtr->getField("m_int16Array", &shortArray, shortArrayLength);
+    auto shortArray = pIPtr->getShortArrayField("m_int16Array");
+    int32_t shortArrayLength = shortArray.size();
     ASSERT(genericValCompare(pdxobjPtr->getShortArrayLength(),
                              shortArrayLength) == true,
            "shortArrayLength should be equal");
@@ -963,7 +957,8 @@ DUNIT_TASK_DEFINITION(CLIENT2, accessPdxInstance)
     ASSERT(pIPtr->getFieldType("m_int16Array") == PdxFieldTypes::SHORT_ARRAY,
            "Type Value SHORT_ARRAY Mismatch");
 
-    pIPtr->getField("m_uint16Array", &shortArray, shortArrayLength);
+    shortArray = pIPtr->getShortArrayField("m_uint16Array");
+    shortArrayLength = shortArray.size();
     ASSERT(genericValCompare(pdxobjPtr->getShortArrayLength(),
                              shortArrayLength) == true,
            "shortArrayLength should be equal");
@@ -973,9 +968,8 @@ DUNIT_TASK_DEFINITION(CLIENT2, accessPdxInstance)
     ASSERT(pIPtr->getFieldType("m_uint16Array") == PdxFieldTypes::SHORT_ARRAY,
            "Type Value SHORT_ARRAY Mismatch");
 
-    int32_t* intArray = nullptr;
-    int32_t intArrayLength = 0;
-    pIPtr->getField("m_int32Array", &intArray, intArrayLength);
+    auto intArray = pIPtr->getIntArrayField("m_int32Array");
+    int32_t intArrayLength = intArray.size();
     ASSERT(genericValCompare(pdxobjPtr->getIntArrayLength(), intArrayLength) ==
                true,
            "intArrayLength should be equal");
@@ -985,7 +979,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, accessPdxInstance)
     ASSERT(pIPtr->getFieldType("m_int32Array") == PdxFieldTypes::INT_ARRAY,
            "Type Value INT_ARRAY Mismatch");
 
-    pIPtr->getField("m_uint32Array", &intArray, intArrayLength);
+    intArray = pIPtr->getIntArrayField("m_uint32Array");
     ASSERT(genericValCompare(pdxobjPtr->getIntArrayLength(), intArrayLength) ==
                true,
            "intArrayLength should be equal");
@@ -995,9 +989,8 @@ DUNIT_TASK_DEFINITION(CLIENT2, accessPdxInstance)
     ASSERT(pIPtr->getFieldType("m_uint32Array") == PdxFieldTypes::INT_ARRAY,
            "Type Value INT_ARRAY Mismatch");
 
-    int64_t* longArray = nullptr;
-    int32_t longArrayLength = 0;
-    pIPtr->getField("m_longArray", &longArray, longArrayLength);
+    auto longArray = pIPtr->getLongArrayField("m_longArray");
+    int32_t longArrayLength = longArray.size();
     ASSERT(genericValCompare(pdxobjPtr->getLongArrayLength(),
                              longArrayLength) == true,
            "longArrayLength should be equal");
@@ -1007,7 +1000,8 @@ DUNIT_TASK_DEFINITION(CLIENT2, accessPdxInstance)
     ASSERT(pIPtr->getFieldType("m_longArray") == PdxFieldTypes::LONG_ARRAY,
            "Type Value LONG_ARRAY Mismatch");
 
-    pIPtr->getField("m_ulongArray", &longArray, longArrayLength);
+    longArray = pIPtr->getLongArrayField("m_ulongArray");
+    longArrayLength = longArray.size();
     ASSERT(genericValCompare(pdxobjPtr->getLongArrayLength(),
                              longArrayLength) == true,
            "longArrayLength should be equal");
@@ -1017,9 +1011,8 @@ DUNIT_TASK_DEFINITION(CLIENT2, accessPdxInstance)
     ASSERT(pIPtr->getFieldType("m_ulongArray") == PdxFieldTypes::LONG_ARRAY,
            "Type Value LONG_ARRAY Mismatch");
 
-    double* doubleArray = nullptr;
-    int32_t doubleArrayLength = 0;
-    pIPtr->getField("m_doubleArray", &doubleArray, doubleArrayLength);
+    auto doubleArray = pIPtr->getDoubleArrayField("m_doubleArray");
+    int32_t doubleArrayLength = doubleArray.size();
     ASSERT(genericValCompare(pdxobjPtr->getDoubleArrayLength(),
                              doubleArrayLength) == true,
            "doubleArrayLength should be equal");
@@ -1029,9 +1022,8 @@ DUNIT_TASK_DEFINITION(CLIENT2, accessPdxInstance)
     ASSERT(pIPtr->getFieldType("m_doubleArray") == PdxFieldTypes::DOUBLE_ARRAY,
            "Type Value DOUBLE_ARRAY Mismatch");
 
-    float* floatArray = nullptr;
-    int32_t floatArrayLength = 0;
-    pIPtr->getField("m_floatArray", &floatArray, floatArrayLength);
+    auto floatArray = pIPtr->getFloatArrayField("m_floatArray");
+    int32_t floatArrayLength = floatArray.size();
     ASSERT(genericValCompare(pdxobjPtr->getFloatArrayLength(),
                              floatArrayLength) == true,
            "floatArrayLength should be equal");
@@ -1383,16 +1375,16 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
           "IllegalStateException");
     }
 
-    int arrayLen = 0;
 
-    bool setBoolArray[] = {true, false, true, false, true, true, false, true};
-    bool* getBoolArray = nullptr;
-    wpiPtr->setField("m_boolArray", setBoolArray, 8);
+    std::vector<bool> setBoolArray{true, false, true, false, true, true, false, true};
+    int arrayLen = setBoolArray.size();
+    wpiPtr->setField("m_boolArray", setBoolArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(newPiPtr->hasField("m_boolArray") == true,
            "m_boolArray = true expected");
-    newPiPtr->getField("m_boolArray", &getBoolArray, arrayLen);
+    auto getBoolArray = newPiPtr->getBooleanArrayField("m_boolArray");
+    arrayLen = getBoolArray.size();
     ASSERT(arrayLen == 8, "Arraylength == 8 expected");
     ASSERT(genericCompare(setBoolArray, getBoolArray, arrayLen) == true,
            "boolArray should be equal");
@@ -1410,14 +1402,14 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
           "IllegalStateException");
     }
 
-    int8_t setByteArray[] = {0x34, 0x64, 0x34, 0x64};
-    int8_t* getByteArray = nullptr;
-    wpiPtr->setField("m_byteArray", setByteArray, 4);
+    std::vector<int8_t> setByteArray{0x34, 0x64, 0x34, 0x64};
+    wpiPtr->setField("m_byteArray", setByteArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(newPiPtr->hasField("m_byteArray") == true,
            "m_byteArray = true expected");
-    newPiPtr->getField("m_byteArray", &getByteArray, arrayLen);
+    auto getByteArray = newPiPtr->getByteArrayField("m_byteArray");
+    arrayLen = getByteArray.size();
     ASSERT(arrayLen == 4, "Arraylength == 4 expected");
     ASSERT(genericCompare(setByteArray, getByteArray, arrayLen) == true,
            "byteArray should be equal");
@@ -1435,14 +1427,14 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
           "IllegalStateException");
     }
 
-    char16_t setCharArray[] = {'c', 'v', 'c', 'v'};
-    char16_t* getCharArray = nullptr;
-    wpiPtr->setField("m_charArray", setCharArray, 4);
+    std::vector<char16_t> setCharArray{'c', 'v', 'c', 'v'};
+    wpiPtr->setField("m_charArray", setCharArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(newPiPtr->hasField("m_charArray") == true,
            "m_charArray = true expected");
-    newPiPtr->getField("m_charArray", &getCharArray, arrayLen);
+    auto getCharArray = newPiPtr->getCharArrayField("m_charArray");
+    arrayLen = getCharArray.size();
     ASSERT(arrayLen == 4, "Arraylength == 4 expected");
     ASSERT(genericCompare(setCharArray, getCharArray, arrayLen) == true,
            "charArray should be equal");
@@ -1460,14 +1452,14 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
           "IllegalStateException");
     }
 
-    int16_t setShortArray[] = {0x2332, 0x4545, 0x88, 0x898};
-    int16_t* getShortArray = nullptr;
-    wpiPtr->setField("m_int16Array", setShortArray, 4);
+    std::vector<int16_t> setShortArray{0x2332, 0x4545, 0x88, 0x898};
+    wpiPtr->setField("m_int16Array", setShortArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(newPiPtr->hasField("m_int16Array") == true,
            "m_int16Array = true expected");
-    newPiPtr->getField("m_int16Array", &getShortArray, arrayLen);
+    auto getShortArray = newPiPtr->getShortArrayField("m_int16Array");
+    arrayLen = getShortArray.size();
     ASSERT(arrayLen == 4, "Arraylength == 4 expected");
     ASSERT(genericCompare(setShortArray, getShortArray, arrayLen) == true,
            "shortArray should be equal");
@@ -1476,7 +1468,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
 
     wpiPtr = pIPtr->createWriter();
     try {
-      wpiPtr->setField("m_int16Array", setCharArray, 4);
+      wpiPtr->setField("m_int16Array", setCharArray);
       FAIL(
           "setField on m_int16Array with setCharArray value should throw "
           "expected IllegalStateException");
@@ -1485,14 +1477,14 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
           "IllegalStateException");
     }
 
-    int32_t setIntArray[3] = {23, 676868, 34343};
-    int32_t* newValArray = nullptr;
-    wpiPtr->setField("m_int32Array", setIntArray, 3);
+    std::vector<int32_t> setIntArray{23, 676868, 34343};
+    wpiPtr->setField("m_int32Array", setIntArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(newPiPtr->hasField("m_int32Array") == true,
            "m_int32Array = true expected");
-    newPiPtr->getField("m_int32Array", &newValArray, arrayLen);
+    auto newValArray = newPiPtr->getIntArrayField("m_int32Array");
+    arrayLen = newValArray.size();
     ASSERT(arrayLen == 3, "Arraylength == 3 expected");
     ASSERT(genericCompare(setIntArray, newValArray, arrayLen) == true,
            "intArray should be equal");
@@ -1501,7 +1493,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
 
     wpiPtr = pIPtr->createWriter();
     try {
-      wpiPtr->setField("m_int32Array", setShortArray, 3);
+      wpiPtr->setField("m_int32Array", setShortArray);
       FAIL(
           "setField on m_int32Array with setShortArray value should throw "
           "expected IllegalStateException");
@@ -1510,14 +1502,14 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
           "IllegalStateException");
     }
 
-    int64_t setLongArray[] = {3245435, 3425435};
-    int64_t* getLongArray = nullptr;
-    wpiPtr->setField("m_longArray", setLongArray, 2);
+    std::vector<int64_t> setLongArray{3245435, 3425435};
+    wpiPtr->setField("m_longArray", setLongArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(newPiPtr->hasField("m_longArray") == true,
            "m_longArray = true expected");
-    newPiPtr->getField("m_longArray", &getLongArray, arrayLen);
+    auto getLongArray = newPiPtr->getLongArrayField("m_longArray");
+    arrayLen = getLongArray.size();
     ASSERT(arrayLen == 2, "Arraylength == 2 expected");
     ASSERT(genericCompare(setLongArray, getLongArray, arrayLen) == true,
            "longArray should be equal");
@@ -1526,7 +1518,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
 
     wpiPtr = pIPtr->createWriter();
     try {
-      wpiPtr->setField("m_longArray", setIntArray, 3);
+      wpiPtr->setField("m_longArray", setIntArray);
       FAIL(
           "setField on m_longArray with setIntArray value should throw "
           "expected "
@@ -1536,14 +1528,14 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
           "IllegalStateException");
     }
 
-    float setFloatArray[] = {232.565f, 234323354.67f};
-    float* getFloatArray = nullptr;
-    wpiPtr->setField("m_floatArray", setFloatArray, 2);
+    std::vector<float> setFloatArray{232.565f, 234323354.67f};
+    wpiPtr->setField("m_floatArray", setFloatArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(newPiPtr->hasField("m_floatArray") == true,
            "m_floatArray = true expected");
-    newPiPtr->getField("m_floatArray", &getFloatArray, arrayLen);
+    auto getFloatArray = newPiPtr->getFloatArrayField("m_floatArray");
+    arrayLen = getFloatArray.size();
     ASSERT(arrayLen == 2, "Arraylength == 2 expected");
     ASSERT(genericCompare(setFloatArray, getFloatArray, arrayLen) == true,
            "floatArray should be equal");
@@ -1552,7 +1544,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
 
     wpiPtr = pIPtr->createWriter();
     try {
-      wpiPtr->setField("m_floatArray", setLongArray, 2);
+      wpiPtr->setField("m_floatArray", setLongArray);
       FAIL(
           "setField on m_floatArray with setLongArray value should throw "
           "expected IllegalStateException");
@@ -1561,14 +1553,14 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
           "IllegalStateException");
     }
 
-    double setDoubleArray[] = {23423432.00, 43242354315.00};
-    double* getDoubleArray = nullptr;
-    wpiPtr->setField("m_doubleArray", setDoubleArray, 2);
+    std::vector<double> setDoubleArray{23423432.00, 43242354315.00};
+    wpiPtr->setField("m_doubleArray", setDoubleArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(newPiPtr->hasField("m_doubleArray") == true,
            "m_doubleArray = true expected");
-    newPiPtr->getField("m_doubleArray", &getDoubleArray, arrayLen);
+    auto getDoubleArray = newPiPtr->getDoubleArrayField("m_doubleArray");
+    arrayLen = getDoubleArray.size();
     ASSERT(arrayLen == 2, "Arraylength == 2 expected");
     ASSERT(genericCompare(setDoubleArray, getDoubleArray, arrayLen) == true,
            "doubleArray should be equal");
@@ -1577,7 +1569,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
 
     wpiPtr = pIPtr->createWriter();
     try {
-      wpiPtr->setField("m_doubleArray", setFloatArray, 2);
+      wpiPtr->setField("m_doubleArray", setFloatArray);
       FAIL(
           "setField on m_doubleArray with setFloatArray value should throw "
           "expected IllegalStateException");
@@ -1588,7 +1580,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
 
     wpiPtr = pIPtr->createWriter();
     try {
-      wpiPtr->setField("m_string", setFloatArray, 2);
+      wpiPtr->setField("m_string", setFloatArray);
       FAIL(
           "setField on m_string with setFloatArray value should throw expected "
           "IllegalStateException");
@@ -1688,7 +1680,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
 
     wpiPtr = pIPtr->createWriter();
     try {
-      wpiPtr->setField("m_arraylist", setFloatArray, 2);
+      wpiPtr->setField("m_arraylist", setFloatArray);
       FAIL(
           "setField on m_arraylist with setFloatArray value should throw "
           "expected IllegalStateException");
@@ -1885,14 +1877,14 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
     auto parentCharVal = newPiPtr->getCharField("m_char");
     ASSERT(parentCharVal == parentCharSetVal, "char is not equal");
 
-    char16_t setParentCharArray[] = {'c', 'v', 'c', 'v'};
-    char16_t* getParentCharArray = nullptr;
-    wpiPtr->setField("m_charArray", setParentCharArray, 4);
+    std::vector<char16_t> setParentCharArray{'c', 'v', 'c', 'v'};
+    wpiPtr->setField("m_charArray", setParentCharArray);
     rptr->put(keyport1, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport1));
     ASSERT(newPiPtr->hasField("m_charArray") == true,
            "m_charArray = true expected");
-    newPiPtr->getField("m_charArray", &getParentCharArray, arrayLen);
+    auto getParentCharArray = newPiPtr->getCharArrayField("m_charArray");
+    arrayLen = getParentCharArray.size();
     ASSERT(arrayLen == 4, "Arraylength == 4 expected");
     ASSERT(genericCompare(setParentCharArray, getParentCharArray, arrayLen) ==
                true,
@@ -1963,100 +1955,100 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstanceAndCheckLocally)
     ASSERT(val + 1 == newVal, "val + 1 == newVal expected");
     ASSERT((*pIPtr.get() == *newPiPtr.get()) == false,
            "PdxInstance should not be equal");
-    int arrayLen = 0;
 
-    bool setBoolArray[] = {true, false, true, false, true, true, false, true};
-    bool* getBoolArray = nullptr;
-    wpiPtr->setField("m_boolArray", setBoolArray, 8);
+    std::vector<bool> setBoolArray{true, false, true, false, true, true, false, true};
+    int arrayLen = setBoolArray.size();
+    wpiPtr->setField("m_boolArray", setBoolArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(pIPtr->hasField("m_boolArray") == true,
            "m_boolArray = true expected");
-    newPiPtr->getField("m_boolArray", &getBoolArray, arrayLen);
+    auto getBoolArray = newPiPtr->getBooleanArrayField("m_boolArray");
+    arrayLen = getBoolArray.size();
     ASSERT(arrayLen == 8, "Arraylength == 8 expected");
     ASSERT(genericCompare(setBoolArray, getBoolArray, arrayLen) == true,
            "boolArray should be equal");
     ASSERT((*pIPtr.get() == *newPiPtr.get()) == false,
            "PdxInstance should not be equal");
 
-    int8_t setByteArray[] = {0x34, 0x64, 0x34, 0x64};
-    int8_t* getByteArray = nullptr;
-    wpiPtr->setField("m_byteArray", setByteArray, 4);
+    std::vector<int8_t> setByteArray{0x34, 0x64, 0x34, 0x64};
+    wpiPtr->setField("m_byteArray", setByteArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(pIPtr->hasField("m_byteArray") == true,
            "m_byteArray = true expected");
-    newPiPtr->getField("m_byteArray", &getByteArray, arrayLen);
+    auto getByteArray = newPiPtr->getByteArrayField("m_byteArray");
+    arrayLen = getByteArray.size();
     ASSERT(arrayLen == 4, "Arraylength == 4 expected");
     ASSERT(genericCompare(setByteArray, getByteArray, arrayLen) == true,
            "byteArray should be equal");
     ASSERT((*pIPtr.get() == *newPiPtr.get()) == false,
            "PdxInstance should not be equal");
 
-    int16_t setShortArray[] = {0x2332, 0x4545, 0x88, 0x898};
-    int16_t* getShortArray = nullptr;
-    wpiPtr->setField("m_int16Array", setShortArray, 4);
+    std::vector<int16_t> setShortArray{0x2332, 0x4545, 0x88, 0x898};
+    wpiPtr->setField("m_int16Array", setShortArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(pIPtr->hasField("m_int16Array") == true,
            "m_int16Array = true expected");
-    newPiPtr->getField("m_int16Array", &getShortArray, arrayLen);
+    auto getShortArray = newPiPtr->getShortArrayField("m_int16Array");
+    arrayLen = getShortArray.size();
     ASSERT(arrayLen == 4, "Arraylength == 4 expected");
     ASSERT(genericCompare(setShortArray, getShortArray, arrayLen) == true,
            "shortArray should be equal");
     ASSERT((*pIPtr.get() == *newPiPtr.get()) == false,
            "PdxInstance should not be equal");
 
-    int32_t setIntArray[3] = {23, 676868, 34343};
-    int32_t* newValArray = nullptr;
-    wpiPtr->setField("m_int32Array", setIntArray, 3);
+    std::vector<int32_t> setIntArray{23, 676868, 34343};
+    wpiPtr->setField("m_int32Array", setIntArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(pIPtr->hasField("m_int32Array") == true,
            "m_int32Array = true expected");
-    newPiPtr->getField("m_int32Array", &newValArray, arrayLen);
+    auto newValArray = newPiPtr->getIntArrayField("m_int32Array");
+    arrayLen = newValArray.size();
     ASSERT(arrayLen == 3, "Arraylength == 3 expected");
     ASSERT(genericCompare(setIntArray, newValArray, arrayLen) == true,
            "intArray should be equal");
     ASSERT((*pIPtr.get() == *newPiPtr.get()) == false,
            "PdxInstance should not be equal");
 
-    int64_t setLongArray[] = {3245435, 3425435};
-    int64_t* getLongArray = nullptr;
-    wpiPtr->setField("m_longArray", setLongArray, 2);
+    std::vector<int64_t> setLongArray{3245435, 3425435};
+    wpiPtr->setField("m_longArray", setLongArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(pIPtr->hasField("m_longArray") == true,
            "m_longArray = true expected");
-    newPiPtr->getField("m_longArray", &getLongArray, arrayLen);
+    auto getLongArray = newPiPtr->getLongArrayField("m_longArray");
+    arrayLen = getLongArray.size();
     ASSERT(arrayLen == 2, "Arraylength == 2 expected");
     ASSERT(genericCompare(setLongArray, getLongArray, arrayLen) == true,
            "longArray should be equal");
     ASSERT((*pIPtr.get() == *newPiPtr.get()) == false,
            "PdxInstance should not be equal");
 
-    float setFloatArray[] = {232.565f, 234323354.67f};
-    float* getFloatArray = nullptr;
-    wpiPtr->setField("m_floatArray", setFloatArray, 2);
+    std::vector<float> setFloatArray{232.565f, 234323354.67f};
+    wpiPtr->setField("m_floatArray", setFloatArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(pIPtr->hasField("m_floatArray") == true,
            "m_floatArray = true expected");
-    newPiPtr->getField("m_floatArray", &getFloatArray, arrayLen);
+    auto getFloatArray = newPiPtr->getFloatArrayField("m_floatArray");
+    arrayLen = getFloatArray.size();
     ASSERT(arrayLen == 2, "Arraylength == 2 expected");
     ASSERT(genericCompare(setFloatArray, getFloatArray, arrayLen) == true,
            "floatArray should be equal");
     ASSERT((*pIPtr.get() == *newPiPtr.get()) == false,
            "PdxInstance should not be equal");
 
-    double setDoubleArray[] = {23423432.00, 43242354315.00};
-    double* getDoubleArray = nullptr;
-    wpiPtr->setField("m_doubleArray", setDoubleArray, 2);
+    std::vector<double> setDoubleArray{23423432.00, 43242354315.00};
+    wpiPtr->setField("m_doubleArray", setDoubleArray);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(pIPtr->hasField("m_doubleArray") == true,
            "m_doubleArray = true expected");
-    newPiPtr->getField("m_doubleArray", &getDoubleArray, arrayLen);
+    auto getDoubleArray = newPiPtr->getDoubleArrayField("m_doubleArray");
+    arrayLen = getDoubleArray.size();
     ASSERT(arrayLen == 2, "Arraylength == 2 expected");
     ASSERT(genericCompare(setDoubleArray, getDoubleArray, arrayLen) == true,
            "doubleArray should be equal");
@@ -2278,19 +2270,19 @@ DUNIT_TASK_DEFINITION(CLIENT1, pdxIFPutGetTest)
     pifPtr->markIdentityField("m_string");
     pifPtr->writeDate("m_dateTime", pdxobj->getDate());
     pifPtr->markIdentityField("m_dateTime");
-    pifPtr->writeBooleanArray("m_boolArray", pdxobj->getBoolArray(), 3);
+    pifPtr->writeBooleanArray("m_boolArray", pdxobj->getBoolArray());
     pifPtr->markIdentityField("m_boolArray");
-    pifPtr->writeByteArray("m_byteArray", pdxobj->getByteArray(), 2);
+    pifPtr->writeByteArray("m_byteArray", pdxobj->getByteArray());
     pifPtr->markIdentityField("m_byteArray");
-    pifPtr->writeShortArray("m_int16Array", pdxobj->getShortArray(), 2);
+    pifPtr->writeShortArray("m_int16Array", pdxobj->getShortArray());
     pifPtr->markIdentityField("m_int16Array");
-    pifPtr->writeIntArray("m_int32Array", pdxobj->getIntArray(), 4);
+    pifPtr->writeIntArray("m_int32Array", pdxobj->getIntArray());
     pifPtr->markIdentityField("m_int32Array");
-    pifPtr->writeLongArray("m_longArray", pdxobj->getLongArray(), 2);
+    pifPtr->writeLongArray("m_longArray", pdxobj->getLongArray());
     pifPtr->markIdentityField("m_longArray");
-    pifPtr->writeFloatArray("m_floatArray", pdxobj->getFloatArray(), 2);
+    pifPtr->writeFloatArray("m_floatArray", pdxobj->getFloatArray());
     pifPtr->markIdentityField("m_floatArray");
-    pifPtr->writeDoubleArray("m_doubleArray", pdxobj->getDoubleArray(), 2);
+    pifPtr->writeDoubleArray("m_doubleArray", pdxobj->getDoubleArray());
     pifPtr->markIdentityField("m_doubleArray");
     pifPtr->writeObject("m_map", pdxobj->getHashMap());
     pifPtr->markIdentityField("m_map");
@@ -2313,7 +2305,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, pdxIFPutGetTest)
     pifPtr->markIdentityField("m_byteByteArray");
     pifPtr->writeChar("m_char", pdxobj->getChar());
     pifPtr->markIdentityField("m_char");
-    pifPtr->writeCharArray("m_charArray", pdxobj->getCharArray(), 2);
+    pifPtr->writeCharArray("m_charArray", pdxobj->getCharArray());
     pifPtr->markIdentityField("m_charArray");
     pifPtr->writeObject("m_chs", pdxobj->getHashSet());
     pifPtr->markIdentityField("m_chs");
@@ -2321,7 +2313,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, pdxIFPutGetTest)
     pifPtr->markIdentityField("m_clhs");
     pifPtr->writeByte("m_sbyte", pdxobj->getSByte());
     pifPtr->markIdentityField("m_sbyte");
-    pifPtr->writeByteArray("m_sbyteArray", pdxobj->getSByteArray(), 2);
+    pifPtr->writeByteArray("m_sbyteArray", pdxobj->getSByteArray());
     pifPtr->markIdentityField("m_sbyteArray");
     pifPtr->writeShort("m_uint16", pdxobj->getUint16());
     pifPtr->markIdentityField("m_uint16");
@@ -2329,20 +2321,20 @@ DUNIT_TASK_DEFINITION(CLIENT1, pdxIFPutGetTest)
     pifPtr->markIdentityField("m_uint32");
     pifPtr->writeLong("m_ulong", pdxobj->getULong());
     pifPtr->markIdentityField("m_ulong");
-    pifPtr->writeShortArray("m_uint16Array", pdxobj->getUInt16Array(), 2);
+    pifPtr->writeShortArray("m_uint16Array", pdxobj->getUInt16Array());
     pifPtr->markIdentityField("m_uint16Array");
-    pifPtr->writeIntArray("m_uint32Array", pdxobj->getUIntArray(), 4);
+    pifPtr->writeIntArray("m_uint32Array", pdxobj->getUIntArray());
     pifPtr->markIdentityField("m_uint32Array");
-    pifPtr->writeLongArray("m_ulongArray", pdxobj->getULongArray(), 2);
+    pifPtr->writeLongArray("m_ulongArray", pdxobj->getULongArray());
     pifPtr->markIdentityField("m_ulongArray");
 
-    pifPtr->writeByteArray("m_byte252", pdxobj->getByte252(), 252);
+    pifPtr->writeByteArray("m_byte252", pdxobj->getByte252());
     pifPtr->markIdentityField("m_byte252");
-    pifPtr->writeByteArray("m_byte253", pdxobj->getByte253(), 253);
+    pifPtr->writeByteArray("m_byte253", pdxobj->getByte253());
     pifPtr->markIdentityField("m_byte253");
-    pifPtr->writeByteArray("m_byte65535", pdxobj->getByte65535(), 65535);
+    pifPtr->writeByteArray("m_byte65535", pdxobj->getByte65535());
     pifPtr->markIdentityField("m_byte65535");
-    pifPtr->writeByteArray("m_byte65536", pdxobj->getByte65536(), 65536);
+    pifPtr->writeByteArray("m_byte65536", pdxobj->getByte65536());
     pifPtr->markIdentityField("m_byte65536");
     pifPtr->writeObject("m_address", pdxobj->getCacheableObjectArray());
 
@@ -2460,7 +2452,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, pdxIFPutGetTest)
     if2->writeObject("m_childPdx", pp->getChildPdx());
     if2->writeChar("m_char", pp->getChar());
     if2->writeChar("m_wideChar", pp->getChar());
-    if2->writeCharArray("m_charArray", pp->getCharArray(), 2);
+    if2->writeCharArray("m_charArray", pp->getCharArray());
 
     LOG("write set done....");
     std::shared_ptr<PdxInstance> ip2 = if2->create();

--- a/cppcache/src/PdxInstanceFactoryImpl.cpp
+++ b/cppcache/src/PdxInstanceFactoryImpl.cpp
@@ -167,76 +167,76 @@ std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeObjectArray(
   return shared_from_this();
 }
 std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeBooleanArray(
-    const std::string& fieldName, bool* value, int32_t length) {
+    const std::string& fieldName, const std::vector<bool>& value) {
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "bool[]",
                                         PdxFieldTypes::BOOLEAN_ARRAY);
-  auto cacheableObject = BooleanArray::create(value, length);
+  auto cacheableObject = CacheableArray<bool>::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }
 
 std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeCharArray(
-    const std::string& fieldName, char16_t* value, int32_t length) {
+    const std::string& fieldName, const std::vector<char16_t>& value) {
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "char[]",
                                         PdxFieldTypes::CHAR_ARRAY);
-  auto cacheableObject = CharArray::create(value, length);
+  auto cacheableObject = CacheableArray<char16_t>::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }
 
 std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeByteArray(
-    const std::string& fieldName, int8_t* value, int32_t length) {
+    const std::string& fieldName, const std::vector<int8_t>& value) {
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "byte[]",
                                         PdxFieldTypes::BYTE_ARRAY);
-  auto cacheableObject = CacheableBytes::create(value, length);
+  auto cacheableObject = CacheableArray<int8_t>::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }
 std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeShortArray(
-    const std::string& fieldName, int16_t* value, int32_t length) {
+    const std::string& fieldName, const std::vector<int16_t>& value) {
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "short[]",
                                         PdxFieldTypes::SHORT_ARRAY);
-  auto cacheableObject = CacheableInt16Array::create(value, length);
+  auto cacheableObject = CacheableArray<int16_t>::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }
 std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeIntArray(
-    const std::string& fieldName, int32_t* value, int32_t length) {
+    const std::string& fieldName, const std::vector<int32_t>& value) {
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "int32[]",
                                         PdxFieldTypes::INT_ARRAY);
-  auto cacheableObject = CacheableInt32Array::create(value, length);
+  auto cacheableObject = CacheableArray<int32_t>::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }
 std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeLongArray(
-    const std::string& fieldName, int64_t* value, int32_t length) {
+    const std::string& fieldName, const std::vector<int64_t>& value) {
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "int64[]",
                                         PdxFieldTypes::LONG_ARRAY);
-  auto cacheableObject = CacheableInt64Array::create(value, length);
+  auto cacheableObject = CacheableArray<int64_t>::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }
 std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeFloatArray(
-    const std::string& fieldName, float* value, int32_t length) {
+    const std::string& fieldName, const std::vector<float>& value) {
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "float[]",
                                         PdxFieldTypes::FLOAT_ARRAY);
-  auto cacheableObject = CacheableFloatArray::create(value, length);
+  auto cacheableObject = CacheableArray<float>::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }
 std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeDoubleArray(
-    const std::string& fieldName, double* value, int32_t length) {
+    const std::string& fieldName, const std::vector<double>& value) {
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "double[]",
                                         PdxFieldTypes::DOUBLE_ARRAY);
-  auto cacheableObject = CacheableDoubleArray::create(value, length);
+  auto cacheableObject = CacheableArray<double>::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }

--- a/cppcache/src/PdxInstanceFactoryImpl.cpp
+++ b/cppcache/src/PdxInstanceFactoryImpl.cpp
@@ -171,7 +171,7 @@ std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeBooleanArray(
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "bool[]",
                                         PdxFieldTypes::BOOLEAN_ARRAY);
-  auto cacheableObject = CacheableArray<bool>::create(value);
+  auto cacheableObject = BooleanArray::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }
@@ -181,7 +181,7 @@ std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeCharArray(
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "char[]",
                                         PdxFieldTypes::CHAR_ARRAY);
-  auto cacheableObject = CacheableArray<char16_t>::create(value);
+  auto cacheableObject = CharArray::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }
@@ -200,7 +200,7 @@ std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeShortArray(
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "short[]",
                                         PdxFieldTypes::SHORT_ARRAY);
-  auto cacheableObject = CacheableArray<int16_t>::create(value);
+  auto cacheableObject = CacheableInt16Array::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }
@@ -209,7 +209,7 @@ std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeIntArray(
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "int32[]",
                                         PdxFieldTypes::INT_ARRAY);
-  auto cacheableObject = CacheableArray<int32_t>::create(value);
+  auto cacheableObject = CacheableInt32Array::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }
@@ -218,7 +218,7 @@ std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeLongArray(
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "int64[]",
                                         PdxFieldTypes::LONG_ARRAY);
-  auto cacheableObject = CacheableArray<int64_t>::create(value);
+  auto cacheableObject = CacheableInt64Array::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }
@@ -227,7 +227,7 @@ std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeFloatArray(
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "float[]",
                                         PdxFieldTypes::FLOAT_ARRAY);
-  auto cacheableObject = CacheableArray<float>::create(value);
+  auto cacheableObject = CacheableFloatArray::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }
@@ -236,7 +236,7 @@ std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeDoubleArray(
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "double[]",
                                         PdxFieldTypes::DOUBLE_ARRAY);
-  auto cacheableObject = CacheableArray<double>::create(value);
+  auto cacheableObject = CacheableDoubleArray::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }

--- a/cppcache/src/PdxInstanceFactoryImpl.cpp
+++ b/cppcache/src/PdxInstanceFactoryImpl.cpp
@@ -191,7 +191,9 @@ std::shared_ptr<PdxInstanceFactory> PdxInstanceFactoryImpl::writeByteArray(
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "byte[]",
                                         PdxFieldTypes::BYTE_ARRAY);
-  auto cacheableObject = CacheableArray<int8_t>::create(value);
+  auto cacheableObject = CacheableArray<int8_t,
+                                        GeodeTypeIds::CacheableBytes>::create(
+                                            value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return shared_from_this();
 }

--- a/cppcache/src/PdxInstanceFactoryImpl.hpp
+++ b/cppcache/src/PdxInstanceFactoryImpl.hpp
@@ -98,28 +98,28 @@ class _GEODE_EXPORT PdxInstanceFactoryImpl
       const std::string& fieldName, std::shared_ptr<Cacheable> value) override;
 
   virtual std::shared_ptr<PdxInstanceFactory> writeBooleanArray(
-      const std::string& fieldName, bool* value, int32_t length) override;
+      const std::string& fieldName, const std::vector<bool>& value) override;
 
   virtual std::shared_ptr<PdxInstanceFactory> writeCharArray(
-      const std::string& fieldName, char16_t* value, int32_t length) override;
+      const std::string& fieldName, const std::vector<char16_t>& value) override;
 
   virtual std::shared_ptr<PdxInstanceFactory> writeByteArray(
-      const std::string& fieldName, int8_t* value, int32_t length) override;
+      const std::string& fieldName, const std::vector<int8_t>& value) override;
 
   virtual std::shared_ptr<PdxInstanceFactory> writeShortArray(
-      const std::string& fieldName, int16_t* value, int32_t length) override;
+      const std::string& fieldName, const std::vector<int16_t>& value) override;
 
   virtual std::shared_ptr<PdxInstanceFactory> writeIntArray(
-      const std::string& fieldName, int32_t* value, int32_t length) override;
+      const std::string& fieldName, const std::vector<int32_t>& value) override;
 
   virtual std::shared_ptr<PdxInstanceFactory> writeLongArray(
-      const std::string& fieldName, int64_t* value, int32_t length) override;
+      const std::string& fieldName, const std::vector<int64_t>& value) override;
 
   virtual std::shared_ptr<PdxInstanceFactory> writeFloatArray(
-      const std::string& fieldName, float* value, int32_t length) override;
+      const std::string& fieldName, const std::vector<float>& value) override;
 
   virtual std::shared_ptr<PdxInstanceFactory> writeDoubleArray(
-      const std::string& fieldName, double* value, int32_t length) override;
+      const std::string& fieldName, const std::vector<double>& value) override;
 
   virtual std::shared_ptr<PdxInstanceFactory> writeStringArray(
       const std::string& fieldName,

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -202,7 +202,7 @@ void PdxInstanceImpl::writeField(PdxWriter& writer,
         std::vector<std::string> strings;
         strings.reserve(size);
         for (int item = 0; item < size; item++) {
-          strings[item] = (*val)[item]->value();
+          strings.push_back((*val)[item]->value());
         }
         writer.writeStringArray(fieldName, strings);
       }

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -155,43 +155,43 @@ void PdxInstanceImpl::writeField(PdxWriter& writer,
       break;
     }
     case PdxFieldTypes::DOUBLE_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<double>>(value)) {
+      if (auto&& val = std::dynamic_pointer_cast<CacheableDoubleArray>(value)) {
         writer.writeDoubleArray(fieldName, val->value());
       }
       break;
     }
     case PdxFieldTypes::FLOAT_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<float>>(value)) {
+      if (auto&& val = std::dynamic_pointer_cast<CacheableFloatArray>(value)) {
         writer.writeFloatArray(fieldName, val->value());
       }
       break;
     }
     case PdxFieldTypes::SHORT_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<int16_t>>(value)) {
+      if (auto&& val = std::dynamic_pointer_cast<CacheableInt16Array>(value)) {
         writer.writeShortArray(fieldName, val->value());
       }
       break;
     }
     case PdxFieldTypes::INT_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<int32_t>>(value)) {
+      if (auto&& val = std::dynamic_pointer_cast<CacheableInt32Array>(value)) {
         writer.writeIntArray(fieldName, val->value());
       }
       break;
     }
     case PdxFieldTypes::LONG_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<int64_t>>(value)) {
+      if (auto&& val = std::dynamic_pointer_cast<CacheableInt64Array>(value)) {
         writer.writeLongArray(fieldName, val->value());
       }
       break;
     }
     case PdxFieldTypes::BOOLEAN_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<bool>>(value)) {
+      if (auto&& val = std::dynamic_pointer_cast<BooleanArray>(value)) {
         writer.writeBooleanArray(fieldName, val->value());
       }
       break;
     }
     case PdxFieldTypes::CHAR_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<char16_t>>(value)) {
+      if (auto&& val = std::dynamic_pointer_cast<CharArray>(value)) {
         writer.writeCharArray(fieldName, val->value());
       }
       break;
@@ -963,8 +963,8 @@ std::string PdxInstanceImpl::toString() const {
         auto value = getCharArrayField(identityFields.at(i)->getFieldName());
         int32_t length = value.size();
         if (length > 0) {
-          for (int i = 0; i < length; i++) {
-            toString += to_utf8(std::u16string(value[i], length));
+          for (auto&& v : value) {
+            toString += to_utf8(std::u16string(v, length));
           }
         }
         break;
@@ -980,8 +980,8 @@ std::string PdxInstanceImpl::toString() const {
         auto value = getByteArrayField(identityFields.at(i)->getFieldName());
         int32_t length = value.size();
         if (length > 0) {
-          for (int i = 0; i < length; i++) {
-            toString += std::to_string(value[i]);
+          for (auto&& v : value) {
+            toString += std::to_string(v);
           }
         }
         break;
@@ -990,8 +990,8 @@ std::string PdxInstanceImpl::toString() const {
         auto value = getShortArrayField(identityFields.at(i)->getFieldName());
         int32_t length = value.size();
         if (length > 0) {
-          for (int i = 0; i < length; i++) {
-            toString += std::to_string(value[i]);
+          for (auto&& v : value) {
+            toString += std::to_string(v);
           }
         }
         break;
@@ -1000,8 +1000,8 @@ std::string PdxInstanceImpl::toString() const {
         auto value = getIntArrayField(identityFields.at(i)->getFieldName());
         int32_t length = value.size();
         if (length > 0) {
-          for (int i = 0; i < length; i++) {
-            toString += std::to_string(value[i]);
+          for (auto&& v : value) {
+            toString += std::to_string(v);
           }
         }
         break;
@@ -1010,8 +1010,8 @@ std::string PdxInstanceImpl::toString() const {
         auto value = getLongArrayField(identityFields.at(i)->getFieldName());
         int32_t length = value.size();
         if (length > 0) {
-          for (int i = 0; i < length; i++) {
-            toString += std::to_string(value[i]);
+          for (auto&& v : value) {
+            toString += std::to_string(v);
           }
         }
         break;
@@ -1020,8 +1020,8 @@ std::string PdxInstanceImpl::toString() const {
         auto value = getFloatArrayField(identityFields.at(i)->getFieldName());
         int32_t length = value.size();
         if (length > 0) {
-          for (int i = 0; i < length; i++) {
-            toString += std::to_string(value[i]);
+          for (auto&& v : value) {
+            toString += std::to_string(v);
           }
         }
         break;
@@ -1030,8 +1030,8 @@ std::string PdxInstanceImpl::toString() const {
         auto value = getDoubleArrayField(identityFields.at(i)->getFieldName());
         int32_t length = value.size();
         if (length > 0) {
-          for (int i = 0; i < length; i++) {
-            toString += std::to_string(value[i]);
+          for (auto&& v : value) {
+            toString += std::to_string(v);
           }
         }
         break;
@@ -1048,8 +1048,8 @@ std::string PdxInstanceImpl::toString() const {
         auto value = getBooleanArrayField(identityFields.at(i)->getFieldName());
         int32_t length = value.size();
         if (length > 0) {
-          for (int i = 0; i < length; i++) {
-            toString += value[i] ? "true" : "false";
+          for (auto&& v : value) {
+            toString += v ? "true" : "false";
           }
         }
         break;
@@ -1654,7 +1654,7 @@ bool PdxInstanceImpl::hasDefaultBytes(std::shared_ptr<PdxFieldType> pField,
 
 void PdxInstanceImpl::setField(const std::string& fieldName, bool value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::BOOLEAN) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
@@ -1668,7 +1668,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName, bool value) {
 void PdxInstanceImpl::setField(const std::string& fieldName,
                                signed char value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::BYTE) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
@@ -1682,7 +1682,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName,
 void PdxInstanceImpl::setField(const std::string& fieldName,
                                unsigned char value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::BYTE) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
@@ -1695,7 +1695,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName,
 
 void PdxInstanceImpl::setField(const std::string& fieldName, int16_t value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::SHORT) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
@@ -1708,7 +1708,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName, int16_t value) {
 
 void PdxInstanceImpl::setField(const std::string& fieldName, int32_t value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::INT) {
     char excpStr[256] = {0};
@@ -1722,7 +1722,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName, int32_t value) {
 
 void PdxInstanceImpl::setField(const std::string& fieldName, int64_t value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::LONG) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
@@ -1749,7 +1749,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName, float value) {
 
 void PdxInstanceImpl::setField(const std::string& fieldName, double value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::DOUBLE) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
@@ -1762,7 +1762,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName, double value) {
 
 void PdxInstanceImpl::setField(const std::string& fieldName, char16_t value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::CHAR) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
@@ -1776,7 +1776,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName, char16_t value) {
 void PdxInstanceImpl::setField(const std::string& fieldName,
                                std::shared_ptr<CacheableDate> value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::DATE) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
@@ -1790,7 +1790,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName,
 void PdxInstanceImpl::setField(const std::string& fieldName,
                                std::shared_ptr<Cacheable> value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::OBJECT) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
@@ -1803,7 +1803,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName,
 void PdxInstanceImpl::setField(const std::string& fieldName,
                                std::shared_ptr<CacheableObjectArray> value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::OBJECT_ARRAY) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
@@ -1816,21 +1816,21 @@ void PdxInstanceImpl::setField(const std::string& fieldName,
 void PdxInstanceImpl::setField(const std::string& fieldName,
                                const std::vector<bool>& value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::BOOLEAN_ARRAY) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = CacheableArray<bool>::create(value);
+  auto cacheableObject = BooleanArray::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 
 void PdxInstanceImpl::setField(const std::string& fieldName,
-                               std::vector<int8_t> value) {
+                               const std::vector<int8_t>& value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::BYTE_ARRAY) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
@@ -1844,91 +1844,91 @@ void PdxInstanceImpl::setField(const std::string& fieldName,
 void PdxInstanceImpl::setField(const std::string& fieldName,
                                const std::vector<int16_t>& value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::SHORT_ARRAY) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = CacheableArray<int16_t>::create(value);
+  auto cacheableObject = CacheableInt16Array::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 
 void PdxInstanceImpl::setField(const std::string& fieldName,
                                const std::vector<int32_t>& value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::INT_ARRAY) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = CacheableArray<int32_t>::create(value);
+  auto cacheableObject = CacheableInt32Array::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 
 void PdxInstanceImpl::setField(const std::string& fieldName,
                                const std::vector<int64_t>& value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::LONG_ARRAY) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = CacheableArray<int64_t>::create(value);
+  auto cacheableObject = CacheableInt64Array::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 
 void PdxInstanceImpl::setField(const std::string& fieldName,
                                const std::vector<float>& value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::FLOAT_ARRAY) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = CacheableArray<float>::create(value);
+  auto cacheableObject = CacheableFloatArray::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 
 void PdxInstanceImpl::setField(const std::string& fieldName,
                                const std::vector<double>& value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::DOUBLE_ARRAY) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = CacheableArray<double>::create(value);
+  auto cacheableObject = CacheableDoubleArray::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 
 void PdxInstanceImpl::setField(const std::string& fieldName,
                                const std::vector<char16_t>& value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::CHAR_ARRAY) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto ptr = CacheableArray<char16_t>::create(value);
+  auto ptr = CharArray::create(value);
   m_updatedFields[fieldName] = ptr;
 }
 
 void PdxInstanceImpl::setField(const std::string& fieldName,
                                const std::string& value) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::STRING) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
@@ -1942,7 +1942,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName,
 void PdxInstanceImpl::setField(const std::string& fieldName, int8_t** value,
                                int32_t arrayLength, int32_t* elementLength) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr &&
       pft->getTypeId() != PdxFieldTypes::ARRAY_OF_BYTE_ARRAYS) {
@@ -1961,7 +1961,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName, int8_t** value,
 void PdxInstanceImpl::setField(const std::string& fieldName, std::string* value,
                                int32_t length) {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldName.c_str());
+  auto pft = pt->getPdxField(fieldName);
 
   if (pft != nullptr && pft->getTypeId() != PdxFieldTypes::STRING_ARRAY) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldName +
@@ -2007,7 +2007,7 @@ std::shared_ptr<PdxTypeRegistry> PdxInstanceImpl::getPdxTypeRegistry() const {
 std::unique_ptr<DataInput> PdxInstanceImpl::getDataInputForField(
     const std::string& fieldname) const {
   auto pt = getPdxType();
-  auto pft = pt->getPdxField(fieldname.c_str());
+  auto pft = pt->getPdxField(fieldname);
 
   if (!pft) {
     throw IllegalStateException("PdxInstance doesn't have field " + fieldname);

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -149,57 +149,50 @@ void PdxInstanceImpl::writeField(PdxWriter& writer,
       break;
     }
     case PdxFieldTypes::BYTE_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableBytes>(value)) {
-        writer.writeByteArray(fieldName, (int8_t*)val->value(), val->length());
+      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<int8_t>>(value)) {
+        writer.writeByteArray(fieldName, val->value());
       }
       break;
     }
     case PdxFieldTypes::DOUBLE_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableDoubleArray>(value)) {
-        writer.writeDoubleArray(fieldName, const_cast<double*>(val->value()),
-                                 val->length());
+      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<double>>(value)) {
+        writer.writeDoubleArray(fieldName, val->value());
       }
       break;
     }
     case PdxFieldTypes::FLOAT_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableFloatArray>(value)) {
-        writer.writeFloatArray(fieldName, const_cast<float*>(val->value()),
-                                val->length());
+      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<float>>(value)) {
+        writer.writeFloatArray(fieldName, val->value());
       }
       break;
     }
     case PdxFieldTypes::SHORT_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableInt16Array>(value)) {
-        writer.writeShortArray(fieldName, const_cast<int16_t*>(val->value()),
-                                val->length());
+      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<int16_t>>(value)) {
+        writer.writeShortArray(fieldName, val->value());
       }
       break;
     }
     case PdxFieldTypes::INT_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableInt32Array>(value)) {
-        writer.writeIntArray(fieldName, const_cast<int32_t*>(val->value()),
-                              val->length());
+      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<int32_t>>(value)) {
+        writer.writeIntArray(fieldName, val->value());
       }
       break;
     }
     case PdxFieldTypes::LONG_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableInt64Array>(value)) {
-        writer.writeLongArray(fieldName, const_cast<int64_t*>(val->value()),
-                               val->length());
+      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<int64_t>>(value)) {
+        writer.writeLongArray(fieldName, val->value());
       }
       break;
     }
     case PdxFieldTypes::BOOLEAN_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<BooleanArray>(value)) {
-        writer.writeBooleanArray(fieldName, const_cast<bool*>(val->value()),
-                                  val->length());
+      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<bool>>(value)) {
+        writer.writeBooleanArray(fieldName, val->value());
       }
       break;
     }
     case PdxFieldTypes::CHAR_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CharArray>(value)) {
-        writer.writeCharArray(fieldName, const_cast<char16_t*>(val->value()),
-                               val->length());
+      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<char16_t>>(value)) {
+        writer.writeCharArray(fieldName, val->value());
       }
       break;
     }
@@ -818,54 +811,44 @@ std::string PdxInstanceImpl::getStringField(
   return dataInput->readString();
 }
 
-void PdxInstanceImpl::getField(const std::string& fieldname, bool** value,
-                               int32_t& length) const {
+std::vector<bool> PdxInstanceImpl::getBooleanArrayField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  dataInput->readBooleanArray(value, length);
+  return dataInput->readBooleanArray();
 }
 
-void PdxInstanceImpl::getField(const std::string& fieldname, int8_t** value,
-                               int32_t& length) const {
+std::vector<int8_t> PdxInstanceImpl::getByteArrayField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  int8_t* temp = nullptr;
-  dataInput->readByteArray(&temp, length);
-  *value = temp;
+  return dataInput->readByteArray();
 }
 
-void PdxInstanceImpl::getField(const std::string& fieldname, int16_t** value,
-                               int32_t& length) const {
+std::vector<int16_t> PdxInstanceImpl::getShortArrayField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  dataInput->readShortArray(value, length);
+  return dataInput->readShortArray();
 }
 
-void PdxInstanceImpl::getField(const std::string& fieldname, int32_t** value,
-                               int32_t& length) const {
+std::vector<int32_t> PdxInstanceImpl::getIntArrayField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  dataInput->readIntArray(value, length);
+  return dataInput->readIntArray();
 }
 
-void PdxInstanceImpl::getField(const std::string& fieldname, int64_t** value,
-                               int32_t& length) const {
+std::vector<int64_t> PdxInstanceImpl::getLongArrayField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  dataInput->readLongArray(value, length);
+  return dataInput->readLongArray();
 }
 
-void PdxInstanceImpl::getField(const std::string& fieldname, float** value,
-                               int32_t& length) const {
+std::vector<float> PdxInstanceImpl::getFloatArrayField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  dataInput->readFloatArray(value, length);
+  return dataInput->readFloatArray();
 }
 
-void PdxInstanceImpl::getField(const std::string& fieldname, double** value,
-                               int32_t& length) const {
+std::vector<double> PdxInstanceImpl::getDoubleArrayField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  dataInput->readDoubleArray(value, length);
+  return dataInput->readDoubleArray();
 }
 
-void PdxInstanceImpl::getField(const std::string& fieldname, char16_t** value,
-                               int32_t& length) const {
+std::vector<char16_t> PdxInstanceImpl::getCharArrayField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  dataInput->readCharArray(value, length);
+  return dataInput->readCharArray();
 }
 
 std::vector<std::string> PdxInstanceImpl::getStringArrayField(
@@ -977,14 +960,12 @@ std::string PdxInstanceImpl::toString() const {
         break;
       }
       case PdxFieldTypes::CHAR_ARRAY: {
-        char16_t* value = 0;
-        int32_t length;
-        getField(identityFields.at(i)->getFieldName(), &value, length);
+        auto value = getCharArrayField(identityFields.at(i)->getFieldName());
+        int32_t length = value.size();
         if (length > 0) {
           for (int i = 0; i < length; i++) {
-            toString += to_utf8(std::u16string(value, length));
+            toString += to_utf8(std::u16string(value[i], length));
           }
-          _GEODE_SAFE_DELETE_ARRAY(value);
         }
         break;
       }
@@ -996,45 +977,38 @@ std::string PdxInstanceImpl::toString() const {
         break;
       }
       case PdxFieldTypes::BYTE_ARRAY: {
-        int8_t* value = 0;
-        int32_t length;
-        getField(identityFields.at(i)->getFieldName(), &value, length);
+        auto value = getByteArrayField(identityFields.at(i)->getFieldName());
+        int32_t length = value.size();
         if (length > 0) {
           for (int i = 0; i < length; i++) {
             toString += std::to_string(value[i]);
           }
-          _GEODE_SAFE_DELETE_ARRAY(value);
         }
         break;
       }
       case PdxFieldTypes::SHORT_ARRAY: {
-        int16_t* value = 0;
-        int32_t length;
-        getField(identityFields.at(i)->getFieldName(), &value, length);
+        auto value = getShortArrayField(identityFields.at(i)->getFieldName());
+        int32_t length = value.size();
         if (length > 0) {
           for (int i = 0; i < length; i++) {
             toString += std::to_string(value[i]);
           }
-          _GEODE_SAFE_DELETE_ARRAY(value);
         }
         break;
       }
       case PdxFieldTypes::INT_ARRAY: {
-        int32_t* value = 0;
-        int32_t length;
-        getField(identityFields.at(i)->getFieldName(), &value, length);
+        auto value = getIntArrayField(identityFields.at(i)->getFieldName());
+        int32_t length = value.size();
         if (length > 0) {
           for (int i = 0; i < length; i++) {
             toString += std::to_string(value[i]);
           }
-          _GEODE_SAFE_DELETE_ARRAY(value);
         }
         break;
       }
       case PdxFieldTypes::LONG_ARRAY: {
-        int64_t* value = 0;
-        int32_t length;
-        getField(identityFields.at(i)->getFieldName(), &value, length);
+        auto value = getLongArrayField(identityFields.at(i)->getFieldName());
+        int32_t length = value.size();
         if (length > 0) {
           for (int i = 0; i < length; i++) {
             toString += std::to_string(value[i]);
@@ -1043,21 +1017,18 @@ std::string PdxInstanceImpl::toString() const {
         break;
       }
       case PdxFieldTypes::FLOAT_ARRAY: {
-        float* value = 0;
-        int32_t length;
-        getField(identityFields.at(i)->getFieldName(), &value, length);
+        auto value = getFloatArrayField(identityFields.at(i)->getFieldName());
+        int32_t length = value.size();
         if (length > 0) {
           for (int i = 0; i < length; i++) {
             toString += std::to_string(value[i]);
           }
-          _GEODE_SAFE_DELETE_ARRAY(value);
         }
         break;
       }
       case PdxFieldTypes::DOUBLE_ARRAY: {
-        double* value = 0;
-        int32_t length;
-        getField(identityFields.at(i)->getFieldName(), &value, length);
+        auto value = getDoubleArrayField(identityFields.at(i)->getFieldName());
+        int32_t length = value.size();
         if (length > 0) {
           for (int i = 0; i < length; i++) {
             toString += std::to_string(value[i]);
@@ -1074,14 +1045,12 @@ std::string PdxInstanceImpl::toString() const {
         break;
       }
       case PdxFieldTypes::BOOLEAN_ARRAY: {
-        bool* value = 0;
-        int32_t length;
-        getField(identityFields.at(i)->getFieldName(), &value, length);
+        auto value = getBooleanArrayField(identityFields.at(i)->getFieldName());
+        int32_t length = value.size();
         if (length > 0) {
           for (int i = 0; i < length; i++) {
             toString += value[i] ? "true" : "false";
           }
-          _GEODE_SAFE_DELETE_ARRAY(value);
         }
         break;
       }
@@ -1844,8 +1813,8 @@ void PdxInstanceImpl::setField(const std::string& fieldName,
   m_updatedFields[fieldName] = value;
 }
 
-void PdxInstanceImpl::setField(const std::string& fieldName, bool* value,
-                               int32_t length) {
+void PdxInstanceImpl::setField(const std::string& fieldName,
+                               const std::vector<bool>& value) {
   auto pt = getPdxType();
   auto pft = pt->getPdxField(fieldName.c_str());
 
@@ -1854,12 +1823,12 @@ void PdxInstanceImpl::setField(const std::string& fieldName, bool* value,
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = BooleanArray::create(value, length);
+  auto cacheableObject = CacheableArray<bool>::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 
-void PdxInstanceImpl::setField(const std::string& fieldName, int8_t* value,
-                               int32_t length) {
+void PdxInstanceImpl::setField(const std::string& fieldName,
+                               std::vector<int8_t> value) {
   auto pt = getPdxType();
   auto pft = pt->getPdxField(fieldName.c_str());
 
@@ -1868,12 +1837,12 @@ void PdxInstanceImpl::setField(const std::string& fieldName, int8_t* value,
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = CacheableBytes::create(value, length);
+  auto cacheableObject = CacheableArray<int8_t>::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 
-void PdxInstanceImpl::setField(const std::string& fieldName, int16_t* value,
-                               int32_t length) {
+void PdxInstanceImpl::setField(const std::string& fieldName,
+                               const std::vector<int16_t>& value) {
   auto pt = getPdxType();
   auto pft = pt->getPdxField(fieldName.c_str());
 
@@ -1882,12 +1851,12 @@ void PdxInstanceImpl::setField(const std::string& fieldName, int16_t* value,
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = CacheableInt16Array::create(value, length);
+  auto cacheableObject = CacheableArray<int16_t>::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 
-void PdxInstanceImpl::setField(const std::string& fieldName, int32_t* value,
-                               int32_t length) {
+void PdxInstanceImpl::setField(const std::string& fieldName,
+                               const std::vector<int32_t>& value) {
   auto pt = getPdxType();
   auto pft = pt->getPdxField(fieldName.c_str());
 
@@ -1896,12 +1865,12 @@ void PdxInstanceImpl::setField(const std::string& fieldName, int32_t* value,
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = CacheableInt32Array::create(value, length);
+  auto cacheableObject = CacheableArray<int32_t>::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 
-void PdxInstanceImpl::setField(const std::string& fieldName, int64_t* value,
-                               int32_t length) {
+void PdxInstanceImpl::setField(const std::string& fieldName,
+                               const std::vector<int64_t>& value) {
   auto pt = getPdxType();
   auto pft = pt->getPdxField(fieldName.c_str());
 
@@ -1910,12 +1879,12 @@ void PdxInstanceImpl::setField(const std::string& fieldName, int64_t* value,
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = CacheableInt64Array::create(value, length);
+  auto cacheableObject = CacheableArray<int64_t>::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 
-void PdxInstanceImpl::setField(const std::string& fieldName, float* value,
-                               int32_t length) {
+void PdxInstanceImpl::setField(const std::string& fieldName,
+                               const std::vector<float>& value) {
   auto pt = getPdxType();
   auto pft = pt->getPdxField(fieldName.c_str());
 
@@ -1924,12 +1893,12 @@ void PdxInstanceImpl::setField(const std::string& fieldName, float* value,
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = CacheableFloatArray::create(value, length);
+  auto cacheableObject = CacheableArray<float>::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 
-void PdxInstanceImpl::setField(const std::string& fieldName, double* value,
-                               int32_t length) {
+void PdxInstanceImpl::setField(const std::string& fieldName,
+                               const std::vector<double>& value) {
   auto pt = getPdxType();
   auto pft = pt->getPdxField(fieldName.c_str());
 
@@ -1938,12 +1907,12 @@ void PdxInstanceImpl::setField(const std::string& fieldName, double* value,
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = CacheableDoubleArray::create(value, length);
+  auto cacheableObject = CacheableArray<double>::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 
-void PdxInstanceImpl::setField(const std::string& fieldName, char16_t* value,
-                               int32_t length) {
+void PdxInstanceImpl::setField(const std::string& fieldName,
+                               const std::vector<char16_t>& value) {
   auto pt = getPdxType();
   auto pft = pt->getPdxField(fieldName.c_str());
 
@@ -1952,7 +1921,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName, char16_t* value,
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto ptr = CharArray::create(value, length);
+  auto ptr = CacheableArray<char16_t>::create(value);
   m_updatedFields[fieldName] = ptr;
 }
 

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -149,7 +149,8 @@ void PdxInstanceImpl::writeField(PdxWriter& writer,
       break;
     }
     case PdxFieldTypes::BYTE_ARRAY: {
-      if (auto&& val = std::dynamic_pointer_cast<CacheableArray<int8_t>>(value)) {
+      if (auto&& val = std::dynamic_pointer_cast<
+          CacheableArray<int8_t, GeodeTypeIds::CacheableBytes>>(value)) {
         writer.writeByteArray(fieldName, val->value());
       }
       break;
@@ -1837,7 +1838,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName,
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject = CacheableArray<int8_t>::create(value);
+  auto cacheableObject = CacheableArray<int8_t, GeodeTypeIds::CacheableBytes>::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 

--- a/cppcache/src/PdxInstanceImpl.hpp
+++ b/cppcache/src/PdxInstanceImpl.hpp
@@ -136,7 +136,7 @@ class _GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
                         const std::vector<bool>& value) override;
 
   virtual void setField(const std::string& fieldName,
-                        std::vector<int8_t> value) override;
+                        const std::vector<int8_t>& value) override;
 
   virtual void setField(const std::string& fieldName,
                         const std::vector<int16_t>& value) override;

--- a/cppcache/src/PdxInstanceImpl.hpp
+++ b/cppcache/src/PdxInstanceImpl.hpp
@@ -68,30 +68,30 @@ class _GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
   virtual std::string getStringField(
       const std::string& fieldName) const override;
 
-  virtual void getField(const std::string& fieldname, bool** value,
-                        int32_t& length) const override;
+  virtual std::vector<bool> getBooleanArrayField(
+      const std::string& fieldname) const override;
 
-  virtual void getField(const std::string& fieldname, int8_t** value,
-                        int32_t& length) const override;
+  virtual std::vector<int8_t> getByteArrayField(
+      const std::string& fieldname) const override;
 
-  virtual void getField(const std::string& fieldname, int16_t** value,
-                        int32_t& length) const override;
+  virtual std::vector<int16_t> getShortArrayField(
+      const std::string& fieldname) const override;
 
-  virtual void getField(const std::string& fieldname, int32_t** value,
-                        int32_t& length) const override;
+  virtual std::vector<int32_t> getIntArrayField(
+      const std::string& fieldname) const override;
 
-  virtual void getField(const std::string& fieldname, int64_t** value,
-                        int32_t& length) const override;
+  virtual std::vector<int64_t> getLongArrayField(
+      const std::string& fieldname) const override;
 
-  virtual void getField(const std::string& fieldname, float** value,
-                        int32_t& length) const override;
+  virtual std::vector<float> getFloatArrayField(
+      const std::string& fieldname) const override;
 
-  virtual void getField(const std::string& fieldname, double** value,
-                        int32_t& length) const override;
+  virtual std::vector<double> getDoubleArrayField(
+      const std::string& fieldname) const override;
 
   // charArray
-  virtual void getField(const std::string& fieldName, char16_t** value,
-                        int32_t& length) const override;
+  virtual std::vector<char16_t> getCharArrayField(
+      const std::string& fieldName) const override;
 
   virtual std::vector<std::string> getStringArrayField(
       const std::string& fieldname) const override;
@@ -132,32 +132,32 @@ class _GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
   virtual void setField(const std::string& fieldName,
                         std::shared_ptr<CacheableDate> value) override;
 
-  virtual void setField(const std::string& fieldName, bool* value,
-                        int32_t length) override;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<bool>& value) override;
 
-  virtual void setField(const std::string& fieldName, int8_t* value,
-                        int32_t length) override;
+  virtual void setField(const std::string& fieldName,
+                        std::vector<int8_t> value) override;
 
-  virtual void setField(const std::string& fieldName, int16_t* value,
-                        int32_t length) override;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<int16_t>& value) override;
 
-  virtual void setField(const std::string& fieldName, int32_t* value,
-                        int32_t length) override;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<int32_t>& value) override;
 
-  virtual void setField(const std::string& fieldName, int64_t* value,
-                        int32_t length) override;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<int64_t>& value) override;
 
-  virtual void setField(const std::string& fieldName, float* value,
-                        int32_t length) override;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<float>& value) override;
 
-  virtual void setField(const std::string& fieldName, double* value,
-                        int32_t length) override;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<double>& value) override;
 
   virtual void setField(const std::string& fieldName,
                         const std::string& value) override;
 
-  virtual void setField(const std::string& fieldName, char16_t* value,
-                        int32_t length) override;
+  virtual void setField(const std::string& fieldName,
+                        const std::vector<char16_t>& value) override;
 
   virtual void setField(const std::string& fieldName, std::string* value,
                         int32_t length) override;

--- a/cppcache/src/PdxLocalReader.cpp
+++ b/cppcache/src/PdxLocalReader.cpp
@@ -141,63 +141,44 @@ std::shared_ptr<Serializable> PdxLocalReader::readObject(
   }
 }
 
-char16_t* PdxLocalReader::readCharArray(
-    const std::string& fieldName,
-    int32_t& length) {  // TODO:: need to return
-  // Length to user for
-  // all primitive arrays
-  char16_t* charArray = nullptr;
-  m_dataInput->readCharArray(&charArray, length);
-  return charArray;
+std::vector<char16_t> PdxLocalReader::readCharArray(
+    const std::string& fieldName) {
+  return m_dataInput->readCharArray();
 }
 
-bool* PdxLocalReader::readBooleanArray(const std::string& fieldName,
-                                       int32_t& length) {
-  bool* boolArray = nullptr;
-  m_dataInput->readBooleanArray(&boolArray, length);
-  return boolArray;
+std::vector<bool> PdxLocalReader::readBooleanArray(
+   const std::string& fieldName) {
+  return m_dataInput->readBooleanArray();
 }
 
-int8_t* PdxLocalReader::readByteArray(const std::string& fieldName,
-                                      int32_t& length) {
-  int8_t* byteArray = nullptr;
-  m_dataInput->readByteArray(&byteArray, length);
-  return byteArray;
+std::vector<int8_t> PdxLocalReader::readByteArray(
+    const std::string& fieldName) {
+  return m_dataInput->readByteArray();
 }
 
-int16_t* PdxLocalReader::readShortArray(const std::string& fieldName,
-                                        int32_t& length) {
-  int16_t* shortArray = nullptr;
-  m_dataInput->readShortArray(&shortArray, length);
-  return shortArray;
+std::vector<int16_t> PdxLocalReader::readShortArray(
+    const std::string& fieldName) {
+  return m_dataInput->readShortArray();
 }
 
-int32_t* PdxLocalReader::readIntArray(const std::string& fieldName,
-                                      int32_t& length) {
-  int32_t* intArray = nullptr;
-  m_dataInput->readIntArray(&intArray, length);
-  return intArray;
+std::vector<int32_t> PdxLocalReader::readIntArray(
+    const std::string& fieldName) {
+  return m_dataInput->readIntArray();
 }
 
-int64_t* PdxLocalReader::readLongArray(const std::string& fieldName,
-                                       int32_t& length) {
-  int64_t* longArray = nullptr;
-  m_dataInput->readLongArray(&longArray, length);
-  return longArray;
+std::vector<int64_t> PdxLocalReader::readLongArray(
+    const std::string& fieldName) {
+  return m_dataInput->readLongArray();
 }
 
-float* PdxLocalReader::readFloatArray(const std::string& fieldName,
-                                      int32_t& length) {
-  float* floatArray = nullptr;
-  m_dataInput->readFloatArray(&floatArray, length);
-  return floatArray;
+std::vector<float> PdxLocalReader::readFloatArray(
+    const std::string& fieldName) {
+  return m_dataInput->readFloatArray();
 }
 
-double* PdxLocalReader::readDoubleArray(const std::string& fieldName,
-                                        int32_t& length) {
-  double* doubleArray = nullptr;
-  m_dataInput->readDoubleArray(&doubleArray, length);
-  return doubleArray;
+std::vector<double> PdxLocalReader::readDoubleArray(
+    const std::string& fieldName) {
+  return m_dataInput->readDoubleArray();
 }
 
 std::vector<std::string> PdxLocalReader::readStringArray(

--- a/cppcache/src/PdxLocalReader.hpp
+++ b/cppcache/src/PdxLocalReader.hpp
@@ -85,29 +85,29 @@ class PdxLocalReader : public PdxReader {
   virtual std::shared_ptr<Serializable> readObject(
       const std::string &fieldName) override;
 
-  virtual char16_t *readCharArray(const std::string &fieldName,
-                                  int32_t &length) override;
+  virtual std::vector<char16_t> readCharArray(
+      const std::string &fieldName) override;
 
-  virtual bool *readBooleanArray(const std::string &fieldName,
-                                 int32_t &length) override;
+  virtual std::vector<bool> readBooleanArray(
+      const std::string &fieldName) override;
 
-  virtual int8_t *readByteArray(const std::string &fieldName,
-                                int32_t &length) override;
+  virtual std::vector<int8_t> readByteArray(
+      const std::string &fieldName) override;
 
-  virtual int16_t *readShortArray(const std::string &fieldName,
-                                  int32_t &length) override;
+  virtual std::vector<int16_t> readShortArray(
+      const std::string &fieldName) override;
 
-  virtual int32_t *readIntArray(const std::string &fieldName,
-                                int32_t &length) override;
+  virtual std::vector<int32_t> readIntArray(
+      const std::string &fieldName) override;
 
-  virtual int64_t *readLongArray(const std::string &fieldName,
-                                 int32_t &length) override;
+  virtual std::vector<int64_t> readLongArray(
+      const std::string &fieldName) override;
 
-  virtual float *readFloatArray(const std::string &fieldName,
-                                int32_t &length) override;
+  virtual std::vector<float> readFloatArray(
+      const std::string &fieldName) override;
 
-  virtual double *readDoubleArray(const std::string &fieldName,
-                                  int32_t &length) override;
+  virtual std::vector<double> readDoubleArray(
+      const std::string &fieldName) override;
 
   virtual std::vector<std::string> readStringArray(
       const std::string &fieldName) override;

--- a/cppcache/src/PdxLocalWriter.cpp
+++ b/cppcache/src/PdxLocalWriter.cpp
@@ -274,53 +274,53 @@ PdxWriter& PdxLocalWriter::writeObject(
   return *this;
 }
 PdxWriter& PdxLocalWriter::writeBooleanArray(const std::string& fieldName,
-                                             bool* array, int length) {
+                                             std::vector<bool> array) {
   addOffset();
-  writeObject(array, length);
+  writeArrayObject(array);
   return *this;
 }
 
 PdxWriter& PdxLocalWriter::writeCharArray(
-    const std::string& fieldName, char16_t* array, int length) {
+    const std::string& fieldName, std::vector<char16_t> array) {
   addOffset();
-  writeObject(array, length);
+  writeArrayObject(array);
   return *this;
 }
 
 PdxWriter& PdxLocalWriter::writeByteArray(
-    const std::string& fieldName, int8_t* array, int length) {
+    const std::string& fieldName, std::vector<int8_t> array) {
   addOffset();
-  writeObject(array, length);
+  writeArrayObject(array);
   return *this;
 }
 PdxWriter& PdxLocalWriter::writeShortArray(const std::string& fieldName,
-                                           int16_t* array, int length) {
+                                           std::vector<int16_t> array) {
   addOffset();
-  writeObject(array, length);
+  writeArrayObject(array);
   return *this;
 }
 PdxWriter& PdxLocalWriter::writeIntArray(const std::string& fieldName,
-                                         int32_t* array, int length) {
+                                         std::vector<int32_t> array) {
   addOffset();
-  writeObject(array, length);
+  writeArrayObject(array);
   return *this;
 }
 PdxWriter& PdxLocalWriter::writeLongArray(const std::string& fieldName,
-                                          int64_t* array, int length) {
+                                          std::vector<int64_t> array) {
   addOffset();
-  writeObject(array, length);
+  writeArrayObject(array);
   return *this;
  }
  PdxWriter& PdxLocalWriter::writeFloatArray(const std::string& fieldName,
-                                            float* array, int length) {
+                                            std::vector<float> array) {
    addOffset();
-   writeObject(array, length);
+   writeArrayObject(array);
    return *this;
  }
  PdxWriter& PdxLocalWriter::writeDoubleArray(const std::string& fieldName,
-                                             double* array, int length) {
+                                             std::vector<double> array) {
    addOffset();
-   writeObject(array, length);
+   writeArrayObject(array);
    return *this;
  }
  PdxWriter& PdxLocalWriter::writeObjectArray(

--- a/cppcache/src/PdxLocalWriter.cpp
+++ b/cppcache/src/PdxLocalWriter.cpp
@@ -274,51 +274,51 @@ PdxWriter& PdxLocalWriter::writeObject(
   return *this;
 }
 PdxWriter& PdxLocalWriter::writeBooleanArray(const std::string& fieldName,
-                                             std::vector<bool> array) {
+                                             const std::vector<bool>& array) {
   addOffset();
   writeArrayObject(array);
   return *this;
 }
 
 PdxWriter& PdxLocalWriter::writeCharArray(
-    const std::string& fieldName, std::vector<char16_t> array) {
+    const std::string& fieldName, const std::vector<char16_t>& array) {
   addOffset();
   writeArrayObject(array);
   return *this;
 }
 
 PdxWriter& PdxLocalWriter::writeByteArray(
-    const std::string& fieldName, std::vector<int8_t> array) {
+    const std::string& fieldName, const std::vector<int8_t>& array) {
   addOffset();
   writeArrayObject(array);
   return *this;
 }
 PdxWriter& PdxLocalWriter::writeShortArray(const std::string& fieldName,
-                                           std::vector<int16_t> array) {
+                                           const std::vector<int16_t>& array) {
   addOffset();
   writeArrayObject(array);
   return *this;
 }
 PdxWriter& PdxLocalWriter::writeIntArray(const std::string& fieldName,
-                                         std::vector<int32_t> array) {
+                                         const std::vector<int32_t>& array) {
   addOffset();
   writeArrayObject(array);
   return *this;
 }
 PdxWriter& PdxLocalWriter::writeLongArray(const std::string& fieldName,
-                                          std::vector<int64_t> array) {
+                                          const std::vector<int64_t>& array) {
   addOffset();
   writeArrayObject(array);
   return *this;
  }
  PdxWriter& PdxLocalWriter::writeFloatArray(const std::string& fieldName,
-                                            std::vector<float> array) {
+                                            const std::vector<float>& array) {
    addOffset();
    writeArrayObject(array);
    return *this;
  }
  PdxWriter& PdxLocalWriter::writeDoubleArray(const std::string& fieldName,
-                                             std::vector<double> array) {
+                                             const std::vector<double>& array) {
    addOffset();
    writeArrayObject(array);
    return *this;

--- a/cppcache/src/PdxLocalWriter.hpp
+++ b/cppcache/src/PdxLocalWriter.hpp
@@ -113,10 +113,8 @@ class PdxLocalWriter : public PdxWriter {
   template <typename mType>
   void writeArrayObject(std::vector<mType> array) {
     m_dataOutput->writeArrayLen(array.size());
-    if (array.size() > 0) {
-      for (auto&& obj : array) {
-        writeObject(obj);
-      }
+    for (auto&& obj : array) {
+      writeObject(obj);
     }
   }
 

--- a/cppcache/src/PdxLocalWriter.hpp
+++ b/cppcache/src/PdxLocalWriter.hpp
@@ -114,9 +114,8 @@ class PdxLocalWriter : public PdxWriter {
   void writeArrayObject(std::vector<mType> array) {
     m_dataOutput->writeArrayLen(array.size());
     if (array.size() > 0) {
-      int i = 0;
-      for (i = 0; i < array.size(); i++) {
-        writeObject(array[i]);
+      for (auto&& obj : array) {
+        writeObject(obj);
       }
     }
   }
@@ -155,29 +154,37 @@ class PdxLocalWriter : public PdxWriter {
       const std::string& fieldName,
       std::shared_ptr<Serializable> value) override;
 
-  virtual PdxWriter& writeBooleanArray(const std::string& fieldName,
-                                       std::vector<bool> array) override;
+  virtual PdxWriter& writeBooleanArray(
+      const std::string& fieldName,
+      const std::vector<bool>& array) override;
 
   virtual PdxWriter& writeCharArray(
-      const std::string& fieldName, std::vector<char16_t> array) override;
+      const std::string& fieldName,
+      const std::vector<char16_t>& array) override;
 
-  virtual PdxWriter& writeByteArray(const std::string& fieldName,
-                                    std::vector<int8_t> array) override;
+  virtual PdxWriter& writeByteArray(
+      const std::string& fieldName,
+      const std::vector<int8_t>& array) override;
 
-  virtual PdxWriter& writeShortArray(const std::string& fieldName,
-                                     std::vector<int16_t> array) override;
+  virtual PdxWriter& writeShortArray(
+      const std::string& fieldName,
+      const std::vector<int16_t>& array) override;
 
-  virtual PdxWriter& writeIntArray(const std::string& fieldName,
-                                   std::vector<int32_t> array) override;
+  virtual PdxWriter& writeIntArray(
+      const std::string& fieldName,
+      const std::vector<int32_t>& array) override;
 
-  virtual PdxWriter& writeLongArray(const std::string& fieldName,
-                                    std::vector<int64_t> array) override;
+  virtual PdxWriter& writeLongArray(
+      const std::string& fieldName,
+      const std::vector<int64_t>& array) override;
 
-  virtual PdxWriter& writeFloatArray(const std::string& fieldName,
-                                     std::vector<float> array) override;
+  virtual PdxWriter& writeFloatArray(
+      const std::string& fieldName,
+      const std::vector<float>& array) override;
 
-  virtual PdxWriter& writeDoubleArray(const std::string& fieldName,
-                                      std::vector<double> array) override;
+  virtual PdxWriter& writeDoubleArray(
+      const std::string& fieldName,
+      const std::vector<double>& array) override;
 
   virtual PdxWriter& writeStringArray(
       const std::string& fieldName,

--- a/cppcache/src/PdxLocalWriter.hpp
+++ b/cppcache/src/PdxLocalWriter.hpp
@@ -110,6 +110,17 @@ class PdxLocalWriter : public PdxWriter {
     }
   }
 
+  template <typename mType>
+  void writeArrayObject(std::vector<mType> array) {
+    m_dataOutput->writeArrayLen(array.size());
+    if (array.size() > 0) {
+      int i = 0;
+      for (i = 0; i < array.size(); i++) {
+        writeObject(array[i]);
+      }
+    }
+  }
+
   virtual PdxWriter& writeChar(const std::string& fieldName,
                                                char16_t value) override;
 
@@ -145,28 +156,28 @@ class PdxLocalWriter : public PdxWriter {
       std::shared_ptr<Serializable> value) override;
 
   virtual PdxWriter& writeBooleanArray(const std::string& fieldName,
-                                       bool* array, int length) override;
+                                       std::vector<bool> array) override;
 
   virtual PdxWriter& writeCharArray(
-      const std::string& fieldName, char16_t* array, int length) override;
+      const std::string& fieldName, std::vector<char16_t> array) override;
 
-  virtual PdxWriter& writeByteArray(const std::string& fieldName, int8_t* array,
-                                    int length) override;
+  virtual PdxWriter& writeByteArray(const std::string& fieldName,
+                                    std::vector<int8_t> array) override;
 
   virtual PdxWriter& writeShortArray(const std::string& fieldName,
-                                     int16_t* array, int length) override;
+                                     std::vector<int16_t> array) override;
 
-  virtual PdxWriter& writeIntArray(const std::string& fieldName, int32_t* array,
-                                   int length) override;
+  virtual PdxWriter& writeIntArray(const std::string& fieldName,
+                                   std::vector<int32_t> array) override;
 
   virtual PdxWriter& writeLongArray(const std::string& fieldName,
-                                    int64_t* array, int length) override;
+                                    std::vector<int64_t> array) override;
 
-  virtual PdxWriter& writeFloatArray(const std::string& fieldName, float* array,
-                                     int length) override;
+  virtual PdxWriter& writeFloatArray(const std::string& fieldName,
+                                     std::vector<float> array) override;
 
   virtual PdxWriter& writeDoubleArray(const std::string& fieldName,
-                                      double* array, int length) override;
+                                      std::vector<double> array) override;
 
   virtual PdxWriter& writeStringArray(
       const std::string& fieldName,

--- a/cppcache/src/PdxReaderWithTypeCollector.cpp
+++ b/cppcache/src/PdxReaderWithTypeCollector.cpp
@@ -243,8 +243,8 @@ std::shared_ptr<Serializable> PdxReaderWithTypeCollector::readObject(
   }
 }
 
-char16_t* PdxReaderWithTypeCollector::readCharArray(
-    const std::string& fieldName, int32_t& length) {
+std::vector<char16_t> PdxReaderWithTypeCollector::readCharArray(
+    const std::string& fieldName) {
   checkType(fieldName, PdxFieldTypes::CHAR_ARRAY, "char[]");
   m_newPdxType->addVariableLengthTypeField(fieldName, "char[]",
                                            PdxFieldTypes::CHAR_ARRAY);
@@ -255,19 +255,19 @@ char16_t* PdxReaderWithTypeCollector::readCharArray(
   if (position != -1) {
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
-    auto retVal = PdxLocalReader::readCharArray(fieldName, length);
+    auto retVal = PdxLocalReader::readCharArray(fieldName);
     int32_t strSize =
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
     return retVal;
   } else {
-    return nullptr;
+    return std::vector<char16_t>{};
   }
 }
 
-bool* PdxReaderWithTypeCollector::readBooleanArray(const std::string& fieldName,
-                                                   int32_t& length) {
+std::vector<bool> PdxReaderWithTypeCollector::readBooleanArray(
+    const std::string& fieldName) {
   checkType(fieldName, PdxFieldTypes::BOOLEAN_ARRAY, "boolean[]");
   m_newPdxType->addVariableLengthTypeField(fieldName, "boolean[]",
                                            PdxFieldTypes::BOOLEAN_ARRAY);
@@ -281,18 +281,18 @@ bool* PdxReaderWithTypeCollector::readBooleanArray(const std::string& fieldName,
   if (position != -1) {
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
-    bool* retVal = PdxLocalReader::readBooleanArray(fieldName, length);
+    std::vector<bool> retVal = PdxLocalReader::readBooleanArray(fieldName);
     int32_t strSize =
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
     return retVal;
   }
-  return nullptr;
+  return std::vector<bool>{};
 }
 
-int8_t* PdxReaderWithTypeCollector::readByteArray(const std::string& fieldName,
-                                                  int32_t& length) {
+std::vector<int8_t> PdxReaderWithTypeCollector::readByteArray(
+    const std::string& fieldName) {
   checkType(fieldName, PdxFieldTypes::BYTE_ARRAY, "byte[]");
   m_newPdxType->addVariableLengthTypeField(fieldName, "byte[]",
                                            PdxFieldTypes::BYTE_ARRAY);
@@ -301,22 +301,22 @@ int8_t* PdxReaderWithTypeCollector::readByteArray(const std::string& fieldName,
   LOGDEBUG("PdxReaderWithTypeCollector::readByteArray(): position = %d",
            position);
   if (position != -1) {
-    int8_t* byteArrptr;
+    std::vector<int8_t> byteArrptr;
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
-    byteArrptr = PdxLocalReader::readByteArray(fieldName, length);
+    byteArrptr = PdxLocalReader::readByteArray(fieldName);
     int32_t strSize =
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
     return byteArrptr;
   } else {
-    return nullptr;
+    return std::vector<int8_t>{};
   }
 }
 
-int16_t* PdxReaderWithTypeCollector::readShortArray(
-    const std::string& fieldName, int32_t& length) {
+std::vector<int16_t> PdxReaderWithTypeCollector::readShortArray(
+    const std::string& fieldName) {
   checkType(fieldName, PdxFieldTypes::SHORT_ARRAY, "short[]");
   m_newPdxType->addVariableLengthTypeField(fieldName, "short[]",
                                            PdxFieldTypes::SHORT_ARRAY);
@@ -325,22 +325,22 @@ int16_t* PdxReaderWithTypeCollector::readShortArray(
   LOGDEBUG("PdxReaderWithTypeCollector::readShortArray():position = %d",
            position);
   if (position != -1) {
-    int16_t* shortArrptr;
+    std::vector<int16_t> shortArrptr;
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
-    shortArrptr = PdxLocalReader::readShortArray(fieldName, length);
+    shortArrptr = PdxLocalReader::readShortArray(fieldName);
     int32_t strSize =
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
     return shortArrptr;
   } else {
-    return nullptr;
+    return std::vector<int16_t>{};
   }
 }
 
-int32_t* PdxReaderWithTypeCollector::readIntArray(const std::string& fieldName,
-                                                  int32_t& length) {
+std::vector<int32_t> PdxReaderWithTypeCollector::readIntArray(
+    const std::string& fieldName) {
   checkType(fieldName, PdxFieldTypes::INT_ARRAY, "int[]");
   m_newPdxType->addVariableLengthTypeField(fieldName, "int[]",
                                            PdxFieldTypes::INT_ARRAY);
@@ -349,22 +349,22 @@ int32_t* PdxReaderWithTypeCollector::readIntArray(const std::string& fieldName,
   LOGDEBUG("PdxReaderWithTypeCollector::readIntArray():position = %d",
            position);
   if (position != -1) {
-    int32_t* intArrayptr;
+    std::vector<int32_t> intArrayptr;
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
-    intArrayptr = PdxLocalReader::readIntArray(fieldName, length);
+    intArrayptr = PdxLocalReader::readIntArray(fieldName);
     int32_t strSize =
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
     return intArrayptr;
   } else {
-    return nullptr;
+    return std::vector<int32_t>{};
   }
 }
 
-int64_t* PdxReaderWithTypeCollector::readLongArray(const std::string& fieldName,
-                                                   int32_t& length) {
+std::vector<int64_t> PdxReaderWithTypeCollector::readLongArray(
+    const std::string& fieldName) {
   checkType(fieldName, PdxFieldTypes::LONG_ARRAY, "long[]");
   m_newPdxType->addVariableLengthTypeField(fieldName, "long[]",
                                            PdxFieldTypes::LONG_ARRAY);
@@ -373,22 +373,22 @@ int64_t* PdxReaderWithTypeCollector::readLongArray(const std::string& fieldName,
   LOGDEBUG("PdxReaderWithTypeCollector::readLongArray():position = %d",
            position);
   if (position != -1) {
-    int64_t* longArrptr;
+    std::vector<int64_t> longArrptr;
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
-    longArrptr = PdxLocalReader::readLongArray(fieldName, length);
+    longArrptr = PdxLocalReader::readLongArray(fieldName);
     int32_t strSize =
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
     return longArrptr;
   } else {
-    return nullptr;
+    return std::vector<int64_t>{};
   }
 }
 
-float* PdxReaderWithTypeCollector::readFloatArray(const std::string& fieldName,
-                                                  int32_t& length) {
+std::vector<float> PdxReaderWithTypeCollector::readFloatArray(
+    const std::string& fieldName) {
   checkType(fieldName, PdxFieldTypes::FLOAT_ARRAY, "float[]");
   m_newPdxType->addVariableLengthTypeField(fieldName, "float[]",
                                            PdxFieldTypes::FLOAT_ARRAY);
@@ -397,22 +397,22 @@ float* PdxReaderWithTypeCollector::readFloatArray(const std::string& fieldName,
   LOGDEBUG("PdxReaderWithTypeCollector::readFloatArray(): position = %d",
            position);
   if (position != -1) {
-    float* floatArrptr;
+    std::vector<float> floatArrptr;
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
-    floatArrptr = PdxLocalReader::readFloatArray(fieldName, length);
+    floatArrptr = PdxLocalReader::readFloatArray(fieldName);
     int32_t strSize =
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
     return floatArrptr;
   } else {
-    return nullptr;
+     return std::vector<float>{};
   }
 }
 
-double* PdxReaderWithTypeCollector::readDoubleArray(
-    const std::string& fieldName, int32_t& length) {
+std::vector<double> PdxReaderWithTypeCollector::readDoubleArray(
+    const std::string& fieldName) {
   checkType(fieldName, PdxFieldTypes::DOUBLE_ARRAY, "double[]");
   m_newPdxType->addVariableLengthTypeField(fieldName, "double[]",
                                            PdxFieldTypes::DOUBLE_ARRAY);
@@ -421,17 +421,17 @@ double* PdxReaderWithTypeCollector::readDoubleArray(
   LOGDEBUG("PdxReaderWithTypeCollector::readDoubleArray():position = %d",
            position);
   if (position != -1) {
-    double* doubleArrptr;
+    std::vector<double> doubleArrptr;
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
-    doubleArrptr = PdxLocalReader::readDoubleArray(fieldName, length);
+    doubleArrptr = PdxLocalReader::readDoubleArray(fieldName);
     int32_t strSize =
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
     return doubleArrptr;
   } else {
-    return nullptr;
+    return std::vector<double>{};
   }
 }
 

--- a/cppcache/src/PdxReaderWithTypeCollector.cpp
+++ b/cppcache/src/PdxReaderWithTypeCollector.cpp
@@ -252,18 +252,17 @@ std::vector<char16_t> PdxReaderWithTypeCollector::readCharArray(
                                              m_offsetSize, m_serializedLength);
   LOGDEBUG("PdxReaderWithTypeCollector::readCharArray():position = %d",
            position);
+  std::vector<char16_t> array;
   if (position != -1) {
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
-    auto retVal = PdxLocalReader::readCharArray(fieldName);
+    array = PdxLocalReader::readCharArray(fieldName);
     int32_t strSize =
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
-    return retVal;
-  } else {
-    return std::vector<char16_t>{};
   }
+  return array;
 }
 
 std::vector<bool> PdxReaderWithTypeCollector::readBooleanArray(
@@ -278,17 +277,17 @@ std::vector<bool> PdxReaderWithTypeCollector::readBooleanArray(
       "NIL:293: PdxReaderWithTypeCollector::readBooleanArray(): Position =%d ",
       position);
 
+  std::vector<bool> array;
   if (position != -1) {
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
-    std::vector<bool> retVal = PdxLocalReader::readBooleanArray(fieldName);
+    array = PdxLocalReader::readBooleanArray(fieldName);
     int32_t strSize =
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
-    return retVal;
   }
-  return std::vector<bool>{};
+  return array;
 }
 
 std::vector<int8_t> PdxReaderWithTypeCollector::readByteArray(
@@ -300,19 +299,17 @@ std::vector<int8_t> PdxReaderWithTypeCollector::readByteArray(
                                              m_offsetSize, m_serializedLength);
   LOGDEBUG("PdxReaderWithTypeCollector::readByteArray(): position = %d",
            position);
+  std::vector<int8_t> array;
   if (position != -1) {
-    std::vector<int8_t> byteArrptr;
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
-    byteArrptr = PdxLocalReader::readByteArray(fieldName);
+    array = PdxLocalReader::readByteArray(fieldName);
     int32_t strSize =
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
-    return byteArrptr;
-  } else {
-    return std::vector<int8_t>{};
   }
+  return array;
 }
 
 std::vector<int16_t> PdxReaderWithTypeCollector::readShortArray(
@@ -324,8 +321,8 @@ std::vector<int16_t> PdxReaderWithTypeCollector::readShortArray(
                                              m_offsetSize, m_serializedLength);
   LOGDEBUG("PdxReaderWithTypeCollector::readShortArray():position = %d",
            position);
+  std::vector<int16_t> shortArrptr;
   if (position != -1) {
-    std::vector<int16_t> shortArrptr;
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     shortArrptr = PdxLocalReader::readShortArray(fieldName);
@@ -333,10 +330,8 @@ std::vector<int16_t> PdxReaderWithTypeCollector::readShortArray(
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
-    return shortArrptr;
-  } else {
-    return std::vector<int16_t>{};
   }
+  return shortArrptr;
 }
 
 std::vector<int32_t> PdxReaderWithTypeCollector::readIntArray(
@@ -348,8 +343,8 @@ std::vector<int32_t> PdxReaderWithTypeCollector::readIntArray(
                                              m_offsetSize, m_serializedLength);
   LOGDEBUG("PdxReaderWithTypeCollector::readIntArray():position = %d",
            position);
+  std::vector<int32_t> intArrayptr;
   if (position != -1) {
-    std::vector<int32_t> intArrayptr;
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     intArrayptr = PdxLocalReader::readIntArray(fieldName);
@@ -357,10 +352,8 @@ std::vector<int32_t> PdxReaderWithTypeCollector::readIntArray(
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
-    return intArrayptr;
-  } else {
-    return std::vector<int32_t>{};
   }
+  return intArrayptr;
 }
 
 std::vector<int64_t> PdxReaderWithTypeCollector::readLongArray(
@@ -372,8 +365,8 @@ std::vector<int64_t> PdxReaderWithTypeCollector::readLongArray(
                                              m_offsetSize, m_serializedLength);
   LOGDEBUG("PdxReaderWithTypeCollector::readLongArray():position = %d",
            position);
+  std::vector<int64_t> longArrptr;
   if (position != -1) {
-    std::vector<int64_t> longArrptr;
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     longArrptr = PdxLocalReader::readLongArray(fieldName);
@@ -381,10 +374,8 @@ std::vector<int64_t> PdxReaderWithTypeCollector::readLongArray(
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
-    return longArrptr;
-  } else {
-    return std::vector<int64_t>{};
   }
+  return longArrptr;
 }
 
 std::vector<float> PdxReaderWithTypeCollector::readFloatArray(
@@ -396,8 +387,8 @@ std::vector<float> PdxReaderWithTypeCollector::readFloatArray(
                                              m_offsetSize, m_serializedLength);
   LOGDEBUG("PdxReaderWithTypeCollector::readFloatArray(): position = %d",
            position);
+  std::vector<float> floatArrptr;
   if (position != -1) {
-    std::vector<float> floatArrptr;
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     floatArrptr = PdxLocalReader::readFloatArray(fieldName);
@@ -405,10 +396,8 @@ std::vector<float> PdxReaderWithTypeCollector::readFloatArray(
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
-    return floatArrptr;
-  } else {
-     return std::vector<float>{};
   }
+  return floatArrptr;
 }
 
 std::vector<double> PdxReaderWithTypeCollector::readDoubleArray(
@@ -420,8 +409,8 @@ std::vector<double> PdxReaderWithTypeCollector::readDoubleArray(
                                              m_offsetSize, m_serializedLength);
   LOGDEBUG("PdxReaderWithTypeCollector::readDoubleArray():position = %d",
            position);
+  std::vector<double> doubleArrptr;
   if (position != -1) {
-    std::vector<double> doubleArrptr;
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     doubleArrptr = PdxLocalReader::readDoubleArray(fieldName);
@@ -429,10 +418,8 @@ std::vector<double> PdxReaderWithTypeCollector::readDoubleArray(
         static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
-    return doubleArrptr;
-  } else {
-    return std::vector<double>{};
   }
+  return doubleArrptr;
 }
 
 std::vector<std::string> PdxReaderWithTypeCollector::readStringArray(

--- a/cppcache/src/PdxReaderWithTypeCollector.cpp
+++ b/cppcache/src/PdxReaderWithTypeCollector.cpp
@@ -209,8 +209,7 @@ std::string PdxReaderWithTypeCollector::readString(
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     auto str = PdxLocalReader::readString(fieldName);
-    int32_t strSize =
-        static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
+    auto strSize = m_dataInput->currentBufferPosition() - startLoc;
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
     return str;
@@ -233,8 +232,7 @@ std::shared_ptr<Serializable> PdxReaderWithTypeCollector::readObject(
     ptr = PdxLocalReader::readObject(fieldName);
     m_newPdxType->addVariableLengthTypeField(fieldName, "Serializable",
                                              PdxFieldTypes::OBJECT);
-    int32_t strSize =
-        static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
+    auto strSize = m_dataInput->currentBufferPosition() - startLoc;
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
     return ptr;
@@ -257,8 +255,7 @@ std::vector<char16_t> PdxReaderWithTypeCollector::readCharArray(
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     array = PdxLocalReader::readCharArray(fieldName);
-    int32_t strSize =
-        static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
+    auto strSize = m_dataInput->currentBufferPosition() - startLoc;
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
   }
@@ -282,8 +279,7 @@ std::vector<bool> PdxReaderWithTypeCollector::readBooleanArray(
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     array = PdxLocalReader::readBooleanArray(fieldName);
-    int32_t strSize =
-        static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
+    auto strSize = m_dataInput->currentBufferPosition() - startLoc;
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
   }
@@ -304,8 +300,7 @@ std::vector<int8_t> PdxReaderWithTypeCollector::readByteArray(
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     array = PdxLocalReader::readByteArray(fieldName);
-    int32_t strSize =
-        static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
+    auto strSize = m_dataInput->currentBufferPosition() - startLoc;
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
   }
@@ -326,8 +321,7 @@ std::vector<int16_t> PdxReaderWithTypeCollector::readShortArray(
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     shortArrptr = PdxLocalReader::readShortArray(fieldName);
-    int32_t strSize =
-        static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
+    auto strSize = m_dataInput->currentBufferPosition() - startLoc;
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
   }
@@ -348,8 +342,7 @@ std::vector<int32_t> PdxReaderWithTypeCollector::readIntArray(
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     intArrayptr = PdxLocalReader::readIntArray(fieldName);
-    int32_t strSize =
-        static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
+    auto strSize =m_dataInput->currentBufferPosition() - startLoc;
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
   }
@@ -370,8 +363,7 @@ std::vector<int64_t> PdxReaderWithTypeCollector::readLongArray(
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     longArrptr = PdxLocalReader::readLongArray(fieldName);
-    int32_t strSize =
-        static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
+    auto strSize = m_dataInput->currentBufferPosition() - startLoc;
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
   }
@@ -392,8 +384,7 @@ std::vector<float> PdxReaderWithTypeCollector::readFloatArray(
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     floatArrptr = PdxLocalReader::readFloatArray(fieldName);
-    int32_t strSize =
-        static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
+    auto strSize = m_dataInput->currentBufferPosition() - startLoc;
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
   }
@@ -414,8 +405,7 @@ std::vector<double> PdxReaderWithTypeCollector::readDoubleArray(
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     doubleArrptr = PdxLocalReader::readDoubleArray(fieldName);
-    int32_t strSize =
-        static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
+    auto strSize =m_dataInput->currentBufferPosition() - startLoc;
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
   }
@@ -458,8 +448,7 @@ PdxReaderWithTypeCollector::readObjectArray(const std::string& fieldName) {
     m_dataInput->advanceCursor(position);
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
    auto retVal = PdxLocalReader::readObjectArray(fieldName);
-   int32_t strSize =
-       static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
+   auto strSize = m_dataInput->currentBufferPosition() - startLoc;
    m_dataInput->rewindCursor(strSize + position);
    startLoc = nullptr;
    return retVal;
@@ -483,8 +472,7 @@ int8_t** PdxReaderWithTypeCollector::readArrayOfByteArrays(
     const uint8_t* startLoc = m_dataInput->currentBufferPosition();
     int8_t** retVal = PdxLocalReader::readArrayOfByteArrays(
         fieldName, arrayLength, elementLength);
-    int32_t strSize =
-        static_cast<int32_t>(m_dataInput->currentBufferPosition() - startLoc);
+    auto strSize = m_dataInput->currentBufferPosition() - startLoc;
     m_dataInput->rewindCursor(strSize + position);
     startLoc = nullptr;
     return retVal;

--- a/cppcache/src/PdxReaderWithTypeCollector.hpp
+++ b/cppcache/src/PdxReaderWithTypeCollector.hpp
@@ -64,29 +64,29 @@ class PdxReaderWithTypeCollector : public PdxLocalReader {
   virtual std::shared_ptr<Serializable> readObject(
       const std::string& fieldName) override;
 
-  virtual char16_t* readCharArray(const std::string& fieldName,
-                                  int32_t& length) override;
+  virtual std::vector<char16_t> readCharArray(
+      const std::string& fieldName) override;
 
-  virtual bool* readBooleanArray(const std::string& fieldName,
-                                 int32_t& length) override;
+  virtual std::vector<bool> readBooleanArray(
+      const std::string& fieldName) override;
 
-  virtual int8_t* readByteArray(const std::string& fieldName,
-                                int32_t& length) override;
+  virtual std::vector<int8_t> readByteArray(
+      const std::string& fieldName) override;
 
-  virtual int16_t* readShortArray(const std::string& fieldName,
-                                  int32_t& length) override;
+  virtual std::vector<int16_t> readShortArray(
+      const std::string& fieldName) override;
 
-  virtual int32_t* readIntArray(const std::string& fieldName,
-                                int32_t& length) override;
+  virtual std::vector<int32_t> readIntArray(
+      const std::string& fieldName) override;
 
-  virtual int64_t* readLongArray(const std::string& fieldName,
-                                 int32_t& length) override;
+  virtual std::vector<int64_t> readLongArray(
+      const std::string& fieldName) override;
 
-  virtual float* readFloatArray(const std::string& fieldName,
-                                int32_t& length) override;
+  virtual std::vector<float> readFloatArray(
+      const std::string& fieldName) override;
 
-  virtual double* readDoubleArray(const std::string& fieldName,
-                                  int32_t& length) override;
+  virtual std::vector<double> readDoubleArray(
+      const std::string& fieldName) override;
 
   virtual std::vector<std::string> readStringArray(
       const std::string& fieldName) override;

--- a/cppcache/src/PdxRemoteReader.cpp
+++ b/cppcache/src/PdxRemoteReader.cpp
@@ -309,221 +309,184 @@ std::shared_ptr<Serializable> PdxRemoteReader::readObject(
 std::vector<char16_t> PdxRemoteReader::readCharArray(const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
+  std::vector<char16_t> array;
   switch (choice) {
     case -2:
-      return PdxLocalReader::readCharArray(fieldName);  // in same order
-    case -1: {
-      return std::vector<char16_t>{};
-    }
+      array = PdxLocalReader::readCharArray(fieldName);  // in same order
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       PdxLocalReader::resettoPdxHead();
       m_dataInput->advanceCursor(position);
-      auto retVal = PdxLocalReader::readCharArray(fieldName);
+      array = PdxLocalReader::readCharArray(fieldName);
       PdxLocalReader::resettoPdxHead();
-      return retVal;
     }
   }
+  return array;
 }
 
 std::vector<bool> PdxRemoteReader::readBooleanArray(
     const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
+  std::vector<bool> array;
   switch (choice) {
     case -2:
-      return PdxLocalReader::readBooleanArray(fieldName);  // in same order
-    case -1: {
-      return std::vector<bool>{}; // null value
-    }
+      array = PdxLocalReader::readBooleanArray(fieldName);  // in same order
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       PdxLocalReader::resettoPdxHead();
       m_dataInput->advanceCursor(position);
-      std::vector<bool> retVal = PdxLocalReader::readBooleanArray(fieldName);
+      array = PdxLocalReader::readBooleanArray(fieldName);
       PdxLocalReader::resettoPdxHead();
-      return retVal;
     }
   }
+  return array;
 }
 
 std::vector<int8_t> PdxRemoteReader::readByteArray(
     const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
+  std::vector<int8_t> array;
   switch (choice) {
     case -2: {
-      return PdxLocalReader::readByteArray(fieldName);  // in same order
-    }
-    case -1: {
-      return std::vector<int8_t>{};
+      array = PdxLocalReader::readByteArray(fieldName);  // in same order
     }
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       if (position != -1) {
-        std::vector<int8_t> byteArrptr;
         PdxLocalReader::resettoPdxHead();
         m_dataInput->advanceCursor(position);
-        byteArrptr = PdxLocalReader::readByteArray(fieldName);
+        array = PdxLocalReader::readByteArray(fieldName);
         PdxLocalReader::resettoPdxHead();
-        return byteArrptr;
-      } else {
-        return std::vector<int8_t>{};
       }
     }
   }
+  return array;
 }
 
 std::vector<int16_t> PdxRemoteReader::readShortArray(
     const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
+  std::vector<int16_t> array;
   switch (choice) {
     case -2: {
-      return PdxLocalReader::readShortArray(fieldName);  // in same
-                                                                 // order
-    }
-    case -1: {
-      return std::vector<int16_t>{};
+      array = PdxLocalReader::readShortArray(fieldName);  // in same order
     }
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       if (position != -1) {
-        std::vector<int16_t> shortArrptr;
         PdxLocalReader::resettoPdxHead();
         m_dataInput->advanceCursor(position);
-        shortArrptr = PdxLocalReader::readShortArray(fieldName);
+        array = PdxLocalReader::readShortArray(fieldName);
         PdxLocalReader::resettoPdxHead();
-        return shortArrptr;
-      } else {
-        return std::vector<int16_t>{};
       }
     }
   }
+  return array;
 }
 
 std::vector<int32_t> PdxRemoteReader::readIntArray(
     const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
+  std::vector<int32_t> array;
   switch (choice) {
     case -2: {
-      return PdxLocalReader::readIntArray(fieldName);  // in same order
-    }
-    case -1: {
-      return std::vector<int32_t>{};
+      array = PdxLocalReader::readIntArray(fieldName);  // in same order
     }
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       if (position != -1) {
-        std::vector<int32_t> intArrptr;
         PdxLocalReader::resettoPdxHead();
         m_dataInput->advanceCursor(position);
-        intArrptr = PdxLocalReader::readIntArray(fieldName);
+        array = PdxLocalReader::readIntArray(fieldName);
         PdxLocalReader::resettoPdxHead();
-        return intArrptr;
-      } else {
-        return std::vector<int32_t>{};
       }
     }
   }
+  return array;
 }
 
 std::vector<int64_t> PdxRemoteReader::readLongArray(const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
+  std::vector<int64_t> array;
   switch (choice) {
     case -2: {
-      return PdxLocalReader::readLongArray(fieldName);  // in same order
-    }
-    case -1: {
-      return std::vector<int64_t>{};
+      array = PdxLocalReader::readLongArray(fieldName);  // in same order
     }
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       if (position != -1) {
-        std::vector<int64_t> longArrptr;
         PdxLocalReader::resettoPdxHead();
         m_dataInput->advanceCursor(position);
-        longArrptr = PdxLocalReader::readLongArray(fieldName);
+        array = PdxLocalReader::readLongArray(fieldName);
         PdxLocalReader::resettoPdxHead();
-        return longArrptr;
-      } else {
-        return std::vector<int64_t>{};
       }
     }
   }
+  return array;
 }
 
 std::vector<float> PdxRemoteReader::readFloatArray(const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
+  std::vector<float> array;
   switch (choice) {
     case -2: {
-      return PdxLocalReader::readFloatArray(fieldName);  // in same
-                                                                 // order
-    }
-    case -1: {
-      return std::vector<float>{};
+      array = PdxLocalReader::readFloatArray(fieldName);  // in same order
     }
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       if (position != -1) {
-        std::vector<float> floatArrptr;
         PdxLocalReader::resettoPdxHead();
         m_dataInput->advanceCursor(position);
-        floatArrptr =
-            PdxLocalReader::readFloatArray(fieldName);  // in same order
+        array = PdxLocalReader::readFloatArray(fieldName);  // in same order
         PdxLocalReader::resettoPdxHead();
-        return floatArrptr;
-      } else {
-        return std::vector<float>{};
       }
     }
   }
+  return array;
 }
 
 std::vector<double> PdxRemoteReader::readDoubleArray(const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
+  std::vector<double> array;
   switch (choice) {
     case -2: {
-      return PdxLocalReader::readDoubleArray(fieldName);  // in same order
-    }
-    case -1: {
-      return std::vector<double>{};
+      array = PdxLocalReader::readDoubleArray(fieldName);  // in same order
     }
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       if (position != -1) {
-        std::vector<double> doubleArrptr;
         PdxLocalReader::resettoPdxHead();
         m_dataInput->advanceCursor(position);
-        doubleArrptr = PdxLocalReader::readDoubleArray(
+        array = PdxLocalReader::readDoubleArray(
             fieldName);  // in same order
         PdxLocalReader::resettoPdxHead();
-        return doubleArrptr;
-      } else {
-        return std::vector<double>{};
       }
     }
   }
+  return array;
 }
 
 std::vector<std::string> PdxRemoteReader::readStringArray(

--- a/cppcache/src/PdxRemoteReader.cpp
+++ b/cppcache/src/PdxRemoteReader.cpp
@@ -306,15 +306,14 @@ std::shared_ptr<Serializable> PdxRemoteReader::readObject(
   }
 }
 
-char16_t* PdxRemoteReader::readCharArray(const std::string& fieldName,
-                                         int32_t& length) {
+std::vector<char16_t> PdxRemoteReader::readCharArray(const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
   switch (choice) {
     case -2:
-      return PdxLocalReader::readCharArray(fieldName, length);  // in same order
+      return PdxLocalReader::readCharArray(fieldName);  // in same order
     case -1: {
-      return nullptr;  // null value
+      return std::vector<char16_t>{};
     }
     default: {
       // sequence id read field and then update
@@ -322,23 +321,22 @@ char16_t* PdxRemoteReader::readCharArray(const std::string& fieldName,
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       PdxLocalReader::resettoPdxHead();
       m_dataInput->advanceCursor(position);
-      auto retVal = PdxLocalReader::readCharArray(fieldName, length);
+      auto retVal = PdxLocalReader::readCharArray(fieldName);
       PdxLocalReader::resettoPdxHead();
       return retVal;
     }
   }
 }
 
-bool* PdxRemoteReader::readBooleanArray(const std::string& fieldName,
-                                        int32_t& length) {
+std::vector<bool> PdxRemoteReader::readBooleanArray(
+    const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
   switch (choice) {
     case -2:
-      return PdxLocalReader::readBooleanArray(fieldName,
-                                              length);  // in same order
+      return PdxLocalReader::readBooleanArray(fieldName);  // in same order
     case -1: {
-      return nullptr;  // null value
+      return std::vector<bool>{}; // null value
     }
     default: {
       // sequence id read field and then update
@@ -346,187 +344,183 @@ bool* PdxRemoteReader::readBooleanArray(const std::string& fieldName,
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       PdxLocalReader::resettoPdxHead();
       m_dataInput->advanceCursor(position);
-      bool* retVal = PdxLocalReader::readBooleanArray(fieldName, length);
+      std::vector<bool> retVal = PdxLocalReader::readBooleanArray(fieldName);
       PdxLocalReader::resettoPdxHead();
       return retVal;
     }
   }
 }
 
-int8_t* PdxRemoteReader::readByteArray(const std::string& fieldName,
-                                       int32_t& length) {
+std::vector<int8_t> PdxRemoteReader::readByteArray(
+    const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
   switch (choice) {
     case -2: {
-      return PdxLocalReader::readByteArray(fieldName, length);  // in same order
+      return PdxLocalReader::readByteArray(fieldName);  // in same order
     }
     case -1: {
-      return nullptr;
+      return std::vector<int8_t>{};
     }
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       if (position != -1) {
-        int8_t* byteArrptr;
+        std::vector<int8_t> byteArrptr;
         PdxLocalReader::resettoPdxHead();
         m_dataInput->advanceCursor(position);
-        byteArrptr = PdxLocalReader::readByteArray(fieldName, length);
+        byteArrptr = PdxLocalReader::readByteArray(fieldName);
         PdxLocalReader::resettoPdxHead();
         return byteArrptr;
       } else {
-        return nullptr;
+        return std::vector<int8_t>{};
       }
     }
   }
 }
 
-int16_t* PdxRemoteReader::readShortArray(const std::string& fieldName,
-                                         int32_t& length) {
+std::vector<int16_t> PdxRemoteReader::readShortArray(
+    const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
   switch (choice) {
     case -2: {
-      return PdxLocalReader::readShortArray(fieldName, length);  // in same
+      return PdxLocalReader::readShortArray(fieldName);  // in same
                                                                  // order
     }
     case -1: {
-      return nullptr;
+      return std::vector<int16_t>{};
     }
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       if (position != -1) {
-        int16_t* shortArrptr;
+        std::vector<int16_t> shortArrptr;
         PdxLocalReader::resettoPdxHead();
         m_dataInput->advanceCursor(position);
-        shortArrptr = PdxLocalReader::readShortArray(fieldName, length);
+        shortArrptr = PdxLocalReader::readShortArray(fieldName);
         PdxLocalReader::resettoPdxHead();
         return shortArrptr;
       } else {
-        return nullptr;
+        return std::vector<int16_t>{};
       }
     }
   }
 }
 
-int32_t* PdxRemoteReader::readIntArray(const std::string& fieldName,
-                                       int32_t& length) {
+std::vector<int32_t> PdxRemoteReader::readIntArray(
+    const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
   switch (choice) {
     case -2: {
-      return PdxLocalReader::readIntArray(fieldName, length);  // in same order
+      return PdxLocalReader::readIntArray(fieldName);  // in same order
     }
     case -1: {
-      return nullptr;
+      return std::vector<int32_t>{};
     }
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       if (position != -1) {
-        int32_t* intArrptr;
+        std::vector<int32_t> intArrptr;
         PdxLocalReader::resettoPdxHead();
         m_dataInput->advanceCursor(position);
-        intArrptr = PdxLocalReader::readIntArray(fieldName, length);
+        intArrptr = PdxLocalReader::readIntArray(fieldName);
         PdxLocalReader::resettoPdxHead();
         return intArrptr;
       } else {
-        return nullptr;
+        return std::vector<int32_t>{};
       }
     }
   }
 }
 
-int64_t* PdxRemoteReader::readLongArray(const std::string& fieldName,
-                                        int32_t& length) {
+std::vector<int64_t> PdxRemoteReader::readLongArray(const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
   switch (choice) {
     case -2: {
-      return PdxLocalReader::readLongArray(fieldName, length);  // in same order
+      return PdxLocalReader::readLongArray(fieldName);  // in same order
     }
     case -1: {
-      return nullptr;
+      return std::vector<int64_t>{};
     }
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       if (position != -1) {
-        int64_t* longArrptr;
+        std::vector<int64_t> longArrptr;
         PdxLocalReader::resettoPdxHead();
         m_dataInput->advanceCursor(position);
-        longArrptr = PdxLocalReader::readLongArray(fieldName, length);
+        longArrptr = PdxLocalReader::readLongArray(fieldName);
         PdxLocalReader::resettoPdxHead();
         return longArrptr;
       } else {
-        return nullptr;
+        return std::vector<int64_t>{};
       }
     }
   }
 }
 
-float* PdxRemoteReader::readFloatArray(const std::string& fieldName,
-                                       int32_t& length) {
+std::vector<float> PdxRemoteReader::readFloatArray(const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
   switch (choice) {
     case -2: {
-      return PdxLocalReader::readFloatArray(fieldName, length);  // in same
+      return PdxLocalReader::readFloatArray(fieldName);  // in same
                                                                  // order
     }
     case -1: {
-      return nullptr;
+      return std::vector<float>{};
     }
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       if (position != -1) {
-        float* floatArrptr;
+        std::vector<float> floatArrptr;
         PdxLocalReader::resettoPdxHead();
         m_dataInput->advanceCursor(position);
         floatArrptr =
-            PdxLocalReader::readFloatArray(fieldName, length);  // in same order
+            PdxLocalReader::readFloatArray(fieldName);  // in same order
         PdxLocalReader::resettoPdxHead();
         return floatArrptr;
       } else {
-        return nullptr;
+        return std::vector<float>{};
       }
     }
   }
 }
 
-double* PdxRemoteReader::readDoubleArray(const std::string& fieldName,
-                                         int32_t& length) {
+std::vector<double> PdxRemoteReader::readDoubleArray(const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
 
   switch (choice) {
     case -2: {
-      return PdxLocalReader::readDoubleArray(fieldName,
-                                             length);  // in same order
+      return PdxLocalReader::readDoubleArray(fieldName);  // in same order
     }
     case -1: {
-      return nullptr;
+      return std::vector<double>{};
     }
     default: {
       // sequence id read field and then update
       int position = m_pdxType->getFieldPosition(
           choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
       if (position != -1) {
-        double* doubleArrptr;
+        std::vector<double> doubleArrptr;
         PdxLocalReader::resettoPdxHead();
         m_dataInput->advanceCursor(position);
         doubleArrptr = PdxLocalReader::readDoubleArray(
-            fieldName, length);  // in same order
+            fieldName);  // in same order
         PdxLocalReader::resettoPdxHead();
         return doubleArrptr;
       } else {
-        return nullptr;
+        return std::vector<double>{};
       }
     }
   }

--- a/cppcache/src/PdxRemoteReader.hpp
+++ b/cppcache/src/PdxRemoteReader.hpp
@@ -61,29 +61,29 @@ class PdxRemoteReader : public PdxLocalReader {
   virtual std::shared_ptr<Serializable> readObject(
       const std::string& fieldName) override;
 
-  virtual char16_t* readCharArray(const std::string& fieldName,
-                                  int32_t& length) override;
+  virtual std::vector<char16_t> readCharArray(
+      const std::string& fieldName) override;
 
-  virtual bool* readBooleanArray(const std::string& fieldName,
-                                 int32_t& length) override;
+  virtual std::vector<bool> readBooleanArray(
+      const std::string& fieldName) override;
 
-  virtual int8_t* readByteArray(const std::string& fieldName,
-                                int32_t& length) override;
+  virtual std::vector<int8_t> readByteArray(
+      const std::string& fieldName) override;
 
-  virtual int16_t* readShortArray(const std::string& fieldName,
-                                  int32_t& length) override;
+  virtual std::vector<int16_t> readShortArray(
+      const std::string& fieldName) override;
 
-  virtual int32_t* readIntArray(const std::string& fieldName,
-                                int32_t& length) override;
+  virtual std::vector<int32_t> readIntArray(
+      const std::string& fieldName) override;
 
-  virtual int64_t* readLongArray(const std::string& fieldName,
-                                 int32_t& length) override;
+  virtual std::vector<int64_t> readLongArray(
+      const std::string& fieldName) override;
 
-  virtual float* readFloatArray(const std::string& fieldName,
-                                int32_t& length) override;
+  virtual std::vector<float> readFloatArray(
+      const std::string& fieldName) override;
 
-  virtual double* readDoubleArray(const std::string& fieldName,
-                                  int32_t& length) override;
+  virtual std::vector<double> readDoubleArray(
+      const std::string& fieldName) override;
 
   virtual std::vector<std::string> readStringArray(
       const std::string& fieldName) override;

--- a/cppcache/src/PdxRemoteWriter.cpp
+++ b/cppcache/src/PdxRemoteWriter.cpp
@@ -207,53 +207,53 @@ PdxWriter& PdxRemoteWriter::writeObject(
   return *this;
 }
 PdxWriter& PdxRemoteWriter::writeBooleanArray(const std::string& fieldName,
-                                              bool* array, int length) {
+                                              std::vector<bool> array) {
   writePreserveData();
-  PdxLocalWriter::writeBooleanArray(fieldName, array, length);
+  PdxLocalWriter::writeBooleanArray(fieldName, array);
   return *this;
 }
 
 PdxWriter& PdxRemoteWriter::writeCharArray(
-    const std::string& fieldName, char16_t* array, int length) {
+    const std::string& fieldName, std::vector<char16_t> array) {
   writePreserveData();
-  PdxLocalWriter::writeCharArray(fieldName, array, length);
+  PdxLocalWriter::writeCharArray(fieldName, array);
   return *this;
 }
 
 PdxWriter& PdxRemoteWriter::writeByteArray(
-    const std::string& fieldName, int8_t* array, int length) {
+    const std::string& fieldName, std::vector<int8_t> array) {
   writePreserveData();
-  PdxLocalWriter::writeByteArray(fieldName, array, length);
+  PdxLocalWriter::writeByteArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxRemoteWriter::writeShortArray(const std::string& fieldName,
-                                            int16_t* array, int length) {
+                                            std::vector<int16_t> array) {
   writePreserveData();
-  PdxLocalWriter::writeShortArray(fieldName, array, length);
+  PdxLocalWriter::writeShortArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxRemoteWriter::writeIntArray(const std::string& fieldName,
-                                          int32_t* array, int length) {
+                                          std::vector<int32_t> array) {
   writePreserveData();
-  PdxLocalWriter::writeIntArray(fieldName, array, length);
+  PdxLocalWriter::writeIntArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxRemoteWriter::writeLongArray(const std::string& fieldName,
-                                           int64_t* array, int length) {
+                                           std::vector<int64_t> array) {
   writePreserveData();
-  PdxLocalWriter::writeLongArray(fieldName, array, length);
+  PdxLocalWriter::writeLongArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxRemoteWriter::writeFloatArray(const std::string& fieldName,
-                                            float* array, int length) {
+                                            std::vector<float> array) {
   writePreserveData();
-  PdxLocalWriter::writeFloatArray(fieldName, array, length);
+  PdxLocalWriter::writeFloatArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxRemoteWriter::writeDoubleArray(const std::string& fieldName,
-                                             double* array, int length) {
+                                             std::vector<double> array) {
   writePreserveData();
-  PdxLocalWriter::writeDoubleArray(fieldName, array, length);
+  PdxLocalWriter::writeDoubleArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxRemoteWriter::writeObjectArray(

--- a/cppcache/src/PdxRemoteWriter.cpp
+++ b/cppcache/src/PdxRemoteWriter.cpp
@@ -207,51 +207,51 @@ PdxWriter& PdxRemoteWriter::writeObject(
   return *this;
 }
 PdxWriter& PdxRemoteWriter::writeBooleanArray(const std::string& fieldName,
-                                              std::vector<bool> array) {
+                                              const std::vector<bool>& array) {
   writePreserveData();
   PdxLocalWriter::writeBooleanArray(fieldName, array);
   return *this;
 }
 
 PdxWriter& PdxRemoteWriter::writeCharArray(
-    const std::string& fieldName, std::vector<char16_t> array) {
+    const std::string& fieldName, const std::vector<char16_t>& array) {
   writePreserveData();
   PdxLocalWriter::writeCharArray(fieldName, array);
   return *this;
 }
 
 PdxWriter& PdxRemoteWriter::writeByteArray(
-    const std::string& fieldName, std::vector<int8_t> array) {
+    const std::string& fieldName, const std::vector<int8_t>& array) {
   writePreserveData();
   PdxLocalWriter::writeByteArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxRemoteWriter::writeShortArray(const std::string& fieldName,
-                                            std::vector<int16_t> array) {
+                                            const std::vector<int16_t>& array) {
   writePreserveData();
   PdxLocalWriter::writeShortArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxRemoteWriter::writeIntArray(const std::string& fieldName,
-                                          std::vector<int32_t> array) {
+                                          const std::vector<int32_t>& array) {
   writePreserveData();
   PdxLocalWriter::writeIntArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxRemoteWriter::writeLongArray(const std::string& fieldName,
-                                           std::vector<int64_t> array) {
+                                           const std::vector<int64_t>& array) {
   writePreserveData();
   PdxLocalWriter::writeLongArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxRemoteWriter::writeFloatArray(const std::string& fieldName,
-                                            std::vector<float> array) {
+                                            const std::vector<float>& array) {
   writePreserveData();
   PdxLocalWriter::writeFloatArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxRemoteWriter::writeDoubleArray(const std::string& fieldName,
-                                             std::vector<double> array) {
+                                             const std::vector<double>& array) {
   writePreserveData();
   PdxLocalWriter::writeDoubleArray(fieldName, array);
   return *this;

--- a/cppcache/src/PdxRemoteWriter.hpp
+++ b/cppcache/src/PdxRemoteWriter.hpp
@@ -99,28 +99,36 @@ class PdxRemoteWriter : public PdxLocalWriter {
       std::shared_ptr<Serializable> value) override;
 
   virtual PdxWriter& writeBooleanArray(
-      const std::string& fieldName, std::vector<bool> array) override;
+      const std::string& fieldName,
+      const std::vector<bool>& array) override;
 
   virtual PdxWriter& writeCharArray(
-      const std::string& fieldName, std::vector<char16_t> array) override;
+      const std::string& fieldName,
+      const std::vector<char16_t>& array) override;
 
   virtual PdxWriter& writeByteArray(
-      const std::string& fieldName, std::vector<int8_t> array) override;
+      const std::string& fieldName,
+      const std::vector<int8_t>& array) override;
 
   virtual PdxWriter& writeShortArray(
-      const std::string& fieldName, std::vector<int16_t> array) override;
+      const std::string& fieldName,
+      const std::vector<int16_t>& array) override;
 
-  virtual PdxWriter& writeIntArray(const std::string& fieldName,
-                                   std::vector<int32_t> array) override;
+  virtual PdxWriter& writeIntArray(
+      const std::string& fieldName,
+      const std::vector<int32_t>& array) override;
 
   virtual PdxWriter& writeLongArray(
-      const std::string& fieldName, std::vector<int64_t> array) override;
+      const std::string& fieldName,
+      const std::vector<int64_t>& array) override;
 
   virtual PdxWriter& writeFloatArray(
-      const std::string& fieldName, std::vector<float> array) override;
+      const std::string& fieldName,
+      const std::vector<float>& array) override;
 
   virtual PdxWriter& writeDoubleArray(
-      const std::string& fieldName, std::vector<double> array) override;
+      const std::string& fieldName,
+      const std::vector<double>& array) override;
 
   virtual PdxWriter& writeStringArray(
       const std::string& fieldName,

--- a/cppcache/src/PdxRemoteWriter.hpp
+++ b/cppcache/src/PdxRemoteWriter.hpp
@@ -99,29 +99,28 @@ class PdxRemoteWriter : public PdxLocalWriter {
       std::shared_ptr<Serializable> value) override;
 
   virtual PdxWriter& writeBooleanArray(
-      const std::string& fieldName, bool* array, int length) override;
+      const std::string& fieldName, std::vector<bool> array) override;
 
   virtual PdxWriter& writeCharArray(
-      const std::string& fieldName, char16_t* array, int length) override;
+      const std::string& fieldName, std::vector<char16_t> array) override;
 
   virtual PdxWriter& writeByteArray(
-      const std::string& fieldName, int8_t* array, int length) override;
+      const std::string& fieldName, std::vector<int8_t> array) override;
 
   virtual PdxWriter& writeShortArray(
-      const std::string& fieldName, int16_t* array, int length) override;
+      const std::string& fieldName, std::vector<int16_t> array) override;
 
   virtual PdxWriter& writeIntArray(const std::string& fieldName,
-                                                   int32_t* array,
-                                                   int length) override;
+                                   std::vector<int32_t> array) override;
 
   virtual PdxWriter& writeLongArray(
-      const std::string& fieldName, int64_t* array, int length) override;
+      const std::string& fieldName, std::vector<int64_t> array) override;
 
   virtual PdxWriter& writeFloatArray(
-      const std::string& fieldName, float* array, int length) override;
+      const std::string& fieldName, std::vector<float> array) override;
 
   virtual PdxWriter& writeDoubleArray(
-      const std::string& fieldName, double* array, int length) override;
+      const std::string& fieldName, std::vector<double> array) override;
 
   virtual PdxWriter& writeStringArray(
       const std::string& fieldName,

--- a/cppcache/src/PdxWriterWithTypeCollector.cpp
+++ b/cppcache/src/PdxWriterWithTypeCollector.cpp
@@ -180,7 +180,7 @@ PdxWriter& PdxWriterWithTypeCollector::writeObject(
   return *this;
 }
 PdxWriter& PdxWriterWithTypeCollector::writeBooleanArray(
-    const std::string& fieldName, std::vector<bool> array) {
+    const std::string& fieldName, const std::vector<bool>& array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "bool[]",
                                         PdxFieldTypes::BOOLEAN_ARRAY);
   PdxLocalWriter::writeBooleanArray(fieldName, array);
@@ -188,7 +188,7 @@ PdxWriter& PdxWriterWithTypeCollector::writeBooleanArray(
 }
 
 PdxWriter& PdxWriterWithTypeCollector::writeCharArray(
-    const std::string& fieldName, std::vector<char16_t> array) {
+    const std::string& fieldName, const std::vector<char16_t>& array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "char[]",
                                         PdxFieldTypes::CHAR_ARRAY);
   PdxLocalWriter::writeCharArray(fieldName, array);
@@ -196,42 +196,42 @@ PdxWriter& PdxWriterWithTypeCollector::writeCharArray(
 }
 
 PdxWriter& PdxWriterWithTypeCollector::writeByteArray(
-    const std::string& fieldName, std::vector<int8_t> array) {
+    const std::string& fieldName, const std::vector<int8_t>& array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "byte[]",
                                         PdxFieldTypes::BYTE_ARRAY);
   PdxLocalWriter::writeByteArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxWriterWithTypeCollector::writeShortArray(
-    const std::string& fieldName, std::vector<int16_t> array) {
+    const std::string& fieldName, const std::vector<int16_t>& array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "short[]",
                                         PdxFieldTypes::SHORT_ARRAY);
   PdxLocalWriter::writeShortArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxWriterWithTypeCollector::writeIntArray(
-    const std::string& fieldName, std::vector<int32_t> array) {
+    const std::string& fieldName, const std::vector<int32_t>& array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "int[]",
                                         PdxFieldTypes::INT_ARRAY);
   PdxLocalWriter::writeIntArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxWriterWithTypeCollector::writeLongArray(
-    const std::string& fieldName, std::vector<int64_t> array) {
+    const std::string& fieldName, const std::vector<int64_t>& array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "long[]",
                                         PdxFieldTypes::LONG_ARRAY);
   PdxLocalWriter::writeLongArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxWriterWithTypeCollector::writeFloatArray(
-    const std::string& fieldName, std::vector<float> array) {
+    const std::string& fieldName, const std::vector<float>& array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "float[]",
                                         PdxFieldTypes::FLOAT_ARRAY);
   PdxLocalWriter::writeFloatArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxWriterWithTypeCollector::writeDoubleArray(
-    const std::string& fieldName, std::vector<double> array) {
+    const std::string& fieldName, const std::vector<double>& array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "double[]",
                                         PdxFieldTypes::DOUBLE_ARRAY);
   PdxLocalWriter::writeDoubleArray(fieldName, array);

--- a/cppcache/src/PdxWriterWithTypeCollector.cpp
+++ b/cppcache/src/PdxWriterWithTypeCollector.cpp
@@ -180,61 +180,61 @@ PdxWriter& PdxWriterWithTypeCollector::writeObject(
   return *this;
 }
 PdxWriter& PdxWriterWithTypeCollector::writeBooleanArray(
-    const std::string& fieldName, bool* array, int length) {
+    const std::string& fieldName, std::vector<bool> array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "bool[]",
                                         PdxFieldTypes::BOOLEAN_ARRAY);
-  PdxLocalWriter::writeBooleanArray(fieldName, array, length);
+  PdxLocalWriter::writeBooleanArray(fieldName, array);
   return *this;
 }
 
 PdxWriter& PdxWriterWithTypeCollector::writeCharArray(
-    const std::string& fieldName, char16_t* array, int length) {
+    const std::string& fieldName, std::vector<char16_t> array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "char[]",
                                         PdxFieldTypes::CHAR_ARRAY);
-  PdxLocalWriter::writeCharArray(fieldName, array, length);
+  PdxLocalWriter::writeCharArray(fieldName, array);
   return *this;
 }
 
 PdxWriter& PdxWriterWithTypeCollector::writeByteArray(
-    const std::string& fieldName, int8_t* array, int length) {
+    const std::string& fieldName, std::vector<int8_t> array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "byte[]",
                                         PdxFieldTypes::BYTE_ARRAY);
-  PdxLocalWriter::writeByteArray(fieldName, array, length);
+  PdxLocalWriter::writeByteArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxWriterWithTypeCollector::writeShortArray(
-    const std::string& fieldName, int16_t* array, int length) {
+    const std::string& fieldName, std::vector<int16_t> array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "short[]",
                                         PdxFieldTypes::SHORT_ARRAY);
-  PdxLocalWriter::writeShortArray(fieldName, array, length);
+  PdxLocalWriter::writeShortArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxWriterWithTypeCollector::writeIntArray(
-    const std::string& fieldName, int32_t* array, int length) {
+    const std::string& fieldName, std::vector<int32_t> array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "int[]",
                                         PdxFieldTypes::INT_ARRAY);
-  PdxLocalWriter::writeIntArray(fieldName, array, length);
+  PdxLocalWriter::writeIntArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxWriterWithTypeCollector::writeLongArray(
-    const std::string& fieldName, int64_t* array, int length) {
+    const std::string& fieldName, std::vector<int64_t> array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "long[]",
                                         PdxFieldTypes::LONG_ARRAY);
-  PdxLocalWriter::writeLongArray(fieldName, array, length);
+  PdxLocalWriter::writeLongArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxWriterWithTypeCollector::writeFloatArray(
-    const std::string& fieldName, float* array, int length) {
+    const std::string& fieldName, std::vector<float> array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "float[]",
                                         PdxFieldTypes::FLOAT_ARRAY);
-  PdxLocalWriter::writeFloatArray(fieldName, array, length);
+  PdxLocalWriter::writeFloatArray(fieldName, array);
   return *this;
 }
 PdxWriter& PdxWriterWithTypeCollector::writeDoubleArray(
-    const std::string& fieldName, double* array, int length) {
+    const std::string& fieldName, std::vector<double> array) {
   m_pdxType->addVariableLengthTypeField(fieldName, "double[]",
                                         PdxFieldTypes::DOUBLE_ARRAY);
-  PdxLocalWriter::writeDoubleArray(fieldName, array, length);
+  PdxLocalWriter::writeDoubleArray(fieldName, array);
   return *this;
 }
 

--- a/cppcache/src/PdxWriterWithTypeCollector.hpp
+++ b/cppcache/src/PdxWriterWithTypeCollector.hpp
@@ -85,29 +85,28 @@ class PdxWriterWithTypeCollector : public PdxLocalWriter {
       std::shared_ptr<Serializable> value) override;
 
   virtual PdxWriter& writeBooleanArray(
-      const std::string& fieldName, bool* array, int length) override;
+      const std::string& fieldName, std::vector<bool> array) override;
 
   virtual PdxWriter& writeCharArray(
-      const std::string& fieldName, char16_t* array, int length) override;
+      const std::string& fieldName, std::vector<char16_t> array) override;
 
   virtual PdxWriter& writeByteArray(
-      const std::string& fieldName, int8_t* array, int length) override;
+      const std::string& fieldName, std::vector<int8_t> array) override;
 
   virtual PdxWriter& writeShortArray(
-      const std::string& fieldName, int16_t* array, int length) override;
+      const std::string& fieldName, std::vector<int16_t> array) override;
 
   virtual PdxWriter& writeIntArray(const std::string& fieldName,
-                                                   int32_t* array,
-                                                   int length) override;
+                                   std::vector<int32_t> array) override;
 
   virtual PdxWriter& writeLongArray(
-      const std::string& fieldName, int64_t* array, int length) override;
+      const std::string& fieldName, std::vector<int64_t> array) override;
 
   virtual PdxWriter& writeFloatArray(
-      const std::string& fieldName, float* array, int length) override;
+      const std::string& fieldName, std::vector<float> array) override;
 
   virtual PdxWriter& writeDoubleArray(
-      const std::string& fieldName, double* array, int length) override;
+      const std::string& fieldName, std::vector<double> array) override;
 
   virtual PdxWriter& writeStringArray(
       const std::string& fieldName,

--- a/cppcache/src/PdxWriterWithTypeCollector.hpp
+++ b/cppcache/src/PdxWriterWithTypeCollector.hpp
@@ -85,28 +85,36 @@ class PdxWriterWithTypeCollector : public PdxLocalWriter {
       std::shared_ptr<Serializable> value) override;
 
   virtual PdxWriter& writeBooleanArray(
-      const std::string& fieldName, std::vector<bool> array) override;
+      const std::string& fieldName,
+      const std::vector<bool>& array) override;
 
   virtual PdxWriter& writeCharArray(
-      const std::string& fieldName, std::vector<char16_t> array) override;
+      const std::string& fieldName,
+      const std::vector<char16_t>& array) override;
 
   virtual PdxWriter& writeByteArray(
-      const std::string& fieldName, std::vector<int8_t> array) override;
+      const std::string& fieldName,
+      const std::vector<int8_t>& array) override;
 
   virtual PdxWriter& writeShortArray(
-      const std::string& fieldName, std::vector<int16_t> array) override;
+      const std::string& fieldName,
+      const std::vector<int16_t>& array) override;
 
-  virtual PdxWriter& writeIntArray(const std::string& fieldName,
-                                   std::vector<int32_t> array) override;
+  virtual PdxWriter& writeIntArray(
+      const std::string& fieldName,
+      const std::vector<int32_t>& array) override;
 
   virtual PdxWriter& writeLongArray(
-      const std::string& fieldName, std::vector<int64_t> array) override;
+      const std::string& fieldName,
+      const std::vector<int64_t>& array) override;
 
   virtual PdxWriter& writeFloatArray(
-      const std::string& fieldName, std::vector<float> array) override;
+      const std::string& fieldName,
+      const std::vector<float>& array) override;
 
   virtual PdxWriter& writeDoubleArray(
-      const std::string& fieldName, std::vector<double> array) override;
+      const std::string& fieldName,
+      const std::vector<double>& array) override;
 
   virtual PdxWriter& writeStringArray(
       const std::string& fieldName,

--- a/cppcache/src/SerializationRegistry.cpp
+++ b/cppcache/src/SerializationRegistry.cpp
@@ -69,12 +69,12 @@ void TheTypeMap::setup() {
 
   bind(CacheableByte::createDeserializable);
   bind(CacheableBoolean::createDeserializable);
-  bind(CacheableArray<bool>::createDeserializable);
+  bind(BooleanArray::createDeserializable);
   bind(CacheableBytes::createDeserializable);
   bind(CacheableFloat::createDeserializable);
-  bind(CacheableArray<float>::createDeserializable);
+  bind(CacheableFloatArray::createDeserializable);
   bind(CacheableDouble::createDeserializable);
-  bind(CacheableArray<double>::createDeserializable);
+  bind(CacheableDoubleArray::createDeserializable);
   bind(CacheableDate::createDeserializable);
   bind(CacheableFileName::createDeserializable);
   bind(CacheableHashMap::createDeserializable);
@@ -83,11 +83,11 @@ void TheTypeMap::setup() {
   bind(CacheableIdentityHashMap::createDeserializable);
   bind(CacheableLinkedHashSet::createDeserializable);
   bind(CacheableInt16::createDeserializable);
-  bind(CacheableArray<int16_t>::createDeserializable);
+  bind(CacheableInt16Array::createDeserializable);
   bind(CacheableInt32::createDeserializable);
-  bind(CacheableArray<int32_t>::createDeserializable);
+  bind(CacheableInt32Array::createDeserializable);
   bind(CacheableInt64::createDeserializable);
-  bind(CacheableArray<int64_t>::createDeserializable);
+  bind(CacheableInt64Array::createDeserializable);
   bind(CacheableObjectArray::createDeserializable);
   bind(CacheableString::createDeserializable);
   bind(CacheableString::createDeserializableHuge);
@@ -99,7 +99,7 @@ void TheTypeMap::setup() {
   bind(CacheableLinkedList::createDeserializable);
   bind(CacheableStack::createDeserializable);
   bind(CacheableCharacter::createDeserializable);
-  bind(CacheableArray<char16_t>::createDeserializable);
+  bind(CharArray::createDeserializable);
   bind(CacheableToken::createDeserializable);
   bind(RegionAttributes::createDeserializable);
   bind(Properties::createDeserializable);

--- a/cppcache/src/SerializationRegistry.cpp
+++ b/cppcache/src/SerializationRegistry.cpp
@@ -69,12 +69,12 @@ void TheTypeMap::setup() {
 
   bind(CacheableByte::createDeserializable);
   bind(CacheableBoolean::createDeserializable);
-  bind(BooleanArray::createDeserializable);
+  bind(CacheableArray<bool>::createDeserializable);
   bind(CacheableBytes::createDeserializable);
   bind(CacheableFloat::createDeserializable);
-  bind(CacheableFloatArray::createDeserializable);
+  bind(CacheableArray<float>::createDeserializable);
   bind(CacheableDouble::createDeserializable);
-  bind(CacheableDoubleArray::createDeserializable);
+  bind(CacheableArray<double>::createDeserializable);
   bind(CacheableDate::createDeserializable);
   bind(CacheableFileName::createDeserializable);
   bind(CacheableHashMap::createDeserializable);
@@ -83,11 +83,11 @@ void TheTypeMap::setup() {
   bind(CacheableIdentityHashMap::createDeserializable);
   bind(CacheableLinkedHashSet::createDeserializable);
   bind(CacheableInt16::createDeserializable);
-  bind(CacheableInt16Array::createDeserializable);
+  bind(CacheableArray<int16_t>::createDeserializable);
   bind(CacheableInt32::createDeserializable);
-  bind(CacheableInt32Array::createDeserializable);
+  bind(CacheableArray<int32_t>::createDeserializable);
   bind(CacheableInt64::createDeserializable);
-  bind(CacheableInt64Array::createDeserializable);
+  bind(CacheableArray<int64_t>::createDeserializable);
   bind(CacheableObjectArray::createDeserializable);
   bind(CacheableString::createDeserializable);
   bind(CacheableString::createDeserializableHuge);
@@ -99,7 +99,7 @@ void TheTypeMap::setup() {
   bind(CacheableLinkedList::createDeserializable);
   bind(CacheableStack::createDeserializable);
   bind(CacheableCharacter::createDeserializable);
-  bind(CharArray::createDeserializable);
+  bind(CacheableArray<char16_t>::createDeserializable);
   bind(CacheableToken::createDeserializable);
   bind(RegionAttributes::createDeserializable);
   bind(Properties::createDeserializable);

--- a/cppcache/test/DataInputTest.cpp
+++ b/cppcache/test/DataInputTest.cpp
@@ -120,8 +120,8 @@ class TestDataInput {
     m_dataInput.readObject(ptr);
   }
 
-  void readCharArray(char16_t **value, int32_t &length) {
-    m_dataInput.readCharArray(value, length);
+  std::vector<char16_t> readCharArray() {
+    return m_dataInput.readCharArray();
   }
 
   std::vector<std::string> readStringArray() {
@@ -518,12 +518,10 @@ TEST_F(DataInputTest, TestReadCharArray) {
   TestDataInput dataInput(
       "1C0059006F007500200068006100640020006D00650020006100740020006D0065006100"
       "7400200074006F0072006E00610064006F002E0000");
-  char16_t *value = nullptr;
-  int32_t length = 0;
-  dataInput.readCharArray(&value, length);
-  ASSERT_EQ((int32_t)28, length) << "Correct length";
+  auto value = dataInput.readCharArray();
+  ASSERT_EQ((int32_t)28, value.size()) << "Correct length";
   EXPECT_EQ(std::u16string(u"You had me at meat tornado."),
-            std::u16string(value))
+            std::u16string(value.data()))
       << "Correct const char *";
 }
 

--- a/cppcache/test/DataInputTest.cpp
+++ b/cppcache/test/DataInputTest.cpp
@@ -128,6 +128,10 @@ class TestDataInput {
     return m_dataInput.readStringArray();
   }
 
+  std::vector<bool> readBooleanArray() {
+    return m_dataInput.readBooleanArray();
+  }
+
   void readArrayOfByteArrays(int8_t ***arrayofBytearr, int32_t &arrayLength,
                              int32_t **elementLength) {
     m_dataInput.readArrayOfByteArrays(arrayofBytearr, arrayLength,
@@ -742,6 +746,12 @@ TEST_F(DataInputTest, TestSetPoolName) {
       << " pool name after setting";
   EXPECT_EQ(poolName, DataInputInternal::getPoolName(dataInput))
       << "Correct pool name after setting";
+}
+
+TEST_F(DataInputTest, TestReadNullArray) {
+  TestDataInput dataInput("FF12345678");
+
+  EXPECT_EQ(0, dataInput.readBooleanArray().size());
 }
 
 }  // namespace

--- a/tests/cpp/testobject/InvalidPdxUsage.cpp
+++ b/tests/cpp/testobject/InvalidPdxUsage.cpp
@@ -111,7 +111,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeBooleanArray("", m_boolArray, 3);
+    pw.writeBooleanArray("", m_boolArray);
     pw.markIdentityField("m_boolArray");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -128,7 +128,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeByteArray("", m_byteArray, 2);
+    pw.writeByteArray("", m_byteArray);
     pw.markIdentityField("m_byteArray");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -137,7 +137,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeCharArray("", m_charArray, 2);
+    pw.writeCharArray("", m_charArray);
     pw.markIdentityField("m_charArray");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -229,7 +229,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeDoubleArray("", m_doubleArray, 2);
+    pw.writeDoubleArray("", m_doubleArray);
     pw.markIdentityField("m_doubleArray");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -246,7 +246,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeFloatArray("", m_floatArray, 2);
+    pw.writeFloatArray("", m_floatArray);
     pw.markIdentityField("m_floatArray");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -279,7 +279,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeIntArray("", m_int32Array, 4);
+    pw.writeIntArray("", m_int32Array);
     pw.markIdentityField("m_int32Array");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -288,7 +288,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeLongArray("", m_longArray, 2);
+    pw.writeLongArray("", m_longArray);
     pw.markIdentityField("m_longArray");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -297,7 +297,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeShortArray("", m_int16Array, 2);
+    pw.writeShortArray("", m_int16Array);
     pw.markIdentityField("m_int16Array");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -314,7 +314,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeByteArray("", m_sbyteArray, 2);
+    pw.writeByteArray("", m_sbyteArray);
     pw.markIdentityField("m_sbyteArray");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -356,7 +356,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeIntArray("", m_uint32Array, 4);
+    pw.writeIntArray("", m_uint32Array);
     pw.markIdentityField("m_uint32Array");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -365,7 +365,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeLongArray("", m_ulongArray, 2);
+    pw.writeLongArray("", m_ulongArray);
     pw.markIdentityField("m_ulongArray");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -374,7 +374,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeShortArray("", m_uint16Array, 2);
+    pw.writeShortArray("", m_uint16Array);
     pw.markIdentityField("m_uint16Array");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -383,7 +383,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeByteArray("", m_byte252, 252);
+    pw.writeByteArray("", m_byte252);
     pw.markIdentityField("m_byte252");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -392,7 +392,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeByteArray("", m_byte253, 253);
+    pw.writeByteArray("", m_byte253);
     pw.markIdentityField("m_byte253");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -401,7 +401,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeByteArray("", m_byte65535, 65535);
+    pw.writeByteArray("", m_byte65535);
     pw.markIdentityField("m_byte65535");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -410,7 +410,7 @@ void InvalidPdxUsage::toData(PdxWriter& pw) const {
   }
 
   try {
-    pw.writeByteArray("", m_byte65536, 65536);
+    pw.writeByteArray("", m_byte65536);
     pw.markIdentityField("m_byte65536");
   } catch (IllegalStateException& excpt) {
     toDataexceptionCounter++;
@@ -491,7 +491,7 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
   }
 
   try {
-    m_boolArray = pr.readBooleanArray("", boolArrayLen);
+    m_boolArray = pr.readBooleanArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readBooleanArray():: Got expected Exception :: %s ",
@@ -506,7 +506,7 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
   }
 
   try {
-    m_byteArray = pr.readByteArray("", byteArrayLen);
+    m_byteArray = pr.readByteArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readByteArray():: Got expected Exception :: %s ",
@@ -514,7 +514,7 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
   }
 
   try {
-    m_charArray = pr.readCharArray("", charArrayLen);
+    m_charArray = pr.readCharArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readWideCharArray():: Got expected Exception :: %s ",
@@ -588,7 +588,7 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
   }
 
   try {
-    m_doubleArray = pr.readDoubleArray("", doubleArrayLen);
+    m_doubleArray = pr.readDoubleArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readDoubleArray():: Got expected Exception :: %s ",
@@ -603,7 +603,7 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
   }
 
   try {
-    m_floatArray = pr.readFloatArray("", floatArrayLen);
+    m_floatArray = pr.readFloatArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readFloatArray():: Got expected Exception :: %s ",
@@ -632,7 +632,7 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
   }
 
   try {
-    m_int32Array = pr.readIntArray("", intArrayLen);
+    m_int32Array = pr.readIntArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readIntArray():: Got expected Exception :: %s ",
@@ -640,7 +640,7 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
   }
 
   try {
-    m_longArray = pr.readLongArray("", longArrayLen);
+    m_longArray = pr.readLongArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readLongArray():: Got expected Exception :: %s ",
@@ -648,7 +648,7 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
   }
 
   try {
-    m_int16Array = pr.readShortArray("", shortArrayLen);
+    m_int16Array = pr.readShortArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readShortArray():: Got expected Exception :: %s ",
@@ -662,7 +662,7 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
     LOGINFO("readByte():: Got expected Exception :: %s ", excpt.what());
   }
   try {
-    m_sbyteArray = pr.readByteArray("", byteArrayLen);
+    m_sbyteArray = pr.readByteArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readByteArray():: Got expected Exception :: %s ",
@@ -699,7 +699,7 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
   }
 
   try {
-    m_uint32Array = pr.readIntArray("", intArrayLen);
+    m_uint32Array = pr.readIntArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readIntArray():: Got expected Exception :: %s ",
@@ -707,7 +707,7 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
   }
 
   try {
-    m_ulongArray = pr.readLongArray("", longArrayLen);
+    m_ulongArray = pr.readLongArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readLongArray():: Got expected Exception :: %s ",
@@ -715,7 +715,7 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
   }
 
   try {
-    m_uint16Array = pr.readShortArray("", shortArrayLen);
+    m_uint16Array = pr.readShortArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readShortArray():: Got expected Exception :: %s ",
@@ -723,22 +723,14 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
   }
 
   try {
-    m_byte252 = pr.readByteArray("", m_byte252Len);
+    m_byte252 = pr.readByteArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readByteArray():: Got expected Exception :: %s ",
             excpt.what());
   }
   try {
-    m_byte253 = pr.readByteArray("", m_byte253Len);
-  } catch (IllegalStateException& excpt) {
-    exceptionCounter++;
-    LOGINFO("readByteArray():: Got expected Exception :: %s ",
-            excpt.what());
-  }
-
-  try {
-    m_byte65535 = pr.readByteArray("", m_byte65535Len);
+    m_byte253 = pr.readByteArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readByteArray():: Got expected Exception :: %s ",
@@ -746,7 +738,15 @@ void InvalidPdxUsage::fromData(PdxReader& pr) {
   }
 
   try {
-    m_byte65536 = pr.readByteArray("", m_byte65536Len);
+    m_byte65535 = pr.readByteArray("");
+  } catch (IllegalStateException& excpt) {
+    exceptionCounter++;
+    LOGINFO("readByteArray():: Got expected Exception :: %s ",
+            excpt.what());
+  }
+
+  try {
+    m_byte65536 = pr.readByteArray("");
   } catch (IllegalStateException& excpt) {
     exceptionCounter++;
     LOGINFO("readByteArray():: Got expected Exception :: %s ",
@@ -824,17 +824,15 @@ bool InvalidPdxUsage::equals(PdxTests::InvalidPdxUsage& other,
   if (ot->m_string != m_string) {
     return false;
   }
-  genericCompare(ot->m_byteArray, m_byteArray, byteArrayLen);
-  genericCompare(ot->m_int16Array, m_int16Array, shortArrayLen);
-  genericCompare(ot->m_int32Array, m_int32Array, intArrayLen);
-  genericCompare(ot->m_longArray, m_longArray, longArrayLen);
-  genericCompare(ot->m_doubleArray, m_doubleArray, doubleArrayLen);
-  genericCompare(ot->m_floatArray, m_floatArray, floatArrayLen);
-  genericCompare(ot->m_uint32Array, m_uint32Array, intArrayLen);
-  genericCompare(ot->m_ulongArray, m_ulongArray, longArrayLen);
-  genericCompare(ot->m_uint16Array, m_uint16Array, shortArrayLen);
-  genericCompare(ot->m_sbyteArray, m_sbyteArray, shortArrayLen);
-  genericCompare(ot->m_charArray, m_charArray, charArrayLen);
+  genericCompare(ot->m_byteArray.data(), m_byteArray.data(), m_byteArray.size());
+  genericCompare(ot->m_int16Array.data(), m_int16Array.data(), m_int16Array.size());
+  genericCompare(ot->m_int32Array.data(), m_int32Array.data(), m_int32Array.size());
+  genericCompare(ot->m_longArray.data(), m_longArray.data(), m_longArray.size());
+  genericCompare(ot->m_uint32Array.data(), m_uint32Array.data(), m_uint32Array.size());
+  genericCompare(ot->m_ulongArray.data(), m_ulongArray.data(), m_ulongArray.size());
+  genericCompare(ot->m_uint16Array.data(), m_uint16Array.data(), m_uint16Array.size());
+  genericCompare(ot->m_sbyteArray.data(), m_sbyteArray.data(), m_sbyteArray.size());
+  genericCompare(ot->m_charArray.data(), m_charArray.data(), m_charArray.size());
   // generic2DCompare(ot->m_byteByteArray, m_byteByteArray, byteByteArrayLen,
   // lengthArr);
 

--- a/tests/cpp/testobject/InvalidPdxUsage.hpp
+++ b/tests/cpp/testobject/InvalidPdxUsage.hpp
@@ -50,7 +50,7 @@ namespace PdxTests {
 class TESTOBJECT_EXPORT CharTypesWithInvalidUsage : public PdxSerializable {
  private:
   char16_t m_ch;
-  char16_t* m_chArray;
+  std::vector<char16_t> m_chArray;
 
   int32_t m_charArrayLen;
 
@@ -58,7 +58,7 @@ class TESTOBJECT_EXPORT CharTypesWithInvalidUsage : public PdxSerializable {
   inline void init() {
     m_ch = 'C';
 
-    m_chArray = new char16_t[2];
+    m_chArray = std::vector<char16_t>(2);
     m_chArray[0] = 'X';
     m_chArray[1] = 'Y';
 
@@ -115,12 +115,12 @@ class TESTOBJECT_EXPORT CharTypesWithInvalidUsage : public PdxSerializable {
 
   void toData(PdxWriter& pw) const override {
     pw.writeChar("m_ch", m_ch);
-    pw.writeCharArray("m_chArray", m_chArray, 2);
+    pw.writeCharArray("m_chArray", m_chArray);
   }
 
   void fromData(PdxReader& pr) override {
     m_ch = pr.readChar("m_ch");
-    m_chArray = pr.readCharArray("m_chArray", m_charArrayLen);
+    m_chArray = pr.readCharArray("m_chArray");
   }
 
   static PdxSerializable* createDeserializable() {
@@ -221,25 +221,25 @@ class TESTOBJECT_EXPORT InvalidPdxUsage : public PdxSerializable {
 
   std::string m_string;
 
-  bool* m_boolArray;
-  int8_t* m_byteArray;
-  int8_t* m_sbyteArray;
+  std::vector<bool> m_boolArray;
+  std::vector<int8_t> m_byteArray;
+  std::vector<int8_t> m_sbyteArray;
 
-  char16_t* m_charArray;
+  std::vector<char16_t> m_charArray;
 
   std::shared_ptr<CacheableDate> m_date;
 
-  int16_t* m_int16Array;
-  int16_t* m_uint16Array;
+  std::vector<int16_t> m_int16Array;
+  std::vector<int16_t> m_uint16Array;
 
-  int32_t* m_int32Array;
-  int32_t* m_uint32Array;
+  std::vector<int32_t> m_int32Array;
+  std::vector<int32_t> m_uint32Array;
 
-  int64_t* m_longArray;
-  int64_t* m_ulongArray;
+  std::vector<int64_t> m_longArray;
+  std::vector<int64_t> m_ulongArray;
 
-  float* m_floatArray;
-  double* m_doubleArray;
+  std::vector<float> m_floatArray;
+  std::vector<double> m_doubleArray;
 
   int8_t** m_byteByteArray;
 
@@ -255,10 +255,10 @@ class TESTOBJECT_EXPORT InvalidPdxUsage : public PdxSerializable {
   std::shared_ptr<CacheableHashSet> m_chs;
   std::shared_ptr<CacheableLinkedHashSet> m_clhs;
 
-  int8_t* m_byte252;
-  int8_t* m_byte253;
-  int8_t* m_byte65535;
-  int8_t* m_byte65536;
+  std::vector<int8_t> m_byte252;
+  std::vector<int8_t> m_byte253;
+  std::vector<int8_t> m_byte65535;
+  std::vector<int8_t> m_byte65536;
   std::shared_ptr<CacheableEnum> m_pdxEnum;
   std::shared_ptr<CacheableObjectArray> m_objectArray;
 
@@ -298,7 +298,7 @@ class TESTOBJECT_EXPORT InvalidPdxUsage : public PdxSerializable {
 
     m_string = "gfestring";
 
-    m_boolArray = new bool[3];
+    m_boolArray = std::vector<bool>(3);
     m_boolArray[0] = true;
     m_boolArray[1] = false;
     m_boolArray[2] = true;
@@ -306,54 +306,54 @@ class TESTOBJECT_EXPORT InvalidPdxUsage : public PdxSerializable {
       m_boolArray[i] = true;
     };*/
 
-    m_byteArray = new int8_t[2];
+    m_byteArray = std::vector<int8_t>(2);
     m_byteArray[0] = 0x34;
     m_byteArray[1] = 0x64;
 
-    m_sbyteArray = new int8_t[2];
+    m_sbyteArray = std::vector<int8_t>(2);
     m_sbyteArray[0] = 0x34;
     m_sbyteArray[1] = 0x64;
 
-    m_charArray = new char16_t[2];
+    m_charArray = std::vector<char16_t>(2);
     m_charArray[0] = L'c';
     m_charArray[1] = L'v';
 
     int64_t d = 1310447869154L;
     m_date = CacheableDate::create(CacheableDate::duration(d));
 
-    m_int16Array = new int16_t[2];
+    m_int16Array = std::vector<int16_t>(2);
     m_int16Array[0] = 0x2332;
     m_int16Array[1] = 0x4545;
 
-    m_uint16Array = new int16_t[2];
+    m_uint16Array = std::vector<int16_t>(2);
     m_uint16Array[0] = 0x3243;
     m_uint16Array[1] = 0x3232;
 
-    m_int32Array = new int32_t[4];
+    m_int32Array = std::vector<int32_t>(4);
     m_int32Array[0] = 23;
     m_int32Array[1] = 676868;
     m_int32Array[2] = 34343;
     m_int32Array[3] = 2323;
 
-    m_uint32Array = new int32_t[4];
+    m_uint32Array = std::vector<int32_t>(4);
     m_uint32Array[0] = 435;
     m_uint32Array[1] = 234324;
     m_uint32Array[2] = 324324;
     m_uint32Array[3] = 23432432;
 
-    m_longArray = new int64_t[2];
+    m_longArray = std::vector<int64_t>(2);
     m_longArray[0] = 324324L;
     m_longArray[1] = 23434545L;
 
-    m_ulongArray = new int64_t[2];
+    m_ulongArray = std::vector<int64_t>(2);
     m_ulongArray[0] = 3245435;
     m_ulongArray[1] = 3425435;
 
-    m_floatArray = new float[2];
+    m_floatArray = std::vector<float>(2);
     m_floatArray[0] = 232.565f;
     m_floatArray[1] = 2343254.67f;
 
-    m_doubleArray = new double[2];
+    m_doubleArray = std::vector<double>(2);
     m_doubleArray[0] = 23423432;
     m_doubleArray[1] = 4324235435.00;
 
@@ -438,22 +438,22 @@ class TESTOBJECT_EXPORT InvalidPdxUsage : public PdxSerializable {
     m_objectArray->push_back(std::shared_ptr<AddressWithInvalidAPIUsage>(
         new AddressWithInvalidAPIUsage(10, "street9", "city9")));
 
-    m_byte252 = new int8_t[252];
+    m_byte252 = std::vector<int8_t>(252);
     for (int i = 0; i < 252; i++) {
       m_byte252[i] = 0;
     }
 
-    m_byte253 = new int8_t[253];
+    m_byte253 = std::vector<int8_t>(253);
     for (int i = 0; i < 253; i++) {
       m_byte253[i] = 0;
     }
 
-    m_byte65535 = new int8_t[65535];
+    m_byte65535 = std::vector<int8_t>(65535);
     for (int i = 0; i < 65535; i++) {
       m_byte65535[i] = 0;
     }
 
-    m_byte65536 = new int8_t[65536];
+    m_byte65536 = std::vector<int8_t>(65536);
     for (int i = 0; i < 65536; i++) {
       m_byte65536[i] = 0;
     }
@@ -509,7 +509,7 @@ class TESTOBJECT_EXPORT InvalidPdxUsage : public PdxSerializable {
 
   char16_t getChar() { return m_char; }
 
-  char16_t* getCharArray() { return m_charArray; }
+  std::vector<char16_t> getCharArray() { return m_charArray; }
 
   int8_t** getArrayOfByteArrays() { return m_byteByteArray; }
 
@@ -525,21 +525,21 @@ class TESTOBJECT_EXPORT InvalidPdxUsage : public PdxSerializable {
 
   int64_t getULong() { return m_ulong; }
 
-  int16_t* getUInt16Array() { return m_uint16Array; }
+  std::vector<int16_t> getUInt16Array() { return m_uint16Array; }
 
-  int32_t* getUIntArray() { return m_uint32Array; }
+  std::vector<int32_t> getUIntArray() { return m_uint32Array; }
 
-  int64_t* getULongArray() { return m_ulongArray; }
+  std::vector<int64_t> getULongArray() { return m_ulongArray; }
 
-  int8_t* getByte252() { return m_byte252; }
+  std::vector<int8_t> getByte252() { return m_byte252; }
 
-  int8_t* getByte253() { return m_byte253; }
+  std::vector<int8_t> getByte253() { return m_byte253; }
 
-  int8_t* getByte65535() { return m_byte65535; }
+  std::vector<int8_t> getByte65535() { return m_byte65535; }
 
-  int8_t* getByte65536() { return m_byte65536; }
+  std::vector<int8_t> getByte65536() { return m_byte65536; }
 
-  int8_t* getSByteArray() { return m_sbyteArray; }
+  std::vector<int8_t> getSByteArray() { return m_sbyteArray; }
 
   std::shared_ptr<CacheableHashSet> getHashSet() { return m_chs; }
 
@@ -565,19 +565,19 @@ class TESTOBJECT_EXPORT InvalidPdxUsage : public PdxSerializable {
 
   const std::string& getString() { return m_string; }
 
-  bool* getBoolArray() { return m_boolArray; }
+  std::vector<bool> getBoolArray() { return m_boolArray; }
 
-  int8_t* getByteArray() { return m_byteArray; }
+  std::vector<int8_t> getByteArray() { return m_byteArray; }
 
-  int16_t* getShortArray() { return m_int16Array; }
+  std::vector<int16_t> getShortArray() { return m_int16Array; }
 
-  int32_t* getIntArray() { return m_int32Array; }
+  std::vector<int32_t> getIntArray() { return m_int32Array; }
 
-  int64_t* getLongArray() { return m_longArray; }
+  std::vector<int64_t> getLongArray() { return m_longArray; }
 
-  double* getDoubleArray() { return m_doubleArray; }
+  std::vector<double> getDoubleArray() { return m_doubleArray; }
 
-  float* getFloatArray() { return m_floatArray; }
+  std::vector<float> getFloatArray() { return m_floatArray; }
 
   const std::vector<std::string>& getStringArray() { return m_stringArray; }
 

--- a/tests/cpp/testobject/NestedPdxObject.cpp
+++ b/tests/cpp/testobject/NestedPdxObject.cpp
@@ -88,7 +88,7 @@ void ParentPdx::toData(PdxWriter& pw) const {
   pw.markIdentityField("m_childPdx");
 
   pw.writeChar("m_char", m_char);
-  pw.writeCharArray("m_charArray", m_charArray, 2);
+  pw.writeCharArray("m_charArray", m_charArray);
 
   LOGDEBUG("ParentPdx::toData() Done......");
 }
@@ -106,7 +106,7 @@ void ParentPdx::fromData(PdxReader& pr) {
   LOGINFO("ParentPdx::fromData() start3...");
 
   m_char = pr.readChar("m_char");
-  m_charArray = pr.readCharArray("m_charArray", m_charArrayLen);
+  m_charArray = pr.readCharArray("m_charArray");
 
   LOGINFO("ParentPdx::fromData() end...");
 }

--- a/tests/cpp/testobject/NestedPdxObject.hpp
+++ b/tests/cpp/testobject/NestedPdxObject.hpp
@@ -96,7 +96,7 @@ class TESTOBJECT_EXPORT ParentPdx : public PdxSerializable {
   std::shared_ptr<Cacheable> m_childPdx;
   std::shared_ptr<CacheableEnum> m_enum;
   char16_t m_char;
-  char16_t* m_charArray;
+  std::vector<char16_t> m_charArray;
 
   int32_t m_charArrayLen;
 
@@ -111,7 +111,7 @@ class TESTOBJECT_EXPORT ParentPdx : public PdxSerializable {
 
     m_char = 'C';
 
-    m_charArray = new char16_t[2];
+    m_charArray = std::vector<char16_t>(2);
     m_charArray[0] = 'X';
     m_charArray[1] = 'Y';
 
@@ -137,7 +137,7 @@ class TESTOBJECT_EXPORT ParentPdx : public PdxSerializable {
 
   char16_t getChar() { return m_char; }
 
-  char16_t* getCharArray() { return m_charArray; }
+  std::vector<char16_t> getCharArray() { return m_charArray; }
 
   int32_t getCharArrayLength() { return m_charArrayLen; }
 

--- a/tests/cpp/testobject/NonPdxType.cpp
+++ b/tests/cpp/testobject/NonPdxType.cpp
@@ -94,17 +94,17 @@ bool PdxTests::NonPdxType::equals(PdxTests::NonPdxType& other,
   if (ot->m_string != m_string) {
     return false;
   }
-  genericCompare(ot->m_byteArray, m_byteArray, byteArrayLen);
-  genericCompare(ot->m_int16Array, m_int16Array, shortArrayLen);
-  genericCompare(ot->m_int32Array, m_int32Array, intArrayLen);
-  genericCompare(ot->m_longArray, m_longArray, longArrayLen);
-  genericCompare(ot->m_doubleArray, m_doubleArray, doubleArrayLen);
-  genericCompare(ot->m_floatArray, m_floatArray, floatArrayLen);
-  genericCompare(ot->m_uint32Array, m_uint32Array, intArrayLen);
-  genericCompare(ot->m_ulongArray, m_ulongArray, longArrayLen);
-  genericCompare(ot->m_uint16Array, m_uint16Array, shortArrayLen);
-  genericCompare(ot->m_sbyteArray, m_sbyteArray, shortArrayLen);
-  genericCompare(ot->m_charArray, m_charArray, charArrayLen);
+  genericCompare(ot->m_byteArray.data(), m_byteArray.data(), m_byteArray.size());
+  genericCompare(ot->m_int16Array.data(), m_int16Array.data(), m_int16Array.size());
+  genericCompare(ot->m_int32Array.data(), m_int32Array.data(), m_int32Array.size());
+  genericCompare(ot->m_longArray.data(), m_longArray.data(), m_longArray.size());
+  genericCompare(ot->m_floatArray.data(), m_floatArray.data(), m_floatArray.size());
+  genericCompare(ot->m_doubleArray.data(), m_doubleArray.data(), m_doubleArray.size());
+  genericCompare(ot->m_uint32Array.data(), m_uint32Array.data(), m_uint32Array.size());
+  genericCompare(ot->m_ulongArray.data(), m_ulongArray.data(), m_ulongArray.size());
+  genericCompare(ot->m_uint16Array.data(), m_uint16Array.data(), m_uint16Array.size());
+  genericCompare(ot->m_sbyteArray.data(), m_sbyteArray.data(), m_sbyteArray.size());
+  genericCompare(ot->m_charArray.data(), m_charArray.data(), m_charArray.size());
   // generic2DCompare(ot->m_byteByteArray, m_byteByteArray, byteByteArrayLen,
   // lengthArr);
 

--- a/tests/cpp/testobject/NonPdxType.hpp
+++ b/tests/cpp/testobject/NonPdxType.hpp
@@ -103,25 +103,25 @@ class TESTOBJECT_EXPORT NonPdxType {
 
   std::string m_string;
 
-  bool* m_boolArray;
-  int8_t* m_byteArray;
-  int8_t* m_sbyteArray;  ///
+  std::vector<bool> m_boolArray;
+  std::vector<int8_t> m_byteArray;
+  std::vector<int8_t> m_sbyteArray;  ///
 
-  char16_t* m_charArray;
+  std::vector<char16_t> m_charArray;
 
   std::shared_ptr<CacheableDate> m_date;
 
-  int16_t* m_int16Array;
-  int16_t* m_uint16Array;
+  std::vector<int16_t> m_int16Array;
+  std::vector<int16_t> m_uint16Array;
 
-  int32_t* m_int32Array;
-  int32_t* m_uint32Array;
+  std::vector<int32_t> m_int32Array;
+  std::vector<int32_t> m_uint32Array;
 
-  int64_t* m_longArray;
-  int64_t* m_ulongArray;
+  std::vector<int64_t> m_longArray;
+  std::vector<int64_t> m_ulongArray;
 
-  float* m_floatArray;
-  double* m_doubleArray;
+  std::vector<float> m_floatArray;
+  std::vector<double> m_doubleArray;
 
   int8_t** m_byteByteArray;
 
@@ -139,10 +139,10 @@ class TESTOBJECT_EXPORT NonPdxType {
   std::shared_ptr<CacheableHashSet> m_chs;
   std::shared_ptr<CacheableLinkedHashSet> m_clhs;
 
-  int8_t* m_byte252;
-  int8_t* m_byte253;
-  int8_t* m_byte65535;
-  int8_t* m_byte65536;
+  std::vector<int8_t> m_byte252;
+  std::vector<int8_t> m_byte253;
+  std::vector<int8_t> m_byte65535;
+  std::vector<int8_t> m_byte65536;
   std::shared_ptr<Cacheable> m_pdxEnum;
 
   std::shared_ptr<CacheableObjectArray> m_objectArray;
@@ -183,7 +183,7 @@ class TESTOBJECT_EXPORT NonPdxType {
 
     m_string = "gfestring";
 
-    m_boolArray = new bool[3];
+    m_boolArray = std::vector<bool>(3);
     m_boolArray[0] = true;
     m_boolArray[1] = false;
     m_boolArray[2] = true;
@@ -191,54 +191,54 @@ class TESTOBJECT_EXPORT NonPdxType {
       m_boolArray[i] = true;
     };*/
 
-    m_byteArray = new int8_t[2];
+    m_byteArray = std::vector<int8_t>(2);
     m_byteArray[0] = 0x34;
     m_byteArray[1] = 0x64;
 
-    m_sbyteArray = new int8_t[2];
+    m_sbyteArray = std::vector<int8_t>(2);
     m_sbyteArray[0] = 0x34;
     m_sbyteArray[1] = 0x64;
 
-    m_charArray = new char16_t[2];
+    m_charArray = std::vector<char16_t>(2);
     m_charArray[0] = 'c';
     m_charArray[1] = 'v';
 
     int64_t d = 1310447869154L;
     m_date = CacheableDate::create(CacheableDate::duration(d));
 
-    m_int16Array = new int16_t[2];
+    m_int16Array = std::vector<int16_t>(2);
     m_int16Array[0] = 0x2332;
     m_int16Array[1] = 0x4545;
 
-    m_uint16Array = new int16_t[2];
+    m_uint16Array = std::vector<int16_t>(2);
     m_uint16Array[0] = 0x3243;
     m_uint16Array[1] = 0x3232;
 
-    m_int32Array = new int32_t[4];
+    m_int32Array = std::vector<int32_t>(4);
     m_int32Array[0] = 23;
     m_int32Array[1] = 676868;
     m_int32Array[2] = 34343;
     m_int32Array[3] = 2323;
 
-    m_uint32Array = new int32_t[4];
+    m_uint32Array = std::vector<int32_t>(4);
     m_uint32Array[0] = 435;
     m_uint32Array[1] = 234324;
     m_uint32Array[2] = 324324;
     m_uint32Array[3] = 23432432;
 
-    m_longArray = new int64_t[2];
+    m_longArray = std::vector<int64_t>(2);
     m_longArray[0] = 324324L;
     m_longArray[1] = 23434545L;
 
-    m_ulongArray = new int64_t[2];
+    m_ulongArray = std::vector<int64_t>(2);
     m_ulongArray[0] = 3245435;
     m_ulongArray[1] = 3425435;
 
-    m_floatArray = new float[2];
+    m_floatArray = std::vector<float>(2);
     m_floatArray[0] = 232.565f;
     m_floatArray[1] = 2343254.67f;
 
-    m_doubleArray = new double[2];
+    m_doubleArray = std::vector<double>(2);
     m_doubleArray[0] = 23423432;
     m_doubleArray[1] = 4324235435.00;
 
@@ -326,22 +326,22 @@ class TESTOBJECT_EXPORT NonPdxType {
         new PdxWrapper(new NonPdxAddress(10, "street9", "city9"),
                        "PdxTests.Address", pdxSerializer)));
 
-    m_byte252 = new int8_t[252];
+    m_byte252 = std::vector<int8_t>(252);
     for (int i = 0; i < 252; i++) {
       m_byte252[i] = 0;
     }
 
-    m_byte253 = new int8_t[253];
+    m_byte253 = std::vector<int8_t>(253);
     for (int i = 0; i < 253; i++) {
       m_byte253[i] = 0;
     }
 
-    m_byte65535 = new int8_t[65535];
+    m_byte65535 = std::vector<int8_t>(65535);
     for (int i = 0; i < 65535; i++) {
       m_byte65535[i] = 0;
     }
 
-    m_byte65536 = new int8_t[65536];
+    m_byte65536 = std::vector<int8_t>(65536);
     for (int i = 0; i < 65536; i++) {
       m_byte65536[i] = 0;
     }
@@ -376,7 +376,7 @@ class TESTOBJECT_EXPORT NonPdxType {
 
   char16_t getChar() { return m_char; }
 
-  char16_t* getCharArray() { return m_charArray; }
+  std::vector<char16_t> getCharArray() { return m_charArray; }
 
   int8_t** getArrayOfByteArrays() { return m_byteByteArray; }
 
@@ -392,21 +392,21 @@ class TESTOBJECT_EXPORT NonPdxType {
 
   int64_t getULong() { return m_ulong; }
 
-  int16_t* getUInt16Array() { return m_uint16Array; }
+  std::vector<int16_t> getUInt16Array() { return m_uint16Array; }
 
-  int32_t* getUIntArray() { return m_uint32Array; }
+  std::vector<int32_t> getUIntArray() { return m_uint32Array; }
 
-  int64_t* getULongArray() { return m_ulongArray; }
+  std::vector<int64_t> getULongArray() { return m_ulongArray; }
 
-  int8_t* getByte252() { return m_byte252; }
+  std::vector<int8_t> getByte252() { return m_byte252; }
 
-  int8_t* getByte253() { return m_byte253; }
+  std::vector<int8_t> getByte253() { return m_byte253; }
 
-  int8_t* getByte65535() { return m_byte65535; }
+  std::vector<int8_t> getByte65535() { return m_byte65535; }
 
-  int8_t* getByte65536() { return m_byte65536; }
+  std::vector<int8_t> getByte65536() { return m_byte65536; }
 
-  int8_t* getSByteArray() { return m_sbyteArray; }
+  std::vector<int8_t> getSByteArray() { return m_sbyteArray; }
 
   std::shared_ptr<CacheableHashSet> getHashSet() { return m_chs; }
 
@@ -432,19 +432,19 @@ class TESTOBJECT_EXPORT NonPdxType {
 
   const std::string& getString() { return m_string; }
 
-  bool* getBoolArray() { return m_boolArray; }
+  std::vector<bool> getBoolArray() { return m_boolArray; }
 
-  int8_t* getByteArray() { return m_byteArray; }
+  std::vector<int8_t> getByteArray() { return m_byteArray; }
 
-  int16_t* getShortArray() { return m_int16Array; }
+  std::vector<int16_t> getShortArray() { return m_int16Array; }
 
-  int32_t* getIntArray() { return m_int32Array; }
+  std::vector<int32_t> getIntArray() { return m_int32Array; }
 
-  int64_t* getLongArray() { return m_longArray; }
+  std::vector<int64_t> getLongArray() { return m_longArray; }
 
-  double* getDoubleArray() { return m_doubleArray; }
+  std::vector<double> getDoubleArray() { return m_doubleArray; }
 
-  float* getFloatArray() { return m_floatArray; }
+  std::vector<float> getFloatArray() { return m_floatArray; }
 
   const std::vector<std::string>& getStringArray() { return m_stringArray; }
 

--- a/tests/cpp/testobject/PdxClassV1.cpp
+++ b/tests/cpp/testobject/PdxClassV1.cpp
@@ -570,7 +570,7 @@ void PdxVersionedV1::init(int32_t size) {
 
   m_string = "gfestring";
 
-  m_boolArray = new bool[3];
+  m_boolArray = std::vector<bool>(3);
   m_boolArray[0] = true;
   m_boolArray[1] = false;
   m_boolArray[2] = true;
@@ -581,11 +581,11 @@ void PdxVersionedV1::init(int32_t size) {
 
   m_dateTime = nullptr;
 
-  m_int16Array = new int16_t[size];
-  m_int32Array = new int32_t[size];
-  m_longArray = new int64_t[size];
-  m_floatArray = new float[size];
-  m_doubleArray = new double[size];
+  m_int16Array = std::vector<int16_t>(size);
+  m_int32Array = std::vector<int32_t>(size);
+  m_longArray = std::vector<int64_t>(size);
+  m_floatArray = std::vector<float>(size);
+  m_doubleArray = std::vector<double>(size);
 
   for (int i = 0; i < size; i++) {
     m_int16Array[i] = 0x2332;
@@ -601,7 +601,6 @@ void PdxVersionedV1::init(int32_t size) {
   shortArrayLen = 0;
   intArrayLen = 0;
   longArrayLen = 0;
-  doubleArrayLen = 0;
   floatArrayLen = 0;
   strLenArray = 0;
 }
@@ -625,14 +624,14 @@ void PdxVersionedV1::toData(PdxWriter& pw) const {
   pw.writeFloat("m_float", m_float);
   pw.writeDouble("m_double", m_double);
   pw.writeString("m_string", m_string);
-  pw.writeBooleanArray("m_boolArray", m_boolArray, 3);
+  pw.writeBooleanArray("m_boolArray", m_boolArray);
   // pw.writeCharArray("m_charArray", m_charArray, 2);
   pw.writeDate("m_dateTime", m_dateTime);
-  pw.writeShortArray("m_int16Array", m_int16Array, 2);
-  pw.writeIntArray("m_int32Array", m_int32Array, 2);
-  pw.writeLongArray("m_longArray", m_longArray, 2);
-  pw.writeFloatArray("m_floatArray", m_floatArray, 2);
-  pw.writeDoubleArray("m_doubleArray", m_doubleArray, 2);
+  pw.writeShortArray("m_int16Array", m_int16Array);
+  pw.writeIntArray("m_int32Array", m_int32Array);
+  pw.writeLongArray("m_longArray", m_longArray);
+  pw.writeFloatArray("m_floatArray", m_floatArray);
+  pw.writeDoubleArray("m_doubleArray", m_doubleArray);
 }
 
 void PdxVersionedV1::fromData(PdxReader& pr) {
@@ -645,14 +644,14 @@ void PdxVersionedV1::fromData(PdxReader& pr) {
   m_float = pr.readFloat("m_float");
   m_double = pr.readDouble("m_double");
   m_string = pr.readString("m_string");
-  m_boolArray = pr.readBooleanArray("m_boolArray", boolArrayLen);
+  m_boolArray = pr.readBooleanArray("m_boolArray");
   // m_charArray = pr.readCharArray("m_charArray");
   m_dateTime = pr.readDate("m_dateTime");
-  m_int16Array = pr.readShortArray("m_int16Array", shortArrayLen);
-  m_int32Array = pr.readIntArray("m_int32Array", intArrayLen);
-  m_longArray = pr.readLongArray("m_longArray", longArrayLen);
-  m_floatArray = pr.readFloatArray("m_floatArray", floatArrayLen);
-  m_doubleArray = pr.readDoubleArray("m_doubleArray", doubleArrayLen);
+  m_int16Array = pr.readShortArray("m_int16Array");
+  m_int32Array = pr.readIntArray("m_int32Array");
+  m_longArray = pr.readLongArray("m_longArray");
+  m_floatArray = pr.readFloatArray("m_floatArray");
+  m_doubleArray = pr.readDoubleArray("m_doubleArray");
 }
 std::string PdxVersionedV1::toString() const {
   char idbuf[4096];

--- a/tests/cpp/testobject/PdxClassV1.hpp
+++ b/tests/cpp/testobject/PdxClassV1.hpp
@@ -316,14 +316,14 @@ class TESTOBJECT_EXPORT PdxVersionedV1 : public PdxSerializable {
   float m_float;
   double m_double;
   std::string m_string;
-  bool* m_boolArray;
+  std::vector<bool> m_boolArray;
   char* m_charArray;
   std::shared_ptr<CacheableDate> m_dateTime;
-  int16_t* m_int16Array;
-  int32_t* m_int32Array;
-  int64_t* m_longArray;
-  float* m_floatArray;
-  double* m_doubleArray;
+  std::vector<int16_t> m_int16Array;
+  std::vector<int32_t> m_int32Array;
+  std::vector<int64_t> m_longArray;
+  std::vector<float> m_floatArray;
+  std::vector<double> m_doubleArray;
 
   // IDictionary<object, object> m_map;
   // List<object> m_list;

--- a/tests/cpp/testobject/PdxClassV2.cpp
+++ b/tests/cpp/testobject/PdxClassV2.cpp
@@ -618,7 +618,7 @@ void PdxVersionedV2::init(int32_t size) {
 
   m_string = "gfestring";
 
-  m_boolArray = new bool[3];
+  m_boolArray = std::vector<bool>(3);
   m_boolArray[0] = true;
   m_boolArray[1] = false;
   m_boolArray[2] = true;
@@ -629,11 +629,11 @@ void PdxVersionedV2::init(int32_t size) {
 
   m_dateTime = nullptr;
 
-  m_int16Array = new int16_t[size];
-  m_int32Array = new int32_t[size];
-  m_longArray = new int64_t[size];
-  m_floatArray = new float[size];
-  m_doubleArray = new double[size];
+  m_int16Array = std::vector<int16_t>(size);
+  m_int32Array = std::vector<int32_t>(size);
+  m_longArray = std::vector<int64_t>(size);
+  m_floatArray = std::vector<float>(size);
+  m_doubleArray = std::vector<double>(size);
 
   for (int i = 0; i < size; i++) {
     m_int16Array[i] = 0x2332;
@@ -648,7 +648,6 @@ void PdxVersionedV2::init(int32_t size) {
   shortArrayLen = 0;
   intArrayLen = 0;
   longArrayLen = 0;
-  doubleArrayLen = 0;
   floatArrayLen = 0;
   strLenArray = 0;
 }
@@ -672,14 +671,14 @@ void PdxVersionedV2::toData(PdxWriter& pw) const {
   pw.writeFloat("m_float", m_float);
   pw.writeDouble("m_double", m_double);
   pw.writeString("m_string", m_string);
-  pw.writeBooleanArray("m_boolArray", m_boolArray, 3);
+  pw.writeBooleanArray("m_boolArray", m_boolArray);
   // pw.writeCharArray("m_charArray", m_charArray, 2);
   pw.writeDate("m_dateTime", m_dateTime);
-  pw.writeShortArray("m_int16Array", m_int16Array, 2);
-  pw.writeIntArray("m_int32Array", m_int32Array, 2);
-  pw.writeLongArray("m_longArray", m_longArray, 2);
-  pw.writeFloatArray("m_floatArray", m_floatArray, 2);
-  pw.writeDoubleArray("m_doubleArray", m_doubleArray, 2);
+  pw.writeShortArray("m_int16Array", m_int16Array);
+  pw.writeIntArray("m_int32Array", m_int32Array);
+  pw.writeLongArray("m_longArray", m_longArray);
+  pw.writeFloatArray("m_floatArray", m_floatArray);
+  pw.writeDoubleArray("m_doubleArray", m_doubleArray);
 }
 
 void PdxVersionedV2::fromData(PdxReader& pr) {
@@ -692,14 +691,14 @@ void PdxVersionedV2::fromData(PdxReader& pr) {
   m_float = pr.readFloat("m_float");
   m_double = pr.readDouble("m_double");
   m_string = pr.readString("m_string");
-  m_boolArray = pr.readBooleanArray("m_boolArray", boolArrayLen);
+  m_boolArray = pr.readBooleanArray("m_boolArray");
   // m_charArray = pr.readCharArray("m_charArray");
   m_dateTime = pr.readDate("m_dateTime");
-  m_int16Array = pr.readShortArray("m_int16Array", shortArrayLen);
-  m_int32Array = pr.readIntArray("m_int32Array", intArrayLen);
-  m_longArray = pr.readLongArray("m_longArray", longArrayLen);
-  m_floatArray = pr.readFloatArray("m_floatArray", floatArrayLen);
-  m_doubleArray = pr.readDoubleArray("m_doubleArray", doubleArrayLen);
+  m_int16Array = pr.readShortArray("m_int16Array");
+  m_int32Array = pr.readIntArray("m_int32Array");
+  m_longArray = pr.readLongArray("m_longArray");
+  m_floatArray = pr.readFloatArray("m_floatArray");
+  m_doubleArray = pr.readDoubleArray("m_doubleArray");
 }
 std::string PdxVersionedV2::toString() const {
   char idbuf[4096];

--- a/tests/cpp/testobject/PdxClassV2.hpp
+++ b/tests/cpp/testobject/PdxClassV2.hpp
@@ -341,14 +341,14 @@ class TESTOBJECT_EXPORT PdxVersionedV2 : public PdxSerializable {
   float m_float;
   double m_double;
   std::string m_string;
-  bool* m_boolArray;
+  std::vector<bool> m_boolArray;
   char* m_charArray;
   std::shared_ptr<CacheableDate> m_dateTime;
-  int16_t* m_int16Array;
-  int32_t* m_int32Array;
-  int64_t* m_longArray;
-  float* m_floatArray;
-  double* m_doubleArray;
+  std::vector<int16_t> m_int16Array;
+  std::vector<int32_t> m_int32Array;
+  std::vector<int64_t> m_longArray;
+  std::vector<float> m_floatArray;
+  std::vector<double> m_doubleArray;
 
   // IDictionary<object, object> m_map;
   // List<object> m_list;

--- a/tests/cpp/testobject/PdxType.cpp
+++ b/tests/cpp/testobject/PdxType.cpp
@@ -83,13 +83,13 @@ void PdxTests::PdxType::toData(PdxWriter& pw) const {
   pw.markIdentityField("m_char");
   pw.writeBoolean("m_bool", m_bool);  // 1
   pw.markIdentityField("m_bool");
-  pw.writeBooleanArray("m_boolArray", m_boolArray, 3);
+  pw.writeBooleanArray("m_boolArray", m_boolArray);
   pw.markIdentityField("m_boolArray");
   pw.writeByte("m_byte", m_byte);
   pw.markIdentityField("m_byte");
-  pw.writeByteArray("m_byteArray", m_byteArray, 2);
+  pw.writeByteArray("m_byteArray", m_byteArray);
   pw.markIdentityField("m_byteArray");
-  pw.writeCharArray("m_charArray", m_charArray, 2);
+  pw.writeCharArray("m_charArray", m_charArray);
   pw.markIdentityField("m_charArray");
   pw.writeObject("m_arraylist", m_arraylist);
   pw.writeObject("m_linkedlist", m_linkedlist);
@@ -110,11 +110,11 @@ void PdxTests::PdxType::toData(PdxWriter& pw) const {
   pw.markIdentityField("m_dateTime");
   pw.writeDouble("m_double", m_double);
   pw.markIdentityField("m_double");
-  pw.writeDoubleArray("m_doubleArray", m_doubleArray, 2);
+  pw.writeDoubleArray("m_doubleArray", m_doubleArray);
   pw.markIdentityField("m_doubleArray");
   pw.writeFloat("m_float", m_float);
   pw.markIdentityField("m_float");
-  pw.writeFloatArray("m_floatArray", m_floatArray, 2);
+  pw.writeFloatArray("m_floatArray", m_floatArray);
   pw.markIdentityField("m_floatArray");
   pw.writeShort("m_int16", m_int16);
   pw.markIdentityField("m_int16");
@@ -122,15 +122,15 @@ void PdxTests::PdxType::toData(PdxWriter& pw) const {
   pw.markIdentityField("m_int32");
   pw.writeLong("m_long", m_long);
   pw.markIdentityField("m_long");
-  pw.writeIntArray("m_int32Array", m_int32Array, 4);
+  pw.writeIntArray("m_int32Array", m_int32Array);
   pw.markIdentityField("m_int32Array");
-  pw.writeLongArray("m_longArray", m_longArray, 2);
+  pw.writeLongArray("m_longArray", m_longArray);
   pw.markIdentityField("m_longArray");
-  pw.writeShortArray("m_int16Array", m_int16Array, 2);
+  pw.writeShortArray("m_int16Array", m_int16Array);
   pw.markIdentityField("m_int16Array");
   pw.writeByte("m_sbyte", m_sbyte);
   pw.markIdentityField("m_sbyte");
-  pw.writeByteArray("m_sbyteArray", m_sbyteArray, 2);
+  pw.writeByteArray("m_sbyteArray", m_sbyteArray);
   pw.markIdentityField("m_sbyteArray");
 
   // int* strlengthArr = new int[2];
@@ -145,20 +145,20 @@ void PdxTests::PdxType::toData(PdxWriter& pw) const {
   pw.markIdentityField("m_uint32");
   pw.writeLong("m_ulong", m_ulong);
   pw.markIdentityField("m_ulong");
-  pw.writeIntArray("m_uint32Array", m_uint32Array, 4);
+  pw.writeIntArray("m_uint32Array", m_uint32Array);
   pw.markIdentityField("m_uint32Array");
-  pw.writeLongArray("m_ulongArray", m_ulongArray, 2);
+  pw.writeLongArray("m_ulongArray", m_ulongArray);
   pw.markIdentityField("m_ulongArray");
-  pw.writeShortArray("m_uint16Array", m_uint16Array, 2);
+  pw.writeShortArray("m_uint16Array", m_uint16Array);
   pw.markIdentityField("m_uint16Array");
 
-  pw.writeByteArray("m_byte252", m_byte252, 252);
+  pw.writeByteArray("m_byte252", m_byte252);
   pw.markIdentityField("m_byte252");
-  pw.writeByteArray("m_byte253", m_byte253, 253);
+  pw.writeByteArray("m_byte253", m_byte253);
   pw.markIdentityField("m_byte253");
-  pw.writeByteArray("m_byte65535", m_byte65535, 65535);
+  pw.writeByteArray("m_byte65535", m_byte65535);
   pw.markIdentityField("m_byte65535");
-  pw.writeByteArray("m_byte65536", m_byte65536, 65536);
+  pw.writeByteArray("m_byte65536", m_byte65536);
   pw.markIdentityField("m_byte65536");
 
   pw.writeObject("m_pdxEnum", m_pdxEnum);
@@ -190,11 +190,11 @@ void PdxTests::PdxType::fromData(PdxReader& pr) {
 
   m_bool = pr.readBoolean("m_bool");
   // GenericValCompare
-  m_boolArray = pr.readBooleanArray("m_boolArray", boolArrayLen);
+  m_boolArray = pr.readBooleanArray("m_boolArray");
 
   m_byte = pr.readByte("m_byte");
-  m_byteArray = pr.readByteArray("m_byteArray", byteArrayLen);
-  m_charArray = pr.readCharArray("m_charArray", charArrayLen);
+  m_byteArray = pr.readByteArray("m_byteArray");
+  m_charArray = pr.readCharArray("m_charArray");
 
   m_arraylist = std::static_pointer_cast<CacheableArrayList>(
       pr.readObject("m_arraylist"));
@@ -223,30 +223,30 @@ void PdxTests::PdxType::fromData(PdxReader& pr) {
 
   m_double = pr.readDouble("m_double");
 
-  m_doubleArray = pr.readDoubleArray("m_doubleArray", doubleArrayLen);
+  m_doubleArray = pr.readDoubleArray("m_doubleArray");
   m_float = pr.readFloat("m_float");
-  m_floatArray = pr.readFloatArray("m_floatArray", floatArrayLen);
+  m_floatArray = pr.readFloatArray("m_floatArray");
   m_int16 = pr.readShort("m_int16");
   m_int32 = pr.readInt("m_int32");
   m_long = pr.readLong("m_long");
-  m_int32Array = pr.readIntArray("m_int32Array", intArrayLen);
-  m_longArray = pr.readLongArray("m_longArray", longArrayLen);
-  m_int16Array = pr.readShortArray("m_int16Array", shortArrayLen);
+  m_int32Array = pr.readIntArray("m_int32Array");
+  m_longArray = pr.readLongArray("m_longArray");
+  m_int16Array = pr.readShortArray("m_int16Array");
   m_sbyte = pr.readByte("m_sbyte");
-  m_sbyteArray = pr.readByteArray("m_sbyteArray", byteArrayLen);
+  m_sbyteArray = pr.readByteArray("m_sbyteArray");
   m_stringArray = pr.readStringArray("m_stringArray");
   m_uint16 = pr.readShort("m_uint16");
   m_uint32 = pr.readInt("m_uint32");
   m_ulong = pr.readLong("m_ulong");
-  m_uint32Array = pr.readIntArray("m_uint32Array", intArrayLen);
-  m_ulongArray = pr.readLongArray("m_ulongArray", longArrayLen);
-  m_uint16Array = pr.readShortArray("m_uint16Array", shortArrayLen);
+  m_uint32Array = pr.readIntArray("m_uint32Array");
+  m_ulongArray = pr.readLongArray("m_ulongArray");
+  m_uint16Array = pr.readShortArray("m_uint16Array");
   // LOGINFO("PdxType::readInt() start...");
 
-  m_byte252 = pr.readByteArray("m_byte252", m_byte252Len);
-  m_byte253 = pr.readByteArray("m_byte253", m_byte253Len);
-  m_byte65535 = pr.readByteArray("m_byte65535", m_byte65535Len);
-  m_byte65536 = pr.readByteArray("m_byte65536", m_byte65536Len);
+  m_byte252 = pr.readByteArray("m_byte252");
+  m_byte253 = pr.readByteArray("m_byte253");
+  m_byte65535 = pr.readByteArray("m_byte65535");
+  m_byte65536 = pr.readByteArray("m_byte65536");
   // TODO:Check for size
 
   m_pdxEnum = pr.readObject("m_pdxEnum");
@@ -296,17 +296,15 @@ bool PdxTests::PdxType::equals(PdxTests::PdxType& other,
   if (ot->m_string != m_string) {
     return false;
   }
-  genericCompare(ot->m_byteArray, m_byteArray, byteArrayLen);
-  genericCompare(ot->m_int16Array, m_int16Array, shortArrayLen);
-  genericCompare(ot->m_int32Array, m_int32Array, intArrayLen);
-  genericCompare(ot->m_longArray, m_longArray, longArrayLen);
-  genericCompare(ot->m_doubleArray, m_doubleArray, doubleArrayLen);
-  genericCompare(ot->m_floatArray, m_floatArray, floatArrayLen);
-  genericCompare(ot->m_uint32Array, m_uint32Array, intArrayLen);
-  genericCompare(ot->m_ulongArray, m_ulongArray, longArrayLen);
-  genericCompare(ot->m_uint16Array, m_uint16Array, shortArrayLen);
-  genericCompare(ot->m_sbyteArray, m_sbyteArray, shortArrayLen);
-  genericCompare(ot->m_charArray, m_charArray, charArrayLen);
+  genericCompare(ot->m_byteArray.data(), m_byteArray.data(), m_byteArray.size());
+  genericCompare(ot->m_int16Array.data(), m_int16Array.data(), m_int16Array.size());
+  genericCompare(ot->m_int32Array.data(), m_int32Array.data(), m_int32Array.size());
+  genericCompare(ot->m_longArray.data(), m_longArray.data(), m_longArray.size());
+  genericCompare(ot->m_uint32Array.data(), m_uint32Array.data(), m_uint32Array.size());
+  genericCompare(ot->m_ulongArray.data(), m_ulongArray.data(), m_ulongArray.size());
+  genericCompare(ot->m_uint16Array.data(), m_uint16Array.data(), m_uint16Array.size());
+  genericCompare(ot->m_sbyteArray.data(), m_sbyteArray.data(), m_sbyteArray.size());
+  genericCompare(ot->m_charArray.data(), m_charArray.data(), m_charArray.size());
   // generic2DCompare(ot->m_byteByteArray, m_byteByteArray, byteByteArrayLen,
   // lengthArr);
 

--- a/tests/cpp/testobject/PdxType.hpp
+++ b/tests/cpp/testobject/PdxType.hpp
@@ -154,7 +154,7 @@ class TESTOBJECT_EXPORT Child : public Parent, public PdxSerializable {
 class TESTOBJECT_EXPORT CharTypes : public PdxSerializable {
  private:
   char16_t m_ch;
-  char16_t* m_chArray;
+  std::vector<char16_t> m_chArray;
 
   int32_t m_charArrayLen;
 
@@ -162,7 +162,7 @@ class TESTOBJECT_EXPORT CharTypes : public PdxSerializable {
   inline void init() {
     m_ch = 'C';
 
-    m_chArray = new char16_t[2];
+    m_chArray = std::vector<char16_t>(2);
     m_chArray[0] = 'X';
     m_chArray[1] = 'Y';
 
@@ -217,12 +217,12 @@ class TESTOBJECT_EXPORT CharTypes : public PdxSerializable {
 
   void toData(PdxWriter& pw) const override {
     pw.writeChar("m_ch", m_ch);
-    pw.writeCharArray("m_chArray", m_chArray, 2);
+    pw.writeCharArray("m_chArray", m_chArray);
   }
 
   void fromData(PdxReader& pr) override {
     m_ch = pr.readChar("m_ch");
-    m_chArray = pr.readCharArray("m_chArray", m_charArrayLen);
+    m_chArray = pr.readCharArray("m_chArray");
   }
 
   static PdxSerializable* createDeserializable() { return new CharTypes(); }
@@ -326,25 +326,25 @@ class TESTOBJECT_EXPORT PdxType : public PdxSerializable {
 
   std::string m_string;
 
-  bool* m_boolArray;
-  int8_t* m_byteArray;
-  int8_t* m_sbyteArray;  ///
+  std::vector<bool> m_boolArray;
+  std::vector<int8_t> m_byteArray;
+  std::vector<int8_t> m_sbyteArray;  ///
 
-  char16_t* m_charArray;
+  std::vector<char16_t> m_charArray;
 
   std::shared_ptr<CacheableDate> m_date;
 
-  int16_t* m_int16Array;
-  int16_t* m_uint16Array;
+  std::vector<int16_t> m_int16Array;
+  std::vector<int16_t> m_uint16Array;
 
-  int32_t* m_int32Array;
-  int32_t* m_uint32Array;
+  std::vector<int32_t> m_int32Array;
+  std::vector<int32_t> m_uint32Array;
 
-  int64_t* m_longArray;
-  int64_t* m_ulongArray;
+  std::vector<int64_t> m_longArray;
+  std::vector<int64_t> m_ulongArray;
 
-  float* m_floatArray;
-  double* m_doubleArray;
+  std::vector<float> m_floatArray;
+  std::vector<double> m_doubleArray;
 
   int8_t** m_byteByteArray;
 
@@ -361,10 +361,10 @@ class TESTOBJECT_EXPORT PdxType : public PdxSerializable {
   std::shared_ptr<CacheableHashSet> m_chs;
   std::shared_ptr<CacheableLinkedHashSet> m_clhs;
 
-  int8_t* m_byte252;
-  int8_t* m_byte253;
-  int8_t* m_byte65535;
-  int8_t* m_byte65536;
+  std::vector<int8_t> m_byte252;
+  std::vector<int8_t> m_byte253;
+  std::vector<int8_t> m_byte65535;
+  std::vector<int8_t> m_byte65536;
   std::shared_ptr<Cacheable> m_pdxEnum;
   std::shared_ptr<CacheableObjectArray> m_objectArray;
   std::shared_ptr<CacheableObjectArray> m_objectArrayEmptyPdxFieldName;
@@ -403,7 +403,7 @@ class TESTOBJECT_EXPORT PdxType : public PdxSerializable {
 
     m_string = "gfestring";
 
-    m_boolArray = new bool[3];
+    m_boolArray = std::vector<bool>(3);
     m_boolArray[0] = true;
     m_boolArray[1] = false;
     m_boolArray[2] = true;
@@ -411,54 +411,54 @@ class TESTOBJECT_EXPORT PdxType : public PdxSerializable {
       m_boolArray[i] = true;
     };*/
 
-    m_byteArray = new int8_t[2];
+    m_byteArray = std::vector<int8_t>(2);
     m_byteArray[0] = 0x34;
     m_byteArray[1] = 0x64;
 
-    m_sbyteArray = new int8_t[2];
+    m_sbyteArray = std::vector<int8_t>(2);
     m_sbyteArray[0] = 0x34;
     m_sbyteArray[1] = 0x64;
 
-    m_charArray = new char16_t[2];
+    m_charArray = std::vector<char16_t>(2);
     m_charArray[0] = L'c';
     m_charArray[1] = L'v';
 
     int64_t d = 1310447869154L;
     m_date = CacheableDate::create(CacheableDate::duration(d));
 
-    m_int16Array = new int16_t[2];
+    m_int16Array = std::vector<int16_t>(2);
     m_int16Array[0] = 0x2332;
     m_int16Array[1] = 0x4545;
 
-    m_uint16Array = new int16_t[2];
+    m_uint16Array = std::vector<int16_t>(2);
     m_uint16Array[0] = 0x3243;
     m_uint16Array[1] = 0x3232;
 
-    m_int32Array = new int32_t[4];
+    m_int32Array = std::vector<int32_t>(4);
     m_int32Array[0] = 23;
     m_int32Array[1] = 676868;
     m_int32Array[2] = 34343;
     m_int32Array[3] = 2323;
 
-    m_uint32Array = new int32_t[4];
+    m_uint32Array = std::vector<int32_t>(4);
     m_uint32Array[0] = 435;
     m_uint32Array[1] = 234324;
     m_uint32Array[2] = 324324;
     m_uint32Array[3] = 23432432;
 
-    m_longArray = new int64_t[2];
+    m_longArray = std::vector<int64_t>(2);
     m_longArray[0] = 324324L;
     m_longArray[1] = 23434545L;
 
-    m_ulongArray = new int64_t[2];
+    m_ulongArray = std::vector<int64_t>(2);
     m_ulongArray[0] = 3245435;
     m_ulongArray[1] = 3425435;
 
-    m_floatArray = new float[2];
+    m_floatArray = std::vector<float>(2);
     m_floatArray[0] = 232.565f;
     m_floatArray[1] = 2343254.67f;
 
-    m_doubleArray = new double[2];
+    m_doubleArray = std::vector<double>(2);
     m_doubleArray[0] = 23423432;
     m_doubleArray[1] = 4324235435.00;
 
@@ -569,22 +569,22 @@ class TESTOBJECT_EXPORT PdxType : public PdxSerializable {
     m_objectArrayEmptyPdxFieldName->push_back(
         std::shared_ptr<Address>(new Address(10, "street9", "city9")));
 
-    m_byte252 = new int8_t[252];
+    m_byte252 = std::vector<int8_t>(252);
     for (int i = 0; i < 252; i++) {
       m_byte252[i] = 0;
     }
 
-    m_byte253 = new int8_t[253];
+    m_byte253 = std::vector<int8_t>(253);
     for (int i = 0; i < 253; i++) {
       m_byte253[i] = 0;
     }
 
-    m_byte65535 = new int8_t[65535];
+    m_byte65535 = std::vector<int8_t>(65535);
     for (int i = 0; i < 65535; i++) {
       m_byte65535[i] = 0;
     }
 
-    m_byte65536 = new int8_t[65536];
+    m_byte65536 = std::vector<int8_t>(65536);
     for (int i = 0; i < 65536; i++) {
       m_byte65536[i] = 0;
     }
@@ -633,7 +633,7 @@ class TESTOBJECT_EXPORT PdxType : public PdxSerializable {
 
   char16_t getChar() { return m_char; }
 
-  char16_t* getCharArray() { return m_charArray; }
+  std::vector<char16_t> getCharArray() { return m_charArray; }
 
   int8_t** getArrayOfByteArrays() { return m_byteByteArray; }
 
@@ -649,21 +649,21 @@ class TESTOBJECT_EXPORT PdxType : public PdxSerializable {
 
   int64_t getULong() { return m_ulong; }
 
-  int16_t* getUInt16Array() { return m_uint16Array; }
+  std::vector<int16_t> getUInt16Array() { return m_uint16Array; }
 
-  int32_t* getUIntArray() { return m_uint32Array; }
+  std::vector<int32_t> getUIntArray() { return m_uint32Array; }
 
-  int64_t* getULongArray() { return m_ulongArray; }
+  std::vector<int64_t> getULongArray() { return m_ulongArray; }
 
-  int8_t* getByte252() { return m_byte252; }
+  std::vector<int8_t> getByte252() { return m_byte252; }
 
-  int8_t* getByte253() { return m_byte253; }
+  std::vector<int8_t> getByte253() { return m_byte253; }
 
-  int8_t* getByte65535() { return m_byte65535; }
+  std::vector<int8_t> getByte65535() { return m_byte65535; }
 
-  int8_t* getByte65536() { return m_byte65536; }
+  std::vector<int8_t> getByte65536() { return m_byte65536; }
 
-  int8_t* getSByteArray() { return m_sbyteArray; }
+  std::vector<int8_t> getSByteArray() { return m_sbyteArray; }
 
   std::shared_ptr<CacheableHashSet> getHashSet() { return m_chs; }
 
@@ -691,19 +691,19 @@ class TESTOBJECT_EXPORT PdxType : public PdxSerializable {
 
   const std::string& getString() { return m_string; }
 
-  bool* getBoolArray() { return m_boolArray; }
+  std::vector<bool> getBoolArray() { return m_boolArray; }
 
-  int8_t* getByteArray() { return m_byteArray; }
+  std::vector<int8_t> getByteArray() { return m_byteArray; }
 
-  int16_t* getShortArray() { return m_int16Array; }
+  std::vector<int16_t> getShortArray() { return m_int16Array; }
 
-  int32_t* getIntArray() { return m_int32Array; }
+  std::vector<int32_t> getIntArray() { return m_int32Array; }
 
-  int64_t* getLongArray() { return m_longArray; }
+  std::vector<int64_t> getLongArray() { return m_longArray; }
 
-  double* getDoubleArray() { return m_doubleArray; }
+  std::vector<double> getDoubleArray() { return m_doubleArray; }
 
-  float* getFloatArray() { return m_floatArray; }
+  std::vector<float> getFloatArray() { return m_floatArray; }
 
   const std::vector<std::string>& getStringArray() { return m_stringArray; }
 

--- a/tests/cpp/testobject/PdxType.hpp
+++ b/tests/cpp/testobject/PdxType.hpp
@@ -569,25 +569,13 @@ class TESTOBJECT_EXPORT PdxType : public PdxSerializable {
     m_objectArrayEmptyPdxFieldName->push_back(
         std::shared_ptr<Address>(new Address(10, "street9", "city9")));
 
-    m_byte252 = std::vector<int8_t>(252);
-    for (int i = 0; i < 252; i++) {
-      m_byte252[i] = 0;
-    }
+    m_byte252 = std::vector<int8_t>(252, 0);
 
-    m_byte253 = std::vector<int8_t>(253);
-    for (int i = 0; i < 253; i++) {
-      m_byte253[i] = 0;
-    }
+    m_byte253 = std::vector<int8_t>(253, 0);
 
-    m_byte65535 = std::vector<int8_t>(65535);
-    for (int i = 0; i < 65535; i++) {
-      m_byte65535[i] = 0;
-    }
+    m_byte65535 = std::vector<int8_t>(65535, 0);
 
-    m_byte65536 = std::vector<int8_t>(65536);
-    for (int i = 0; i < 65536; i++) {
-      m_byte65536[i] = 0;
-    }
+    m_byte65536 = std::vector<int8_t>(65536, 0);
 
     /*for (int32_t index = 0; index <3; ++index) {
       m_objectArray->push_back(objectArray[index]);

--- a/tests/cpp/testobject/PdxVersioned1.cpp
+++ b/tests/cpp/testobject/PdxVersioned1.cpp
@@ -131,7 +131,7 @@ void PdxVersioned1::init(const char* key) {
   m_float = 23324.324f;
   m_double = 3243298498.00;
   m_string = std::string("PdxVersioned ") + key;
-  m_boolArray = new bool[3];
+  m_boolArray = std::vector<bool>(3);
   m_boolArray[0] = true;
   m_boolArray[1] = false;
   m_boolArray[2] = true;
@@ -139,54 +139,54 @@ void PdxVersioned1::init(const char* key) {
     m_boolArray[i] = true;
   };*/
 
-  m_byteArray = new int8_t[2];
+  m_byteArray = std::vector<int8_t>(2);
   m_byteArray[0] = 0x34;
   m_byteArray[1] = 0x64;
 
-  m_sbyteArray = new int8_t[2];
+  m_sbyteArray = std::vector<int8_t>(2);
   m_sbyteArray[0] = 0x34;
   m_sbyteArray[1] = 0x64;
 
-  m_charArray = new char16_t[2];
+  m_charArray = std::vector<char16_t>(2);
   m_charArray[0] = L'c';
   m_charArray[1] = L'v';
 
   int64_t d = 1310447869154L;
   m_date = CacheableDate::create(CacheableDate::duration(d));
 
-  m_int16Array = new int16_t[2];
+  m_int16Array = std::vector<int16_t>(2);
   m_int16Array[0] = 0x2332;
   m_int16Array[1] = 0x4545;
 
-  m_uint16Array = new int16_t[2];
+  m_uint16Array = std::vector<int16_t>(2);
   m_uint16Array[0] = 0x3243;
   m_uint16Array[1] = 0x3232;
 
-  m_int32Array = new int32_t[4];
+  m_int32Array = std::vector<int32_t>(4);
   m_int32Array[0] = 23;
   m_int32Array[1] = 676868;
   m_int32Array[2] = 34343;
   m_int32Array[3] = 2323;
 
-  m_uint32Array = new int32_t[4];
+  m_uint32Array = std::vector<int32_t>(4);
   m_uint32Array[0] = 435;
   m_uint32Array[1] = 234324;
   m_uint32Array[2] = 324324;
   m_uint32Array[3] = 23432432;
 
-  m_longArray = new int64_t[2];
+  m_longArray = std::vector<int64_t>(2);
   m_longArray[0] = 324324L;
   m_longArray[1] = 23434545L;
 
-  m_ulongArray = new int64_t[2];
+  m_ulongArray = std::vector<int64_t>(2);
   m_ulongArray[0] = 3245435;
   m_ulongArray[1] = 3425435;
 
-  m_floatArray = new float[2];
+  m_floatArray = std::vector<float>(2);
   m_floatArray[0] = 232.565f;
   m_floatArray[1] = 2343254.67f;
 
-  m_doubleArray = new double[2];
+  m_doubleArray = std::vector<double>(2);
   m_doubleArray[0] = 23423432;
   m_doubleArray[1] = 4324235435.00;
 
@@ -210,22 +210,22 @@ void PdxVersioned1::init(const char* key) {
   m_map->emplace(CacheableInt32::create(1), CacheableInt32::create(1));
   m_map->emplace(CacheableInt32::create(2), CacheableInt32::create(2));
   m_pdxEnum = CacheableEnum::create("pdxEnumTest", "pdx2", pdx2);
-  m_byte252 = new int8_t[252];
+  m_byte252 = std::vector<int8_t>(252);
   for (int i = 0; i < 252; i++) {
     m_byte252[i] = 0;
   }
 
-  m_byte253 = new int8_t[253];
+  m_byte253 = std::vector<int8_t>(253);
   for (int i = 0; i < 253; i++) {
     m_byte253[i] = 0;
   }
 
-  m_byte65535 = new int8_t[65535];
+  m_byte65535 = std::vector<int8_t>(65535);
   for (int i = 0; i < 65535; i++) {
     m_byte65535[i] = 0;
   }
 
-  m_byte65536 = new int8_t[65536];
+  m_byte65536 = std::vector<int8_t>(65536);
   for (int i = 0; i < 65536; i++) {
     m_byte65536[i] = 0;
   }
@@ -268,26 +268,26 @@ void PdxTests::PdxVersioned1::toData(PdxWriter& pw) const {
   pw.writeArrayOfByteArrays("m_byteByteArray", m_byteByteArray, 2, lengthArr);
   pw.writeChar("m_char", m_char);
   pw.writeBoolean("m_bool", m_bool);  // 1
-  pw.writeBooleanArray("m_boolArray", m_boolArray, 3);
+  pw.writeBooleanArray("m_boolArray", m_boolArray);
   pw.writeByte("m_byte", m_byte);
-  pw.writeByteArray("m_byteArray", m_byteArray, 2);
-  pw.writeCharArray("m_charArray", m_charArray, 2);
+  pw.writeByteArray("m_byteArray", m_byteArray);
+  pw.writeCharArray("m_charArray", m_charArray);
   pw.writeObject("m_arraylist", m_arraylist);
   pw.writeObject("m_map", m_map);
   pw.writeString("m_string", m_string);
   pw.writeDate("m_dateTime", m_date);
   pw.writeDouble("m_double", m_double);
-  pw.writeDoubleArray("m_doubleArray", m_doubleArray, 2);
+  pw.writeDoubleArray("m_doubleArray", m_doubleArray);
   pw.writeFloat("m_float", m_float);
-  pw.writeFloatArray("m_floatArray", m_floatArray, 2);
+  pw.writeFloatArray("m_floatArray", m_floatArray);
   pw.writeShort("m_int16", m_int16);
   pw.writeInt("m_int32", m_int32);
   // pw.writeLong("m_long", m_long);
-  pw.writeIntArray("m_int32Array", m_int32Array, 4);
-  pw.writeLongArray("m_longArray", m_longArray, 2);
-  pw.writeShortArray("m_int16Array", m_int16Array, 2);
+  pw.writeIntArray("m_int32Array", m_int32Array);
+  pw.writeLongArray("m_longArray", m_longArray);
+  pw.writeShortArray("m_int16Array", m_int16Array);
   pw.writeByte("m_sbyte", m_sbyte);
-  pw.writeByteArray("m_sbyteArray", m_sbyteArray, 2);
+  pw.writeByteArray("m_sbyteArray", m_sbyteArray);
   // int* strlengthArr = new int[2];
 
   // strlengthArr[0] = 5;
@@ -296,13 +296,13 @@ void PdxTests::PdxVersioned1::toData(PdxWriter& pw) const {
   pw.writeShort("m_uint16", m_uint16);
   // pw.writeInt("m_uint32", m_uint32);
   pw.writeLong("m_ulong", m_ulong);
-  pw.writeIntArray("m_uint32Array", m_uint32Array, 4);
-  pw.writeLongArray("m_ulongArray", m_ulongArray, 2);
-  pw.writeShortArray("m_uint16Array", m_uint16Array, 2);
-  pw.writeByteArray("m_byte252", m_byte252, 252);
-  pw.writeByteArray("m_byte253", m_byte253, 253);
-  pw.writeByteArray("m_byte65535", m_byte65535, 65535);
-  pw.writeByteArray("m_byte65536", m_byte65536, 65536);
+  pw.writeIntArray("m_uint32Array", m_uint32Array);
+  pw.writeLongArray("m_ulongArray", m_ulongArray);
+  pw.writeShortArray("m_uint16Array", m_uint16Array);
+  pw.writeByteArray("m_byte252", m_byte252);
+  pw.writeByteArray("m_byte253", m_byte253);
+  pw.writeByteArray("m_byte65535", m_byte65535);
+  pw.writeByteArray("m_byte65536", m_byte65536);
   pw.writeObject("m_pdxEnum", m_pdxEnum);
 
   // TODO:delete it later
@@ -322,10 +322,10 @@ void PdxTests::PdxVersioned1::fromData(PdxReader& pr) {
   // GenericValCompare
   m_bool = pr.readBoolean("m_bool");
   // GenericValCompare
-  m_boolArray = pr.readBooleanArray("m_boolArray", boolArrayLen);
+  m_boolArray = pr.readBooleanArray("m_boolArray");
   m_byte = pr.readByte("m_byte");
-  m_byteArray = pr.readByteArray("m_byteArray", byteArrayLen);
-  m_charArray = pr.readCharArray("m_charArray", charArrayLen);
+  m_byteArray = pr.readByteArray("m_byteArray");
+  m_charArray = pr.readCharArray("m_charArray");
   m_arraylist = std::static_pointer_cast<CacheableArrayList>(
       pr.readObject("m_arraylist"));
   m_map = std::static_pointer_cast<CacheableHashMap>(pr.readObject("m_map"));
@@ -333,30 +333,30 @@ void PdxTests::PdxVersioned1::fromData(PdxReader& pr) {
   m_string = pr.readString("m_string");  // GenericValCompare
   m_date = pr.readDate("m_dateTime");    // compareData
   m_double = pr.readDouble("m_double");
-  m_doubleArray = pr.readDoubleArray("m_doubleArray", doubleArrayLen);
+  m_doubleArray = pr.readDoubleArray("m_doubleArray");
   m_float = pr.readFloat("m_float");
-  m_floatArray = pr.readFloatArray("m_floatArray", floatArrayLen);
+  m_floatArray = pr.readFloatArray("m_floatArray");
   m_int16 = pr.readShort("m_int16");
   m_int32 = pr.readInt("m_int32");
   // m_long = pr.readLong("m_long");
-  m_int32Array = pr.readIntArray("m_int32Array", intArrayLen);
-  m_longArray = pr.readLongArray("m_longArray", longArrayLen);
-  m_int16Array = pr.readShortArray("m_int16Array", shortArrayLen);
+  m_int32Array = pr.readIntArray("m_int32Array");
+  m_longArray = pr.readLongArray("m_longArray");
+  m_int16Array = pr.readShortArray("m_int16Array");
   m_sbyte = pr.readByte("m_sbyte");
-  m_sbyteArray = pr.readByteArray("m_sbyteArray", byteArrayLen);
+  m_sbyteArray = pr.readByteArray("m_sbyteArray");
   m_stringArray = pr.readStringArray("m_stringArray");
   m_uint16 = pr.readShort("m_uint16");
   // m_uint32 = pr.readInt("m_uint32");
   m_ulong = pr.readLong("m_ulong");
-  m_uint32Array = pr.readIntArray("m_uint32Array", intArrayLen);
-  m_ulongArray = pr.readLongArray("m_ulongArray", longArrayLen);
-  m_uint16Array = pr.readShortArray("m_uint16Array", shortArrayLen);
+  m_uint32Array = pr.readIntArray("m_uint32Array");
+  m_ulongArray = pr.readLongArray("m_ulongArray");
+  m_uint16Array = pr.readShortArray("m_uint16Array");
   // LOGINFO("PdxVersioned1::readInt() start...");
 
-  m_byte252 = pr.readByteArray("m_byte252", m_byte252Len);
-  m_byte253 = pr.readByteArray("m_byte253", m_byte253Len);
-  m_byte65535 = pr.readByteArray("m_byte65535", m_byte65535Len);
-  m_byte65536 = pr.readByteArray("m_byte65536", m_byte65536Len);
+  m_byte252 = pr.readByteArray("m_byte252");
+  m_byte253 = pr.readByteArray("m_byte253");
+  m_byte65535 = pr.readByteArray("m_byte65535");
+  m_byte65536 = pr.readByteArray("m_byte65536");
   // TODO:Check for size
   m_pdxEnum = pr.readObject("m_pdxEnum");
 }
@@ -389,17 +389,15 @@ bool PdxTests::PdxVersioned1::equals(PdxTests::PdxVersioned1& other,
   if (ot->m_string != m_string) {
     return false;
   }
-  genericCompare(ot->m_byteArray, m_byteArray, byteArrayLen);
-  genericCompare(ot->m_int16Array, m_int16Array, shortArrayLen);
-  genericCompare(ot->m_int32Array, m_int32Array, intArrayLen);
-  genericCompare(ot->m_longArray, m_longArray, longArrayLen);
-  genericCompare(ot->m_doubleArray, m_doubleArray, doubleArrayLen);
-  genericCompare(ot->m_floatArray, m_floatArray, floatArrayLen);
-  genericCompare(ot->m_uint32Array, m_uint32Array, intArrayLen);
-  genericCompare(ot->m_ulongArray, m_ulongArray, longArrayLen);
-  genericCompare(ot->m_uint16Array, m_uint16Array, shortArrayLen);
-  genericCompare(ot->m_sbyteArray, m_sbyteArray, shortArrayLen);
-  genericCompare(ot->m_charArray, m_charArray, charArrayLen);
+  genericCompare(ot->m_byteArray.data(), m_byteArray.data(), m_byteArray.size());
+  genericCompare(ot->m_int16Array.data(), m_int16Array.data(), m_int16Array.size());
+  genericCompare(ot->m_int32Array.data(), m_int32Array.data(), m_int32Array.size());
+  genericCompare(ot->m_longArray.data(), m_longArray.data(), m_longArray.size());
+  genericCompare(ot->m_uint32Array.data(), m_uint32Array.data(), m_uint32Array.size());
+  genericCompare(ot->m_ulongArray.data(), m_ulongArray.data(), m_ulongArray.size());
+  genericCompare(ot->m_uint16Array.data(), m_uint16Array.data(), m_uint16Array.size());
+  genericCompare(ot->m_sbyteArray.data(), m_sbyteArray.data(), m_sbyteArray.size());
+  genericCompare(ot->m_charArray.data(), m_charArray.data(), m_charArray.size());
   // generic2DCompare(ot->m_byteByteArray, m_byteByteArray, byteByteArrayLen,
   // lengthArr);
 

--- a/tests/cpp/testobject/PdxVersioned1.cpp
+++ b/tests/cpp/testobject/PdxVersioned1.cpp
@@ -143,52 +143,28 @@ void PdxVersioned1::init(const char* key) {
   m_byteArray[0] = 0x34;
   m_byteArray[1] = 0x64;
 
-  m_sbyteArray = std::vector<int8_t>(2);
-  m_sbyteArray[0] = 0x34;
-  m_sbyteArray[1] = 0x64;
+  m_sbyteArray = std::vector<int8_t>{0x34, 0x64};
 
-  m_charArray = std::vector<char16_t>(2);
-  m_charArray[0] = L'c';
-  m_charArray[1] = L'v';
+  m_charArray = std::vector<char16_t>{u'c', u'v'};
 
   int64_t d = 1310447869154L;
   m_date = CacheableDate::create(CacheableDate::duration(d));
 
-  m_int16Array = std::vector<int16_t>(2);
-  m_int16Array[0] = 0x2332;
-  m_int16Array[1] = 0x4545;
+  m_int16Array = std::vector<int16_t>{0x2332, 0x4545};
 
-  m_uint16Array = std::vector<int16_t>(2);
-  m_uint16Array[0] = 0x3243;
-  m_uint16Array[1] = 0x3232;
+  m_uint16Array = std::vector<int16_t>{0x3243, 0x3232};
 
-  m_int32Array = std::vector<int32_t>(4);
-  m_int32Array[0] = 23;
-  m_int32Array[1] = 676868;
-  m_int32Array[2] = 34343;
-  m_int32Array[3] = 2323;
+  m_int32Array = std::vector<int32_t>{23, 676868, 34343, 2323};
 
-  m_uint32Array = std::vector<int32_t>(4);
-  m_uint32Array[0] = 435;
-  m_uint32Array[1] = 234324;
-  m_uint32Array[2] = 324324;
-  m_uint32Array[3] = 23432432;
+  m_uint32Array = std::vector<int32_t>{435, 234324, 324324, 23432432};
 
-  m_longArray = std::vector<int64_t>(2);
-  m_longArray[0] = 324324L;
-  m_longArray[1] = 23434545L;
+  m_longArray = std::vector<int64_t>{324324L, 23434545L};
 
-  m_ulongArray = std::vector<int64_t>(2);
-  m_ulongArray[0] = 3245435;
-  m_ulongArray[1] = 3425435;
+  m_ulongArray = std::vector<int64_t>{3245435, 3425435};
 
-  m_floatArray = std::vector<float>(2);
-  m_floatArray[0] = 232.565f;
-  m_floatArray[1] = 2343254.67f;
+  m_floatArray = std::vector<float>{232.565f, 2343254.67f};
 
-  m_doubleArray = std::vector<double>(2);
-  m_doubleArray[0] = 23423432;
-  m_doubleArray[1] = 4324235435.00;
+  m_doubleArray = std::vector<double>{23423432, 4324235435.00};
 
   m_byteByteArray = new int8_t*[2];
   // for(int i=0; i<2; i++){

--- a/tests/cpp/testobject/PdxVersioned1.hpp
+++ b/tests/cpp/testobject/PdxVersioned1.hpp
@@ -63,25 +63,25 @@ class TESTOBJECT_EXPORT PdxVersioned1 : public PdxSerializable {
 
   std::string m_string;
 
-  bool* m_boolArray;
-  int8_t* m_byteArray;
-  int8_t* m_sbyteArray;  ///
+  std::vector<bool> m_boolArray;
+  std::vector<int8_t> m_byteArray;
+  std::vector<int8_t> m_sbyteArray;  ///
 
-  char16_t* m_charArray;
+  std::vector<char16_t> m_charArray;
 
   std::shared_ptr<CacheableDate> m_date;
 
-  int16_t* m_int16Array;
-  int16_t* m_uint16Array;
+  std::vector<int16_t> m_int16Array;
+  std::vector<int16_t> m_uint16Array;
 
-  int32_t* m_int32Array;
-  int32_t* m_uint32Array;
+  std::vector<int32_t> m_int32Array;
+  std::vector<int32_t> m_uint32Array;
 
-  int64_t* m_longArray;
-  int64_t* m_ulongArray;
+  std::vector<int64_t> m_longArray;
+  std::vector<int64_t> m_ulongArray;
 
-  float* m_floatArray;
-  double* m_doubleArray;
+  std::vector<float> m_floatArray;
+  std::vector<double> m_doubleArray;
 
   int8_t** m_byteByteArray;
 
@@ -89,10 +89,10 @@ class TESTOBJECT_EXPORT PdxVersioned1 : public PdxSerializable {
   std::shared_ptr<CacheableArrayList> m_arraylist;
   std::shared_ptr<CacheableHashMap> m_map;
 
-  int8_t* m_byte252;
-  int8_t* m_byte253;
-  int8_t* m_byte65535;
-  int8_t* m_byte65536;
+  std::vector<int8_t> m_byte252;
+  std::vector<int8_t> m_byte253;
+  std::vector<int8_t> m_byte65535;
+  std::vector<int8_t> m_byte65536;
   enum pdxEnumTest { pdx1, pdx2, pdx3, pdx4 };
   std::shared_ptr<Cacheable> m_pdxEnum;
 
@@ -135,7 +135,7 @@ class TESTOBJECT_EXPORT PdxVersioned1 : public PdxSerializable {
   // void checkNullAndDelete(void *data);
   char16_t getChar() { return m_char; }
 
-  char16_t* getCharArray() { return m_charArray; }
+  std::vector<char16_t> getCharArray() { return m_charArray; }
 
   int8_t** getArrayOfByteArrays() { return m_byteByteArray; }
 
@@ -153,21 +153,21 @@ class TESTOBJECT_EXPORT PdxVersioned1 : public PdxSerializable {
 
   int64_t getULong() { return m_ulong; }
 
-  int16_t* getUInt16Array() { return m_uint16Array; }
+  std::vector<int16_t> getUInt16Array() { return m_uint16Array; }
 
-  int32_t* getUIntArray() { return m_uint32Array; }
+  std::vector<int32_t> getUIntArray() { return m_uint32Array; }
 
-  int64_t* getULongArray() { return m_ulongArray; }
+  std::vector<int64_t> getULongArray() { return m_ulongArray; }
 
-  int8_t* getByte252() { return m_byte252; }
+  std::vector<int8_t> getByte252() { return m_byte252; }
 
-  int8_t* getByte253() { return m_byte253; }
+  std::vector<int8_t> getByte253() { return m_byte253; }
 
-  int8_t* getByte65535() { return m_byte65535; }
+  std::vector<int8_t> getByte65535() { return m_byte65535; }
 
-  int8_t* getByte65536() { return m_byte65536; }
+  std::vector<int8_t> getByte65536() { return m_byte65536; }
 
-  int8_t* getSByteArray() { return m_sbyteArray; }
+  std::vector<int8_t> getSByteArray() { return m_sbyteArray; }
 
   std::shared_ptr<CacheableArrayList> getArrayList() { return m_arraylist; }
 
@@ -187,19 +187,19 @@ class TESTOBJECT_EXPORT PdxVersioned1 : public PdxSerializable {
 
   const std::string& getString() { return m_string; }
 
-  bool* getBoolArray() { return m_boolArray; }
+  std::vector<bool> getBoolArray() { return m_boolArray; }
 
-  int8_t* getByteArray() { return m_byteArray; }
+  std::vector<int8_t> getByteArray() { return m_byteArray; }
 
-  int16_t* getShortArray() { return m_int16Array; }
+  std::vector<int16_t> getShortArray() { return m_int16Array; }
 
-  int32_t* getIntArray() { return m_int32Array; }
+  std::vector<int32_t> getIntArray() { return m_int32Array; }
 
-  int64_t* getLongArray() { return m_longArray; }
+  std::vector<int64_t> getLongArray() { return m_longArray; }
 
-  double* getDoubleArray() { return m_doubleArray; }
+  std::vector<double> getDoubleArray() { return m_doubleArray; }
 
-  float* getFloatArray() { return m_floatArray; }
+  std::vector<float> getFloatArray() { return m_floatArray; }
 
   const std::vector<std::string>& getStringArray() { return m_stringArray; }
 

--- a/tests/cpp/testobject/PdxVersioned2.cpp
+++ b/tests/cpp/testobject/PdxVersioned2.cpp
@@ -135,7 +135,7 @@ void PdxVersioned2::init(const char* key) {
   m_float = 23324.324f;
   m_double = 3243298498.00;
   m_string = std::string("PdxVersioned ") + key;
-  m_boolArray = new bool[3];
+  m_boolArray = std::vector<bool>(3);
   m_boolArray[0] = true;
   m_boolArray[1] = false;
   m_boolArray[2] = true;
@@ -143,54 +143,54 @@ void PdxVersioned2::init(const char* key) {
     m_boolArray[i] = true;
   };*/
 
-  m_byteArray = new int8_t[2];
+  m_byteArray = std::vector<int8_t>(2);
   m_byteArray[0] = 0x34;
   m_byteArray[1] = 0x64;
 
-  m_sbyteArray = new int8_t[2];
+  m_sbyteArray = std::vector<int8_t>(2);
   m_sbyteArray[0] = 0x34;
   m_sbyteArray[1] = 0x64;
 
-  m_charArray = new char16_t[2];
+  m_charArray = std::vector<char16_t>(2);
   m_charArray[0] = L'c';
   m_charArray[1] = L'v';
 
   int64_t d = 1310447869154L;
   m_date = CacheableDate::create(CacheableDate::duration(d));
 
-  m_int16Array = new int16_t[2];
+  m_int16Array = std::vector<int16_t>(2);
   m_int16Array[0] = 0x2332;
   m_int16Array[1] = 0x4545;
 
-  m_uint16Array = new int16_t[2];
+  m_uint16Array = std::vector<int16_t>(2);
   m_uint16Array[0] = 0x3243;
   m_uint16Array[1] = 0x3232;
 
-  m_int32Array = new int32_t[4];
+  m_int32Array = std::vector<int32_t>(4);
   m_int32Array[0] = 23;
   m_int32Array[1] = 676868;
   m_int32Array[2] = 34343;
   m_int32Array[3] = 2323;
 
-  m_uint32Array = new int32_t[4];
+  m_uint32Array = std::vector<int32_t>(4);
   m_uint32Array[0] = 435;
   m_uint32Array[1] = 234324;
   m_uint32Array[2] = 324324;
   m_uint32Array[3] = 23432432;
 
-  m_longArray = new int64_t[2];
+  m_longArray = std::vector<int64_t>(2);
   m_longArray[0] = 324324L;
   m_longArray[1] = 23434545L;
 
-  m_ulongArray = new int64_t[2];
+  m_ulongArray = std::vector<int64_t>(2);
   m_ulongArray[0] = 3245435;
   m_ulongArray[1] = 3425435;
 
-  m_floatArray = new float[2];
+  m_floatArray = std::vector<float>(2);
   m_floatArray[0] = 232.565f;
   m_floatArray[1] = 2343254.67f;
 
-  m_doubleArray = new double[2];
+  m_doubleArray = std::vector<double>(2);
   m_doubleArray[0] = 23423432;
   m_doubleArray[1] = 4324235435.00;
 
@@ -214,22 +214,22 @@ void PdxVersioned2::init(const char* key) {
   m_map->emplace(CacheableInt32::create(1), CacheableInt32::create(1));
   m_map->emplace(CacheableInt32::create(2), CacheableInt32::create(2));
   m_pdxEnum = CacheableEnum::create("pdxEnumTest1", "pdx2", pdx2);
-  m_byte252 = new int8_t[252];
+  m_byte252 = std::vector<int8_t>(252);
   for (int i = 0; i < 252; i++) {
     m_byte252[i] = 0;
   }
 
-  m_byte253 = new int8_t[253];
+  m_byte253 = std::vector<int8_t>(253);
   for (int i = 0; i < 253; i++) {
     m_byte253[i] = 0;
   }
 
-  m_byte65535 = new int8_t[65535];
+  m_byte65535 = std::vector<int8_t>(65535);
   for (int i = 0; i < 65535; i++) {
     m_byte65535[i] = 0;
   }
 
-  m_byte65536 = new int8_t[65536];
+  m_byte65536 = std::vector<int8_t>(65536);
   for (int i = 0; i < 65536; i++) {
     m_byte65536[i] = 0;
   }
@@ -272,26 +272,26 @@ void PdxTests::PdxVersioned2::toData(PdxWriter& pw) const {
   pw.writeArrayOfByteArrays("m_byteByteArray", m_byteByteArray, 2, lengthArr);
   pw.writeChar("m_char", m_char);
   pw.writeBoolean("m_bool", m_bool);  // 1
-  pw.writeBooleanArray("m_boolArray", m_boolArray, 3);
+  pw.writeBooleanArray("m_boolArray", m_boolArray);
   pw.writeByte("m_byte", m_byte);
-  pw.writeByteArray("m_byteArray", m_byteArray, 2);
-  pw.writeCharArray("m_charArray", m_charArray, 2);
+  pw.writeByteArray("m_byteArray", m_byteArray);
+  pw.writeCharArray("m_charArray", m_charArray);
   pw.writeObject("m_arraylist", m_arraylist);
   pw.writeObject("m_map", m_map);
   pw.writeString("m_string", m_string);
   pw.writeDate("m_dateTime", m_date);
   pw.writeDouble("m_double", m_double);
-  pw.writeDoubleArray("m_doubleArray", m_doubleArray, 2);
+  pw.writeDoubleArray("m_doubleArray", m_doubleArray);
   pw.writeFloat("m_float", m_float);
-  pw.writeFloatArray("m_floatArray", m_floatArray, 2);
+  pw.writeFloatArray("m_floatArray", m_floatArray);
   pw.writeShort("m_int16", m_int16);
   pw.writeInt("m_int32", m_int32);
   pw.writeLong("m_long", m_long);
-  pw.writeIntArray("m_int32Array", m_int32Array, 4);
-  pw.writeLongArray("m_longArray", m_longArray, 2);
-  pw.writeShortArray("m_int16Array", m_int16Array, 2);
+  pw.writeIntArray("m_int32Array", m_int32Array);
+  pw.writeLongArray("m_longArray", m_longArray);
+  pw.writeShortArray("m_int16Array", m_int16Array);
   pw.writeByte("m_sbyte", m_sbyte);
-  pw.writeByteArray("m_sbyteArray", m_sbyteArray, 2);
+  pw.writeByteArray("m_sbyteArray", m_sbyteArray);
   // int* strlengthArr = new int[2];
 
   // strlengthArr[0] = 5;
@@ -300,13 +300,13 @@ void PdxTests::PdxVersioned2::toData(PdxWriter& pw) const {
   pw.writeShort("m_uint16", m_uint16);
   pw.writeInt("m_uint32", m_uint32);
   pw.writeLong("m_ulong", m_ulong);
-  pw.writeIntArray("m_uint32Array", m_uint32Array, 4);
-  pw.writeLongArray("m_ulongArray", m_ulongArray, 2);
-  pw.writeShortArray("m_uint16Array", m_uint16Array, 2);
-  pw.writeByteArray("m_byte252", m_byte252, 252);
-  pw.writeByteArray("m_byte253", m_byte253, 253);
-  pw.writeByteArray("m_byte65535", m_byte65535, 65535);
-  pw.writeByteArray("m_byte65536", m_byte65536, 65536);
+  pw.writeIntArray("m_uint32Array", m_uint32Array);
+  pw.writeLongArray("m_ulongArray", m_ulongArray);
+  pw.writeShortArray("m_uint16Array", m_uint16Array);
+  pw.writeByteArray("m_byte252", m_byte252);
+  pw.writeByteArray("m_byte253", m_byte253);
+  pw.writeByteArray("m_byte65535", m_byte65535);
+  pw.writeByteArray("m_byte65536", m_byte65536);
   pw.writeObject("m_pdxEnum", m_pdxEnum);
 
   LOGDEBUG("PdxObject::writeObject() for enum Done......");
@@ -329,10 +329,10 @@ void PdxTests::PdxVersioned2::fromData(PdxReader& pr) {
   // GenericValCompare
   m_bool = pr.readBoolean("m_bool");
   // GenericValCompare
-  m_boolArray = pr.readBooleanArray("m_boolArray", boolArrayLen);
+  m_boolArray = pr.readBooleanArray("m_boolArray");
   m_byte = pr.readByte("m_byte");
-  m_byteArray = pr.readByteArray("m_byteArray", byteArrayLen);
-  m_charArray = pr.readCharArray("m_charArray", charArrayLen);
+  m_byteArray = pr.readByteArray("m_byteArray");
+  m_charArray = pr.readCharArray("m_charArray");
   m_arraylist = std::static_pointer_cast<CacheableArrayList>(
       pr.readObject("m_arraylist"));
   m_map = std::static_pointer_cast<CacheableHashMap>(pr.readObject("m_map"));
@@ -340,30 +340,30 @@ void PdxTests::PdxVersioned2::fromData(PdxReader& pr) {
   m_string = pr.readString("m_string");  // GenericValCompare
   m_date = pr.readDate("m_dateTime");    // compareData
   m_double = pr.readDouble("m_double");
-  m_doubleArray = pr.readDoubleArray("m_doubleArray", doubleArrayLen);
+  m_doubleArray = pr.readDoubleArray("m_doubleArray");
   m_float = pr.readFloat("m_float");
-  m_floatArray = pr.readFloatArray("m_floatArray", floatArrayLen);
+  m_floatArray = pr.readFloatArray("m_floatArray");
   m_int16 = pr.readShort("m_int16");
   m_int32 = pr.readInt("m_int32");
   m_long = pr.readLong("m_long");
-  m_int32Array = pr.readIntArray("m_int32Array", intArrayLen);
-  m_longArray = pr.readLongArray("m_longArray", longArrayLen);
-  m_int16Array = pr.readShortArray("m_int16Array", shortArrayLen);
+  m_int32Array = pr.readIntArray("m_int32Array");
+  m_longArray = pr.readLongArray("m_longArray");
+  m_int16Array = pr.readShortArray("m_int16Array");
   m_sbyte = pr.readByte("m_sbyte");
-  m_sbyteArray = pr.readByteArray("m_sbyteArray", byteArrayLen);
+  m_sbyteArray = pr.readByteArray("m_sbyteArray");
   m_stringArray = pr.readStringArray("m_stringArray");
   m_uint16 = pr.readShort("m_uint16");
   m_uint32 = pr.readInt("m_uint32");
   m_ulong = pr.readLong("m_ulong");
-  m_uint32Array = pr.readIntArray("m_uint32Array", intArrayLen);
-  m_ulongArray = pr.readLongArray("m_ulongArray", longArrayLen);
-  m_uint16Array = pr.readShortArray("m_uint16Array", shortArrayLen);
+  m_uint32Array = pr.readIntArray("m_uint32Array");
+  m_ulongArray = pr.readLongArray("m_ulongArray");
+  m_uint16Array = pr.readShortArray("m_uint16Array");
   // LOGINFO("PdxVersioned2::readInt() start...");
 
-  m_byte252 = pr.readByteArray("m_byte252", m_byte252Len);
-  m_byte253 = pr.readByteArray("m_byte253", m_byte253Len);
-  m_byte65535 = pr.readByteArray("m_byte65535", m_byte65535Len);
-  m_byte65536 = pr.readByteArray("m_byte65536", m_byte65536Len);
+  m_byte252 = pr.readByteArray("m_byte252");
+  m_byte253 = pr.readByteArray("m_byte253");
+  m_byte65535 = pr.readByteArray("m_byte65535");
+  m_byte65536 = pr.readByteArray("m_byte65536");
   // TODO:Check for size
   m_pdxEnum = pr.readObject("m_pdxEnum");
 }
@@ -395,17 +395,15 @@ bool PdxTests::PdxVersioned2::equals(PdxTests::PdxVersioned2& other,
   if (ot->m_string != m_string) {
     return false;
   }
-  genericCompare(ot->m_byteArray, m_byteArray, byteArrayLen);
-  genericCompare(ot->m_int16Array, m_int16Array, shortArrayLen);
-  genericCompare(ot->m_int32Array, m_int32Array, intArrayLen);
-  genericCompare(ot->m_longArray, m_longArray, longArrayLen);
-  genericCompare(ot->m_doubleArray, m_doubleArray, doubleArrayLen);
-  genericCompare(ot->m_floatArray, m_floatArray, floatArrayLen);
-  genericCompare(ot->m_uint32Array, m_uint32Array, intArrayLen);
-  genericCompare(ot->m_ulongArray, m_ulongArray, longArrayLen);
-  genericCompare(ot->m_uint16Array, m_uint16Array, shortArrayLen);
-  genericCompare(ot->m_sbyteArray, m_sbyteArray, shortArrayLen);
-  genericCompare(ot->m_charArray, m_charArray, charArrayLen);
+  genericCompare(ot->m_byteArray.data(), m_byteArray.data(), m_byteArray.size());
+  genericCompare(ot->m_int16Array.data(), m_int16Array.data(), m_int16Array.size());
+  genericCompare(ot->m_int32Array.data(), m_int32Array.data(), m_int32Array.size());
+  genericCompare(ot->m_longArray.data(), m_longArray.data(), m_longArray.size());
+  genericCompare(ot->m_uint32Array.data(), m_uint32Array.data(), m_uint32Array.size());
+  genericCompare(ot->m_ulongArray.data(), m_ulongArray.data(), m_ulongArray.size());
+  genericCompare(ot->m_uint16Array.data(), m_uint16Array.data(), m_uint16Array.size());
+  genericCompare(ot->m_sbyteArray.data(), m_sbyteArray.data(), m_sbyteArray.size());
+  genericCompare(ot->m_charArray.data(), m_charArray.data(), m_charArray.size());
   // generic2DCompare(ot->m_byteByteArray, m_byteByteArray, byteByteArrayLen,
   // lengthArr);
 

--- a/tests/cpp/testobject/PdxVersioned2.hpp
+++ b/tests/cpp/testobject/PdxVersioned2.hpp
@@ -63,25 +63,25 @@ class TESTOBJECT_EXPORT PdxVersioned2 : public PdxSerializable {
 
   std::string m_string;
 
-  bool* m_boolArray;
-  int8_t* m_byteArray;
-  int8_t* m_sbyteArray;  ///
+  std::vector<bool> m_boolArray;
+  std::vector<int8_t> m_byteArray;
+  std::vector<int8_t> m_sbyteArray;  ///
 
-  char16_t* m_charArray;
+  std::vector<char16_t> m_charArray;
 
   std::shared_ptr<CacheableDate> m_date;
 
-  int16_t* m_int16Array;
-  int16_t* m_uint16Array;
+  std::vector<int16_t> m_int16Array;
+  std::vector<int16_t> m_uint16Array;
 
-  int32_t* m_int32Array;
-  int32_t* m_uint32Array;
+  std::vector<int32_t> m_int32Array;
+  std::vector<int32_t> m_uint32Array;
 
-  int64_t* m_longArray;
-  int64_t* m_ulongArray;
+  std::vector<int64_t> m_longArray;
+  std::vector<int64_t> m_ulongArray;
 
-  float* m_floatArray;
-  double* m_doubleArray;
+  std::vector<float> m_floatArray;
+  std::vector<double> m_doubleArray;
 
   int8_t** m_byteByteArray;
 
@@ -89,10 +89,10 @@ class TESTOBJECT_EXPORT PdxVersioned2 : public PdxSerializable {
   std::shared_ptr<CacheableArrayList> m_arraylist;
   std::shared_ptr<CacheableHashMap> m_map;
 
-  int8_t* m_byte252;
-  int8_t* m_byte253;
-  int8_t* m_byte65535;
-  int8_t* m_byte65536;
+  std::vector<int8_t> m_byte252;
+  std::vector<int8_t> m_byte253;
+  std::vector<int8_t> m_byte65535;
+  std::vector<int8_t> m_byte65536;
   enum pdxEnumTest { pdx1, pdx2, pdx3, pdx4 };
   std::shared_ptr<Cacheable> m_pdxEnum;
 
@@ -139,7 +139,7 @@ class TESTOBJECT_EXPORT PdxVersioned2 : public PdxSerializable {
   // void checkNullAndDelete(void *data);
   char16_t getChar() { return m_char; }
 
-  char16_t* getCharArray() { return m_charArray; }
+  std::vector<char16_t> getCharArray() { return m_charArray; }
 
   int8_t** getArrayOfByteArrays() { return m_byteByteArray; }
 
@@ -155,21 +155,21 @@ class TESTOBJECT_EXPORT PdxVersioned2 : public PdxSerializable {
 
   int64_t getULong() { return m_ulong; }
 
-  int16_t* getUInt16Array() { return m_uint16Array; }
+  std::vector<int16_t> getUInt16Array() { return m_uint16Array; }
 
-  int32_t* getUIntArray() { return m_uint32Array; }
+  std::vector<int32_t> getUIntArray() { return m_uint32Array; }
 
-  int64_t* getULongArray() { return m_ulongArray; }
+  std::vector<int64_t> getULongArray() { return m_ulongArray; }
 
-  int8_t* getByte252() { return m_byte252; }
+  std::vector<int8_t> getByte252() { return m_byte252; }
 
-  int8_t* getByte253() { return m_byte253; }
+  std::vector<int8_t> getByte253() { return m_byte253; }
 
-  int8_t* getByte65535() { return m_byte65535; }
+  std::vector<int8_t> getByte65535() { return m_byte65535; }
 
-  int8_t* getByte65536() { return m_byte65536; }
+  std::vector<int8_t> getByte65536() { return m_byte65536; }
 
-  int8_t* getSByteArray() { return m_sbyteArray; }
+  std::vector<int8_t> getSByteArray() { return m_sbyteArray; }
 
   std::shared_ptr<CacheableArrayList> getArrayList() { return m_arraylist; }
 
@@ -187,19 +187,19 @@ class TESTOBJECT_EXPORT PdxVersioned2 : public PdxSerializable {
 
   const std::string& getString() { return m_string; }
 
-  bool* getBoolArray() { return m_boolArray; }
+  std::vector<bool> getBoolArray() { return m_boolArray; }
 
-  int8_t* getByteArray() { return m_byteArray; }
+  std::vector<int8_t> getByteArray() { return m_byteArray; }
 
-  int16_t* getShortArray() { return m_int16Array; }
+  std::vector<int16_t> getShortArray() { return m_int16Array; }
 
-  int32_t* getIntArray() { return m_int32Array; }
+  std::vector<int32_t> getIntArray() { return m_int32Array; }
 
-  int64_t* getLongArray() { return m_longArray; }
+  std::vector<int64_t> getLongArray() { return m_longArray; }
 
-  double* getDoubleArray() { return m_doubleArray; }
+  std::vector<double> getDoubleArray() { return m_doubleArray; }
 
-  float* getFloatArray() { return m_floatArray; }
+  std::vector<float> getFloatArray() { return m_floatArray; }
 
   const std::vector<std::string>& getStringArray() { return m_stringArray; }
 

--- a/tests/cpp/testobject/PortfolioPdx.cpp
+++ b/tests/cpp/testobject/PortfolioPdx.cpp
@@ -47,7 +47,7 @@ PortfolioPdx::PortfolioPdx(int32_t i, int32_t size, std::vector<std::string> nm)
       CacheableString::create(secIds[PositionPdx::cnt % numSecIds]), position1);
 
   if (size > 0) {
-    newVal = new int8_t[size];
+    newVal = std::vector<int8_t>(size);
     for (int index = 0; index < size; index++) {
       newVal[index] = static_cast<int8_t>('B');
     }
@@ -56,15 +56,7 @@ PortfolioPdx::PortfolioPdx(int32_t i, int32_t size, std::vector<std::string> nm)
 
   time_t timeVal = 1310447869;
   creationDate = CacheableDate::create(timeVal);
-  arrayNull = NULL;
-  arrayZeroSize = new int8_t[0];
-}
-
-PortfolioPdx::~PortfolioPdx() {
-  if (newVal != NULL) {
-    delete[] newVal;
-    newVal = NULL;
-  }
+  arrayZeroSize = std::vector<int8_t>(0);
 }
 
 void PortfolioPdx::toData(PdxWriter& pw) const {
@@ -92,14 +84,14 @@ void PortfolioPdx::toData(PdxWriter& pw) const {
   pw.writeStringArray("names", names);
   pw.markIdentityField("names");
 
-  pw.writeByteArray("newVal", newVal, newValSize);
+  pw.writeByteArray("newVal", newVal);
   pw.markIdentityField("newVal");
 
   pw.writeDate("creationDate", creationDate);
   pw.markIdentityField("creationDate");
 
-  pw.writeByteArray("arrayNull", arrayNull, 0);
-  pw.writeByteArray("arrayZeroSize", arrayZeroSize, 0);
+  pw.writeByteArray("arrayNull", arrayNull);
+  pw.writeByteArray("arrayZeroSize", arrayZeroSize);
 }
 
 void PortfolioPdx::fromData(PdxReader& pr) {
@@ -116,12 +108,12 @@ void PortfolioPdx::fromData(PdxReader& pr) {
   int32_t strLenArray = 0;
   names = pr.readStringArray("names");
   int32_t byteArrayLen = 0;
-  newVal = pr.readByteArray("newVal", byteArrayLen);
+  newVal = pr.readByteArray("newVal");
   creationDate = pr.readDate("creationDate");
   int32_t arrayNullLen = 0;
-  arrayNull = pr.readByteArray("arrayNull", arrayNullLen);
+  arrayNull = pr.readByteArray("arrayNull");
   int32_t arrayZeroSizeLen = 0;
-  arrayZeroSize = pr.readByteArray("arrayZeroSize", arrayZeroSizeLen);
+  arrayZeroSize = pr.readByteArray("arrayZeroSize");
 }
 std::string PortfolioPdx::toString() const {
   LOGINFO("PortfolioPdx::toString() Start");

--- a/tests/cpp/testobject/PortfolioPdx.hpp
+++ b/tests/cpp/testobject/PortfolioPdx.hpp
@@ -43,11 +43,11 @@ class TESTOBJECT_EXPORT PortfolioPdx : public PdxSerializable {
   std::string status;
   std::vector<std::string> names;
   static const char* secIds[];
-  int8_t* newVal;
+  std::vector<int8_t> newVal;
   int32_t newValSize;
   std::shared_ptr<CacheableDate> creationDate;
-  int8_t* arrayNull;
-  int8_t* arrayZeroSize;
+  std::vector<int8_t> arrayNull;
+  std::vector<int8_t> arrayZeroSize;
 
  public:
   PortfolioPdx()
@@ -55,14 +55,12 @@ class TESTOBJECT_EXPORT PortfolioPdx : public PdxSerializable {
         pkid(),
         type(),
         status(),
-        newVal(NULL),
+        newVal(),
         creationDate(nullptr),
-        arrayNull(NULL),
-        arrayZeroSize(NULL) {}
+        arrayNull(),
+        arrayZeroSize() {}
 
   PortfolioPdx(int32_t id, int32_t size = 0, std::vector<std::string> nm = {});
-
-  virtual ~PortfolioPdx();
 
   int32_t getID() { return id; }
 
@@ -80,7 +78,7 @@ class TESTOBJECT_EXPORT PortfolioPdx : public PdxSerializable {
 
   bool isActive() { return status == "active"; }
 
-  int8_t* getNewVal() { return newVal; }
+  std::vector<int8_t> getNewVal() { return newVal; }
 
   int32_t getNewValSize() { return newValSize; }
 
@@ -88,9 +86,9 @@ class TESTOBJECT_EXPORT PortfolioPdx : public PdxSerializable {
 
   std::shared_ptr<CacheableDate> getCreationDate() { return creationDate; }
 
-  int8_t* getArrayNull() { return arrayNull; }
+  std::vector<int8_t> getArrayNull() { return arrayNull; }
 
-  int8_t* getArrayZeroSize() { return arrayZeroSize; }
+  std::vector<int8_t> getArrayZeroSize() { return arrayZeroSize; }
 
   static PdxSerializable* createDeserializable() { return new PortfolioPdx(); }
 

--- a/tests/cpp/testobject/VariousPdxTypes.cpp
+++ b/tests/cpp/testobject/VariousPdxTypes.cpp
@@ -328,7 +328,7 @@ void PdxTypes5::fromData(PdxReader &pr) {
 PdxTypes6::PdxTypes6() {
   m_s1 = "one";
   m_s2 = "two";
-  bytes128 = new int8_t[2];
+  bytes128 = std::vector<int8_t>(2);
   bytes128[0] = 0x34;
   ;
   bytes128[1] = 0x64;
@@ -389,7 +389,7 @@ std::string PdxTypes6::toString() const {
 void PdxTypes6::toData(PdxWriter &pw) const {
   pw.writeString("s1", m_s1);
   pw.writeInt("i1", m_i1);
-  pw.writeByteArray("bytes128", bytes128, 2);
+  pw.writeByteArray("bytes128", bytes128);
   pw.writeInt("i2", m_i2);
   pw.writeInt("i3", m_i3);
   pw.writeInt("i4", m_i4);
@@ -403,7 +403,7 @@ void PdxTypes6::fromData(PdxReader &pr) {
   m_i1 = pr.readInt("i1");
   // LOGDEBUG("PdxTypes6::fromData m_i1 = %d", m_i1);
   int32_t byteArrLen = 0;
-  bytes128 = pr.readByteArray("bytes128", byteArrLen);
+  bytes128 = pr.readByteArray("bytes128");
   m_i2 = pr.readInt("i2");
   // LOGDEBUG("PdxTypes6::fromData m_i2 = %d", m_i2);
 
@@ -424,7 +424,7 @@ PdxTypes7::PdxTypes7() {
   m_s1 = "one";
   m_s2 = "two";
   m_i1 = 34324;
-  bytes38000 = new int8_t[38000];
+  bytes38000 = std::vector<int8_t>(38000);
   m_i2 = 2144;
   m_i3 = 4645734;
   m_i4 = 73567;
@@ -467,7 +467,7 @@ std::string PdxTypes7::toString() const {
    pw.writeInt("i1", m_i1);
    pw.writeInt("i2", m_i2);
    pw.writeString("s1", m_s1);
-   pw.writeByteArray("bytes38000", bytes38000, 2);
+   pw.writeByteArray("bytes38000", bytes38000);
    pw.writeInt("i3", m_i3);
    pw.writeInt("i4", m_i4);
    pw.writeString("s2", m_s2);
@@ -478,7 +478,7 @@ std::string PdxTypes7::toString() const {
    m_i2 = pr.readInt("i2");
    m_s1 = pr.readString("s1");
    int32_t byteArrLen = 0;
-   bytes38000 = pr.readByteArray("bytes38000", byteArrLen);
+   bytes38000 = pr.readByteArray("bytes38000");
    m_i3 = pr.readInt("i3");
    m_i4 = pr.readInt("i4");
    m_s2 = pr.readString("s2");
@@ -492,14 +492,12 @@ PdxTypes8::PdxTypes8() {
   m_s1 = "one";
   m_s2 = "two";
   m_i1 = 34324;
-  bytes300 = new int8_t[300];
+  bytes300 = std::vector<int8_t>(300);
   _enum = CacheableEnum::create("PdxTests.pdxEnumTest", "pdx2", pdx2);
   m_i2 = 2144;
   m_i3 = 4645734;
   m_i4 = 73567;
 }
-
-PdxTypes8::~PdxTypes8() { delete[] bytes300; }
 
 int32_t PdxTypes8::getHashCode() { return 1; }
 
@@ -534,7 +532,7 @@ std::string PdxTypes8::toString() const {
    pw.writeInt("i1", m_i1);
    pw.writeInt("i2", m_i2);
    pw.writeString("s1", m_s1);
-   pw.writeByteArray("bytes300", bytes300, 2);
+   pw.writeByteArray("bytes300", bytes300);
    pw.writeObject("_enum", _enum);
    pw.writeString("s2", m_s2);
    pw.writeInt("i3", m_i3);
@@ -546,7 +544,7 @@ std::string PdxTypes8::toString() const {
    m_i2 = pr.readInt("i2");
    m_s1 = pr.readString("s1");
    int32_t byteArrLen = 0;
-   bytes300 = pr.readByteArray("bytes300", byteArrLen);
+   bytes300 = pr.readByteArray("bytes300");
    _enum = pr.readObject("_enum");
    m_s2 = pr.readString("s2");
    m_i3 = pr.readInt("i3");
@@ -560,12 +558,10 @@ PdxTypes9::PdxTypes9() {
   m_s1 = "one";
   m_s2 = "two";
   m_s3 = "three";
-  m_bytes66000 = new int8_t[66000];
+  m_bytes66000 = std::vector<int8_t>(66000);
   m_s4 = "four";
   m_s5 = "five";
 }
-
-PdxTypes9::~PdxTypes9() { delete[] m_bytes66000; }
 
 int32_t PdxTypes9::getHashCode() { return 1; }
 
@@ -597,7 +593,7 @@ std::string PdxTypes9::toString() const {
 void PdxTypes9::toData(PdxWriter &pw) const {
   pw.writeString("s1", m_s1);
   pw.writeString("s2", m_s2);
-  pw.writeByteArray("bytes66000", m_bytes66000, 2);
+  pw.writeByteArray("bytes66000", m_bytes66000);
   pw.writeString("s3", m_s3);
   pw.writeString("s4", m_s4);
   pw.writeString("s5", m_s5);
@@ -607,7 +603,7 @@ void PdxTypes9::fromData(PdxReader &pr) {
   m_s1 = pr.readString("s1");
   m_s2 = pr.readString("s2");
   int32_t byteArrLen = 0;
-  m_bytes66000 = pr.readByteArray("bytes66000", byteArrLen);
+  m_bytes66000 = pr.readByteArray("bytes66000");
   m_s3 = pr.readString("s3");
   m_s4 = pr.readString("s4");
   m_s5 = pr.readString("s5");
@@ -620,12 +616,10 @@ PdxTypes10::PdxTypes10() {
   m_s1 = "one";
   m_s2 = "two";
   m_s3 = "three";
-  m_bytes66000 = new int8_t[66000];
+  m_bytes66000 = std::vector<int8_t>(66000);
   m_s4 = "four";
   m_s5 = "five";
 }
-
-PdxTypes10::~PdxTypes10() { delete[] m_bytes66000; }
 
 int32_t PdxTypes10::getHashCode() { return 1; }
 
@@ -657,7 +651,7 @@ std::string PdxTypes10::toString() const {
 void PdxTypes10::toData(PdxWriter &pw) const {
   pw.writeString("s1", m_s1);
   pw.writeString("s2", m_s2);
-  pw.writeByteArray("bytes66000", m_bytes66000, 2);
+  pw.writeByteArray("bytes66000", m_bytes66000);
   pw.writeString("s3", m_s3);
   pw.writeString("s4", m_s4);
   pw.writeString("s5", m_s5);
@@ -667,7 +661,7 @@ void PdxTypes10::fromData(PdxReader &pr) {
   m_s1 = pr.readString("s1");
   m_s2 = pr.readString("s2");
   int32_t byteArrLen = 0;
-  m_bytes66000 = pr.readByteArray("bytes66000", byteArrLen);
+  m_bytes66000 = pr.readByteArray("bytes66000");
   m_s3 = pr.readString("s3");
   m_s4 = pr.readString("s4");
   m_s5 = pr.readString("s5");

--- a/tests/cpp/testobject/VariousPdxTypes.hpp
+++ b/tests/cpp/testobject/VariousPdxTypes.hpp
@@ -232,7 +232,7 @@ class TESTOBJECT_EXPORT PdxTypes6 : public PdxSerializable {
  private:
   std::string m_s1;  //"one"
   std::string m_s2;
-  int8_t* bytes128;
+  std::vector<int8_t> bytes128;
   int32_t m_i1;
   int32_t m_i2;
   int32_t m_i3;
@@ -272,7 +272,7 @@ class TESTOBJECT_EXPORT PdxTypes7 : public PdxSerializable {
   std::string m_s1;  //"one"
   std::string m_s2;
   int32_t m_i1;
-  int8_t* bytes38000;
+  std::vector<int8_t> bytes38000;
   int32_t m_i2;
   int32_t m_i3;
   int32_t m_i4;
@@ -312,7 +312,7 @@ class TESTOBJECT_EXPORT PdxTypes8 : public PdxSerializable {
   std::string m_s1;  //"one"
   std::string m_s2;
   int32_t m_i1;
-  int8_t* bytes300;
+  std::vector<int8_t> bytes300;
   std::shared_ptr<Cacheable> _enum;
   int32_t m_i2;
   int32_t m_i3;
@@ -320,8 +320,6 @@ class TESTOBJECT_EXPORT PdxTypes8 : public PdxSerializable {
 
  public:
   PdxTypes8();
-
-  virtual ~PdxTypes8();
 
   int32_t getHashCode();
 
@@ -352,14 +350,12 @@ class TESTOBJECT_EXPORT PdxTypes9 : public PdxSerializable {
   std::string m_s1;  //"one"
   std::string m_s2;
   std::string m_s3;
-  int8_t* m_bytes66000;
+  std::vector<int8_t> m_bytes66000;
   std::string m_s4;
   std::string m_s5;
 
  public:
   PdxTypes9();
-
-  virtual ~PdxTypes9();
 
   int32_t getHashCode();
 
@@ -391,14 +387,12 @@ class TESTOBJECT_EXPORT PdxTypes10 : public PdxSerializable {
   std::string m_s1;  //"one"
   std::string m_s2;
   std::string m_s3;
-  int8_t* m_bytes66000;
+  std::vector<int8_t> m_bytes66000;
   std::string m_s4;
   std::string m_s5;
 
  public:
   PdxTypes10();
-
-  virtual ~PdxTypes10();
 
   int32_t getHashCode();
 


### PR DESCRIPTION
It is probably worth noting that this change also removes support for nullable arrays.

Testing: C++/.NET unit/integration tests passed on Linux, Windows, and Mac