### PR TITLE
GEODE-4899: Add missing patch to RHEL7

### DIFF
--- a/packer/rhel/install-build-rpms.sh
+++ b/packer/rhel/install-build-rpms.sh
@@ -6,9 +6,9 @@
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,4 +17,4 @@
 
 set -x -e -o pipefail
 
-yum install -y git2u make doxygen zlib-devel
+yum install -y git2u make doxygen zlib-devel patch


### PR DESCRIPTION
Cause apparently RHEL7 base image no longer has patch