### PR TITLE
GEODE-4425: Replaces ACE map with std::unordered_map.

### DIFF
--- a/cppcache/include/geode/CacheableKey.hpp
+++ b/cppcache/include/geode/CacheableKey.hpp
@@ -109,17 +109,16 @@ class _GEODE_EXPORT CacheableKey : public Cacheable {
 
 using namespace apache::geode::client::internal;
 
-typedef std::unordered_map<std::shared_ptr<CacheableKey>,
-                           std::shared_ptr<Cacheable>,
-                           dereference_hash<std::shared_ptr<CacheableKey>>,
-                           dereference_equal_to<std::shared_ptr<CacheableKey>>>
-    HashMapOfCacheable;
+using HashMapOfCacheable =
+    std::unordered_map<std::shared_ptr<CacheableKey>,
+                       std::shared_ptr<Cacheable>,
+                       dereference_hash<std::shared_ptr<CacheableKey>>,
+                       dereference_equal_to<std::shared_ptr<CacheableKey>>>;
 
-typedef std::unordered_set<std::shared_ptr<CacheableKey>,
-                           dereference_hash<std::shared_ptr<CacheableKey>>,
-                           dereference_equal_to<std::shared_ptr<CacheableKey>>>
-    HashSetOfCacheableKey;
-
+using HashSetOfCacheableKey =
+    std::unordered_set<std::shared_ptr<CacheableKey>,
+                       dereference_hash<std::shared_ptr<CacheableKey>>,
+                       dereference_equal_to<std::shared_ptr<CacheableKey>>>;
 
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/Properties.hpp
+++ b/cppcache/include/geode/Properties.hpp
@@ -26,11 +26,11 @@
 
 #include <string>
 #include <memory>
+#include <unordered_map>
 
 #include "internal/geode_globals.hpp"
-#include "Serializable.hpp"
-#include "Serializable.hpp"
 #include "internal/chrono/duration.hpp"
+#include "CacheableKey.hpp"
 
 namespace apache {
 namespace geode {
@@ -40,16 +40,13 @@ using namespace apache::geode::internal::chrono::duration;
 
 class DataInput;
 class DataOutput;
-class CacheableKey;
 class CacheableString;
 
 /**
  * @class Properties Properties.hpp
  * Contains a set of (key, value) pair properties with key being the name of
  * the property; value, the value of the property.
- *
  */
-
 class _GEODE_EXPORT Properties : public Serializable {
  public:
   class Visitor {
@@ -161,17 +158,14 @@ class _GEODE_EXPORT Properties : public Serializable {
     return 0;  // don't care to set the right value
   }
 
-  /** destructor. */
-  ~Properties() noexcept;
+  ~Properties() override = default;
+  Properties(const Properties&) = delete;
+  Properties& operator=(const Properties&) = delete;
 
  private:
-  Properties();
+  HashMapOfCacheable m_map;
 
-  void* m_map;
-
- private:
-  Properties(const Properties&);
-  const Properties& operator=(const Properties&);
+  Properties() = default;
 
   _GEODE_FRIEND_STD_SHARED_PTR(Properties)
 };


### PR DESCRIPTION
You should notice that I dropped the half implemented thread safety in this class. Properties are never kept or shared between threads. I believe the original was made, incompletely, thread safe to mimic Java Properties class, which is fully synchronized.