### PR TITLE
GEODE-5025: Convert remaining CacheableBuiltins macros into templates

### DIFF
--- a/cppcache/include/geode/SelectResultsIterator.hpp
+++ b/cppcache/include/geode/SelectResultsIterator.hpp
@@ -40,7 +40,6 @@ namespace client {
 
 class ResultSetImpl;
 class StructSetImpl;
-class CacheableVector;
 class SelectResults;
 class Serializable;
 


### PR DESCRIPTION
Admittedly, I have not tested this out thoroughly.  It may be broken on Windows.

Testing: Built and passed unittests on mac.