### PR TITLE
GEODE-4426: Refactor PdxFieldTypes as enum class.

### DIFF
--- a/cppcache/include/geode/PdxFieldTypes.hpp
+++ b/cppcache/include/geode/PdxFieldTypes.hpp
@@ -20,39 +20,36 @@
 #ifndef GEODE_PDXFIELDTYPES_H_
 #define GEODE_PDXFIELDTYPES_H_
 
-#include "internal/geode_base.hpp"
-
 namespace apache {
 namespace geode {
 namespace client {
 
-class _GEODE_EXPORT PdxFieldTypes {
- public:
-  enum PdxFieldType {
-    BOOLEAN,
-    BYTE,
-    CHAR,
-    SHORT,
-    INT,
-    LONG,
-    FLOAT,
-    DOUBLE,
-    DATE,
-    STRING,
-    OBJECT,
-    BOOLEAN_ARRAY,
-    CHAR_ARRAY,
-    BYTE_ARRAY,
-    SHORT_ARRAY,
-    INT_ARRAY,
-    LONG_ARRAY,
-    FLOAT_ARRAY,
-    DOUBLE_ARRAY,
-    STRING_ARRAY,
-    OBJECT_ARRAY,
-    ARRAY_OF_BYTE_ARRAYS
-  };
+enum class PdxFieldTypes : int8_t {
+  UNKNOWN = 0,
+  BOOLEAN,
+  BYTE,
+  CHAR,
+  SHORT,
+  INT,
+  LONG,
+  FLOAT,
+  DOUBLE,
+  DATE,
+  STRING,
+  OBJECT,
+  BOOLEAN_ARRAY,
+  CHAR_ARRAY,
+  BYTE_ARRAY,
+  SHORT_ARRAY,
+  INT_ARRAY,
+  LONG_ARRAY,
+  FLOAT_ARRAY,
+  DOUBLE_ARRAY,
+  STRING_ARRAY,
+  OBJECT_ARRAY,
+  ARRAY_OF_BYTE_ARRAYS
 };
+
 }  // namespace client
 }  // namespace geode
 }  // namespace apache

--- a/cppcache/include/geode/PdxInstance.hpp
+++ b/cppcache/include/geode/PdxInstance.hpp
@@ -509,7 +509,7 @@ class _GEODE_EXPORT PdxInstance : public PdxSerializable {
    * @throws IllegalStateException if the PdxInstance typeid is not defined yet,
    * to get classname or if PdxType is not defined for PdxInstance.
    */
-  virtual PdxFieldTypes::PdxFieldType getFieldType(
+  virtual PdxFieldTypes getFieldType(
       const std::string& fieldname) const = 0;
 
  protected:

--- a/cppcache/src/PdxFieldType.cpp
+++ b/cppcache/src/PdxFieldType.cpp
@@ -37,7 +37,7 @@ PdxFieldType::PdxFieldType()
     : Serializable(),
       m_fieldName(),
       m_className(),
-      m_typeId(0),
+      m_typeId(PdxFieldTypes::UNKNOWN),
       m_sequenceId(0),
       m_isVariableLengthType(false),
       m_fixedSize(0),
@@ -47,7 +47,7 @@ PdxFieldType::PdxFieldType()
       m_vlOffsetIndex(0) {}
 
 PdxFieldType::PdxFieldType(std::string fieldName, std::string className,
-                           uint8_t typeId, int32_t sequenceId,
+                           PdxFieldTypes typeId, int32_t sequenceId,
                            bool isVariableLengthType, int32_t fixedSize,
                            int32_t varLenFieldIdx)
     : Serializable(),
@@ -68,7 +68,7 @@ void PdxFieldType::toData(DataOutput& output) const {
   output.writeString(m_fieldName);
   output.writeInt(m_sequenceId);
   output.writeInt(m_varLenFieldIdx);
-  output.write(m_typeId);
+  output.write(static_cast<int8_t>(m_typeId));
 
   output.writeInt(m_relativeOffset);
   output.writeInt(m_vlOffsetIndex);
@@ -79,7 +79,7 @@ void PdxFieldType::fromData(DataInput& input) {
   m_fieldName = input.readString();
   m_sequenceId = input.readInt32();
   m_varLenFieldIdx = input.readInt32();
-  m_typeId = input.read();
+  m_typeId = PdxFieldTypes(input.read());
   m_relativeOffset = input.readInt32();
   m_vlOffsetIndex = input.readInt32();
   m_isIdentityField = input.readBoolean();
@@ -138,7 +138,7 @@ std::string PdxFieldType::toString() const {
   char stringBuf[1024];
   ACE_OS::snprintf(
       stringBuf, 1024,
-      " PdxFieldName=%s TypeId=%d VarLenFieldIdx=%d sequenceid=%d\n",
+      " PdxFieldName=%s TypeId=%hhd VarLenFieldIdx=%d sequenceid=%d\n",
       this->m_fieldName.c_str(), this->m_typeId, this->m_varLenFieldIdx,
       this->m_sequenceId);
   return std::string(stringBuf);

--- a/cppcache/src/PdxFieldType.hpp
+++ b/cppcache/src/PdxFieldType.hpp
@@ -20,24 +20,24 @@
 #ifndef GEODE_PDXFIELDTYPE_H_
 #define GEODE_PDXFIELDTYPE_H_
 
+#include <string>
+
 #include <geode/internal/geode_globals.hpp>
 #include <geode/Serializable.hpp>
 #include <geode/CacheableString.hpp>
 #include <geode/DataInput.hpp>
 #include <geode/DataOutput.hpp>
-#include <string>
+#include <geode/PdxFieldTypes.hpp>
 
 namespace apache {
 namespace geode {
 namespace client {
 
-class PdxFieldType;
-
 class _GEODE_EXPORT PdxFieldType : public Serializable {
  private:
   std::string m_fieldName;
   std::string m_className;
-  uint8_t m_typeId;
+  PdxFieldTypes m_typeId;
   uint32_t m_sequenceId;
 
   bool m_isVariableLengthType;
@@ -51,7 +51,7 @@ class _GEODE_EXPORT PdxFieldType : public Serializable {
   int32_t getFixedTypeSize() const;
 
  public:
-  PdxFieldType(std::string fieldName, std::string className, uint8_t typeId,
+  PdxFieldType(std::string fieldName, std::string className, PdxFieldTypes typeId,
                int32_t sequenceId, bool isVariableLengthType, int32_t fixedSize,
                int32_t varLenFieldIdx);
 
@@ -61,7 +61,7 @@ class _GEODE_EXPORT PdxFieldType : public Serializable {
 
   inline const char* getClassName() { return m_className.c_str(); }
 
-  inline uint8_t getTypeId() { return m_typeId; }
+  inline PdxFieldTypes getTypeId() { return m_typeId; }
 
   inline uint8_t getSequenceId() { return m_sequenceId; }
 
@@ -86,7 +86,7 @@ class _GEODE_EXPORT PdxFieldType : public Serializable {
 
   virtual void fromData(DataInput& input) override;
 
-  virtual int32_t classId() const override { return m_typeId; }
+  virtual int32_t classId() const override { return static_cast<int32_t>(m_typeId); }
 
   virtual size_t objectSize() const override {
     auto size = sizeof(PdxFieldType);

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -57,7 +57,7 @@ int8_t PdxInstanceImpl::m_ObjectDefaultBytes[] = {
     apache::geode::client::GeodeTypeIds::NullObj};
 int8_t PdxInstanceImpl::m_NULLARRAYDefaultBytes[] = {-1};
 std::shared_ptr<PdxFieldType> PdxInstanceImpl::m_DefaultPdxFieldType(
-    new PdxFieldType("default", "default", static_cast<uint8_t>(-1),
+    new PdxFieldType("default", "default", PdxFieldTypes::UNKNOWN,
                      -1 /*field index*/, false, 1, -1 /*var len field idx*/));
 
 bool sortFunc(std::shared_ptr<PdxFieldType> field1,
@@ -91,7 +91,8 @@ PdxInstanceImpl::PdxInstanceImpl(
 }
 
 void PdxInstanceImpl::writeField(PdxWriter& writer,
-                                 const std::string& fieldName, int typeId,
+                                 const std::string& fieldName,
+                                 PdxFieldTypes typeId,
                                  std::shared_ptr<Cacheable> value) {
   switch (typeId) {
     case PdxFieldTypes::INT: {
@@ -733,7 +734,7 @@ int32_t PdxInstanceImpl::hashcode() const {
          * Use snprintf() instead, or correct precision specifiers.
          * Fix : using ACE_OS::snprintf
          */
-        ACE_OS::snprintf(excpStr, 256, "PdxInstance not found typeid %d ",
+        ACE_OS::snprintf(excpStr, 256, "PdxInstance not found typeid %hhd ",
                          pField->getTypeId());
         throw IllegalStateException(excpStr);
       }
@@ -1203,7 +1204,7 @@ bool PdxInstanceImpl::operator==(const CacheableKey& other) const {
   auto otherDataInput =
       m_cache->createDataInput(otherPdx->m_buffer, otherPdx->m_bufferLength);
 
-  int fieldTypeId = -1;
+  PdxFieldTypes fieldTypeId;
   for (size_t i = 0; i < myPdxIdentityFieldList.size(); i++) {
     auto myPFT = myPdxIdentityFieldList.at(i);
     auto otherPFT = otherPdxIdentityFieldList.at(i);
@@ -1300,7 +1301,7 @@ bool PdxInstanceImpl::operator==(const CacheableKey& other) const {
          * Use snprintf() instead, or correct precision specifiers.
          * Fix : using ACE_OS::snprintf
          */
-        ACE_OS::snprintf(excpStr, 256, "PdxInstance not found typeid  %d ",
+        ACE_OS::snprintf(excpStr, 256, "PdxInstance not found typeid  %hhd ",
                          myPFT->getTypeId());
         throw IllegalStateException(excpStr);
       }
@@ -1377,7 +1378,7 @@ std::shared_ptr<CacheableStringArray> PdxInstanceImpl::getFieldNames() {
   return nullptr;
 }
 
-PdxFieldTypes::PdxFieldType PdxInstanceImpl::getFieldType(
+PdxFieldTypes PdxInstanceImpl::getFieldType(
     const std::string& fieldname) const {
   auto pt = getPdxType();
   auto pft = pt->getPdxField(fieldname.c_str());
@@ -1386,7 +1387,7 @@ PdxFieldTypes::PdxFieldType PdxInstanceImpl::getFieldType(
     throw IllegalStateException("PdxInstance doesn't have field " + fieldname);
   }
 
-  return static_cast<PdxFieldTypes::PdxFieldType>(pft->getTypeId());
+  return pft->getTypeId();
 }
 
 void PdxInstanceImpl::writeUnmodifieldField(DataInput& dataInput, int startPos,

--- a/cppcache/src/PdxInstanceImpl.hpp
+++ b/cppcache/src/PdxInstanceImpl.hpp
@@ -204,7 +204,7 @@ class _GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
 
   virtual const std::string& getClassName() const override;
 
-  virtual PdxFieldTypes::PdxFieldType getFieldType(
+  virtual PdxFieldTypes getFieldType(
       const std::string& fieldname) const override;
 
   void setPdxId(int32_t typeId);
@@ -276,8 +276,8 @@ class _GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
   bool compareDefaultBytes(DataInput& dataInput, int start, int end,
                            int8_t* defaultBytes, int32_t length) const;
 
-  void writeField(PdxWriter& writer, const std::string& fieldName, int typeId,
-                  std::shared_ptr<Cacheable> value);
+  void writeField(PdxWriter& writer, const std::string& fieldName,
+                  PdxFieldTypes typeId, std::shared_ptr<Cacheable> value);
 
   void writeUnmodifieldField(DataInput& dataInput, int startPos, int endPos,
                              PdxLocalWriter& localWriter);

--- a/cppcache/src/PdxLocalReader.cpp
+++ b/cppcache/src/PdxLocalReader.cpp
@@ -299,12 +299,6 @@ bool PdxLocalReader::isIdentityField(const std::string& fieldName) {
   return (pft != nullptr) && (pft->getIdentityField());
 }
 
-void PdxLocalReader::readCollection(
-    const std::string& fieldName,
-    std::shared_ptr<CacheableArrayList>& collection) {
-  collection =
-      std::static_pointer_cast<CacheableArrayList>(m_dataInput->readObject());
-}
 std::shared_ptr<PdxUnreadFields> PdxLocalReader::readUnreadFields() {
   LOGDEBUG("readUnreadFields:: %d ignore property %d", m_isDataNeedToPreserve,
            m_pdxTypeRegistry->getPdxIgnoreUnreadFields());

--- a/cppcache/src/PdxLocalReader.hpp
+++ b/cppcache/src/PdxLocalReader.hpp
@@ -126,9 +126,6 @@ class PdxLocalReader : public PdxReader {
 
   virtual bool isIdentityField(const std::string &fieldName) override;
 
-  virtual void readCollection(const std::string &fieldName,
-                              std::shared_ptr<CacheableArrayList> &collection);
-
   virtual std::shared_ptr<PdxUnreadFields> readUnreadFields() override;
 
  protected:

--- a/cppcache/src/PdxReaderWithTypeCollector.cpp
+++ b/cppcache/src/PdxReaderWithTypeCollector.cpp
@@ -42,7 +42,7 @@ PdxReaderWithTypeCollector::PdxReaderWithTypeCollector(
 PdxReaderWithTypeCollector::~PdxReaderWithTypeCollector() {}
 
 void PdxReaderWithTypeCollector::checkType(const std::string& fieldName,
-                                           int8_t typeId,
+                                           PdxFieldTypes typeId,
                                            const std::string& fieldType) {
   auto pft = m_pdxType->getPdxField(fieldName);
   if (pft != nullptr) {
@@ -505,6 +505,7 @@ int8_t** PdxReaderWithTypeCollector::readArrayOfByteArrays(
     return nullptr;
   }
 }
+
 std::shared_ptr<CacheableDate> PdxReaderWithTypeCollector::readDate(
     const std::string& fieldName) {
   checkType(fieldName, PdxFieldTypes::DATE, "Date");
@@ -523,26 +524,6 @@ std::shared_ptr<CacheableDate> PdxReaderWithTypeCollector::readDate(
   }
 }
 
-void PdxReaderWithTypeCollector::readCollection(
-    const std::string& fieldName,
-    std::shared_ptr<CacheableArrayList>& collection) {
-  checkType(fieldName, apache::geode::client::GeodeTypeIds::CacheableArrayList,
-            "Collection");
-  m_newPdxType->addVariableLengthTypeField(
-      fieldName, "Collection",
-      apache::geode::client::GeodeTypeIds::CacheableArrayList);
-  int position = m_pdxType->getFieldPosition(fieldName, m_offsetsBuffer,
-                                             m_offsetSize, m_serializedLength);
-  LOGDEBUG("PdxReaderWithTypeCollector::readCollection() position = %d",
-           position);
-  if (position != -1) {
-    m_dataInput->advanceCursor(position);
-    PdxLocalReader::readCollection(fieldName, collection);
-    m_dataInput->rewindCursor(position);
-  } else {
-    collection = nullptr;
-  }
-}
 }  // namespace client
 }  // namespace geode
 }  // namespace apache

--- a/cppcache/src/PdxReaderWithTypeCollector.hpp
+++ b/cppcache/src/PdxReaderWithTypeCollector.hpp
@@ -31,7 +31,7 @@ class PdxReaderWithTypeCollector : public PdxLocalReader {
  private:
   std::shared_ptr<PdxType> m_newPdxType;
 
-  void checkType(const std::string& fieldName, int8_t typeId,
+  void checkType(const std::string& fieldName, PdxFieldTypes typeId,
                  const std::string& fieldType);
 
  public:
@@ -101,9 +101,6 @@ class PdxReaderWithTypeCollector : public PdxLocalReader {
   virtual std::shared_ptr<CacheableDate> readDate(
       const std::string& fieldName) override;
 
-  virtual void readCollection(
-      const std::string& fieldName,
-      std::shared_ptr<CacheableArrayList>& collection) override;
 };
 
 }  // namespace client

--- a/cppcache/src/PdxRemoteReader.cpp
+++ b/cppcache/src/PdxRemoteReader.cpp
@@ -607,6 +607,7 @@ int8_t** PdxRemoteReader::readArrayOfByteArrays(const std::string& fieldName,
     }
   }
 }
+
 std::shared_ptr<CacheableDate> PdxRemoteReader::readDate(
     const std::string& fieldName) {
   int choice = m_localToRemoteMap[m_currentIndex++];
@@ -629,36 +630,6 @@ std::shared_ptr<CacheableDate> PdxRemoteReader::readDate(
   }
 }
 
-void PdxRemoteReader::readCollection(
-    const std::string& fieldName,
-    std::shared_ptr<CacheableArrayList>& collection) {
-  int choice = m_localToRemoteMap[m_currentIndex++];
-
-  switch (choice) {
-    case -2: {
-      PdxLocalReader::readCollection(fieldName, collection);  // in same order
-      break;
-    }
-    case -1: {
-      collection = nullptr;
-      break;  // null value
-    }
-    default: {
-      // sequence id read field and then update
-      int position = m_pdxType->getFieldPosition(
-          choice, m_offsetsBuffer, m_offsetSize, m_serializedLength);
-      if (position != -1) {
-        PdxLocalReader::resettoPdxHead();
-        m_dataInput->advanceCursor(position);
-        PdxLocalReader::readCollection(fieldName, collection);
-        PdxLocalReader::resettoPdxHead();
-      } else {
-        collection = nullptr;
-      }
-      break;
-    }
-  }
-}
 }  // namespace client
 }  // namespace geode
 }  // namespace apache

--- a/cppcache/src/PdxRemoteReader.hpp
+++ b/cppcache/src/PdxRemoteReader.hpp
@@ -98,9 +98,6 @@ class PdxRemoteReader : public PdxLocalReader {
   virtual std::shared_ptr<CacheableDate> readDate(
       const std::string& fieldName) override;
 
-  virtual void readCollection(
-      const std::string& fieldName,
-      std::shared_ptr<CacheableArrayList>& collection) override;
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/src/PdxType.cpp
+++ b/cppcache/src/PdxType.cpp
@@ -125,7 +125,7 @@ void PdxType::fromData(DataInput& input) {
 
 void PdxType::addFixedLengthTypeField(const std::string& fieldName,
                                       const std::string& className,
-                                      int8_t typeId, int32_t size) {
+                                      PdxFieldTypes typeId, int32_t size) {
   if (m_fieldNameVsPdxType.find(fieldName) != m_fieldNameVsPdxType.end()) {
     throw IllegalStateException("Field: " + fieldName +
                                 " is already added to PdxWriter");
@@ -139,7 +139,7 @@ void PdxType::addFixedLengthTypeField(const std::string& fieldName,
 
 void PdxType::addVariableLengthTypeField(const std::string& fieldName,
                                          const std::string& className,
-                                         int8_t typeId) {
+                                         PdxFieldTypes typeId) {
   if (m_fieldNameVsPdxType.find(fieldName) != m_fieldNameVsPdxType.end()) {
     throw IllegalStateException("Field: " + fieldName +
                                 " is already added to PdxWriter");

--- a/cppcache/src/PdxType.hpp
+++ b/cppcache/src/PdxType.hpp
@@ -30,6 +30,7 @@
 
 #include <geode/Serializable.hpp>
 #include <geode/CacheableBuiltins.hpp>
+#include <geode/PdxFieldTypes.hpp>
 
 #include "PdxFieldType.hpp"
 #include "ReadWriteLock.hpp"
@@ -182,10 +183,11 @@ class PdxType : public Serializable,
   }
 
   void addFixedLengthTypeField(const std::string& fieldName,
-                               const std::string& className, int8_t typeId,
-                               int32_t size);
+                               const std::string& className,
+                               PdxFieldTypes typeId, int32_t size);
   void addVariableLengthTypeField(const std::string& fieldName,
-                                  const std::string& className, int8_t typeId);
+                                  const std::string& className,
+                                  PdxFieldTypes typeId);
   void InitializeType();
   std::shared_ptr<PdxType> mergeVersion(std::shared_ptr<PdxType> otherVersion);
   int32_t getFieldPosition(const std::string& fieldName,


### PR DESCRIPTION
- Removes unused readCollection, which had an undefined PDX field type.