### PR TITLE
GEODE-4956: revert to latest chocolatey

### DIFF
--- a/packer/windows/install-chocolatey.ps1
+++ b/packer/windows/install-chocolatey.ps1
@@ -19,9 +19,6 @@ write-host "Installing Chocolatey"
 # Avoid bug in 7zip when running via WinRM
 $Env:chocolateyUseWindowsCompression = $true
 
-# Avoid https://github.com/chocolatey/choco/issues/1529
-$Env:chocolateyVersion = '0.10.8'
-
 iwr https://chocolatey.org/install.ps1 | iex
 
 write-host "Chocolatey Installed"


### PR DESCRIPTION
https://github.com/chocolatey/choco/issues/1529 has been resolved and chocolatey 0.10.10 does not have the issue when running packer now