### PR TITLE
Geode 3993 remove setPoolName from DataInput/OutputInternal

### DIFF
--- a/clicache/src/DataInput.cpp
+++ b/clicache/src/DataInput.cpp
@@ -1164,11 +1164,11 @@ namespace Apache
         }
       }
 
-      String^ DataInput::GetPoolName()
+      native::Pool* DataInput::GetPool()
       {
         try
         {
-          return marshal_as<String^>(native::DataInputInternal::getPoolName(*m_nativeptr));
+          return native::DataInputInternal::getPool(*m_nativeptr);
         }
         finally {
           GC::KeepAlive(m_nativeptr);

--- a/clicache/src/DataInput.hpp
+++ b/clicache/src/DataInput.hpp
@@ -308,7 +308,7 @@ namespace Apache
         /// </summary>
         String^ ReadASCIIHuge( );
 
-        String^ GetPoolName();
+        native::Pool* GetPool();
 
         Object^ ReadDotNetTypes(int8_t typeId);
 

--- a/clicache/src/DataOutput.cpp
+++ b/clicache/src/DataOutput.cpp
@@ -936,11 +936,11 @@ namespace Apache
         WriteObject<double>(doubleArray);
       }
 
-      String^ DataOutput::GetPoolName()
+      native::Pool* DataOutput::GetPool()
       {
         try
         {
-          return marshal_as<String^>(native::DataOutputInternal::getPoolName(*m_nativeptr));
+          return native::DataOutputInternal::getPool(*m_nativeptr);
         }
         finally
         {

--- a/clicache/src/DataOutput.hpp
+++ b/clicache/src/DataOutput.hpp
@@ -403,7 +403,7 @@ namespace Apache
           return m_cursor;
         }
 
-        String^ GetPoolName();
+        native::Pool* GetPool();
 
         void WriteStringArray(array<String^>^ strArray);
 

--- a/clicache/src/Serializable.cpp
+++ b/clicache/src/Serializable.cpp
@@ -248,16 +248,19 @@ namespace Apache
         return (Apache::Geode::Client::Serializable^)CacheableStringArray::Create(value);
       }
 
-      System::Int32 Serializable::GetPDXIdForType(String^ poolName, IGeodeSerializable^ pdxType, Cache^ cache)
+      System::Int32 Serializable::GetPDXIdForType(native::Pool* pool, IGeodeSerializable^ pdxType, Cache^ cache)
       {
         std::shared_ptr<native::Cacheable> kPtr(SafeMSerializableConvertGeneric(pdxType));
-        return CacheRegionHelper::getCacheImpl(cache->GetNative().get())->getSerializationRegistry()->GetPDXIdForType(cache->GetNative()->getPoolManager().find(marshal_as<std::string>(poolName)), kPtr);
+        return CacheRegionHelper::getCacheImpl(cache->GetNative().get())
+            ->getSerializationRegistry()
+            ->GetPDXIdForType(pool, kPtr);
       }
 
-      IGeodeSerializable^ Serializable::GetPDXTypeById(String^ poolName, System::Int32 typeId, Cache^ cache)
+      IGeodeSerializable^ Serializable::GetPDXTypeById(native::Pool* pool, System::Int32 typeId, Cache^ cache)
       {        
-        std::shared_ptr<apache::geode::client::Serializable> sPtr = 
-            CacheRegionHelper::getCacheImpl(cache->GetNative().get())->getSerializationRegistry()->GetPDXTypeById(cache->GetNative()->getPoolManager().find(marshal_as<std::string>(poolName)), typeId);
+        auto sPtr =  CacheRegionHelper::getCacheImpl(cache->GetNative().get())
+            ->getSerializationRegistry()
+            ->GetPDXTypeById(pool, typeId);
         return SafeUMSerializableConvertGeneric(sPtr);
       }
 

--- a/clicache/src/Serializable.hpp
+++ b/clicache/src/Serializable.hpp
@@ -249,8 +249,8 @@ namespace Apache
 
       internal:
         static std::shared_ptr<CacheableKey> wrapIGeodeSerializable(IGeodeSerializable^ managedObject);
-				static System::Int32 GetPDXIdForType(String^ poolName, IGeodeSerializable^ pdxType, Cache^ cache);
-				static IGeodeSerializable^ GetPDXTypeById(String^ poolName, System::Int32 typeId, Cache^ cache);
+				static System::Int32 GetPDXIdForType(native::Pool* pool, IGeodeSerializable^ pdxType, Cache^ cache);
+				static IGeodeSerializable^ GetPDXTypeById(native::Pool* pool, System::Int32 typeId, Cache^ cache);
 				static void RegisterPDXManagedCacheableKey(Cache^ cache);
         
         static int GetEnumValue(Internal::EnumInfo^ ei, Cache^ cache);

--- a/clicache/src/impl/PdxHelper.cpp
+++ b/clicache/src/impl/PdxHelper.cpp
@@ -73,7 +73,7 @@ namespace Apache
               PdxType^ piPt = pdxII->getPdxType();
               if(piPt != nullptr && piPt->TypeId == 0)//from pdxInstance factory need to get typeid from server
               {
-                int typeId = dataOutput->Cache->GetPdxTypeRegistry()->GetPDXIdForType(piPt, dataOutput->GetPoolName());
+                int typeId = dataOutput->Cache->GetPdxTypeRegistry()->GetPDXIdForType(piPt, dataOutput->GetPool());
                 pdxII->setPdxId(typeId);
               }
               PdxLocalWriter^ plw = gcnew PdxLocalWriter(dataOutput, piPt);  
@@ -108,7 +108,7 @@ namespace Apache
 
 						//get type id from server and then set it
             int nTypeId = dataOutput->Cache->GetPdxTypeRegistry()->GetPDXIdForType(pdxType, 
-																														dataOutput->GetPoolName(), nType, true);
+																														dataOutput->GetPool(), nType, true);
             nType->TypeId = nTypeId;
 
             ptc->EndObjectWriting();//now write typeid
@@ -200,7 +200,7 @@ namespace Apache
             {
               if(pType == nullptr)
               {
-                pType = (PdxType^)(Serializable::GetPDXTypeById(dataInput->GetPoolName(), typeId, dataInput->Cache));
+                pType = (PdxType^)(Serializable::GetPDXTypeById(dataInput->GetPool(), typeId, dataInput->Cache));
                 pdxLocalType = dataInput->Cache->GetPdxTypeRegistry()->GetLocalPdxType(pType->PdxClassName);//this should be fine for IPdxTypeMappers
               }
               
@@ -245,7 +245,7 @@ namespace Apache
                   //need to know local type and then merge type
                   pdxLocalType->InitializeType(dataInput->Cache);
                   pdxLocalType->TypeId = dataInput->Cache->GetPdxTypeRegistry()->GetPDXIdForType(pdxObject->GetType(), 
-																																				  dataInput->GetPoolName(), 
+																																				  dataInput->GetPool(), 
 																																				  pdxLocalType, true);
                   pdxLocalType->IsLocal = true;
                   dataInput->Cache->GetPdxTypeRegistry()->AddLocalPdxType(pdxClassname, pdxLocalType);//added local type
@@ -323,7 +323,7 @@ namespace Apache
 
             if(pType == nullptr)
             {
-              PdxType^ pType = (PdxType^)(Serializable::GetPDXTypeById(dataInput->GetPoolName(), typeId, dataInput->Cache));
+              PdxType^ pType = (PdxType^)(Serializable::GetPDXTypeById(dataInput->GetPool(), typeId, dataInput->Cache));
               //this should be fine for IPdxTypeMapper
               dataInput->Cache->GetPdxTypeRegistry()->AddLocalPdxType(pType->PdxClassName, pType);
               dataInput->Cache->GetPdxTypeRegistry()->AddPdxType(pType->TypeId, pType); 
@@ -379,7 +379,7 @@ namespace Apache
           {//need to create new version            
             mergedVersion->InitializeType(dataInput->Cache);
             if(mergedVersion->TypeId == 0)
-              mergedVersion->TypeId = Serializable::GetPDXIdForType(dataInput->GetPoolName(), mergedVersion, dataInput->Cache);              
+              mergedVersion->TypeId = Serializable::GetPDXIdForType(dataInput->GetPool(), mergedVersion, dataInput->Cache);              
             
            // dataInput->Cache->GetPdxTypeRegistry()->AddPdxType(remoteType->TypeId, mergedVersion);
             dataInput->Cache->GetPdxTypeRegistry()->AddPdxType(mergedVersion->TypeId, mergedVersion);  

--- a/clicache/src/impl/PdxTypeRegistry.cpp
+++ b/clicache/src/impl/PdxTypeRegistry.cpp
@@ -48,7 +48,7 @@ namespace Apache
 					return preserveData->Count;
 				}
 
-        Int32 PdxTypeRegistry::GetPDXIdForType(Type^ pdxType, String^ poolname, PdxType^ nType, bool checkIfThere)
+        Int32 PdxTypeRegistry::GetPDXIdForType(Type^ pdxType, native::Pool* pool, PdxType^ nType, bool checkIfThere)
         {
           if(checkIfThere)
           {
@@ -70,7 +70,7 @@ namespace Apache
                   return lpdx->TypeId;
               } 
             }
-            return Serializable::GetPDXIdForType(poolname, nType, m_cache);            
+            return Serializable::GetPDXIdForType(pool, nType, m_cache);            
           }
           finally
           {
@@ -79,7 +79,7 @@ namespace Apache
             
         }
 
-        Int32 PdxTypeRegistry::GetPDXIdForType(PdxType^ pType, String^ poolname)
+        Int32 PdxTypeRegistry::GetPDXIdForType(PdxType^ pType, native::Pool* pool)
         {
           IDictionary<PdxType^, Int32>^ tmp = pdxTypeToTypeId;
           Int32 typeId = 0;
@@ -100,7 +100,7 @@ namespace Apache
                 return typeId;
 
             }
-            typeId = Serializable::GetPDXIdForType(poolname, pType, m_cache);            
+            typeId = Serializable::GetPDXIdForType(pool, pType, m_cache);            
             pType->TypeId = typeId;
 
             IDictionary<PdxType^, Int32>^ newDict = gcnew Dictionary<PdxType^, Int32>(pdxTypeToTypeId);

--- a/clicache/src/impl/PdxTypeRegistry.hpp
+++ b/clicache/src/impl/PdxTypeRegistry.hpp
@@ -68,9 +68,9 @@ namespace Apache
 
            void clear();
 
-            Int32 GetPDXIdForType(Type^ type, String^ poolname, PdxType^ nType, bool checkIfThere);
+            Int32 GetPDXIdForType(Type^ type, native::Pool* pool, PdxType^ nType, bool checkIfThere);
 
-            Int32 GetPDXIdForType(PdxType^ type, String^ poolname);
+            Int32 GetPDXIdForType(PdxType^ type, native::Pool*);
 
             Int32 GetEnumValue(EnumInfo^ ei);
 

--- a/cppcache/include/geode/Cache.hpp
+++ b/cppcache/include/geode/Cache.hpp
@@ -234,7 +234,7 @@ class APACHE_GEODE_EXPORT Cache : public GeodeCache {
       std::string className) const override;
 
   virtual std::unique_ptr<DataInput> createDataInput(const uint8_t* m_buffer,
-                                                     size_t len, const std::string& poolName = EMPTY_STRING) const;
+                                                     size_t len) const;
   virtual std::unique_ptr<DataOutput> createDataOutput() const;
 
   virtual PoolManager& getPoolManager() const;

--- a/cppcache/include/geode/Cache.hpp
+++ b/cppcache/include/geode/Cache.hpp
@@ -234,7 +234,7 @@ class APACHE_GEODE_EXPORT Cache : public GeodeCache {
       std::string className) const override;
 
   virtual std::unique_ptr<DataInput> createDataInput(const uint8_t* m_buffer,
-                                                     size_t len) const;
+                                                     size_t len, const std::string& poolName = EMPTY_STRING) const;
   virtual std::unique_ptr<DataOutput> createDataOutput() const;
 
   virtual PoolManager& getPoolManager() const;

--- a/cppcache/include/geode/CacheableBuiltins.hpp
+++ b/cppcache/include/geode/CacheableBuiltins.hpp
@@ -140,7 +140,8 @@ inline void copyArray(std::shared_ptr<TObj>* dest,
 
 /** Template class for container Cacheable types. */
 template <typename TBase, int8_t TYPEID>
-class APACHE_GEODE_EXPORT CacheableContainerType : public Cacheable, public TBase {
+class APACHE_GEODE_EXPORT CacheableContainerType : public Cacheable,
+                                                   public TBase {
  protected:
   inline CacheableContainerType() : TBase() {}
 
@@ -193,10 +194,9 @@ class APACHE_GEODE_EXPORT CacheableContainerType : public Cacheable, public TBas
 #pragma warning(disable : 4231)
 #endif
 
-#define _GEODE_CACHEABLE_KEY_TYPE_DEF_(p, k)           \
-  extern const char tName_##k[];                       \
-  template class                                       \
-      CacheableKeyType<p, GeodeTypeIds::k, tName_##k>; \
+#define _GEODE_CACHEABLE_KEY_TYPE_DEF_(p, k)                      \
+  extern const char tName_##k[];                                  \
+  template class CacheableKeyType<p, GeodeTypeIds::k, tName_##k>; \
   typedef CacheableKeyType<p, GeodeTypeIds::k, tName_##k> _##k;
 
 // use a class instead of typedef for bug #283
@@ -230,9 +230,8 @@ class APACHE_GEODE_EXPORT CacheableContainerType : public Cacheable, public TBas
     return k::create(value);                                            \
   }
 
-#define _GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(p, c) \
-  template class                                   \
-      CacheableContainerType<p, GeodeTypeIds::c>;  \
+#define _GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(p, c)           \
+  template class CacheableContainerType<p, GeodeTypeIds::c>; \
   typedef CacheableContainerType<p, GeodeTypeIds::c> _##c;
 
 // use a class instead of typedef for bug #283

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -48,6 +48,7 @@ class Serializable;
 class SerializationRegistry;
 class CacheImpl;
 class DataInputInternal;
+class Pool;
 
 /**
  * Provide operations for reading primitive data values, byte arrays,
@@ -490,12 +491,7 @@ class APACHE_GEODE_EXPORT DataInput {
  protected:
   /** constructor given a pre-allocated byte array with size */
   DataInput(const uint8_t* m_buffer, size_t len, const CacheImpl* cache,
-            const std::string& poolName)
-      : m_buf(m_buffer),
-        m_bufHead(m_buffer),
-        m_bufLength(len),
-        m_poolName(poolName),
-        m_cache(cache) {}
+            Pool* pool);
 
   virtual const SerializationRegistry& getSerializationRegistry() const;
 
@@ -503,7 +499,7 @@ class APACHE_GEODE_EXPORT DataInput {
   const uint8_t* m_buf;
   const uint8_t* m_bufHead;
   size_t m_bufLength;
-  const std::string& m_poolName;
+  Pool* m_pool;
   const CacheImpl* m_cache;
 
   std::shared_ptr<Serializable> readObjectInternal(int8_t typeId = -1);
@@ -646,7 +642,7 @@ class APACHE_GEODE_EXPORT DataInput {
     value.assign(reinterpret_cast<const wchar_t*>(tmp.data()), tmp.length());
   }
 
-  const std::string& getPoolName() const { return m_poolName; }
+  Pool* getPool() const { return m_pool; }
 
   friend Cache;
   friend CacheImpl;

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -429,9 +429,6 @@ class APACHE_GEODE_EXPORT DataInput {
     }
   }
 
-  /** destructor */
-  ~DataInput() {}
-
   /**
    * Get the pointer to current buffer position. This should be treated
    * as readonly and modification of contents using this internal pointer
@@ -484,6 +481,11 @@ class APACHE_GEODE_EXPORT DataInput {
   }
 
   virtual const Cache* getCache();
+
+  ~DataInput() = default;
+  DataInput() = delete;
+  DataInput(const DataInput&) = delete;
+  DataInput& operator=(const DataInput&) = delete;
 
  protected:
   /** constructor given a pre-allocated byte array with size */
@@ -645,11 +647,6 @@ class APACHE_GEODE_EXPORT DataInput {
   }
 
   const std::string& getPoolName() const { return m_poolName; }
-
-  // disable other constructors and assignment
-  DataInput() = delete;
-  DataInput(const DataInput&) = delete;
-  DataInput& operator=(const DataInput&) = delete;
 
   friend Cache;
   friend CacheImpl;

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -487,7 +487,8 @@ class APACHE_GEODE_EXPORT DataInput {
 
  protected:
   /** constructor given a pre-allocated byte array with size */
-  DataInput(const uint8_t* m_buffer, size_t len, const CacheImpl* cache, const std::string& poolName = EMPTY_STRING)
+  DataInput(const uint8_t* m_buffer, size_t len, const CacheImpl* cache,
+            const std::string& poolName = EMPTY_STRING)
       : m_buf(m_buffer),
         m_bufHead(m_buffer),
         m_bufLength(len),

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -488,7 +488,7 @@ class APACHE_GEODE_EXPORT DataInput {
  protected:
   /** constructor given a pre-allocated byte array with size */
   DataInput(const uint8_t* m_buffer, size_t len, const CacheImpl* cache,
-            const std::string& poolName = EMPTY_STRING)
+            const std::string& poolName)
       : m_buf(m_buffer),
         m_bufHead(m_buffer),
         m_bufLength(len),

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -46,7 +46,6 @@ class CacheableString;
 class DataInput;
 class Serializable;
 class SerializationRegistry;
-class DataInputInternal;
 class CacheImpl;
 class DataInputInternal;
 
@@ -126,7 +125,7 @@ class APACHE_GEODE_EXPORT DataInput {
    * @param len output parameter to hold the length of array read from stream
    */
   inline void readBytes(uint8_t** bytes, int32_t* len) {
-    int32_t length = readArrayLen();
+    auto length = readArrayLen();
     *len = length;
     uint8_t* buffer = nullptr;
     if (length > 0) {
@@ -149,7 +148,7 @@ class APACHE_GEODE_EXPORT DataInput {
    * @param len output parameter to hold the length of array read from stream
    */
   inline void readBytes(int8_t** bytes, int32_t* len) {
-    int32_t length = readArrayLen();
+    auto length = readArrayLen();
     *len = length;
     int8_t* buffer = nullptr;
     if (length > 0) {
@@ -179,7 +178,7 @@ class APACHE_GEODE_EXPORT DataInput {
    */
   inline int32_t readInt32() {
     _GEODE_CHECK_BUFFER_SIZE(4);
-    int32_t tmp = *(m_buf++);
+    auto tmp = *(m_buf++);
     tmp = (tmp << 8) | *(m_buf++);
     tmp = (tmp << 8) | *(m_buf++);
     tmp = (tmp << 8) | *(m_buf++);
@@ -333,7 +332,6 @@ class APACHE_GEODE_EXPORT DataInput {
 
   inline bool readNativeBool() {
     read();  // ignore type id
-
     return readBoolean();
   }
 
@@ -398,7 +396,7 @@ class APACHE_GEODE_EXPORT DataInput {
   inline std::vector<std::string> readStringArray() {
     std::vector<std::string> value;
 
-    int32_t arrLen = readArrayLen();
+    auto arrLen = readArrayLen();
     if (arrLen > 0) {
       value.reserve(arrLen);
       for (int i = 0; i < arrLen; i++) {
@@ -412,7 +410,7 @@ class APACHE_GEODE_EXPORT DataInput {
   inline void readArrayOfByteArrays(int8_t*** arrayofBytearr,
                                     int32_t& arrayLength,
                                     int32_t** elementLength) {
-    int32_t arrLen = readArrayLen();
+    auto arrLen = readArrayLen();
     arrayLength = arrLen;
 
     if (arrLen == -1) {
@@ -502,14 +500,14 @@ class APACHE_GEODE_EXPORT DataInput {
   const uint8_t* m_buf;
   const uint8_t* m_bufHead;
   size_t m_bufLength;
-  std::reference_wrapper<const std::string> m_poolName;
+  const std::string& m_poolName;
   const CacheImpl* m_cache;
 
   std::shared_ptr<Serializable> readObjectInternal(int8_t typeId = -1);
 
   template <typename mType>
   void readObject(mType** value, int32_t& length) {
-    int arrayLen = readArrayLen();
+    auto arrayLen = readArrayLen();
     length = arrayLen;
     mType* objArray;
     if (arrayLen > 0) {
@@ -526,7 +524,7 @@ class APACHE_GEODE_EXPORT DataInput {
 
   template <typename T>
   std::vector<T> readArray() {
-    int arrayLen = readArrayLen();
+    auto arrayLen = readArrayLen();
     std::vector<T> objArray;
     if (arrayLen >= 0) {
       objArray.reserve(arrayLen);
@@ -646,10 +644,6 @@ class APACHE_GEODE_EXPORT DataInput {
   }
 
   const std::string& getPoolName() const { return m_poolName; }
-
-  void setPoolName(const std::string& poolName) {
-    m_poolName = std::ref(poolName);
-  }
 
   // disable other constructors and assignment
   DataInput() = delete;

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -125,7 +125,7 @@ class APACHE_GEODE_EXPORT DataInput {
    * @param len output parameter to hold the length of array read from stream
    */
   inline void readBytes(uint8_t** bytes, int32_t* len) {
-    auto length = readArrayLen();
+    auto length = readArrayLength();
     *len = length;
     uint8_t* buffer = nullptr;
     if (length > 0) {
@@ -148,7 +148,7 @@ class APACHE_GEODE_EXPORT DataInput {
    * @param len output parameter to hold the length of array read from stream
    */
   inline void readBytes(int8_t** bytes, int32_t* len) {
-    auto length = readArrayLen();
+    auto length = readArrayLength();
     *len = length;
     int8_t* buffer = nullptr;
     if (length > 0) {
@@ -178,7 +178,7 @@ class APACHE_GEODE_EXPORT DataInput {
    */
   inline int32_t readInt32() {
     _GEODE_CHECK_BUFFER_SIZE(4);
-    auto tmp = *(m_buf++);
+    int32_t tmp = *(m_buf++);
     tmp = (tmp << 8) | *(m_buf++);
     tmp = (tmp << 8) | *(m_buf++);
     tmp = (tmp << 8) | *(m_buf++);
@@ -227,7 +227,7 @@ class APACHE_GEODE_EXPORT DataInput {
    * @param len output parameter to hold the 32-bit signed length
    *   read from stream
    */
-  inline int32_t readArrayLen() {
+  inline int32_t readArrayLength() {
     const uint8_t code = read();
     if (code == 0xFF) {
       return -1;
@@ -396,7 +396,7 @@ class APACHE_GEODE_EXPORT DataInput {
   inline std::vector<std::string> readStringArray() {
     std::vector<std::string> value;
 
-    auto arrLen = readArrayLen();
+    auto arrLen = readArrayLength();
     if (arrLen > 0) {
       value.reserve(arrLen);
       for (int i = 0; i < arrLen; i++) {
@@ -410,7 +410,7 @@ class APACHE_GEODE_EXPORT DataInput {
   inline void readArrayOfByteArrays(int8_t*** arrayofBytearr,
                                     int32_t& arrayLength,
                                     int32_t** elementLength) {
-    auto arrLen = readArrayLen();
+    auto arrLen = readArrayLength();
     arrayLength = arrLen;
 
     if (arrLen == -1) {
@@ -507,7 +507,7 @@ class APACHE_GEODE_EXPORT DataInput {
 
   template <typename mType>
   void readObject(mType** value, int32_t& length) {
-    auto arrayLen = readArrayLen();
+    auto arrayLen = readArrayLength();
     length = arrayLen;
     mType* objArray;
     if (arrayLen > 0) {
@@ -524,7 +524,7 @@ class APACHE_GEODE_EXPORT DataInput {
 
   template <typename T>
   std::vector<T> readArray() {
-    auto arrayLen = readArrayLen();
+    auto arrayLen = readArrayLength();
     std::vector<T> objArray;
     if (arrayLen >= 0) {
       objArray.reserve(arrayLen);

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -489,11 +489,11 @@ class APACHE_GEODE_EXPORT DataInput {
 
  protected:
   /** constructor given a pre-allocated byte array with size */
-  DataInput(const uint8_t* m_buffer, size_t len, const CacheImpl* cache)
+  DataInput(const uint8_t* m_buffer, size_t len, const CacheImpl* cache, const std::string& poolName = EMPTY_STRING)
       : m_buf(m_buffer),
         m_bufHead(m_buffer),
         m_bufLength(len),
-        m_poolName(EMPTY_STRING),
+        m_poolName(poolName),
         m_cache(cache) {}
 
   virtual const SerializationRegistry& getSerializationRegistry() const;

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -30,16 +30,14 @@
 #include "Serializable.hpp"
 #include "CacheableString.hpp"
 
-/**
- * @file
- */
-
 namespace apache {
 namespace geode {
 namespace client {
+
 class SerializationRegistry;
 class DataOutputInternal;
 class CacheImpl;
+class Pool;
 
 /**
  * Provide operations for writing primitive data values, byte arrays,
@@ -508,7 +506,7 @@ class APACHE_GEODE_EXPORT DataOutput {
   /**
    * Construct a new DataOutput.
    */
-  DataOutput(const CacheImpl* cache, const std::string& poolName);
+  DataOutput(const CacheImpl* cache, Pool* pool);
 
   virtual const SerializationRegistry& getSerializationRegistry() const;
 
@@ -530,7 +528,7 @@ class APACHE_GEODE_EXPORT DataOutput {
   // flag to indicate we have a big buffer
   volatile bool m_haveBigBuffer;
   const CacheImpl* m_cache;
-  const std::string& m_poolName;
+  Pool* m_pool;
 
   inline void writeAscii(const std::string& value) {
     uint16_t len = static_cast<uint16_t>(
@@ -743,7 +741,7 @@ class APACHE_GEODE_EXPORT DataOutput {
     writeNoCheck(static_cast<uint8_t>(value));
   }
 
-  const std::string& getPoolName() const { return m_poolName; }
+  Pool* getPool() const { return m_pool; }
 
   static uint8_t* checkoutBuffer(size_t* size);
   static void checkinBuffer(uint8_t* buffer, size_t size);

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -503,9 +503,9 @@ class APACHE_GEODE_EXPORT DataOutput {
   /**
    * Construct a new DataOutput.
    */
-  DataOutput(const CacheImpl* cache);
+  DataOutput(const CacheImpl* cache, const std::string& poolName = EMPTY_STRING);
 
-  DataOutput() : DataOutput(nullptr) {}
+  DataOutput() : DataOutput(nullptr, EMPTY_STRING) {}
 
   virtual const SerializationRegistry& getSerializationRegistry() const;
 
@@ -527,7 +527,7 @@ class APACHE_GEODE_EXPORT DataOutput {
   // flag to indicate we have a big buffer
   volatile bool m_haveBigBuffer;
   const CacheImpl* m_cache;
-  std::reference_wrapper<const std::string> m_poolName;
+  const std::string& m_poolName;
 
   inline void writeAscii(const std::string& value) {
     uint16_t len = static_cast<uint16_t>(
@@ -741,10 +741,6 @@ class APACHE_GEODE_EXPORT DataOutput {
   }
 
   const std::string& getPoolName() const { return m_poolName; }
-
-  void setPoolName(const std::string& poolName) {
-    m_poolName = std::ref(poolName);
-  }
 
   static uint8_t* checkoutBuffer(size_t* size);
   static void checkinBuffer(uint8_t* buffer, size_t size);

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -503,7 +503,7 @@ class APACHE_GEODE_EXPORT DataOutput {
   /**
    * Construct a new DataOutput.
    */
-  DataOutput(const CacheImpl* cache, const std::string& poolName = EMPTY_STRING);
+  DataOutput(const CacheImpl* cache, const std::string& poolName);
 
   DataOutput() : DataOutput(nullptr, EMPTY_STRING) {}
 

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -393,11 +393,6 @@ class APACHE_GEODE_EXPORT DataOutput {
   }
 
   uint8_t getValueAtPos(size_t offset) { return m_bytes[offset]; }
-  /** Destruct a DataOutput, including releasing the created buffer. */
-  ~DataOutput() {
-    reset();
-    DataOutput::checkinBuffer(m_bytes, m_size);
-  }
 
   /**
    * Get a pointer to the internal buffer of <code>DataOutput</code>.
@@ -499,13 +494,21 @@ class APACHE_GEODE_EXPORT DataOutput {
 
   virtual const Cache* getCache();
 
+  /** Destruct a DataOutput, including releasing the created buffer. */
+  ~DataOutput() {
+    reset();
+    DataOutput::checkinBuffer(m_bytes, m_size);
+  }
+
+  DataOutput() = delete;
+  DataOutput(const DataOutput&) = delete;
+  DataOutput& operator=(const DataOutput&) = delete;
+
  protected:
   /**
    * Construct a new DataOutput.
    */
   DataOutput(const CacheImpl* cache, const std::string& poolName);
-
-  DataOutput() : DataOutput(nullptr, EMPTY_STRING) {}
 
   virtual const SerializationRegistry& getSerializationRegistry() const;
 
@@ -744,10 +747,6 @@ class APACHE_GEODE_EXPORT DataOutput {
 
   static uint8_t* checkoutBuffer(size_t* size);
   static void checkinBuffer(uint8_t* buffer, size_t size);
-
-  // disable copy constructor and assignment
-  DataOutput(const DataOutput&);
-  DataOutput& operator=(const DataOutput&);
 
   friend Cache;
   friend CacheImpl;

--- a/cppcache/include/geode/ExceptionTypes.hpp
+++ b/cppcache/include/geode/ExceptionTypes.hpp
@@ -776,7 +776,8 @@ class APACHE_GEODE_EXPORT CommitConflictException : public Exception {
  * being modified by the transaction.
  * This can be thrown while doing transactional operations or during commit.
  **/
-class APACHE_GEODE_EXPORT TransactionDataNodeHasDepartedException : public Exception {
+class APACHE_GEODE_EXPORT TransactionDataNodeHasDepartedException
+    : public Exception {
  public:
   using Exception::Exception;
   virtual ~TransactionDataNodeHasDepartedException() noexcept {}
@@ -789,7 +790,8 @@ class APACHE_GEODE_EXPORT TransactionDataNodeHasDepartedException : public Excep
  *transaction.
  * This can be thrown while doing transactional operations or during commit.
  **/
-class APACHE_GEODE_EXPORT TransactionDataRebalancedException : public Exception {
+class APACHE_GEODE_EXPORT TransactionDataRebalancedException
+    : public Exception {
  public:
   using Exception::Exception;
   virtual ~TransactionDataRebalancedException() noexcept {}

--- a/cppcache/include/geode/PdxWrapper.hpp
+++ b/cppcache/include/geode/PdxWrapper.hpp
@@ -44,7 +44,6 @@ class PdxWriter;
  * a PdxSerializer registered that can handle the user domain class.
  */
 class APACHE_GEODE_EXPORT PdxWrapper : public PdxSerializable {
-
  public:
   /**
    * Constructor which takes the address of the user object to contain for PDX

--- a/cppcache/include/geode/Serializer.hpp
+++ b/cppcache/include/geode/Serializer.hpp
@@ -233,7 +233,7 @@ template <typename TObj>
 inline std::vector<TObj> readArrayObject(
     apache::geode::client::DataInput& input) {
   std::vector<TObj> array;
-  int len = input.readArrayLen();
+  int len = input.readArrayLength();
   if (len >= 0) {
     array.resize(len);
     for (auto&& obj : array) {
@@ -246,7 +246,7 @@ inline std::vector<TObj> readArrayObject(
 template <typename TObj, typename TLen>
 inline void readObject(apache::geode::client::DataInput& input, TObj*& array,
                        TLen& len) {
-  len = input.readArrayLen();
+  len = input.readArrayLength();
   if (len > 0) {
     _GEODE_NEW(array, TObj[len]);
     TObj* startArray = array;
@@ -326,7 +326,7 @@ inline size_t objectSize(const std::vector<std::shared_ptr<Cacheable>>& value) {
 template <typename TObj, typename _tail>
 inline void readObject(apache::geode::client::DataInput& input,
                        std::vector<TObj, _tail>& value) {
-  int32_t len = input.readArrayLen();
+  int32_t len = input.readArrayLength();
   if (len >= 0) {
     TObj obj;
     for (int32_t index = 0; index < len; index++) {
@@ -366,7 +366,7 @@ template <typename TKey, typename TValue, typename Hash, typename KeyEqual,
 inline void readObject(
     apache::geode::client::DataInput& input,
     std::unordered_map<TKey, TValue, Hash, KeyEqual, Allocator>& value) {
-  int32_t len = input.readArrayLen();
+  int32_t len = input.readArrayLength();
   value.reserve(len);
   TKey key;
   TValue val;
@@ -401,7 +401,7 @@ template <typename TKey, typename Hash, typename KeyEqual, typename Allocator>
 inline void readObject(
     apache::geode::client::DataInput& input,
     std::unordered_set<TKey, Hash, KeyEqual, Allocator>& value) {
-  int32_t len = input.readArrayLen();
+  int32_t len = input.readArrayLength();
   if (len > 0) {
     TKey key;
     for (int32_t index = 0; index < len; index++) {

--- a/cppcache/integration-test/testSerialization.cpp
+++ b/cppcache/integration-test/testSerialization.cpp
@@ -86,7 +86,7 @@ class OtherType : public Serializable {
   size_t objectSize() const override { return sizeof(CData); }
 
   void fromData(DataInput& input) override {
-    int32_t size = input.readArrayLen();
+    int32_t size = input.readArrayLength();
     input.readBytesOnly(reinterpret_cast<uint8_t*>(&m_struct), size);
     m_classIdToReturn = input.readInt32();
   }

--- a/cppcache/src/Cache.cpp
+++ b/cppcache/src/Cache.cpp
@@ -238,8 +238,8 @@ PoolManager& Cache::getPoolManager() const {
 }
 
 std::unique_ptr<DataInput> Cache::createDataInput(const uint8_t* m_buffer,
-                                                  size_t len, const std::string& poolName) const {
-  return m_cacheImpl->createDataInput(m_buffer, len, poolName);
+                                                  size_t len) const {
+  return m_cacheImpl->createDataInput(m_buffer, len);
 }
 
 std::unique_ptr<DataOutput> Cache::createDataOutput() const {

--- a/cppcache/src/Cache.cpp
+++ b/cppcache/src/Cache.cpp
@@ -139,8 +139,8 @@ Cache::Cache(std::shared_ptr<Properties> dsProp, bool ignorePdxUnreadFields,
              const std::shared_ptr<AuthInitialize>& authInitialize) {
   auto distributedSystem = DistributedSystem::create(DEFAULT_DS_NAME, dsProp);
   m_cacheImpl = std::unique_ptr<CacheImpl>(
-      new CacheImpl(this, std::move(distributedSystem),
-                    ignorePdxUnreadFields, readPdxSerialized, authInitialize));
+      new CacheImpl(this, std::move(distributedSystem), ignorePdxUnreadFields,
+                    readPdxSerialized, authInitialize));
   m_cacheImpl->getDistributedSystem().connect(this);
   m_typeRegistry =
       std::unique_ptr<TypeRegistry>(new TypeRegistry(m_cacheImpl.get()));

--- a/cppcache/src/Cache.cpp
+++ b/cppcache/src/Cache.cpp
@@ -238,9 +238,8 @@ PoolManager& Cache::getPoolManager() const {
 }
 
 std::unique_ptr<DataInput> Cache::createDataInput(const uint8_t* m_buffer,
-                                                  size_t len) const {
-  return std::unique_ptr<DataInput>(
-      new DataInput(m_buffer, len, m_cacheImpl.get()));
+                                                  size_t len, const std::string& poolName) const {
+  return m_cacheImpl->createDataInput(m_buffer, len, poolName);
 }
 
 std::unique_ptr<DataOutput> Cache::createDataOutput() const {

--- a/cppcache/src/Cache.cpp
+++ b/cppcache/src/Cache.cpp
@@ -243,7 +243,7 @@ std::unique_ptr<DataInput> Cache::createDataInput(const uint8_t* m_buffer,
 }
 
 std::unique_ptr<DataOutput> Cache::createDataOutput() const {
-  return std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl.get()));
+  return m_cacheImpl->createDataOutput();
 }
 
 }  // namespace client

--- a/cppcache/src/CacheImpl.cpp
+++ b/cppcache/src/CacheImpl.cpp
@@ -742,21 +742,30 @@ CacheImpl::getMemberListForVersionStamp() {
   return *versionStampMemIdList;
 }
 
-std::unique_ptr<DataInput> CacheImpl::createDataInput(const uint8_t* buffer,
-                                                      size_t len) const {
-  auto poolName = getPoolManager().getDefaultPool()->getName();
-  return std::unique_ptr<DataInput>(new DataInput(buffer, len, this, poolName));
+std::unique_ptr<DataOutput> CacheImpl::createDataOutput() const {
+  return CacheImpl::createDataOutput(nullptr);
 }
 
-std::unique_ptr<DataOutput> CacheImpl::createDataOutput() const {
-  auto defaultPool = getPoolManager().getDefaultPool();
-
-  if (defaultPool != nullptr) {
-    return std::unique_ptr<DataOutput>(
-        new DataOutput(this, defaultPool->getName()));
+std::unique_ptr<DataOutput> CacheImpl::createDataOutput(Pool* pool) const {
+  if (!pool) {
+    pool = this->getPoolManager().getDefaultPool().get();
   }
 
-  return std::unique_ptr<DataOutput>(new DataOutput(this, EMPTY_STRING));
+  return std::unique_ptr<DataOutput>(new DataOutput(this, pool));
+}
+
+std::unique_ptr<DataInput> CacheImpl::createDataInput(const uint8_t* buffer,
+                                                      size_t len) const {
+  return CacheImpl::createDataInput(buffer, len, nullptr);
+}
+
+std::unique_ptr<DataInput> CacheImpl::createDataInput(const uint8_t* buffer,
+                                                      size_t len,
+                                                      Pool* pool) const {
+  if (!pool) {
+    pool = this->getPoolManager().getDefaultPool().get();
+  }
+  return std::unique_ptr<DataInput>(new DataInput(buffer, len, this, pool));
 }
 
 void CacheImpl::setCache(Cache* cache) { m_cache = cache; }

--- a/cppcache/src/CacheImpl.cpp
+++ b/cppcache/src/CacheImpl.cpp
@@ -45,10 +45,10 @@
 
 using namespace apache::geode::client;
 
-CacheImpl::CacheImpl(Cache* c, DistributedSystem&& distributedSystem, bool iPUF,
-                     bool readPdxSerialized,
+CacheImpl::CacheImpl(Cache* c, DistributedSystem&& distributedSystem,
+                     bool ignorePdxUnreadFields, bool readPdxSerialized,
                      const std::shared_ptr<AuthInitialize>& authInitialize)
-    : m_ignorePdxUnreadFields(iPUF),
+    : m_ignorePdxUnreadFields(ignorePdxUnreadFields),
       m_readPdxSerialized(readPdxSerialized),
       m_expiryTaskManager(
           std::unique_ptr<ExpiryTaskManager>(new ExpiryTaskManager())),

--- a/cppcache/src/CacheImpl.cpp
+++ b/cppcache/src/CacheImpl.cpp
@@ -171,11 +171,11 @@ int CacheImpl::removeRegion(const char* name) {
 }
 
 std::shared_ptr<QueryService> CacheImpl::getQueryService(bool noInit) {
-  if (getPoolManager().getDefaultPool() != nullptr) {
-    if (getPoolManager().getDefaultPool()->isDestroyed()) {
+  if (auto&& defaultPool = getPoolManager().getDefaultPool()) {
+    if (defaultPool->isDestroyed()) {
       throw IllegalStateException("Pool has been destroyed.");
     }
-    return getPoolManager().getDefaultPool()->getQueryService();
+    return defaultPool->getQueryService();
   }
 
   if (m_remoteQueryServicePtr == nullptr) {
@@ -220,9 +220,9 @@ const std::string& CacheImpl::getName() const {
 
 bool CacheImpl::isClosed() const { return m_closed; }
 
-void CacheImpl::setAttributes(const std::shared_ptr<CacheAttributes>& attrs) {
-  if (m_attributes == nullptr && attrs != nullptr) {
-    m_attributes = attrs;
+void CacheImpl::setAttributes(const std::shared_ptr<CacheAttributes>& attributes) {
+  if (m_attributes == nullptr && attributes != nullptr) {
+    m_attributes = attributes;
   }
 }
 

--- a/cppcache/src/CacheImpl.cpp
+++ b/cppcache/src/CacheImpl.cpp
@@ -744,4 +744,10 @@ CacheImpl::getMemberListForVersionStamp() {
   return *versionStampMemIdList;
 }
 
+std::unique_ptr<DataInput> CacheImpl::createDataInput(const uint8_t* buffer,
+                                                              size_t len) const {
+  auto poolName = getPoolManager().getDefaultPool()->getName();
+  return std::unique_ptr<DataInput>(new DataInput(buffer, len, this, poolName));
+}
+
 void CacheImpl::setCache(Cache* cache) { m_cache = cache; }

--- a/cppcache/src/CacheImpl.cpp
+++ b/cppcache/src/CacheImpl.cpp
@@ -749,8 +749,13 @@ std::unique_ptr<DataInput> CacheImpl::createDataInput(const uint8_t* buffer,
 }
 
 std::unique_ptr<DataOutput> CacheImpl::createDataOutput() const {
-  auto poolName = getPoolManager().getDefaultPool()->getName();
-  return std::unique_ptr<DataOutput>(new DataOutput(this, poolName));
+  auto defaultPool = getPoolManager().getDefaultPool();
+
+  if(defaultPool != nullptr) {
+    return std::unique_ptr<DataOutput>(new DataOutput(this, defaultPool->getName()));
+  }
+
+  return std::unique_ptr<DataOutput>(new DataOutput(this));
 }
 
 void CacheImpl::setCache(Cache* cache) { m_cache = cache; }

--- a/cppcache/src/CacheImpl.cpp
+++ b/cppcache/src/CacheImpl.cpp
@@ -751,11 +751,12 @@ std::unique_ptr<DataInput> CacheImpl::createDataInput(const uint8_t* buffer,
 std::unique_ptr<DataOutput> CacheImpl::createDataOutput() const {
   auto defaultPool = getPoolManager().getDefaultPool();
 
-  if(defaultPool != nullptr) {
-    return std::unique_ptr<DataOutput>(new DataOutput(this, defaultPool->getName()));
+  if (defaultPool != nullptr) {
+    return std::unique_ptr<DataOutput>(
+        new DataOutput(this, defaultPool->getName()));
   }
 
-  return std::unique_ptr<DataOutput>(new DataOutput(this));
+  return std::unique_ptr<DataOutput>(new DataOutput(this, EMPTY_STRING));
 }
 
 void CacheImpl::setCache(Cache* cache) { m_cache = cache; }

--- a/cppcache/src/CacheImpl.hpp
+++ b/cppcache/src/CacheImpl.hpp
@@ -272,23 +272,26 @@ class APACHE_GEODE_EXPORT CacheImpl : private NonCopyable, private NonAssignable
     return m_authInitialize;
   }
 
-  virtual std::unique_ptr<DataOutput> createDataOutput() const {
-    return std::unique_ptr<DataOutput>(new DataOutput(this));
+  virtual std::unique_ptr<DataOutput> createDataOutput() const;
+
+  virtual std::unique_ptr<DataOutput> createDataOutput(
+      const std::string& poolName) const {
+    return std::unique_ptr<DataOutput>(new DataOutput(this, poolName));
   }
 
   virtual std::unique_ptr<DataInput> createDataInput(const uint8_t* buffer,
                                                      size_t len) const;
 
-  virtual std::unique_ptr<DataInput> createDataInput(const uint8_t* buffer,
-                                                     size_t len, std::string poolName) const {
-    return std::unique_ptr<DataInput>(new DataInput(buffer, len, this, poolName));
+  virtual std::unique_ptr<DataInput> createDataInput(
+      const uint8_t* buffer, size_t len, const std::string& poolName) const {
+    return std::unique_ptr<DataInput>(
+        new DataInput(buffer, len, this, poolName));
   }
 
  private:
   std::atomic<bool> m_networkhop;
   std::atomic<int> m_blacklistBucketTimeout;
   std::atomic<int8_t> m_serverGroupFlag;
-  std::shared_ptr<Pool> m_defaultPool;
   bool m_ignorePdxUnreadFields;
   bool m_readPdxSerialized;
   std::unique_ptr<ExpiryTaskManager> m_expiryTaskManager;

--- a/cppcache/src/CacheImpl.hpp
+++ b/cppcache/src/CacheImpl.hpp
@@ -276,8 +276,8 @@ class APACHE_GEODE_EXPORT CacheImpl : private NonCopyable, private NonAssignable
   }
 
   virtual std::unique_ptr<DataInput> createDataInput(const uint8_t* buffer,
-                                                     size_t len) const {
-    return std::unique_ptr<DataInput>(new DataInput(buffer, len, this));
+                                                     size_t len, std::string poolName = EMPTY_STRING) const {
+    return std::unique_ptr<DataInput>(new DataInput(buffer, len, this, poolName));
   }
 
  private:

--- a/cppcache/src/CacheImpl.hpp
+++ b/cppcache/src/CacheImpl.hpp
@@ -211,6 +211,7 @@ class APACHE_GEODE_EXPORT CacheImpl : private NonCopyable, private NonAssignable
   }
 
   Cache* getCache() const { return m_cache; }
+
   TcrConnectionManager& tcrConnectionManager() {
     return *m_tcrConnectionManager;
   }

--- a/cppcache/src/CacheImpl.hpp
+++ b/cppcache/src/CacheImpl.hpp
@@ -85,7 +85,8 @@ class SerializationRegistry;
  *
  */
 
-class APACHE_GEODE_EXPORT CacheImpl : private NonCopyable, private NonAssignable {
+class APACHE_GEODE_EXPORT CacheImpl : private NonCopyable,
+                                      private NonAssignable {
   /**
    * @brief public methods
    */
@@ -274,19 +275,14 @@ class APACHE_GEODE_EXPORT CacheImpl : private NonCopyable, private NonAssignable
 
   virtual std::unique_ptr<DataOutput> createDataOutput() const;
 
-  virtual std::unique_ptr<DataOutput> createDataOutput(
-      const std::string& poolName) const {
-    return std::unique_ptr<DataOutput>(new DataOutput(this, poolName));
-  }
+  virtual std::unique_ptr<DataOutput> createDataOutput(Pool* pool) const;
 
   virtual std::unique_ptr<DataInput> createDataInput(const uint8_t* buffer,
                                                      size_t len) const;
 
-  virtual std::unique_ptr<DataInput> createDataInput(
-      const uint8_t* buffer, size_t len, const std::string& poolName) const {
-    return std::unique_ptr<DataInput>(
-        new DataInput(buffer, len, this, poolName));
-  }
+  virtual std::unique_ptr<DataInput> createDataInput(const uint8_t* buffer,
+                                                     size_t len,
+                                                     Pool* pool) const;
 
  private:
   std::atomic<bool> m_networkhop;

--- a/cppcache/src/CacheImpl.hpp
+++ b/cppcache/src/CacheImpl.hpp
@@ -137,7 +137,7 @@ class APACHE_GEODE_EXPORT CacheImpl : private NonCopyable,
   }
 
   /** Set the <code>CacheAttributes</code> for this cache. */
-  void setAttributes(const std::shared_ptr<CacheAttributes>& attrs);
+  void setAttributes(const std::shared_ptr<CacheAttributes>& attributes);
 
   /**
    * Returns the distributed system that this cache was

--- a/cppcache/src/CacheImpl.hpp
+++ b/cppcache/src/CacheImpl.hpp
@@ -276,7 +276,10 @@ class APACHE_GEODE_EXPORT CacheImpl : private NonCopyable, private NonAssignable
   }
 
   virtual std::unique_ptr<DataInput> createDataInput(const uint8_t* buffer,
-                                                     size_t len, std::string poolName = EMPTY_STRING) const {
+                                                     size_t len) const;
+
+  virtual std::unique_ptr<DataInput> createDataInput(const uint8_t* buffer,
+                                                     size_t len, std::string poolName) const {
     return std::unique_ptr<DataInput>(new DataInput(buffer, len, this, poolName));
   }
 

--- a/cppcache/src/CacheableEnum.cpp
+++ b/cppcache/src/CacheableEnum.cpp
@@ -52,7 +52,7 @@ void CacheableEnum::toData(apache::geode::client::DataOutput& output) const {
 
 void CacheableEnum::fromData(apache::geode::client::DataInput& input) {
   auto dsId = input.read();
-  int32_t arrLen = input.readArrayLen();
+  int32_t arrLen = input.readArrayLength();
   int enumId = (dsId << 24) | (arrLen & 0xFFFFFF);
   auto enumVal = PdxHelper::getEnum(
       enumId,

--- a/cppcache/src/CacheableObjectArray.cpp
+++ b/cppcache/src/CacheableObjectArray.cpp
@@ -36,7 +36,7 @@ void CacheableObjectArray::toData(DataOutput& output) const {
 }
 
 void CacheableObjectArray::fromData(DataInput& input) {
-  int32_t len = input.readArrayLen();
+  int32_t len = input.readArrayLength();
   if (len >= 0) {
     input.read();        // ignore CLASS typeid
     input.readString();  // ignore class name

--- a/cppcache/src/CacheableObjectPartList.cpp
+++ b/cppcache/src/CacheableObjectPartList.cpp
@@ -57,7 +57,7 @@ void CacheableObjectPartList::fromData(DataInput& input) {
       uint8_t byte = input.read();
 
       if (byte == 2 /* for exception*/) {
-        input.advanceCursor(input.readArrayLen());
+        input.advanceCursor(input.readArrayLength());
         // input.readObject(exMsgPtr, true);// Changed
         auto exMsg = input.readString();
         if (exMsg == "org.apache.geode.security.NotAuthorizedException") {

--- a/cppcache/src/ClientProxyMembershipID.cpp
+++ b/cppcache/src/ClientProxyMembershipID.cpp
@@ -220,7 +220,7 @@ void ClientProxyMembershipID::fromData(DataInput& input) {
   std::shared_ptr<CacheableString> hostname, dsName, uniqueTag, durableClientId;
   int8_t splitbrain, vmKind;
 
-  len = input.readArrayLen();  // inetaddress len
+  len = input.readArrayLength();  // inetaddress len
   m_hostAddrLocalMem = true;
   /* adongre  - Coverity II
    * CID 29184: Out-of-bounds access (OVERRUN_DYNAMIC)
@@ -268,7 +268,7 @@ Serializable* ClientProxyMembershipID::readEssentialData(DataInput& input) {
   int32_t len, hostPort, vmViewId = 0;
   std::shared_ptr<CacheableString> hostname, dsName, uniqueTag, vmViewIdstr;
 
-  len = input.readArrayLen();  // inetaddress len
+  len = input.readArrayLength();  // inetaddress len
   m_hostAddrLocalMem = true;
   /* adongre - Coverity II
    * CID 29183: Out-of-bounds access (OVERRUN_DYNAMIC)

--- a/cppcache/src/CqService.hpp
+++ b/cppcache/src/CqService.hpp
@@ -58,9 +58,10 @@ namespace client {
  *
  */
 
-class APACHE_GEODE_EXPORT CqService : private NonCopyable,
-                                private NonAssignable,
-                                public std::enable_shared_from_this<CqService> {
+class APACHE_GEODE_EXPORT CqService
+    : private NonCopyable,
+      private NonAssignable,
+      public std::enable_shared_from_this<CqService> {
  private:
   ThinClientBaseDM* m_tccdm;
   statistics::StatisticsFactory* m_statisticsFactory;

--- a/cppcache/src/DataInput.cpp
+++ b/cppcache/src/DataInput.cpp
@@ -22,10 +22,19 @@
 #include "CacheImpl.hpp"
 #include "util/string.hpp"
 #include "util/JavaModifiedUtf8.hpp"
+#include <geode/PoolManager.hpp>
 
 namespace apache {
 namespace geode {
 namespace client {
+
+DataInput::DataInput(const uint8_t* m_buffer, size_t len,
+                     const CacheImpl* cache, Pool* pool)
+    : m_buf(m_buffer),
+      m_bufHead(m_buffer),
+      m_bufLength(len),
+      m_pool(pool),
+      m_cache(cache) {}
 
 std::shared_ptr<Serializable> DataInput::readObjectInternal(int8_t typeId) {
   return getSerializationRegistry().deserialize(*this, typeId);

--- a/cppcache/src/DataInputInternal.hpp
+++ b/cppcache/src/DataInputInternal.hpp
@@ -29,10 +29,10 @@ namespace client {
 class DataInputInternal : public DataInput {
  public:
   DataInputInternal(const uint8_t* buffer, size_t len)
-      : DataInput(buffer, len, nullptr) {}
+      : DataInput(buffer, len, nullptr, EMPTY_STRING) {}
 
   DataInputInternal(const uint8_t* buffer, size_t len, const CacheImpl* cache)
-      : DataInput(buffer, len, cache) {}
+      : DataInput(buffer, len, cache, EMPTY_STRING) {}
 
   virtual const Cache* getCache() override {
     throw FatalInternalException("DataInputInternal does not have a Cache");

--- a/cppcache/src/DataInputInternal.hpp
+++ b/cppcache/src/DataInputInternal.hpp
@@ -41,11 +41,6 @@ class DataInputInternal : public DataInput {
   inline static const std::string& getPoolName(const DataInput& dataInput) {
     return dataInput.getPoolName();
   }
-
-  inline static void setPoolName(DataInput& dataInput,
-                                 const std::string& poolName) {
-    return dataInput.setPoolName(poolName);
-  }
 };
 
 }  // namespace client

--- a/cppcache/src/DataInputInternal.hpp
+++ b/cppcache/src/DataInputInternal.hpp
@@ -29,17 +29,13 @@ namespace client {
 class DataInputInternal : public DataInput {
  public:
   DataInputInternal(const uint8_t* buffer, size_t len)
-      : DataInput(buffer, len, nullptr, EMPTY_STRING) {}
+      : DataInput(buffer, len, nullptr, nullptr) {}
 
   DataInputInternal(const uint8_t* buffer, size_t len, const CacheImpl* cache)
-      : DataInput(buffer, len, cache, EMPTY_STRING) {}
+      : DataInput(buffer, len, cache, nullptr) {}
 
-  virtual const Cache* getCache() override {
-    throw FatalInternalException("DataInputInternal does not have a Cache");
-  }
-
-  inline static const std::string& getPoolName(const DataInput& dataInput) {
-    return dataInput.getPoolName();
+  inline static Pool* getPool(const DataInput& dataInput) {
+    return dataInput.getPool();
   }
 };
 

--- a/cppcache/src/DataOutput.cpp
+++ b/cppcache/src/DataOutput.cpp
@@ -113,11 +113,8 @@ TSSDataOutput::~TSSDataOutput() {
 
 ACE_TSS<TSSDataOutput> TSSDataOutput::s_tssDataOutput;
 
-DataOutput::DataOutput(const CacheImpl* cache, const std::string& poolName)
-    : m_cache(cache),
-      m_size(0),
-      m_haveBigBuffer(false), 
-      m_poolName(poolName) {
+DataOutput::DataOutput(const CacheImpl* cache, Pool* pool)
+    : m_cache(cache), m_size(0), m_haveBigBuffer(false), m_pool(pool) {
   m_buf = m_bytes = DataOutput::checkoutBuffer(&m_size);
 }
 

--- a/cppcache/src/DataOutput.cpp
+++ b/cppcache/src/DataOutput.cpp
@@ -113,11 +113,11 @@ TSSDataOutput::~TSSDataOutput() {
 
 ACE_TSS<TSSDataOutput> TSSDataOutput::s_tssDataOutput;
 
-DataOutput::DataOutput(const CacheImpl* cache)
-    : m_size(0),
-      m_haveBigBuffer(false),
-      m_cache(cache),
-      m_poolName(EMPTY_STRING) {
+DataOutput::DataOutput(const CacheImpl* cache, const std::string& poolName)
+    : m_cache(cache),
+      m_size(0),
+      m_haveBigBuffer(false), 
+      m_poolName(poolName) {
   m_buf = m_bytes = DataOutput::checkoutBuffer(&m_size);
 }
 

--- a/cppcache/src/DataOutput.cpp
+++ b/cppcache/src/DataOutput.cpp
@@ -114,7 +114,7 @@ TSSDataOutput::~TSSDataOutput() {
 ACE_TSS<TSSDataOutput> TSSDataOutput::s_tssDataOutput;
 
 DataOutput::DataOutput(const CacheImpl* cache, Pool* pool)
-    : m_cache(cache), m_size(0), m_haveBigBuffer(false), m_pool(pool) {
+    : m_size(0), m_haveBigBuffer(false), m_cache(cache), m_pool(pool) {
   m_buf = m_bytes = DataOutput::checkoutBuffer(&m_size);
 }
 

--- a/cppcache/src/DataOutputInternal.hpp
+++ b/cppcache/src/DataOutputInternal.hpp
@@ -22,6 +22,9 @@
 
 #include <geode/DataOutput.hpp>
 
+#include "CacheImpl.hpp"          // TODO remove
+#include <geode/PoolManager.hpp>  // TODO remove
+
 namespace apache {
 namespace geode {
 namespace client {
@@ -30,12 +33,12 @@ class CacheImpl;
 
 class DataOutputInternal : public DataOutput {
  public:
-  DataOutputInternal() : DataOutput(nullptr, EMPTY_STRING) {}
+  DataOutputInternal() : DataOutput(nullptr, nullptr) {}
 
-  DataOutputInternal(CacheImpl* cache) : DataOutput(cache, EMPTY_STRING) {}
+  DataOutputInternal(CacheImpl* cache) : DataOutput(cache, nullptr) {}
 
-  inline static const std::string& getPoolName(const DataOutput& dataOutput) {
-    return dataOutput.getPoolName();
+  inline static Pool* getPool(const DataOutput& dataOutput) {
+    return dataOutput.getPool();
   }
 };
 

--- a/cppcache/src/DataOutputInternal.hpp
+++ b/cppcache/src/DataOutputInternal.hpp
@@ -41,11 +41,6 @@ class DataOutputInternal : public DataOutput {
   inline static const std::string& getPoolName(const DataOutput& dataOutput) {
     return dataOutput.getPoolName();
   }
-
-  inline static void setPoolName(DataOutput& dataOutput,
-                                 const std::string& poolName) {
-    return dataOutput.setPoolName(poolName);
-  }
 };
 
 }  // namespace client

--- a/cppcache/src/DataOutputInternal.hpp
+++ b/cppcache/src/DataOutputInternal.hpp
@@ -32,7 +32,7 @@ class DataOutputInternal : public DataOutput {
  public:
   DataOutputInternal() : DataOutput() {}
 
-  DataOutputInternal(CacheImpl* cache) : DataOutput(cache) {}
+  DataOutputInternal(CacheImpl* cache) : DataOutput(cache, EMPTY_STRING) {}
 
   virtual const Cache* getCache() override {
     throw FatalInternalException("DataOutputInternal does not have a Cache");

--- a/cppcache/src/DataOutputInternal.hpp
+++ b/cppcache/src/DataOutputInternal.hpp
@@ -30,13 +30,9 @@ class CacheImpl;
 
 class DataOutputInternal : public DataOutput {
  public:
-  DataOutputInternal() : DataOutput() {}
+  DataOutputInternal() : DataOutput(nullptr, EMPTY_STRING) {}
 
   DataOutputInternal(CacheImpl* cache) : DataOutput(cache, EMPTY_STRING) {}
-
-  virtual const Cache* getCache() override {
-    throw FatalInternalException("DataOutputInternal does not have a Cache");
-  }
 
   inline static const std::string& getPoolName(const DataOutput& dataOutput) {
     return dataOutput.getPoolName();

--- a/cppcache/src/EventId.cpp
+++ b/cppcache/src/EventId.cpp
@@ -73,9 +73,9 @@ void EventId::toData(DataOutput& output) const {
 
 void EventId::fromData(DataInput& input) {
   // TODO: statics being assigned; not thread-safe??
-  m_eidMemLen = input.readArrayLen();
+  m_eidMemLen = input.readArrayLength();
   input.readBytesOnly(reinterpret_cast<int8_t*>(m_eidMem), m_eidMemLen);
-  input.readArrayLen();  // ignore arrayLen
+  input.readArrayLength();  // ignore arrayLen
   m_eidThr = getEventIdData(input, input.read());
   m_eidSeq = getEventIdData(input, input.read());
   m_bucketId = input.readInt32();

--- a/cppcache/src/ExpMapEntry.hpp
+++ b/cppcache/src/ExpMapEntry.hpp
@@ -32,7 +32,7 @@ namespace client {
  * This subclass adds expiration times.
  */
 class APACHE_GEODE_EXPORT ExpMapEntry : public MapEntryImpl,
-                                  public ExpEntryProperties {
+                                        public ExpEntryProperties {
  public:
   virtual ~ExpMapEntry() {}
 
@@ -60,7 +60,7 @@ class APACHE_GEODE_EXPORT ExpMapEntry : public MapEntryImpl,
 };
 
 class APACHE_GEODE_EXPORT VersionedExpMapEntry : public ExpMapEntry,
-                                           public VersionStamp {
+                                                 public VersionStamp {
  public:
   virtual ~VersionedExpMapEntry() {}
 

--- a/cppcache/src/FarSideEntryOp.cpp
+++ b/cppcache/src/FarSideEntryOp.cpp
@@ -90,7 +90,7 @@ void FarSideEntryOp::fromData(DataInput& input, bool largeModCount,
         }
       } else {
         // uint8_t* buf = nullptr;
-        input.readArrayLen();  // ignore len
+        input.readArrayLength();  // ignore len
         input.readObject(m_value);
 
         // input.readBytes(&buf, &len);
@@ -129,10 +129,10 @@ void FarSideEntryOp::skipFilterRoutingInfo(DataInput& input) {
       // memId.fromData(input);
       memId.readEssentialData(input);
 
-      int32_t len = input.readArrayLen();
+      int32_t len = input.readArrayLength();
 
       if (input.readBoolean()) {
-        len = input.readArrayLen();
+        len = input.readArrayLength();
         for (int j = 0; j < len; j++) {
           input.readUnsignedVL();
           input.readUnsignedVL();

--- a/cppcache/src/LRUEntriesMap.hpp
+++ b/cppcache/src/LRUEntriesMap.hpp
@@ -58,8 +58,8 @@ class EvictionController;
  * Fix : Make the class Non Assinable
  */
 class APACHE_GEODE_EXPORT LRUEntriesMap : public ConcurrentEntriesMap,
-                                    private NonCopyable,
-                                    private NonAssignable {
+                                          private NonCopyable,
+                                          private NonAssignable {
  protected:
   LRUAction* m_action;
   LRUList<MapEntryImpl, MapEntryT<LRUMapEntry, 0, 0> > m_lruList;

--- a/cppcache/src/LRUExpMapEntry.hpp
+++ b/cppcache/src/LRUExpMapEntry.hpp
@@ -32,8 +32,8 @@ namespace client {
  * @brief Hold region mapped entry value and lru information.
  */
 class APACHE_GEODE_EXPORT LRUExpMapEntry : public MapEntryImpl,
-                                     public LRUEntryProperties,
-                                     public ExpEntryProperties {
+                                           public LRUEntryProperties,
+                                           public ExpEntryProperties {
  public:
   virtual ~LRUExpMapEntry() {}
 
@@ -64,7 +64,7 @@ class APACHE_GEODE_EXPORT LRUExpMapEntry : public MapEntryImpl,
 };
 
 class APACHE_GEODE_EXPORT VersionedLRUExpMapEntry : public LRUExpMapEntry,
-                                              public VersionStamp {
+                                                    public VersionStamp {
  public:
   virtual ~VersionedLRUExpMapEntry() {}
 

--- a/cppcache/src/LRUMapEntry.hpp
+++ b/cppcache/src/LRUMapEntry.hpp
@@ -60,7 +60,7 @@ namespace client {
  *
  */
 class APACHE_GEODE_EXPORT LRUMapEntry : public MapEntryImpl,
-                                  public LRUEntryProperties {
+                                        public LRUEntryProperties {
  public:
   virtual ~LRUMapEntry() {}
 
@@ -88,7 +88,7 @@ class APACHE_GEODE_EXPORT LRUMapEntry : public MapEntryImpl,
 };
 
 class APACHE_GEODE_EXPORT VersionedLRUMapEntry : public LRUMapEntry,
-                                           public VersionStamp {
+                                                 public VersionStamp {
  public:
   virtual ~VersionedLRUMapEntry() {}
 

--- a/cppcache/src/MapEntry.hpp
+++ b/cppcache/src/MapEntry.hpp
@@ -261,7 +261,7 @@ class MapEntryImpl : public MapEntry,
 };
 
 class APACHE_GEODE_EXPORT VersionedMapEntryImpl : public MapEntryImpl,
-                                            public VersionStamp {
+                                                  public VersionStamp {
  public:
   virtual ~VersionedMapEntryImpl() {}
 

--- a/cppcache/src/PdxHelper.cpp
+++ b/cppcache/src/PdxHelper.cpp
@@ -65,7 +65,7 @@ void PdxHelper::serializePdx(
             0)  // from pdxInstance factory need to get typeid from server
     {
       int typeId = pdxTypeRegistry->getPDXIdForType(
-          piPt, DataOutputInternal::getPoolName(output).c_str());
+          piPt, DataOutputInternal::getPool(output));
       pdxII->setPdxId(typeId);
     }
     auto plw = PdxLocalWriter(output, piPt, pdxTypeRegistry);
@@ -92,8 +92,7 @@ void PdxHelper::serializePdx(
 
     nType->InitializeType();
     int32_t nTypeId = pdxTypeRegistry->getPDXIdForType(
-        className.c_str(), DataOutputInternal::getPoolName(output).c_str(),
-        nType, true);
+        className.c_str(), DataOutputInternal::getPool(output), nType, true);
     nType->setTypeId(nTypeId);
 
     ptc.endObjectWriting();
@@ -188,9 +187,7 @@ std::shared_ptr<PdxSerializable> PdxHelper::deserializePdx(DataInput& dataInput,
     if (pType == nullptr) {
       pType = std::static_pointer_cast<PdxType>(
           serializationRegistry->GetPDXTypeById(
-              cacheImpl->getCache()->getPoolManager().find(
-                  DataInputInternal::getPoolName(dataInput)),
-              typeId));
+              DataInputInternal::getPool(dataInput), typeId));
       pdxLocalType = pdxTypeRegistry->getLocalPdxType(pType->getPdxClassName());
     }
     /* adongre  - Coverity II
@@ -220,9 +217,8 @@ std::shared_ptr<PdxSerializable> PdxHelper::deserializePdx(DataInput& dataInput,
         // Need to know local type and then merge type
         pdxLocalType->InitializeType();
         pdxLocalType->setTypeId(pdxTypeRegistry->getPDXIdForType(
-            pdxObjectptr->getClassName(),
-            DataInputInternal::getPoolName(dataInput).c_str(), pdxLocalType,
-            true));
+            pdxObjectptr->getClassName(), DataInputInternal::getPool(dataInput),
+            pdxLocalType, true));
         pdxLocalType->setLocal(true);
         pdxTypeRegistry->addLocalPdxType(pdxRealObject->getClassName(),
                                          pdxLocalType);  // added local type
@@ -296,9 +292,7 @@ std::shared_ptr<PdxSerializable> PdxHelper::deserializePdx(
       // TODO shared_ptr why redef?
       auto pType = std::static_pointer_cast<PdxType>(
           serializationRegistry->GetPDXTypeById(
-              cacheImpl->getCache()->getPoolManager().find(
-                  DataInputInternal::getPoolName(dataInput)),
-              typeId));
+              DataInputInternal::getPool(dataInput), typeId));
       pdxTypeRegistry->addLocalPdxType(pType->getPdxClassName(), pType);
       pdxTypeRegistry->addPdxType(pType->getTypeId(), pType);
     }
@@ -335,9 +329,7 @@ void PdxHelper::createMergedType(std::shared_ptr<PdxType> localType,
     mergedVersion->InitializeType();
     if (mergedVersion->getTypeId() == 0) {
       mergedVersion->setTypeId(serializaionRegistry->GetPDXIdForType(
-          dataInput.getCache()->getPoolManager().find(
-              DataInputInternal::getPoolName(dataInput)),
-          mergedVersion));
+          DataInputInternal::getPool(dataInput), mergedVersion));
     }
 
     // PdxTypeRegistry::AddPdxType(remoteType->TypeId, mergedVersion);

--- a/cppcache/src/PdxType.cpp
+++ b/cppcache/src/PdxType.cpp
@@ -100,7 +100,7 @@ void PdxType::fromData(DataInput& input) {
 
   m_varLenFieldIdx = input.readInt32();
 
-  int len = input.readArrayLen();
+  int len = input.readArrayLength();
 
   bool foundVarLenType = false;
 

--- a/cppcache/src/PdxTypeRegistry.cpp
+++ b/cppcache/src/PdxTypeRegistry.cpp
@@ -41,8 +41,7 @@ size_t PdxTypeRegistry::testNumberOfPreservedData() const {
   return preserveData.size();
 }
 
-int32_t PdxTypeRegistry::getPDXIdForType(const std::string& type,
-                                         const std::string& poolname,
+int32_t PdxTypeRegistry::getPDXIdForType(const std::string& type, Pool* pool,
                                          std::shared_ptr<PdxType> nType,
                                          bool checkIfThere) {
   // WriteGuard guard(g_readerWriterLock);
@@ -56,8 +55,7 @@ int32_t PdxTypeRegistry::getPDXIdForType(const std::string& type,
     }
   }
 
-  int typeId = cache->getSerializationRegistry()
-                    ->GetPDXIdForType(cache->getPoolManager().find(poolname), nType);
+  int typeId = cache->getSerializationRegistry()->GetPDXIdForType(pool, nType);
   nType->setTypeId(typeId);
 
   PdxTypeRegistry::addPdxType(typeId, nType);
@@ -65,7 +63,7 @@ int32_t PdxTypeRegistry::getPDXIdForType(const std::string& type,
 }
 
 int32_t PdxTypeRegistry::getPDXIdForType(std::shared_ptr<PdxType> nType,
-                                         const std::string& poolname) {
+                                         Pool* pool) {
   int32_t typeId = 0;
   {
     ReadGuard read(g_readerWriterLock);
@@ -88,8 +86,7 @@ int32_t PdxTypeRegistry::getPDXIdForType(std::shared_ptr<PdxType> nType,
     }
   }
 
-  typeId = cache->getSerializationRegistry()
-                ->GetPDXIdForType(cache->getPoolManager().find(poolname), nType);
+  typeId = cache->getSerializationRegistry()->GetPDXIdForType(pool, nType);
   nType->setTypeId(typeId);
   pdxTypeToTypeIdMap.insert(std::make_pair(nType, typeId));
   addPdxType(typeId, nType);

--- a/cppcache/src/PdxTypeRegistry.hpp
+++ b/cppcache/src/PdxTypeRegistry.hpp
@@ -119,7 +119,7 @@ class APACHE_GEODE_EXPORT PdxTypeRegistry
 
   void clear();
 
-  int32_t getPDXIdForType(const std::string& type, const std::string& poolname,
+  int32_t getPDXIdForType(const std::string& type, Pool* pool,
                           std::shared_ptr<PdxType> nType, bool checkIfThere);
 
   bool getPdxIgnoreUnreadFields() const { return pdxIgnoreUnreadFields; }
@@ -138,8 +138,7 @@ class APACHE_GEODE_EXPORT PdxTypeRegistry
 
   std::shared_ptr<EnumInfo> getEnum(int32_t enumVal);
 
-  int32_t getPDXIdForType(std::shared_ptr<PdxType> nType,
-                          const std::string& poolname);
+  int32_t getPDXIdForType(std::shared_ptr<PdxType> nType, Pool* pool);
 
   ACE_RW_Thread_Mutex& getPreservedDataLock() const {
     return g_preservedDataLock;

--- a/cppcache/src/PoolManagerImpl.cpp
+++ b/cppcache/src/PoolManagerImpl.cpp
@@ -69,7 +69,7 @@ std::shared_ptr<Pool> PoolManagerImpl::find(const std::string& name) const {
 
 std::shared_ptr<Pool> PoolManagerImpl::find(
     std::shared_ptr<Region> region) const {
-  return find(region->getAttributes().getPoolName().c_str());
+  return find(region->getAttributes().getPoolName());
 }
 
 const HashMapOfPools& PoolManagerImpl::getAll() const {

--- a/cppcache/src/PreservedDataExpiryHandler.hpp
+++ b/cppcache/src/PreservedDataExpiryHandler.hpp
@@ -38,7 +38,8 @@ namespace client {
  * when a preserved data expires.
  *
  */
-class APACHE_GEODE_EXPORT PreservedDataExpiryHandler : public ACE_Event_Handler {
+class APACHE_GEODE_EXPORT PreservedDataExpiryHandler
+    : public ACE_Event_Handler {
  public:
   /**
    * Constructor

--- a/cppcache/src/Properties.cpp
+++ b/cppcache/src/Properties.cpp
@@ -209,7 +209,7 @@ void Properties::toData(DataOutput& output) const {
 }
 
 void Properties::fromData(DataInput& input) {
-  auto mapSize = input.readArrayLen();
+  auto mapSize = input.readArrayLength();
   m_map.reserve(mapSize);
 
   for (int i = 0; i < mapSize; i++) {

--- a/cppcache/src/PutAllPartialResultServerException.hpp
+++ b/cppcache/src/PutAllPartialResultServerException.hpp
@@ -35,7 +35,8 @@ class PutAllPartialResultServerException;
  * @brief PutAllPartialResultServerException class is used to encapsulate
  *geode PutAllPartialResultServerException in case of PutAll execution.
  **/
-class APACHE_GEODE_EXPORT PutAllPartialResultServerException : public Serializable {
+class APACHE_GEODE_EXPORT PutAllPartialResultServerException
+    : public Serializable {
   /**
    * @brief public methods
    */

--- a/cppcache/src/RegionAttributes.cpp
+++ b/cppcache/src/RegionAttributes.cpp
@@ -302,7 +302,7 @@ void writeString(DataOutput& out, const std::string& field) {
 
 void readString(DataInput& in, std::string& field) {
   // length including null terminator
-  auto len = in.readArrayLen();
+  auto len = in.readArrayLength();
   // currentBufferPosition is read-only and we are only reading, cast away const
   field = std::string(const_cast<char*>(reinterpret_cast<const char*>(
                           in.currentBufferPosition())),

--- a/cppcache/src/SerializationRegistry.cpp
+++ b/cppcache/src/SerializationRegistry.cpp
@@ -254,39 +254,43 @@ std::shared_ptr<PdxSerializable> SerializationRegistry::getPdxType(
   return pdxObj;
 }
 
-void SerializationRegistry::setPdxSerializer(std::shared_ptr<PdxSerializer> serializer) {
+void SerializationRegistry::setPdxSerializer(
+    std::shared_ptr<PdxSerializer> serializer) {
   this->pdxSerializer = serializer;
 }
+
 std::shared_ptr<PdxSerializer> SerializationRegistry::getPdxSerializer() {
   return pdxSerializer;
 }
 
-int32_t SerializationRegistry::GetPDXIdForType(std::shared_ptr<Pool> pool,
-                                               std::shared_ptr<Serializable> pdxType) const {
-  if (pool == nullptr) {
-    throw IllegalStateException("Pool not found, Pdx operation failed");
+int32_t SerializationRegistry::GetPDXIdForType(
+    Pool* pool, std::shared_ptr<Serializable> pdxType) const {
+  if (auto poolDM = dynamic_cast<ThinClientPoolDM*>(pool)) {
+    return poolDM->GetPDXIdForType(pdxType);
   }
 
-  return static_cast<ThinClientPoolDM*>(pool.get())->GetPDXIdForType(pdxType);
+  throw IllegalStateException("Pool not found, Pdx operation failed");
 }
- std::shared_ptr<Serializable> SerializationRegistry::GetPDXTypeById(std::shared_ptr<Pool> pool,
-                                                      int32_t typeId) const {
-   if (pool == nullptr) {
-     throw IllegalStateException("Pool not found, Pdx operation failed");
+
+std::shared_ptr<Serializable> SerializationRegistry::GetPDXTypeById(
+    Pool* pool, int32_t typeId) const {
+  if (auto poolDM = dynamic_cast<ThinClientPoolDM*>(pool)) {
+    return poolDM->GetPDXTypeById(typeId);
   }
 
-  return static_cast<ThinClientPoolDM*>(pool.get())->GetPDXTypeById(typeId);
+  throw IllegalStateException("Pool not found, Pdx operation failed");
 }
 
-int32_t SerializationRegistry::GetEnumValue(std::shared_ptr<Pool> pool,
-                                            std::shared_ptr<Serializable> enumInfo) const {
+int32_t SerializationRegistry::GetEnumValue(
+    std::shared_ptr<Pool> pool, std::shared_ptr<Serializable> enumInfo) const {
   if (pool == nullptr) {
     throw IllegalStateException("Pool not found, Pdx operation failed");
   }
 
   return static_cast<ThinClientPoolDM*>(pool.get())->GetEnumValue(enumInfo);
-} std::shared_ptr<Serializable> SerializationRegistry::GetEnum(std::shared_ptr<Pool> pool,
-                                               int32_t val) const {
+}
+std::shared_ptr<Serializable> SerializationRegistry::GetEnum(
+    std::shared_ptr<Pool> pool, int32_t val) const {
   if (pool == nullptr) {
     throw IllegalStateException("Pool not found, Pdx operation failed");
   }

--- a/cppcache/src/SerializationRegistry.hpp
+++ b/cppcache/src/SerializationRegistry.hpp
@@ -215,13 +215,15 @@ class APACHE_GEODE_EXPORT SerializationRegistry {
 
   void removeType2(int64_t compId);
 
-  int32_t GetPDXIdForType(std::shared_ptr<Pool> pool,
+  int32_t GetPDXIdForType(Pool* pool,
                           std::shared_ptr<Serializable> pdxType) const;
 
-  std::shared_ptr<Serializable> GetPDXTypeById(std::shared_ptr<Pool> pool,
+  std::shared_ptr<Serializable> GetPDXTypeById(Pool* pool,
                                                int32_t typeId) const;
 
-  int32_t GetEnumValue(std::shared_ptr<Pool> pool, std::shared_ptr<Serializable> enumInfo) const;
+  int32_t GetEnumValue(std::shared_ptr<Pool> pool,
+                       std::shared_ptr<Serializable> enumInfo) const;
+
   std::shared_ptr<Serializable> GetEnum(std::shared_ptr<Pool> pool,
                                         int32_t val) const;
 

--- a/cppcache/src/Struct.cpp
+++ b/cppcache/src/Struct.cpp
@@ -65,19 +65,19 @@ void Struct::fromData(DataInput& input) {
   input.advanceCursor(2);  // ignore classType
   skipClassName(input);
 
-  int32_t numOfFields = input.readArrayLen();
+  int32_t numOfFields = input.readArrayLength();
 
   m_parent = nullptr;
   for (int32_t i = 0; i < numOfFields; i++) {
     m_fieldNames.emplace(input.readString(), i);
   }
-  int32_t lengthForTypes = input.readArrayLen();
+  int32_t lengthForTypes = input.readArrayLength();
   skipClassName(input);
   for (int i = 0; i < lengthForTypes; i++) {
     input.advanceCursor(2);  // ignore classType
     skipClassName(input);
   }
-  int32_t numOfSerializedValues = input.readArrayLen();
+  int32_t numOfSerializedValues = input.readArrayLength();
   skipClassName(input);
   for (int i = 0; i < numOfSerializedValues; i++) {
     std::shared_ptr<Serializable> val;

--- a/cppcache/src/TXCommitMessage.cpp
+++ b/cppcache/src/TXCommitMessage.cpp
@@ -82,7 +82,7 @@ void TXCommitMessage::fromData(DataInput& input) {
     if (dfsid == GeodeTypeIdsImpl::ClientProxyMembershipId) {
       ClientProxyMembershipID memId1;
 
-      input.advanceCursor(input.readArrayLen());
+      input.advanceCursor(input.readArrayLength());
 
       input.readInt32();
     } else {
@@ -104,7 +104,7 @@ void TXCommitMessage::fromData(DataInput& input) {
         GF_CACHE_ILLEGAL_STATE_EXCEPTION);
   }
 
-  int32_t len = input.readArrayLen();
+  int32_t len = input.readArrayLength();
   for (int j = 0; j < len; j++) {
     std::shared_ptr<Cacheable> tmp;
     input.readObject(tmp);

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -1232,7 +1232,7 @@ void TcrMessage::handleByteArrayResponse(
         LOGDEBUG("Expected typeID %d, got %d", GeodeTypeIds::CacheableArrayList,
                  bits8);
 
-        bits32 = input->readArrayLen();  // array length
+        bits32 = input->readArrayLength();  // array length
         LOGDEBUG("Array length = %d ", bits32);
         if (bits32 > 0) {
           std::vector<std::shared_ptr<BucketServerLocation>>
@@ -1288,7 +1288,7 @@ void TcrMessage::handleByteArrayResponse(
         input->read();                // ignore isObj;
         input->read();  // ignore cacheable CacheableHashSet typeid
 
-        bits32 = input->readArrayLen();  // array length
+        bits32 = input->readArrayLength();  // array length
         if (bits32 > 0) {
           m_fpaSet =
               new std::vector<std::shared_ptr<FixedPartitionAttributesImpl>>();
@@ -2927,7 +2927,7 @@ void TcrMessage::readHashMapForGCVersions(
     throw Exception(
         "Reading HashMap For GC versions. Expecting type id of hash map. ");
   }
-  int32_t len = input.readArrayLen();
+  int32_t len = input.readArrayLength();
 
   if (len > 0) {
     std::shared_ptr<CacheableKey> key;
@@ -2960,7 +2960,7 @@ void TcrMessage::readHashSetForGCVersions(
     throw Exception(
         "Reading HashSet For GC versions. Expecting type id of hash set. ");
   }
-  int32_t len = input.readArrayLen();
+  int32_t len = input.readArrayLength();
 
   if (len > 0) {
     std::shared_ptr<CacheableKey> key;

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -909,11 +909,10 @@ void TcrMessage::handleByteArrayResponse(
     const SerializationRegistry& serializationRegistry,
     MemberListForVersionStamp& memberListForVersionStamp) {
   auto input = m_tcdm->getConnectionManager().getCacheImpl()->createDataInput(
-      (uint8_t*)bytearray, len);
+      (uint8_t*)bytearray, len, getPoolName());
   // TODO:: this need to make sure that pool is there
   //  if(m_tcdm == nullptr)
   //  throw IllegalArgumentException("Pool is nullptr in TcrMessage");
-  DataInputInternal::setPoolName(*input, getPoolName());
   m_msgType = input->readInt32();
   int32_t msglen;
   msglen = input->readInt32();

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -584,8 +584,6 @@ void TcrMessage::writeBytesOnly(const std::shared_ptr<Serializable>& se) {
 }
 
 void TcrMessage::writeHeader(uint32_t msgType, uint32_t numOfParts) {
-  DataOutputInternal::setPoolName(*m_request, getPoolName());
-
   int8_t earlyAck = 0x0;
   LOGDEBUG("TcrMessage::writeHeader m_isMetaRegion = %d", m_isMetaRegion);
   if (m_tcdm != nullptr) {
@@ -2556,7 +2554,8 @@ void TcrMessage::createUserCredentialMessage(TcrConnection* conn) {
   m_isSecurityHeaderAdded = false;
   writeHeader(m_msgType, 1);
 
-  auto dOut = m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput();
+  auto dOut = m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput(
+      getPoolName());
 
   if (m_creds != nullptr) m_creds->toData(*dOut);
 
@@ -2585,7 +2584,8 @@ void TcrMessage::addSecurityPart(int64_t connectionId, int64_t unique_id,
   m_isSecurityHeaderAdded = true;
   LOGDEBUG("addSecurityPart( , ) ");
   auto dOutput =
-      m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput();
+      m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput(
+          getPoolName());
 
   dOutput->writeInt(connectionId);
   dOutput->writeInt(unique_id);
@@ -2616,7 +2616,8 @@ void TcrMessage::addSecurityPart(int64_t connectionId, TcrConnection* conn) {
   m_isSecurityHeaderAdded = true;
   LOGDEBUG("TcrMessage::addSecurityPart only connid");
   auto dOutput =
-      m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput();
+      m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput(
+          getPoolName());
 
   dOutput->writeInt(connectionId);
 
@@ -2785,8 +2786,8 @@ void TcrMessage::setData(const char* bytearray, int32_t len, uint16_t memId,
                          const SerializationRegistry& serializationRegistry,
                          MemberListForVersionStamp& memberListForVersionStamp) {
   if (m_request == nullptr) {
-    m_request =
-        m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput();
+    m_request = m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput(
+        getPoolName());
   }
   if (bytearray) {
     DeleteArray<const char> delByteArr(bytearray);

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -881,13 +881,11 @@ void TcrMessage::processChunk(const uint8_t* bytes, int32_t len,
   }
 }
 
-const std::string& TcrMessage::getPoolName() const {
+Pool* TcrMessage::getPool() const {
   if (m_region) {
-    if (const auto& p = m_region->getPool()) {
-      return p->getName();
-    }
+    return m_region->getPool().get();
   }
-  return EMPTY_STRING;
+  return nullptr;
 }
 
 void TcrMessage::chunkSecurityHeader(int skipPart, const uint8_t* bytes,
@@ -907,7 +905,7 @@ void TcrMessage::handleByteArrayResponse(
     const SerializationRegistry& serializationRegistry,
     MemberListForVersionStamp& memberListForVersionStamp) {
   auto input = m_tcdm->getConnectionManager().getCacheImpl()->createDataInput(
-      (uint8_t*)bytearray, len, getPoolName());
+      (uint8_t*)bytearray, len, getPool());
   // TODO:: this need to make sure that pool is there
   //  if(m_tcdm == nullptr)
   //  throw IllegalArgumentException("Pool is nullptr in TcrMessage");
@@ -2555,7 +2553,7 @@ void TcrMessage::createUserCredentialMessage(TcrConnection* conn) {
   writeHeader(m_msgType, 1);
 
   auto dOut = m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput(
-      getPoolName());
+      getPool());
 
   if (m_creds != nullptr) m_creds->toData(*dOut);
 
@@ -2585,7 +2583,7 @@ void TcrMessage::addSecurityPart(int64_t connectionId, int64_t unique_id,
   LOGDEBUG("addSecurityPart( , ) ");
   auto dOutput =
       m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput(
-          getPoolName());
+          getPool());
 
   dOutput->writeInt(connectionId);
   dOutput->writeInt(unique_id);
@@ -2617,7 +2615,7 @@ void TcrMessage::addSecurityPart(int64_t connectionId, TcrConnection* conn) {
   LOGDEBUG("TcrMessage::addSecurityPart only connid");
   auto dOutput =
       m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput(
-          getPoolName());
+          getPool());
 
   dOutput->writeInt(connectionId);
 
@@ -2787,7 +2785,7 @@ void TcrMessage::setData(const char* bytearray, int32_t len, uint16_t memId,
                          MemberListForVersionStamp& memberListForVersionStamp) {
   if (m_request == nullptr) {
     m_request = m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput(
-        getPoolName());
+        getPool());
   }
   if (bytearray) {
     DeleteArray<const char> delByteArr(bytearray);

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -257,7 +257,7 @@ class APACHE_GEODE_EXPORT TcrMessage {
     }
   }
 
-  const std::string& getPoolName() const;
+  Pool* getPool() const;
 
   /**
    * Whether the request is meant to be

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -3339,7 +3339,8 @@ void ChunkedInterestResponse::handleChunk(const uint8_t* chunk,
                                           int32_t chunkLen,
                                           uint8_t isLastChunkWithSecurity,
                                           const CacheImpl* cacheImpl) {
-  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_replyMsg.getPoolName());
+  auto input =
+      cacheImpl->createDataInput(chunk, chunkLen, m_replyMsg.getPool());
 
   uint32_t partLen;
   if (TcrMessageHelper::readChunkPartHeader(
@@ -3369,7 +3370,8 @@ void ChunkedKeySetResponse::reset() {
 void ChunkedKeySetResponse::handleChunk(const uint8_t* chunk, int32_t chunkLen,
                                         uint8_t isLastChunkWithSecurity,
                                         const CacheImpl* cacheImpl) {
-  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_replyMsg.getPoolName());
+  auto input =
+      cacheImpl->createDataInput(chunk, chunkLen, m_replyMsg.getPool());
 
   uint32_t partLen;
   if (TcrMessageHelper::readChunkPartHeader(
@@ -3443,7 +3445,7 @@ void ChunkedQueryResponse::handleChunk(const uint8_t* chunk, int32_t chunkLen,
                                        uint8_t isLastChunkWithSecurity,
                                        const CacheImpl* cacheImpl) {
   LOGDEBUG("ChunkedQueryResponse::handleChunk..");
-  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPoolName());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPool());
 
   uint32_t partLen;
   TcrMessageHelper::ChunkObjectType objType;
@@ -3584,7 +3586,7 @@ void ChunkedFunctionExecutionResponse::handleChunk(
     const uint8_t* chunk, int32_t chunkLen, uint8_t isLastChunkWithSecurity,
     const CacheImpl* cacheImpl) {
   LOGDEBUG("ChunkedFunctionExecutionResponse::handleChunk");
-  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPoolName());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPool());
 
   uint32_t partLen;
 
@@ -3718,7 +3720,7 @@ void ChunkedGetAllResponse::reset() {
 void ChunkedGetAllResponse::handleChunk(const uint8_t* chunk, int32_t chunkLen,
                                         uint8_t isLastChunkWithSecurity,
                                         const CacheImpl* cacheImpl) {
-  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPoolName());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPool());
 
   uint32_t partLen;
   if (TcrMessageHelper::readChunkPartHeader(
@@ -3772,7 +3774,7 @@ void ChunkedPutAllResponse::reset() {
 void ChunkedPutAllResponse::handleChunk(const uint8_t* chunk, int32_t chunkLen,
                                         uint8_t isLastChunkWithSecurity,
                                         const CacheImpl* cacheImpl) {
-  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPoolName());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPool());
 
   uint32_t partLen;
   int8_t chunkType;
@@ -3806,10 +3808,10 @@ void ChunkedPutAllResponse::handleChunk(const uint8_t* chunk, int32_t chunkLen,
     const auto byte1 = input->read();
     m_msg.readSecureObjectPart(*input, false, true, isLastChunkWithSecurity);
 
-    auto pool = cacheImpl->getPoolManager().find(m_msg.getPoolName());
+    auto pool = m_msg.getPool();
     if (pool != nullptr && !pool->isDestroyed() &&
         pool->getPRSingleHopEnabled()) {
-      ThinClientPoolDM* poolDM = dynamic_cast<ThinClientPoolDM*>(pool.get());
+      auto poolDM = dynamic_cast<ThinClientPoolDM*>(pool);
       if ((poolDM != nullptr) &&
           (poolDM->getClientMetaDataService() != nullptr) && (byte0 != 0)) {
         LOGFINE("enqueued region " + m_region->getFullPath() +
@@ -3832,7 +3834,7 @@ void ChunkedRemoveAllResponse::handleChunk(const uint8_t* chunk,
                                            int32_t chunkLen,
                                            uint8_t isLastChunkWithSecurity,
                                            const CacheImpl* cacheImpl) {
-  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPoolName());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPool());
 
   uint32_t partLen;
   int8_t chunkType;
@@ -3867,10 +3869,10 @@ void ChunkedRemoveAllResponse::handleChunk(const uint8_t* chunk,
     const auto byte1 = input->read();
     m_msg.readSecureObjectPart(*input, false, true, isLastChunkWithSecurity);
 
-    auto pool = cacheImpl->getPoolManager().find(m_msg.getPoolName());
+    auto pool = m_msg.getPool();
     if (pool != nullptr && !pool->isDestroyed() &&
         pool->getPRSingleHopEnabled()) {
-      ThinClientPoolDM* poolDM = dynamic_cast<ThinClientPoolDM*>(pool.get());
+      auto poolDM = dynamic_cast<ThinClientPoolDM*>(pool);
       if ((poolDM != nullptr) &&
           (poolDM->getClientMetaDataService() != nullptr) && (byte0 != 0)) {
         LOGFINE("enqueued region " + m_region->getFullPath() +
@@ -3893,7 +3895,7 @@ void ChunkedDurableCQListResponse::handleChunk(const uint8_t* chunk,
                                                int32_t chunkLen,
                                                uint8_t,
                                                const CacheImpl* cacheImpl) {
-  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPoolName());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPool());
 
   // read and ignore part length
   input->readInt32();

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -3339,9 +3339,7 @@ void ChunkedInterestResponse::handleChunk(const uint8_t* chunk,
                                           int32_t chunkLen,
                                           uint8_t isLastChunkWithSecurity,
                                           const CacheImpl* cacheImpl) {
-  auto input = cacheImpl->createDataInput(chunk, chunkLen);
-
-  DataInputInternal::setPoolName(*input, m_replyMsg.getPoolName());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_replyMsg.getPoolName());
 
   uint32_t partLen;
   if (TcrMessageHelper::readChunkPartHeader(
@@ -3371,9 +3369,7 @@ void ChunkedKeySetResponse::reset() {
 void ChunkedKeySetResponse::handleChunk(const uint8_t* chunk, int32_t chunkLen,
                                         uint8_t isLastChunkWithSecurity,
                                         const CacheImpl* cacheImpl) {
-  auto input = cacheImpl->createDataInput(chunk, chunkLen);
-
-  DataInputInternal::setPoolName(*input, m_replyMsg.getPoolName());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_replyMsg.getPoolName());
 
   uint32_t partLen;
   if (TcrMessageHelper::readChunkPartHeader(
@@ -3447,8 +3443,8 @@ void ChunkedQueryResponse::handleChunk(const uint8_t* chunk, int32_t chunkLen,
                                        uint8_t isLastChunkWithSecurity,
                                        const CacheImpl* cacheImpl) {
   LOGDEBUG("ChunkedQueryResponse::handleChunk..");
-  auto input = cacheImpl->createDataInput(chunk, chunkLen);
-  DataInputInternal::setPoolName(*input, m_msg.getPoolName());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPoolName());
+
   uint32_t partLen;
   TcrMessageHelper::ChunkObjectType objType;
   if ((objType = TcrMessageHelper::readChunkPartHeader(
@@ -3588,8 +3584,8 @@ void ChunkedFunctionExecutionResponse::handleChunk(
     const uint8_t* chunk, int32_t chunkLen, uint8_t isLastChunkWithSecurity,
     const CacheImpl* cacheImpl) {
   LOGDEBUG("ChunkedFunctionExecutionResponse::handleChunk");
-  auto input = cacheImpl->createDataInput(chunk, chunkLen);
-  DataInputInternal::setPoolName(*input, m_msg.getPoolName());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPoolName());
+
   uint32_t partLen;
 
   int8_t arrayType;
@@ -3722,8 +3718,8 @@ void ChunkedGetAllResponse::reset() {
 void ChunkedGetAllResponse::handleChunk(const uint8_t* chunk, int32_t chunkLen,
                                         uint8_t isLastChunkWithSecurity,
                                         const CacheImpl* cacheImpl) {
-  auto input = cacheImpl->createDataInput(chunk, chunkLen);
-  DataInputInternal::setPoolName(*input, m_msg.getPoolName());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPoolName());
+
   uint32_t partLen;
   if (TcrMessageHelper::readChunkPartHeader(
           m_msg, *input, GeodeTypeIdsImpl::FixedIDByte,
@@ -3776,8 +3772,8 @@ void ChunkedPutAllResponse::reset() {
 void ChunkedPutAllResponse::handleChunk(const uint8_t* chunk, int32_t chunkLen,
                                         uint8_t isLastChunkWithSecurity,
                                         const CacheImpl* cacheImpl) {
-  auto input = cacheImpl->createDataInput(chunk, chunkLen);
-  DataInputInternal::setPoolName(*input, m_msg.getPoolName());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPoolName());
+
   uint32_t partLen;
   int8_t chunkType;
   if ((chunkType = (TcrMessageHelper::ChunkObjectType)
@@ -3836,8 +3832,8 @@ void ChunkedRemoveAllResponse::handleChunk(const uint8_t* chunk,
                                            int32_t chunkLen,
                                            uint8_t isLastChunkWithSecurity,
                                            const CacheImpl* cacheImpl) {
-  auto input = cacheImpl->createDataInput(chunk, chunkLen);
-  DataInputInternal::setPoolName(*input, m_msg.getPoolName());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPoolName());
+
   uint32_t partLen;
   int8_t chunkType;
   if ((chunkType = (TcrMessageHelper::ChunkObjectType)
@@ -3894,10 +3890,10 @@ void ChunkedDurableCQListResponse::reset() {
 
 // handles the chunk response for GETDURABLECQS_MSG_TYPE
 void ChunkedDurableCQListResponse::handleChunk(const uint8_t* chunk,
-                                               int32_t chunkLen, uint8_t,
-                                               const CacheImpl* m_cacheImpl) {
-  auto input = m_cacheImpl->createDataInput(chunk, chunkLen);
-  DataInputInternal::setPoolName(*input, m_msg.getPoolName());
+                                               int32_t chunkLen,
+                                               uint8_t,
+                                               const CacheImpl* cacheImpl) {
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPoolName());
 
   // read and ignore part length
   input->readInt32();

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -3402,7 +3402,7 @@ void ChunkedQueryResponse::readObjectPartList(DataInput& input,
 
   for (int32_t index = 0; index < len; ++index) {
     if (input.read() == 2 /* for exception*/) {
-      input.advanceCursor(input.readArrayLen());  // skipLen
+      input.advanceCursor(input.readArrayLength());  // skipLen
       auto exMsgPtr = input.readString();
       throw IllegalStateException(exMsgPtr);
     } else {
@@ -3486,7 +3486,7 @@ void ChunkedQueryResponse::handleChunk(const uint8_t* chunk, int32_t chunkLen,
   const auto isStructTypeImpl = input->readString();
 
   if (isStructTypeImpl == "org.apache.geode.cache.query.Struct") {
-    int32_t numOfFldNames = input->readArrayLen();
+    int32_t numOfFldNames = input->readArrayLength();
     bool skip = false;
     if (m_structFieldNames.size() != 0) {
       skip = true;
@@ -3520,7 +3520,7 @@ void ChunkedQueryResponse::handleChunk(const uint8_t* chunk, int32_t chunkLen,
   auto arrayType = input->read();
 
   if (arrayType == GeodeTypeIds::CacheableObjectArray) {
-    int32_t arraySize = input->readArrayLen();
+    int32_t arraySize = input->readArrayLength();
     skipClass(*input);
     for (int32_t arrayItem = 0; arrayItem < arraySize; ++arrayItem) {
       std::shared_ptr<Serializable> value;
@@ -3529,7 +3529,7 @@ void ChunkedQueryResponse::handleChunk(const uint8_t* chunk, int32_t chunkLen,
         m_queryResults->push_back(value);
       } else {
         input->read();
-        int32_t arraySize2 = input->readArrayLen();
+        int32_t arraySize2 = input->readArrayLength();
         skipClass(*input);
         for (int32_t index = 0; index < arraySize2; ++index) {
           input->readObject(value);
@@ -3614,7 +3614,7 @@ void ChunkedFunctionExecutionResponse::handleChunk(
       input->getBytesRead() -
       1;  // from here need to look value part + memberid AND -1 for array type
   // iread adn gnore array length
-  input->readArrayLen();
+  input->readArrayLength();
 
   // read a byte to determine whether to read exception part for sendException
   // or read objects.
@@ -3660,7 +3660,7 @@ void ChunkedFunctionExecutionResponse::handleChunk(
       arrayType = input->read();
 
       // read and ignore its len which is 2
-      input->readArrayLen();
+      input->readArrayLength();
     }
   } else {
     // rewind cursor by 1 to what we had read a byte to determine whether to

--- a/cppcache/src/VersionedCacheableObjectPartList.cpp
+++ b/cppcache/src/VersionedCacheableObjectPartList.cpp
@@ -45,7 +45,7 @@ void VersionedCacheableObjectPartList::readObjectPart(
 
   if (isException) {  // Exception case
     // Skip the exception that is in java serialized format, we cant read it.
-    input.advanceCursor(input.readArrayLen());
+    input.advanceCursor(input.readArrayLength());
     const auto exMsg = input.readString();  ////4.1
 
     std::shared_ptr<Exception> ex;
@@ -59,7 +59,7 @@ void VersionedCacheableObjectPartList::readObjectPart(
     m_exceptions->emplace(keyPtr, ex);
   } else if (m_serializeValues) {
     // read length
-    int32_t skipLen = input.readArrayLen();
+    int32_t skipLen = input.readArrayLength();
     int8_t* bytes = nullptr;
     if (skipLen > 0) {
       // readObject

--- a/cppcache/src/statistics/HostStatSampler.hpp
+++ b/cppcache/src/statistics/HostStatSampler.hpp
@@ -64,8 +64,8 @@ class StatisticsManager;
  * statistics. It only has the common functionalities which any sampler needs.
  */
 class APACHE_GEODE_EXPORT HostStatSampler : public ACE_Task_Base,
-                                      private NonCopyable,
-                                      private NonAssignable {
+                                            private NonCopyable,
+                                            private NonAssignable {
  public:
   /*
    * Constructor:

--- a/cppcache/src/statistics/StatArchiveWriter.hpp
+++ b/cppcache/src/statistics/StatArchiveWriter.hpp
@@ -139,7 +139,8 @@ class APACHE_GEODE_EXPORT StatDataOutput {
   friend class StatArchiveWriter;
 };
 
-class APACHE_GEODE_EXPORT ResourceType : private NonCopyable, private NonAssignable {
+class APACHE_GEODE_EXPORT ResourceType : private NonCopyable,
+                                         private NonAssignable {
  public:
   ResourceType(int32_t id, const StatisticsType *type);
   int32_t getId() const;
@@ -166,7 +167,8 @@ class APACHE_GEODE_EXPORT ResourceType : private NonCopyable, private NonAssigna
  * FIX : Make the class NonCopyable
  */
 
-class APACHE_GEODE_EXPORT ResourceInst : private NonCopyable, private NonAssignable {
+class APACHE_GEODE_EXPORT ResourceInst : private NonCopyable,
+                                         private NonAssignable {
  public:
   ResourceInst(int32_t id, Statistics *, const ResourceType *,
                StatDataOutput *);

--- a/cppcache/src/util/exception.hpp
+++ b/cppcache/src/util/exception.hpp
@@ -30,7 +30,7 @@ namespace geode {
 namespace client {
 
 extern void APACHE_GEODE_EXPORT GfErrTypeThrowException(const char* str,
-                                                  GfErrType err);
+                                                        GfErrType err);
 
 #define GfErrTypeToException(str, err)   \
   {                                      \

--- a/cppcache/test/DataInputTest.cpp
+++ b/cppcache/test/DataInputTest.cpp
@@ -59,8 +59,6 @@ class TestDataInput {
     // NOP
   }
 
-  operator DataInput &() { return m_dataInput; }
-
   void read(uint8_t *value) { *value = m_dataInput.read(); }
 
   void read(int8_t *value) { *value = m_dataInput.read(); }
@@ -142,8 +140,6 @@ class TestDataInput {
   void reset() { m_dataInput.reset(); }
 
   void setBuffer() { m_dataInput.setBuffer(); }
-
-  Pool *getPool() { return DataInputInternal::getPool(m_dataInput); }
 
   template <class CharT = char, class... Tail>
   inline std::basic_string<CharT, Tail...> readUTF() {

--- a/cppcache/test/DataInputTest.cpp
+++ b/cppcache/test/DataInputTest.cpp
@@ -91,7 +91,7 @@ class TestDataInput {
 
   int64_t readInt64() { return m_dataInput.readInt64(); }
 
-  int32_t readArrayLen() { return m_dataInput.readArrayLen(); }
+  int32_t readArrayLen() { return m_dataInput.readArrayLength(); }
 
   int64_t readUnsignedVL() { return m_dataInput.readUnsignedVL(); }
 

--- a/cppcache/test/DataInputTest.cpp
+++ b/cppcache/test/DataInputTest.cpp
@@ -143,6 +143,10 @@ class TestDataInput {
 
   void setBuffer() { m_dataInput.setBuffer(); }
 
+  const std::string &getPoolName() {
+    return DataInputInternal::getPoolName(m_dataInput);
+  }
+
   template <class CharT = char, class... Tail>
   inline std::basic_string<CharT, Tail...> readUTF() {
     return m_dataInput.readUTF<CharT, Tail...>();
@@ -714,19 +718,6 @@ TEST_F(DataInputTest, TestSetBuffer) {
       << "Correct bytes read after the setting";
   EXPECT_EQ(static_cast<size_t>(0), dataInput.getBytesRemaining())
       << "Correct bytes remaining after the setting";
-}
-
-TEST_F(DataInputTest, TestSetPoolName) {
-  std::string poolName = "Das Schwimmbad";
-
-  TestDataInput dataInput("123456789ABCDEF0");
-  EXPECT_TRUE(DataInputInternal::getPoolName(dataInput).empty())
-      << "Empty pool name before setting";
-  DataInputInternal::setPoolName(dataInput, poolName);
-  EXPECT_FALSE(DataInputInternal::getPoolName(dataInput).empty())
-      << " pool name after setting";
-  EXPECT_EQ(poolName, DataInputInternal::getPoolName(dataInput))
-      << "Correct pool name after setting";
 }
 
 TEST_F(DataInputTest, TestReadNullArray) {

--- a/cppcache/test/DataInputTest.cpp
+++ b/cppcache/test/DataInputTest.cpp
@@ -143,9 +143,7 @@ class TestDataInput {
 
   void setBuffer() { m_dataInput.setBuffer(); }
 
-  const std::string &getPoolName() {
-    return DataInputInternal::getPoolName(m_dataInput);
-  }
+  Pool *getPool() { return DataInputInternal::getPool(m_dataInput); }
 
   template <class CharT = char, class... Tail>
   inline std::basic_string<CharT, Tail...> readUTF() {

--- a/cppcache/test/TcrMessage_unittest.cpp
+++ b/cppcache/test/TcrMessage_unittest.cpp
@@ -32,6 +32,15 @@ class DataOutputUnderTest : public DataOutput {
  public:
   using DataOutput::DataOutput;
   DataOutputUnderTest() : DataOutput(nullptr, nullptr) {}
+
+ protected:
+  virtual const SerializationRegistry &getSerializationRegistry()
+  const override {
+    return m_serializationRegistry;
+  }
+
+ private:
+  SerializationRegistry m_serializationRegistry;
 };
 
 #define EXPECT_MESSAGE_EQ(e, a) EXPECT_PRED_FORMAT2(assertMessageEqual, e, a)

--- a/cppcache/test/TcrMessage_unittest.cpp
+++ b/cppcache/test/TcrMessage_unittest.cpp
@@ -31,7 +31,7 @@ using namespace apache::geode::client;
 class DataOutputUnderTest : public DataOutput {
  public:
   using DataOutput::DataOutput;
-  DataOutputUnderTest() : DataOutput(nullptr, EMPTY_STRING) {}
+  DataOutputUnderTest() : DataOutput(nullptr, nullptr) {}
 };
 
 #define EXPECT_MESSAGE_EQ(e, a) EXPECT_PRED_FORMAT2(assertMessageEqual, e, a)

--- a/cppcache/test/TcrMessage_unittest.cpp
+++ b/cppcache/test/TcrMessage_unittest.cpp
@@ -31,15 +31,7 @@ using namespace apache::geode::client;
 class DataOutputUnderTest : public DataOutput {
  public:
   using DataOutput::DataOutput;
-
- protected:
-  virtual const SerializationRegistry &getSerializationRegistry()
-      const override {
-    return m_serializationRegistry;
-  }
-
- private:
-  SerializationRegistry m_serializationRegistry;
+  DataOutputUnderTest() : DataOutput(nullptr, EMPTY_STRING) {}
 };
 
 #define EXPECT_MESSAGE_EQ(e, a) EXPECT_PRED_FORMAT2(assertMessageEqual, e, a)

--- a/tests/cli/QueryHelper/CMakeLists.txt
+++ b/tests/cli/QueryHelper/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(QueryWrapper
   PRIVATE
     c++cli
     c++11
+	_WarningsAsError
 )
 
 # Makes project only reference, no .lib.

--- a/tests/cli/QueryHelper/QueryStringsM.cpp
+++ b/tests/cli/QueryHelper/QueryStringsM.cpp
@@ -212,8 +212,8 @@ namespace Apache
 
           StructSetRowCounts = gcnew array<Int32>( testData::SS_ARRAY_SIZE );
           for (Int32 index = 0; index < testData::SS_ARRAY_SIZE; ++index) {
-            StructSetRowCounts[ index ] =
-              testData::structsetRowCounts[ index ];
+            StructSetRowCounts[ index ] = static_cast<int32_t>(
+              testData::structsetRowCounts[ index ]);
           }
 
           StructSetPQRowCounts = gcnew array<Int32>( testData::SSP_ARRAY_SIZE );
@@ -260,8 +260,8 @@ namespace Apache
 
           RegionQueryRowCounts = gcnew array<Int32>( testData::RQ_ARRAY_SIZE );
           for (Int32 index = 0; index < testData::RQ_ARRAY_SIZE; ++index) {
-            RegionQueryRowCounts[ index ] =
-              testData::regionQueryRowCounts[ index ];
+            RegionQueryRowCounts[ index ] = static_cast<int32_t>(
+              testData::regionQueryRowCounts[ index ]);
           }
 
           CqResultSetQueries = gcnew array<QueryStrings^>(


### PR DESCRIPTION
Looking for feed back to see if this is any better than what was there (no reference wrapper now)

DataOutputInternal::setPoolName was used pretty far from where it DataOutput is created, so not sure we caught every case.