### PR TITLE
GEODE-4994: Fix windows compilation

### DIFF
--- a/cppcache/integration-test/testXmlCacheCreationWithPools.cpp
+++ b/cppcache/integration-test/testXmlCacheCreationWithPools.cpp
@@ -16,11 +16,12 @@
  */
 
 #include <inttypes.h>
-#include <geode/internal/chrono/duration.hpp>
 #include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>
+
+#include <geode/internal/chrono/duration.hpp>
 
 #include "fw_dunit.hpp"
 

--- a/cppcache/integration-test/testXmlCacheCreationWithPools.cpp
+++ b/cppcache/integration-test/testXmlCacheCreationWithPools.cpp
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-#include "fw_dunit.hpp"
-
+#include <inttypes.h>
 #include <geode/internal/chrono/duration.hpp>
 #include <cstdint>
-#include <inttypes.h>
 #include <iostream>
 #include <string>
 #include <vector>
+
+#include "fw_dunit.hpp"
 
 #define CLIENT1 s1p1
 #define SERVER1 s2p1

--- a/cppcache/integration-test/testXmlCacheCreationWithPools.cpp
+++ b/cppcache/integration-test/testXmlCacheCreationWithPools.cpp
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-#include <string>
-#include <iostream>
-#include <vector>
-#include <cstdint>
-
 #include "fw_dunit.hpp"
 
 #include <geode/internal/chrono/duration.hpp>
+#include <cstdint>
+#include <inttypes.h>
+#include <iostream>
+#include <string>
+#include <vector>
 
 #define CLIENT1 s1p1
 #define SERVER1 s2p1

--- a/cryptoimpl/DHImpl.cpp
+++ b/cryptoimpl/DHImpl.cpp
@@ -99,35 +99,29 @@ ASN1_SEQUENCE(
 
   dhimpl->m_dh = DH_new();
 
-
   const BIGNUM *pbn, *gbn;
   DH_get0_pqg(dhimpl->m_dh, &pbn, NULL, &gbn);
   BN_dec2bn((BIGNUM **)&pbn, dhP);
-  LOGDH(" DHInit: BN_dec2bn dhP ret %d", ret);
 
   LOGDH(" DHInit: P ptr is %p", pbn);
   LOGDH(" DHInit: G ptr is %p", gbn);
   LOGDH(" DHInit: length is %d", DH_get_length(dhimpl->m_dh));
 
   BN_dec2bn((BIGNUM **)&gbn, dhG);
-  LOGDH(" DHInit: BN_dec2bn dhG ret %d", ret);
 
   DH_set_length(dhimpl->m_dh, dhL);
 
   DH_generate_key(dhimpl->m_dh);
-  LOGDH(" DHInit: DH_generate_key ret %d", ret);
 
   const BIGNUM *pub_key, *priv_key;
   DH_get0_key(dhimpl->m_dh, &pub_key, &priv_key);
   BN_num_bits(priv_key);
-  LOGDH(" DHInit: BN_num_bits priv_key is %d", ret);
 
   BN_num_bits(pub_key);
-  LOGDH(" DHInit: BN_num_bits pub_key is %d", ret);
 
   int codes = 0;
   DH_check(dhimpl->m_dh, &codes);
-  LOGDH(" DHInit: DH_check ret %d : codes is 0x%04X", ret, codes);
+  LOGDH(" DHInit: DH_check codes is 0x%04X", codes);
   LOGDH(" DHInit: DH_size is %d", DH_size(dhimpl->m_dh));
 
   // load the server's RSA public key for server authentication
@@ -371,7 +365,6 @@ unsigned char *gf_encryptDH(void *dhCtx, const unsigned char *cleartext,
     int keySize = dhimpl->m_keySize > 128 ? dhimpl->m_keySize / 8 : 16;
     EVP_EncryptInit_ex(ctx, cipherFunc, NULL, NULL,
                        (unsigned char *)dhimpl->m_key + keySize);
-    LOGDH("DHencrypt: init BF ret %d", ret);
     EVP_CIPHER_CTX_set_key_length(ctx, keySize);
     LOGDH("DHencrypt: BF keysize is %d", keySize);
     EVP_EncryptInit_ex(ctx, NULL, NULL, (unsigned char *)dhimpl->m_key, NULL);

--- a/dhimpl/DHImpl.cpp
+++ b/dhimpl/DHImpl.cpp
@@ -100,7 +100,7 @@ ASN1_SEQUENCE(
 
   int codes = 0;
   DH_check(m_dh, &codes);
-  LOGDH(" DHInit: DH_check ret %d : codes is 0x%04X", ret, codes);
+  LOGDH(" DHInit: DH_check codes is 0x%04X", codes);
   LOGDH(" DHInit: DH_size is %d", DH_size(m_dh));
 
   // load the server's RSA public key for server authentication
@@ -336,7 +336,6 @@ unsigned char *gf_encryptDH(const unsigned char *cleartext, int len,
     int keySize = m_keySize > 128 ? m_keySize / 8 : 16;
     EVP_EncryptInit_ex(ctx, cipherFunc, NULL, NULL,
                        (unsigned char *)m_key + keySize);
-    LOGDH("DHencrypt: init BF ret %d", ret);
     EVP_CIPHER_CTX_set_key_length(ctx, keySize);
     LOGDH("DHencrypt: BF keysize is %d", keySize);
     EVP_EncryptInit_ex(ctx, NULL, NULL, (unsigned char *)m_key, NULL);

--- a/tests/cpp/testobject/BatchObject.hpp
+++ b/tests/cpp/testobject/BatchObject.hpp
@@ -24,16 +24,16 @@
  * @brief User class for testing the cq functionality.
  */
 
+#include <inttypes.h>
+#include <ace/ACE.h>
+#include <ace/OS.h>
+#include <ace/Time_Value.h>
+#include <string>
+
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include "TimestampedObject.hpp"
 #include "testobject_export.h"
-
-#include <ace/ACE.h>
-#include <ace/OS.h>
-#include <ace/Time_Value.h>
-#include <inttypes.h>
-#include <string>
 
 using namespace apache::geode::client;
 using namespace testframework;

--- a/tests/cpp/testobject/BatchObject.hpp
+++ b/tests/cpp/testobject/BatchObject.hpp
@@ -20,15 +20,12 @@
 #ifndef GEODE_TESTOBJECT_BATCHOBJECT_H_
 #define GEODE_TESTOBJECT_BATCHOBJECT_H_
 
-/*
- * @brief User class for testing the cq functionality.
- */
-
 #include <inttypes.h>
+#include <string>
+
 #include <ace/ACE.h>
 #include <ace/OS.h>
 #include <ace/Time_Value.h>
-#include <string>
 
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
@@ -38,6 +35,9 @@
 using namespace apache::geode::client;
 using namespace testframework;
 namespace testobject {
+/**
+ * @brief User class for testing the cq functionality.
+ */
 class TESTOBJECT_EXPORT BatchObject : public TimestampedObject {
  private:
   int32_t index;

--- a/tests/cpp/testobject/BatchObject.hpp
+++ b/tests/cpp/testobject/BatchObject.hpp
@@ -24,15 +24,16 @@
  * @brief User class for testing the cq functionality.
  */
 
-#include <string>
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include "TimestampedObject.hpp"
+#include "testobject_export.h"
+
 #include <ace/ACE.h>
 #include <ace/OS.h>
 #include <ace/Time_Value.h>
-
-#include "testobject_export.h"
+#include <inttypes.h>
+#include <string>
 
 using namespace apache::geode::client;
 using namespace testframework;

--- a/tests/cpp/testobject/DeltaFastAssetAccount.hpp
+++ b/tests/cpp/testobject/DeltaFastAssetAccount.hpp
@@ -20,16 +20,14 @@
 #ifndef GEODE_TESTOBJECT_DELTAFASTASSETACCOUNT_H_
 #define GEODE_TESTOBJECT_DELTAFASTASSETACCOUNT_H_
 
-/*
- * @brief User class for testing the query functionality.
- */
-
 #include <inttypes.h>
-#include <geode/Delta.hpp>
+#include <string>
+
 #include <ace/ACE.h>
 #include <ace/OS.h>
 #include <ace/Time_Value.h>
-#include <string>
+
+#include <geode/Delta.hpp>
 
 #include "fwklib/FrameworkTest.hpp"
 #include "FastAsset.hpp"
@@ -38,7 +36,9 @@
 using namespace apache::geode::client;
 using namespace testframework;
 namespace testobject {
-
+/**
+ * @brief User class for testing the query functionality.
+ */
 class TESTOBJECT_EXPORT DeltaFastAssetAccount : public Cacheable, public Delta {
  private:
   bool encodeTimestamp;

--- a/tests/cpp/testobject/DeltaFastAssetAccount.hpp
+++ b/tests/cpp/testobject/DeltaFastAssetAccount.hpp
@@ -24,16 +24,16 @@
  * @brief User class for testing the query functionality.
  */
 
-#include "fwklib/FrameworkTest.hpp"
-#include "FastAsset.hpp"
-#include "testobject_export.h"
-
+#include <inttypes.h>
 #include <geode/Delta.hpp>
 #include <ace/ACE.h>
 #include <ace/OS.h>
 #include <ace/Time_Value.h>
-#include <inttypes.h>
 #include <string>
+
+#include "fwklib/FrameworkTest.hpp"
+#include "FastAsset.hpp"
+#include "testobject_export.h"
 
 using namespace apache::geode::client;
 using namespace testframework;

--- a/tests/cpp/testobject/DeltaFastAssetAccount.hpp
+++ b/tests/cpp/testobject/DeltaFastAssetAccount.hpp
@@ -23,19 +23,17 @@
 /*
  * @brief User class for testing the query functionality.
  */
-#include <string>
 
+#include "fwklib/FrameworkTest.hpp"
+#include "FastAsset.hpp"
+#include "testobject_export.h"
+
+#include <geode/Delta.hpp>
 #include <ace/ACE.h>
 #include <ace/OS.h>
 #include <ace/Time_Value.h>
-
-#include <geode/Delta.hpp>
-
-#include "fwklib/FrameworkTest.hpp"
-
-#include "FastAsset.hpp"
-
-#include "testobject_export.h"
+#include <inttypes.h>
+#include <string>
 
 using namespace apache::geode::client;
 using namespace testframework;

--- a/tests/cpp/testobject/DeltaPSTObject.hpp
+++ b/tests/cpp/testobject/DeltaPSTObject.hpp
@@ -24,16 +24,17 @@
  * @brief User class for testing the put functionality for object.
  */
 
-#include <string>
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include "TimestampedObject.hpp"
 #include "testobject/PSTObject.hpp"
+#include "testobject_export.h"
+
 #include <ace/ACE.h>
 #include <ace/OS.h>
 #include <ace/Time_Value.h>
-
-#include "testobject_export.h"
+#include <inttypes.h>
+#include <string>
 
 using namespace apache::geode::client;
 using namespace testframework;

--- a/tests/cpp/testobject/DeltaPSTObject.hpp
+++ b/tests/cpp/testobject/DeltaPSTObject.hpp
@@ -20,9 +20,12 @@
 #ifndef GEODE_TESTOBJECT_DELTAPSTOBJECT_H_
 #define GEODE_TESTOBJECT_DELTAPSTOBJECT_H_
 
-/*
- * @brief User class for testing the put functionality for object.
- */
+#include <inttypes.h>
+#include <string>
+
+#include <ace/ACE.h>
+#include <ace/OS.h>
+#include <ace/Time_Value.h>
 
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
@@ -30,15 +33,12 @@
 #include "testobject/PSTObject.hpp"
 #include "testobject_export.h"
 
-#include <ace/ACE.h>
-#include <ace/OS.h>
-#include <ace/Time_Value.h>
-#include <inttypes.h>
-#include <string>
-
 using namespace apache::geode::client;
 using namespace testframework;
 namespace testobject {
+/**
+ * @brief User class for testing the put functionality for object.
+ */
 class TESTOBJECT_EXPORT DeltaPSTObject : public Cacheable, public Delta {
  private:
   uint64_t timestamp;

--- a/tests/cpp/testobject/EqStruct.hpp
+++ b/tests/cpp/testobject/EqStruct.hpp
@@ -24,15 +24,16 @@
  * @brief User class for testing the put functionality for object.
  */
 
-#include <string>
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include "TimestampedObject.hpp"
+#include "testobject_export.h"
+
 #include <ace/ACE.h>
 #include <ace/OS.h>
 #include <ace/Time_Value.h>
-
-#include "testobject_export.h"
+#include <inttypes.h>
+#include <string>
 
 using namespace apache::geode::client;
 using namespace testframework;

--- a/tests/cpp/testobject/EqStruct.hpp
+++ b/tests/cpp/testobject/EqStruct.hpp
@@ -24,16 +24,16 @@
  * @brief User class for testing the put functionality for object.
  */
 
+#include <inttypes.h>
+#include <ace/ACE.h>
+#include <ace/OS.h>
+#include <ace/Time_Value.h>
+#include <string>
+
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include "TimestampedObject.hpp"
 #include "testobject_export.h"
-
-#include <ace/ACE.h>
-#include <ace/OS.h>
-#include <ace/Time_Value.h>
-#include <inttypes.h>
-#include <string>
 
 using namespace apache::geode::client;
 using namespace testframework;

--- a/tests/cpp/testobject/EqStruct.hpp
+++ b/tests/cpp/testobject/EqStruct.hpp
@@ -20,24 +20,24 @@
 #ifndef GEODE_TESTOBJECT_EQSTRUCT_H_
 #define GEODE_TESTOBJECT_EQSTRUCT_H_
 
-/*
- * @brief User class for testing the put functionality for object.
- */
-
 #include <inttypes.h>
+#include <string>
+
 #include <ace/ACE.h>
 #include <ace/OS.h>
 #include <ace/Time_Value.h>
-#include <string>
 
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
-#include "TimestampedObject.hpp"
 #include "testobject_export.h"
+#include "TimestampedObject.hpp"
 
 using namespace apache::geode::client;
 using namespace testframework;
 namespace testobject {
+/**
+ * @brief User class for testing the put functionality for object.
+ */
 class TESTOBJECT_EXPORT EqStruct : public TimestampedObject {
   int myIndex;
   std::string state;

--- a/tests/cpp/testobject/PSTObject.hpp
+++ b/tests/cpp/testobject/PSTObject.hpp
@@ -24,15 +24,16 @@
  * @brief User class for testing the put functionality for object.
  */
 
-#include <string>
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include "TimestampedObject.hpp"
+#include "testobject_export.h"
+
 #include <ace/ACE.h>
 #include <ace/OS.h>
 #include <ace/Time_Value.h>
-
-#include "testobject_export.h"
+#include <inttypes.h>
+#include <string>
 
 using namespace apache::geode::client;
 using namespace testframework;

--- a/tests/cpp/testobject/PSTObject.hpp
+++ b/tests/cpp/testobject/PSTObject.hpp
@@ -24,16 +24,16 @@
  * @brief User class for testing the put functionality for object.
  */
 
+#include <inttypes.h>
+#include <ace/ACE.h>
+#include <ace/OS.h>
+#include <ace/Time_Value.h>
+#include <string>
+
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
 #include "TimestampedObject.hpp"
 #include "testobject_export.h"
-
-#include <ace/ACE.h>
-#include <ace/OS.h>
-#include <ace/Time_Value.h>
-#include <inttypes.h>
-#include <string>
 
 using namespace apache::geode::client;
 using namespace testframework;

--- a/tests/cpp/testobject/PSTObject.hpp
+++ b/tests/cpp/testobject/PSTObject.hpp
@@ -20,24 +20,24 @@
 #ifndef GEODE_TESTOBJECT_PSTOBJECT_H_
 #define GEODE_TESTOBJECT_PSTOBJECT_H_
 
-/*
- * @brief User class for testing the put functionality for object.
- */
-
 #include <inttypes.h>
+#include <string>
+
 #include <ace/ACE.h>
 #include <ace/OS.h>
 #include <ace/Time_Value.h>
-#include <string>
 
 #include "fwklib/Timer.hpp"
 #include "fwklib/FrameworkTest.hpp"
-#include "TimestampedObject.hpp"
 #include "testobject_export.h"
+#include "TimestampedObject.hpp"
 
 using namespace apache::geode::client;
 using namespace testframework;
 namespace testobject {
+/**
+ * @brief User class for testing the put functionality for object.
+ */
 class TESTOBJECT_EXPORT PSTObject : public TimestampedObject {
  protected:
   uint64_t timestamp;


### PR DESCRIPTION
- Missing inttypes.h header added
- Remaining references to 'ret' in log messages removed
