### PR TITLE
GEODE-4889 Return Value for CreateDataOutput and CreateDataInput

### DIFF
--- a/clicache/src/DataInput.cpp
+++ b/clicache/src/DataInput.cpp
@@ -61,7 +61,9 @@ namespace Apache
         if (buffer != nullptr && size > 0) {
           _GF_MG_EXCEPTION_TRY2
 
-          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(std::unique_ptr<native::DataInput>(new native::DataInput(cache->GetNative()->createDataInput(buffer, size))));
+          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(
+            std::unique_ptr<native::DataInput>(
+              new native::DataInput(cache->GetNative()->createDataInput(buffer, size))));
           m_cursor = 0;
           m_isManagedObject = false;
           m_forStringDecode = gcnew array<Char>(100);

--- a/clicache/src/DataInput.cpp
+++ b/clicache/src/DataInput.cpp
@@ -98,7 +98,7 @@ namespace Apache
           _GEODE_NEW(m_buffer, System::Byte[len]);
           pin_ptr<const Byte> pin_buffer = &buffer[0];
           memcpy(m_buffer, (void*)pin_buffer, len);
-          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(std::unique_ptr<native::DataInput>(new native::DataInput(m_cache->GetNative()->createDataInput(m_buffer, len))));
+          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(std::make_unique<native::DataInput>(m_cache->GetNative()->createDataInput(m_buffer, len)));
 
           m_cursor = 0;
           m_isManagedObject = false;

--- a/clicache/src/DataInput.cpp
+++ b/clicache/src/DataInput.cpp
@@ -62,8 +62,7 @@ namespace Apache
           _GF_MG_EXCEPTION_TRY2
 
           m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(
-            std::unique_ptr<native::DataInput>(
-              new native::DataInput(cache->GetNative()->createDataInput(buffer, size))));
+            std::make_unique<native::DataInput>(cache->GetNative()->createDataInput(buffer, size)));
           m_cursor = 0;
           m_isManagedObject = false;
           m_forStringDecode = gcnew array<Char>(100);
@@ -98,8 +97,8 @@ namespace Apache
           _GEODE_NEW(m_buffer, System::Byte[len]);
           pin_ptr<const Byte> pin_buffer = &buffer[0];
           memcpy(m_buffer, (void*)pin_buffer, len);
-          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(std::make_unique<native::DataInput>(m_cache->GetNative()->createDataInput(m_buffer, len)));
-
+          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(
+            std::make_unique<native::DataInput>(m_cache->GetNative()->createDataInput(m_buffer, len)));
           m_cursor = 0;
           m_isManagedObject = false;
           m_forStringDecode = gcnew array<Char>(100);
@@ -140,7 +139,8 @@ namespace Apache
             _GEODE_NEW(m_buffer, System::Byte[len]);
           pin_ptr<const Byte> pin_buffer = &buffer[0];
           memcpy(m_buffer, (void*)pin_buffer, len);
-          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(std::unique_ptr<native::DataInput>(new native::DataInput(m_cache->GetNative()->createDataInput(m_buffer, len))));
+          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(
+            std::make_unique<native::DataInput>(m_cache->GetNative()->createDataInput(m_buffer, len)));
 
           try
           {

--- a/clicache/src/DataInput.cpp
+++ b/clicache/src/DataInput.cpp
@@ -61,7 +61,7 @@ namespace Apache
         if (buffer != nullptr && size > 0) {
           _GF_MG_EXCEPTION_TRY2
 
-          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(cache->GetNative()->createDataInput(buffer, size));
+          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(std::unique_ptr<native::DataInput>(new native::DataInput(cache->GetNative()->createDataInput(buffer, size))));
           m_cursor = 0;
           m_isManagedObject = false;
           m_forStringDecode = gcnew array<Char>(100);
@@ -96,7 +96,7 @@ namespace Apache
           _GEODE_NEW(m_buffer, System::Byte[len]);
           pin_ptr<const Byte> pin_buffer = &buffer[0];
           memcpy(m_buffer, (void*)pin_buffer, len);
-          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(m_cache->GetNative()->createDataInput(m_buffer, len));
+          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(std::unique_ptr<native::DataInput>(new native::DataInput(m_cache->GetNative()->createDataInput(m_buffer, len))));
 
           m_cursor = 0;
           m_isManagedObject = false;
@@ -138,7 +138,7 @@ namespace Apache
             _GEODE_NEW(m_buffer, System::Byte[len]);
           pin_ptr<const Byte> pin_buffer = &buffer[0];
           memcpy(m_buffer, (void*)pin_buffer, len);
-          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(m_cache->GetNative()->createDataInput(m_buffer, len));
+          m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(std::unique_ptr<native::DataInput>(new native::DataInput(m_cache->GetNative()->createDataInput(m_buffer, len))));
 
           try
           {

--- a/clicache/src/DataOutput.cpp
+++ b/clicache/src/DataOutput.cpp
@@ -47,7 +47,7 @@ namespace Apache
       { 
         m_cache = cache;
         m_nativeptr = gcnew native_conditional_unique_ptr<native::DataOutput>(
-          std::unique_ptr<native::DataOutput>(new native::DataOutput(cache->GetNative()->createDataOutput())));
+          std::make_unique<native::DataOutput>(cache->GetNative()->createDataOutput()));
         m_isManagedObject = true;
         m_cursor = 0;
         try

--- a/clicache/src/DataOutput.cpp
+++ b/clicache/src/DataOutput.cpp
@@ -46,7 +46,8 @@ namespace Apache
       DataOutput::DataOutput(Apache::Geode::Client::Cache^ cache)
       { 
         m_cache = cache;
-        m_nativeptr = gcnew native_conditional_unique_ptr<native::DataOutput>(cache->GetNative()->createDataOutput());
+        m_nativeptr = gcnew native_conditional_unique_ptr<native::DataOutput>(
+          std::unique_ptr<native::DataOutput>(new native::DataOutput(cache->GetNative()->createDataOutput())));
         m_isManagedObject = true;
         m_cursor = 0;
         try

--- a/clicache/src/LocalRegion.cpp
+++ b/clicache/src/LocalRegion.cpp
@@ -206,13 +206,13 @@ namespace Apache
           }
           auto out1 = m_nativeptr->get_shared_ptr()->getCache().createDataOutput();
           auto out2 = m_nativeptr->get_shared_ptr()->getCache().createDataOutput();
-          val1->toData(*out1);
-          val2->toData(*out2);
-          if ( out1->getBufferLength() != out2->getBufferLength() )
+          val1->toData(out1);
+          val2->toData(out2);
+          if ( out1.getBufferLength() != out2.getBufferLength() )
           {
             return false;
           }
-          else if (memcmp(out1->getBuffer(), out2->getBuffer(), out1->getBufferLength()) != 0)
+          else if (memcmp(out1.getBuffer(), out2.getBuffer(), out1.getBufferLength()) != 0)
           {
             return false;
           }

--- a/clicache/src/Region.cpp
+++ b/clicache/src/Region.cpp
@@ -250,15 +250,15 @@ namespace Apache
           }
           auto out1 = m_nativeptr->get_conditional_shared_ptr()->getCache().createDataOutput();
           auto out2 = m_nativeptr->get_conditional_shared_ptr()->getCache().createDataOutput();
-          val1->toData(*out1);
-          val2->toData(*out2);
+          val1->toData(out1);
+          val2->toData(out2);
 
           GC::KeepAlive(m_nativeptr);
-          if (out1->getBufferLength() != out2->getBufferLength())
+          if (out1.getBufferLength() != out2.getBufferLength())
           {
             return false;
           }
-          else if (memcmp(out1->getBuffer(), out2->getBuffer(), out1->getBufferLength()) != 0)
+          else if (memcmp(out1.getBuffer(), out2.getBuffer(), out1.getBufferLength()) != 0)
           {
             return false;
           }

--- a/clicache/src/impl/PdxInstanceImpl.cpp
+++ b/clicache/src/impl/PdxInstanceImpl.cpp
@@ -61,10 +61,10 @@ namespace Apache
           m_cachePerfStats = &CacheRegionHelper::getCacheImpl(cache->GetNative().get())->getCachePerfStats();
           m_pdxType->InitializeType(cache);//to generate static position map
 
-          //need to initiailize stream. this will call todata and in toData we will have stream
+          //need to initialize stream. this will call todata and in toData we will have stream
           auto output = m_cache->GetNative()->createDataOutput();
 
-          Apache::Geode::Client::DataOutput mg_output(new native::DataOutput(std::move(output)), true, cache);
+          Apache::Geode::Client::DataOutput mg_output(&output, true, cache);
           Apache::Geode::Client::Internal::PdxHelper::SerializePdx(%mg_output, this);
         }
 

--- a/clicache/src/impl/PdxInstanceImpl.cpp
+++ b/clicache/src/impl/PdxInstanceImpl.cpp
@@ -64,7 +64,7 @@ namespace Apache
           //need to initiailize stream. this will call todata and in toData we will have stream
           auto output = m_cache->GetNative()->createDataOutput();
 
-          Apache::Geode::Client::DataOutput mg_output(output.get(), true, cache);
+          Apache::Geode::Client::DataOutput mg_output(new native::DataOutput(std::move(output)), true, cache);
           Apache::Geode::Client::Internal::PdxHelper::SerializePdx(%mg_output, this);
         }
 

--- a/clicache/src/impl/PdxInstanceImpl.cpp
+++ b/clicache/src/impl/PdxInstanceImpl.cpp
@@ -86,8 +86,8 @@ namespace Apache
           DataInput^ dataInput = gcnew DataInput(m_buffer, m_bufferLength, m_cache);
           dataInput->setRootObjectPdx(true);
           System::Int64 sampleStartNanos = Utils::startStatOpTime();
-          Object^ ret = Internal::PdxHelper::DeserializePdx(dataInput, true, m_typeId, m_bufferLength, CacheRegionHelper::getCacheImpl(m_cache->GetNative().get())->getSerializationRegistry().get());
-          //dataInput->ResetPdx(0);
+          Object^ ret = Internal::PdxHelper::DeserializePdx(dataInput, true, m_typeId, m_bufferLength,
+            CacheRegionHelper::getCacheImpl(m_cache->GetNative().get())->getSerializationRegistry().get());
 
           if(m_cachePerfStats)
           {

--- a/cppcache/include/geode/Cache.hpp
+++ b/cppcache/include/geode/Cache.hpp
@@ -231,7 +231,7 @@ class APACHE_GEODE_EXPORT Cache : public GeodeCache {
   PdxInstanceFactory createPdxInstanceFactory(
       const std::string& className) const override;
 
-  virtual std::unique_ptr<DataInput> createDataInput(const uint8_t* m_buffer,
+  virtual DataInput createDataInput(const uint8_t* m_buffer,
                                                      size_t len) const;
 
   virtual std::unique_ptr<DataOutput> createDataOutput() const;

--- a/cppcache/include/geode/Cache.hpp
+++ b/cppcache/include/geode/Cache.hpp
@@ -234,7 +234,7 @@ class APACHE_GEODE_EXPORT Cache : public GeodeCache {
   virtual DataInput createDataInput(const uint8_t* m_buffer,
                                                      size_t len) const;
 
-  virtual std::unique_ptr<DataOutput> createDataOutput() const;
+  virtual DataOutput createDataOutput() const;
 
   virtual PoolManager& getPoolManager() const;
 

--- a/cppcache/include/geode/Cache.hpp
+++ b/cppcache/include/geode/Cache.hpp
@@ -231,8 +231,7 @@ class APACHE_GEODE_EXPORT Cache : public GeodeCache {
   PdxInstanceFactory createPdxInstanceFactory(
       const std::string& className) const override;
 
-  virtual DataInput createDataInput(const uint8_t* m_buffer,
-                                                     size_t len) const;
+  virtual DataInput createDataInput(const uint8_t* m_buffer, size_t len) const;
 
   virtual DataOutput createDataOutput() const;
 

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -492,7 +492,7 @@ class APACHE_GEODE_EXPORT DataInput {
 
  protected:
   /** constructor given a pre-allocated byte array with size */
-  DataInput(const uint8_t* m_buffer, size_t len, const CacheImpl* cache,
+  DataInput(const uint8_t* buffer, size_t len, const CacheImpl* cache,
             Pool* pool);
 
   virtual const SerializationRegistry& getSerializationRegistry() const;

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -487,6 +487,8 @@ class APACHE_GEODE_EXPORT DataInput {
   DataInput() = delete;
   DataInput(const DataInput&) = delete;
   DataInput& operator=(const DataInput&) = delete;
+  DataInput(DataInput&&) = default;
+  DataInput& operator=(DataInput&&) = default;
 
  protected:
   /** constructor given a pre-allocated byte array with size */

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -494,16 +494,35 @@ class APACHE_GEODE_EXPORT DataOutput {
   /** Destruct a DataOutput, including releasing the created buffer. */
   ~DataOutput() {
     reset();
-    if (m_bytes != nullptr) {
+    if (m_bytes) {
       DataOutput::checkinBuffer(m_bytes, m_size);
     }
+  }
+
+  void move(DataOutput&& other) {
+    m_bytes = other.m_bytes;
+    m_buf = other.m_buf;
+    m_size = other.m_size;
+    m_lowWaterMark = other.m_lowWaterMark;
+    m_highWaterMark = other.m_highWaterMark;
+    m_haveBigBuffer = other.m_haveBigBuffer;
+    m_cache = other.m_cache;
+    m_pool = other.m_pool;
+    other.m_bytes = other.m_buf = nullptr;
+    other.m_size = 0;
   }
 
   DataOutput() = delete;
   DataOutput(const DataOutput&) = delete;
   DataOutput& operator=(const DataOutput&) = delete;
-  DataOutput(DataOutput&&) = default;
-  DataOutput& operator=(DataOutput&&) = default;
+  DataOutput& operator=(DataOutput&& other) {
+    move(std::move(other));
+    return *this;
+  }
+
+  DataOutput(DataOutput&& other) {
+    move(std::move(other));
+  }
 
  protected:
   /**

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -501,6 +501,8 @@ class APACHE_GEODE_EXPORT DataOutput {
   DataOutput() = delete;
   DataOutput(const DataOutput&) = delete;
   DataOutput& operator=(const DataOutput&) = delete;
+  DataOutput(DataOutput&&) = default;
+  DataOutput& operator=(DataOutput&&) = default;
 
  protected:
   /**

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -494,7 +494,7 @@ class APACHE_GEODE_EXPORT DataOutput {
   /** Destruct a DataOutput, including releasing the created buffer. */
   ~DataOutput() {
     reset();
-    if (m_bytes != nullptr) {
+    if (m_bytes) {
       DataOutput::checkinBuffer(m_bytes.release(), m_size);
     }
   }

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -387,17 +387,17 @@ class APACHE_GEODE_EXPORT DataOutput {
   void rewindCursor(size_t offset) { m_buf -= offset; }
 
   void updateValueAtPos(size_t offset, uint8_t value) {
-    m_bytes[offset] = value;
+    m_bytes.get()[offset] = value;
   }
 
-  uint8_t getValueAtPos(size_t offset) { return m_bytes[offset]; }
+  uint8_t getValueAtPos(size_t offset) { return m_bytes.get()[offset]; }
 
   /**
    * Get a pointer to the internal buffer of <code>DataOutput</code>.
    */
   inline const uint8_t* getBuffer() const {
     // GF_R_ASSERT(!((uint32_t)(m_bytes) % 4));
-    return m_bytes;
+    return m_bytes.get();
   }
 
   /**
@@ -415,19 +415,19 @@ class APACHE_GEODE_EXPORT DataOutput {
    *   should not be nullptr
    */
   inline const uint8_t* getBuffer(size_t* rsize) const {
-    *rsize = m_buf - m_bytes;
+    *rsize = m_buf - m_bytes.get();
     // GF_R_ASSERT(!((uint32_t)(m_bytes) % 4));
-    return m_bytes;
+    return m_bytes.get();
   }
 
   inline uint8_t* getBufferCopy() {
-    size_t size = m_buf - m_bytes;
+    size_t size = m_buf - m_bytes.get();
     uint8_t* result;
     result = (uint8_t*)std::malloc(size * sizeof(uint8_t));
     if (result == nullptr) {
       throw OutOfMemoryException("Out of Memory while resizing buffer");
     }
-    std::memcpy(result, m_bytes, size);
+    std::memcpy(result, m_bytes.get(), size);
     return result;
   }
 
@@ -435,16 +435,15 @@ class APACHE_GEODE_EXPORT DataOutput {
    * Get the length of current data in the internal buffer of
    * <code>DataOutput</code>.
    */
-  inline size_t getBufferLength() const { return m_buf - m_bytes; }
+  inline size_t getBufferLength() const { return m_buf - m_bytes.get(); }
 
   /**
    * Reset the internal cursor to the start of the buffer.
    */
   inline void reset() {
     if (m_haveBigBuffer) {
-      std::free(m_bytes);
       // create smaller buffer
-      m_bytes = (uint8_t*)std::malloc(m_lowWaterMark * sizeof(uint8_t));
+      m_bytes.reset((uint8_t*)std::malloc(m_lowWaterMark * sizeof(uint8_t)));
       if (m_bytes == nullptr) {
         throw OutOfMemoryException("Out of Memory while resizing buffer");
       }
@@ -454,12 +453,12 @@ class APACHE_GEODE_EXPORT DataOutput {
       // release the lock
       releaseLock();
     }
-    m_buf = m_bytes;
+    m_buf = m_bytes.get();
   }
 
   // make sure there is room left for the requested size item.
   inline void ensureCapacity(size_t size) {
-    size_t offset = m_buf - m_bytes;
+    size_t offset = m_buf - m_bytes.get();
     if ((m_size - offset) < size) {
       size_t newSize = m_size * 2 + (8192 * (size / 8192));
       if (newSize >= m_highWaterMark && !m_haveBigBuffer) {
@@ -470,12 +469,13 @@ class APACHE_GEODE_EXPORT DataOutput {
       }
       m_size = newSize;
 
-      auto tmp = (uint8_t*)std::realloc(m_bytes, m_size * sizeof(uint8_t));
+      auto bytes = m_bytes.release();
+      auto tmp = (uint8_t*)std::realloc(bytes, m_size * sizeof(uint8_t));
       if (tmp == nullptr) {
         throw OutOfMemoryException("Out of Memory while resizing buffer");
       }
-      m_bytes = tmp;
-      m_buf = m_bytes + offset;
+      m_bytes.reset(tmp);
+      m_buf = m_bytes.get() + offset;
     }
   }
 
@@ -495,34 +495,15 @@ class APACHE_GEODE_EXPORT DataOutput {
   ~DataOutput() {
     reset();
     if (m_bytes) {
-      DataOutput::checkinBuffer(m_bytes, m_size);
+      DataOutput::checkinBuffer(m_bytes.release(), m_size);
     }
-  }
-
-  void move(DataOutput&& other) {
-    m_bytes = other.m_bytes;
-    m_buf = other.m_buf;
-    m_size = other.m_size;
-    m_lowWaterMark = other.m_lowWaterMark;
-    m_highWaterMark = other.m_highWaterMark;
-    m_haveBigBuffer = other.m_haveBigBuffer;
-    m_cache = other.m_cache;
-    m_pool = other.m_pool;
-    other.m_bytes = other.m_buf = nullptr;
-    other.m_size = 0;
   }
 
   DataOutput() = delete;
   DataOutput(const DataOutput&) = delete;
   DataOutput& operator=(const DataOutput&) = delete;
-  DataOutput& operator=(DataOutput&& other) {
-    move(std::move(other));
-    return *this;
-  }
-
-  DataOutput(DataOutput&& other) {
-    move(std::move(other));
-  }
+  DataOutput(DataOutput&&) = default;
+  DataOutput& operator=(DataOutput&&) = default;
 
  protected:
   /**
@@ -539,7 +520,7 @@ class APACHE_GEODE_EXPORT DataOutput {
   static void releaseLock();
 
   // memory m_buffer to encode to.
-  uint8_t* m_bytes;
+  std::unique_ptr<uint8_t> m_bytes;
   // cursor.
   uint8_t* m_buf;
   // size of m_bytes.

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -387,17 +387,17 @@ class APACHE_GEODE_EXPORT DataOutput {
   void rewindCursor(size_t offset) { m_buf -= offset; }
 
   void updateValueAtPos(size_t offset, uint8_t value) {
-    m_bytes[offset] = value;
+    m_bytes.get()[offset] = value;
   }
 
-  uint8_t getValueAtPos(size_t offset) { return m_bytes[offset]; }
+  uint8_t getValueAtPos(size_t offset) { return m_bytes.get()[offset]; }
 
   /**
    * Get a pointer to the internal buffer of <code>DataOutput</code>.
    */
   inline const uint8_t* getBuffer() const {
     // GF_R_ASSERT(!((uint32_t)(m_bytes) % 4));
-    return m_bytes;
+    return m_bytes.get();
   }
 
   /**
@@ -415,19 +415,19 @@ class APACHE_GEODE_EXPORT DataOutput {
    *   should not be nullptr
    */
   inline const uint8_t* getBuffer(size_t* rsize) const {
-    *rsize = m_buf - m_bytes;
+    *rsize = m_buf - m_bytes.get();
     // GF_R_ASSERT(!((uint32_t)(m_bytes) % 4));
-    return m_bytes;
+    return m_bytes.get();
   }
 
   inline uint8_t* getBufferCopy() {
-    size_t size = m_buf - m_bytes;
+    size_t size = m_buf - m_bytes.get();
     uint8_t* result;
     result = (uint8_t*)std::malloc(size * sizeof(uint8_t));
     if (result == nullptr) {
       throw OutOfMemoryException("Out of Memory while resizing buffer");
     }
-    std::memcpy(result, m_bytes, size);
+    std::memcpy(result, m_bytes.get(), size);
     return result;
   }
 
@@ -435,17 +435,15 @@ class APACHE_GEODE_EXPORT DataOutput {
    * Get the length of current data in the internal buffer of
    * <code>DataOutput</code>.
    */
-  inline size_t getBufferLength() const { return m_buf - m_bytes; }
+  inline size_t getBufferLength() const { return m_buf - m_bytes.get(); }
 
   /**
    * Reset the internal cursor to the start of the buffer.
    */
   inline void reset() {
     if (m_haveBigBuffer) {
-      // free existing buffer
-      std::free(m_bytes);
       // create smaller buffer
-      m_bytes = (uint8_t*)std::malloc(m_lowWaterMark * sizeof(uint8_t));
+      m_bytes.reset((uint8_t*)std::malloc(m_lowWaterMark * sizeof(uint8_t)));
       if (m_bytes == nullptr) {
         throw OutOfMemoryException("Out of Memory while resizing buffer");
       }
@@ -455,12 +453,12 @@ class APACHE_GEODE_EXPORT DataOutput {
       // release the lock
       releaseLock();
     }
-    m_buf = m_bytes;
+    m_buf = m_bytes.get();
   }
 
   // make sure there is room left for the requested size item.
   inline void ensureCapacity(size_t size) {
-    size_t offset = m_buf - m_bytes;
+    size_t offset = m_buf - m_bytes.get();
     if ((m_size - offset) < size) {
       size_t newSize = m_size * 2 + (8192 * (size / 8192));
       if (newSize >= m_highWaterMark && !m_haveBigBuffer) {
@@ -471,12 +469,13 @@ class APACHE_GEODE_EXPORT DataOutput {
       }
       m_size = newSize;
 
-      auto tmp = (uint8_t*)std::realloc(m_bytes, m_size * sizeof(uint8_t));
+      auto bytes = m_bytes.release();
+      auto tmp = (uint8_t*)std::realloc(bytes, m_size * sizeof(uint8_t));
       if (tmp == nullptr) {
         throw OutOfMemoryException("Out of Memory while resizing buffer");
       }
-      m_bytes = tmp;
-      m_buf = m_bytes + offset;
+      m_bytes.reset(tmp);
+      m_buf = m_bytes.get() + offset;
     }
   }
 
@@ -495,7 +494,9 @@ class APACHE_GEODE_EXPORT DataOutput {
   /** Destruct a DataOutput, including releasing the created buffer. */
   ~DataOutput() {
     reset();
-    DataOutput::checkinBuffer(m_bytes, m_size);
+    if (m_bytes != nullptr) {
+      DataOutput::checkinBuffer(m_bytes.release(), m_size);
+    }
   }
 
   DataOutput() = delete;
@@ -519,7 +520,7 @@ class APACHE_GEODE_EXPORT DataOutput {
   static void releaseLock();
 
   // memory m_buffer to encode to.
-  uint8_t* m_bytes;
+  std::unique_ptr<uint8_t>  m_bytes;
   // cursor.
   uint8_t* m_buf;
   // size of m_bytes.

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -387,17 +387,17 @@ class APACHE_GEODE_EXPORT DataOutput {
   void rewindCursor(size_t offset) { m_buf -= offset; }
 
   void updateValueAtPos(size_t offset, uint8_t value) {
-    m_bytes.get()[offset] = value;
+    m_bytes[offset] = value;
   }
 
-  uint8_t getValueAtPos(size_t offset) { return m_bytes.get()[offset]; }
+  uint8_t getValueAtPos(size_t offset) { return m_bytes[offset]; }
 
   /**
    * Get a pointer to the internal buffer of <code>DataOutput</code>.
    */
   inline const uint8_t* getBuffer() const {
     // GF_R_ASSERT(!((uint32_t)(m_bytes) % 4));
-    return m_bytes.get();
+    return m_bytes;
   }
 
   /**
@@ -415,19 +415,19 @@ class APACHE_GEODE_EXPORT DataOutput {
    *   should not be nullptr
    */
   inline const uint8_t* getBuffer(size_t* rsize) const {
-    *rsize = m_buf - m_bytes.get();
+    *rsize = m_buf - m_bytes;
     // GF_R_ASSERT(!((uint32_t)(m_bytes) % 4));
-    return m_bytes.get();
+    return m_bytes;
   }
 
   inline uint8_t* getBufferCopy() {
-    size_t size = m_buf - m_bytes.get();
+    size_t size = m_buf - m_bytes;
     uint8_t* result;
     result = (uint8_t*)std::malloc(size * sizeof(uint8_t));
     if (result == nullptr) {
       throw OutOfMemoryException("Out of Memory while resizing buffer");
     }
-    std::memcpy(result, m_bytes.get(), size);
+    std::memcpy(result, m_bytes, size);
     return result;
   }
 
@@ -435,15 +435,16 @@ class APACHE_GEODE_EXPORT DataOutput {
    * Get the length of current data in the internal buffer of
    * <code>DataOutput</code>.
    */
-  inline size_t getBufferLength() const { return m_buf - m_bytes.get(); }
+  inline size_t getBufferLength() const { return m_buf - m_bytes; }
 
   /**
    * Reset the internal cursor to the start of the buffer.
    */
   inline void reset() {
     if (m_haveBigBuffer) {
+      std::free(m_bytes);
       // create smaller buffer
-      m_bytes.reset((uint8_t*)std::malloc(m_lowWaterMark * sizeof(uint8_t)));
+      m_bytes = (uint8_t*)std::malloc(m_lowWaterMark * sizeof(uint8_t));
       if (m_bytes == nullptr) {
         throw OutOfMemoryException("Out of Memory while resizing buffer");
       }
@@ -453,12 +454,12 @@ class APACHE_GEODE_EXPORT DataOutput {
       // release the lock
       releaseLock();
     }
-    m_buf = m_bytes.get();
+    m_buf = m_bytes;
   }
 
   // make sure there is room left for the requested size item.
   inline void ensureCapacity(size_t size) {
-    size_t offset = m_buf - m_bytes.get();
+    size_t offset = m_buf - m_bytes;
     if ((m_size - offset) < size) {
       size_t newSize = m_size * 2 + (8192 * (size / 8192));
       if (newSize >= m_highWaterMark && !m_haveBigBuffer) {
@@ -469,13 +470,12 @@ class APACHE_GEODE_EXPORT DataOutput {
       }
       m_size = newSize;
 
-      auto bytes = m_bytes.release();
-      auto tmp = (uint8_t*)std::realloc(bytes, m_size * sizeof(uint8_t));
+      auto tmp = (uint8_t*)std::realloc(m_bytes, m_size * sizeof(uint8_t));
       if (tmp == nullptr) {
         throw OutOfMemoryException("Out of Memory while resizing buffer");
       }
-      m_bytes.reset(tmp);
-      m_buf = m_bytes.get() + offset;
+      m_bytes = tmp;
+      m_buf = m_bytes + offset;
     }
   }
 
@@ -494,8 +494,8 @@ class APACHE_GEODE_EXPORT DataOutput {
   /** Destruct a DataOutput, including releasing the created buffer. */
   ~DataOutput() {
     reset();
-    if (m_bytes) {
-      DataOutput::checkinBuffer(m_bytes.release(), m_size);
+    if (m_bytes != nullptr) {
+      DataOutput::checkinBuffer(m_bytes, m_size);
     }
   }
 
@@ -520,7 +520,7 @@ class APACHE_GEODE_EXPORT DataOutput {
   static void releaseLock();
 
   // memory m_buffer to encode to.
-  std::unique_ptr<uint8_t> m_bytes;
+  uint8_t* m_bytes;
   // cursor.
   uint8_t* m_buf;
   // size of m_bytes.

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -520,7 +520,7 @@ class APACHE_GEODE_EXPORT DataOutput {
   static void releaseLock();
 
   // memory m_buffer to encode to.
-  std::unique_ptr<uint8_t>  m_bytes;
+  std::unique_ptr<uint8_t> m_bytes;
   // cursor.
   uint8_t* m_buf;
   // size of m_bytes.

--- a/cppcache/integration-test/BuiltinCacheableWrappers.hpp
+++ b/cppcache/integration-test/BuiltinCacheableWrappers.hpp
@@ -162,17 +162,17 @@ inline uint32_t crc32(const int8_t* buffer, size_t bufLen) {
 template <typename TPRIM>
 inline uint32_t crc32(TPRIM value) {
   auto output = CacheHelper::getHelper().getCache()->createDataOutput();
-  apache::geode::client::serializer::writeObject(*output, value);
-  return crc32(output->getBuffer(), output->getBufferLength());
+  apache::geode::client::serializer::writeObject(output, value);
+  return crc32(output.getBuffer(), output.getBufferLength());
 }
 
 template <typename TPRIM>
 inline uint32_t crc32Array(const std::vector<TPRIM> arr) {
   auto output = CacheHelper::getHelper().getCache()->createDataOutput();
   for (auto obj : arr) {
-    apache::geode::client::serializer::writeObject(*output, obj);
+    apache::geode::client::serializer::writeObject(output, obj);
   }
-  return crc32(output->getBuffer(), output->getBufferLength());
+  return crc32(output.getBuffer(), output.getBufferLength());
 }
 
 inline bool isContainerTypeId(int8_t typeId) {

--- a/cppcache/integration-test/testSerialization.cpp
+++ b/cppcache/integration-test/testSerialization.cpp
@@ -50,7 +50,7 @@ std::shared_ptr<T> duplicate(const std::shared_ptr<T>& orig) {
   dout.writeObject(orig);
 
   size_t length = 0;
-  const uint8_t* buffer = dout.getBuffer(&length);
+  auto&& buffer = dout.getBuffer(&length);
   auto din = getHelper()->getCache()->createDataInput(buffer, length);
   din.readObject(result);
 

--- a/cppcache/integration-test/testSerialization.cpp
+++ b/cppcache/integration-test/testSerialization.cpp
@@ -52,7 +52,7 @@ std::shared_ptr<T> duplicate(const std::shared_ptr<T>& orig) {
   size_t length = 0;
   const uint8_t* buffer = dout->getBuffer(&length);
   auto din = getHelper()->getCache()->createDataInput(buffer, length);
-  din->readObject(result);
+  din.readObject(result);
 
   return result;
 }

--- a/cppcache/integration-test/testSerialization.cpp
+++ b/cppcache/integration-test/testSerialization.cpp
@@ -47,10 +47,10 @@ template <class T>
 std::shared_ptr<T> duplicate(const std::shared_ptr<T>& orig) {
   std::shared_ptr<T> result;
   auto dout = getHelper()->getCache()->createDataOutput();
-  dout->writeObject(orig);
+  dout.writeObject(orig);
 
   size_t length = 0;
-  const uint8_t* buffer = dout->getBuffer(&length);
+  const uint8_t* buffer = dout.getBuffer(&length);
   auto din = getHelper()->getCache()->createDataInput(buffer, length);
   din.readObject(result);
 

--- a/cppcache/integration-test/testThinClientCqDelta.cpp
+++ b/cppcache/integration-test/testThinClientCqDelta.cpp
@@ -58,7 +58,7 @@ class CqDeltaListener : public CqListener {
     auto input = getHelper()->getCache()->createDataInput(
         reinterpret_cast<const uint8_t*>(deltaValue->value().data()),
         deltaValue->length());
-    newValue.fromDelta(*input);
+    newValue.fromDelta(input);
     if (newValue.getIntVar() == 5) {
       m_deltaCount++;
     }

--- a/cppcache/src/AdminRegion.cpp
+++ b/cppcache/src/AdminRegion.cpp
@@ -77,8 +77,9 @@ GfErrType AdminRegion::putNoThrow(const std::shared_ptr<CacheableKey>& keyPtr,
   GfErrType err = GF_NOERR;
 
   TcrMessagePut request(
-          std::unique_ptr<DataOutput>(new DataOutput(m_connectionMgr->getCacheImpl()->getCache()->createDataOutput())), nullptr,
-      keyPtr, valuePtr, nullptr, false, m_distMngr, true, false,
+      std::unique_ptr<DataOutput>(new DataOutput(
+          m_connectionMgr->getCacheImpl()->getCache()->createDataOutput())),
+      nullptr, keyPtr, valuePtr, nullptr, false, m_distMngr, true, false,
       m_fullPath.c_str());
   request.setMetaRegion(true);
   TcrMessageReply reply(true, m_distMngr);

--- a/cppcache/src/AdminRegion.cpp
+++ b/cppcache/src/AdminRegion.cpp
@@ -77,7 +77,7 @@ GfErrType AdminRegion::putNoThrow(const std::shared_ptr<CacheableKey>& keyPtr,
   GfErrType err = GF_NOERR;
 
   TcrMessagePut request(
-      m_connectionMgr->getCacheImpl()->getCache()->createDataOutput(), nullptr,
+          std::unique_ptr<DataOutput>(new DataOutput(m_connectionMgr->getCacheImpl()->getCache()->createDataOutput())), nullptr,
       keyPtr, valuePtr, nullptr, false, m_distMngr, true, false,
       m_fullPath.c_str());
   request.setMetaRegion(true);

--- a/cppcache/src/AdminRegion.cpp
+++ b/cppcache/src/AdminRegion.cpp
@@ -77,8 +77,7 @@ GfErrType AdminRegion::putNoThrow(const std::shared_ptr<CacheableKey>& keyPtr,
   GfErrType err = GF_NOERR;
 
   TcrMessagePut request(
-      std::unique_ptr<DataOutput>(
-          new DataOutput(m_connectionMgr->getCacheImpl()->createDataOutput())),
+      new DataOutput(m_connectionMgr->getCacheImpl()->createDataOutput()),
       nullptr, keyPtr, valuePtr, nullptr, false, m_distMngr, true, false,
       m_fullPath.c_str());
   request.setMetaRegion(true);

--- a/cppcache/src/AdminRegion.cpp
+++ b/cppcache/src/AdminRegion.cpp
@@ -77,8 +77,8 @@ GfErrType AdminRegion::putNoThrow(const std::shared_ptr<CacheableKey>& keyPtr,
   GfErrType err = GF_NOERR;
 
   TcrMessagePut request(
-      std::unique_ptr<DataOutput>(new DataOutput(
-          m_connectionMgr->getCacheImpl()->getCache()->createDataOutput())),
+      std::unique_ptr<DataOutput>(
+          new DataOutput(m_connectionMgr->getCacheImpl()->createDataOutput())),
       nullptr, keyPtr, valuePtr, nullptr, false, m_distMngr, true, false,
       m_fullPath.c_str());
   request.setMetaRegion(true);

--- a/cppcache/src/Cache.cpp
+++ b/cppcache/src/Cache.cpp
@@ -164,7 +164,7 @@ SystemProperties& Cache::getSystemProperties() const {
   return m_cacheImpl->getSystemProperties();
 }
 
-std::unique_ptr<DataInput> Cache::createDataInput(const uint8_t* m_buffer,
+DataInput Cache::createDataInput(const uint8_t* m_buffer,
                                                   size_t len) const {
   return m_cacheImpl->createDataInput(m_buffer, len);
 }

--- a/cppcache/src/Cache.cpp
+++ b/cppcache/src/Cache.cpp
@@ -169,7 +169,7 @@ DataInput Cache::createDataInput(const uint8_t* m_buffer,
   return m_cacheImpl->createDataInput(m_buffer, len);
 }
 
-std::unique_ptr<DataOutput> Cache::createDataOutput() const {
+DataOutput Cache::createDataOutput() const {
   return m_cacheImpl->createDataOutput();
 }
 

--- a/cppcache/src/Cache.cpp
+++ b/cppcache/src/Cache.cpp
@@ -164,8 +164,7 @@ SystemProperties& Cache::getSystemProperties() const {
   return m_cacheImpl->getSystemProperties();
 }
 
-DataInput Cache::createDataInput(const uint8_t* m_buffer,
-                                                  size_t len) const {
+DataInput Cache::createDataInput(const uint8_t* m_buffer, size_t len) const {
   return m_cacheImpl->createDataInput(m_buffer, len);
 }
 

--- a/cppcache/src/CacheImpl.cpp
+++ b/cppcache/src/CacheImpl.cpp
@@ -724,14 +724,14 @@ void CacheImpl::processMarker() {
       if (const auto tcrHARegion =
               std::dynamic_pointer_cast<ThinClientHARegion>(q.int_id_)) {
         auto regionMsg = new TcrMessageClientMarker(
-            this->getCache()->createDataOutput(), true);
+            std::unique_ptr<DataOutput>(new DataOutput(this->getCache()->createDataOutput())), true);
         tcrHARegion->receiveNotification(regionMsg);
         for (const auto& iter : tcrHARegion->subregions(true)) {
           if (!iter->isDestroyed()) {
             if (const auto subregion =
                     std::dynamic_pointer_cast<ThinClientHARegion>(iter)) {
               regionMsg = new TcrMessageClientMarker(
-                  this->getCache()->createDataOutput(), true);
+                  std::unique_ptr<DataOutput>(new DataOutput(this->getCache()->createDataOutput())), true);
               subregion->receiveNotification(regionMsg);
             }
           }
@@ -808,16 +808,16 @@ CacheImpl::getMemberListForVersionStamp() {
   return *versionStampMemIdList;
 }
 
-std::unique_ptr<DataOutput> CacheImpl::createDataOutput() const {
+DataOutput CacheImpl::createDataOutput() const {
   return CacheImpl::createDataOutput(nullptr);
 }
 
-std::unique_ptr<DataOutput> CacheImpl::createDataOutput(Pool* pool) const {
+DataOutput CacheImpl::createDataOutput(Pool *pool) const {
   if (!pool) {
     pool = this->getPoolManager().getDefaultPool().get();
   }
 
-  return std::unique_ptr<DataOutput>(new DataOutput(this, pool));
+  return DataOutput(this, pool);
 }
 
 DataInput CacheImpl::createDataInput(const uint8_t* buffer,

--- a/cppcache/src/CacheImpl.cpp
+++ b/cppcache/src/CacheImpl.cpp
@@ -820,18 +820,18 @@ std::unique_ptr<DataOutput> CacheImpl::createDataOutput(Pool* pool) const {
   return std::unique_ptr<DataOutput>(new DataOutput(this, pool));
 }
 
-std::unique_ptr<DataInput> CacheImpl::createDataInput(const uint8_t* buffer,
+DataInput CacheImpl::createDataInput(const uint8_t* buffer,
                                                       size_t len) const {
   return CacheImpl::createDataInput(buffer, len, nullptr);
 }
 
-std::unique_ptr<DataInput> CacheImpl::createDataInput(const uint8_t* buffer,
+DataInput CacheImpl::createDataInput(const uint8_t* buffer,
                                                       size_t len,
                                                       Pool* pool) const {
   if (!pool) {
     pool = this->getPoolManager().getDefaultPool().get();
   }
-  return std::unique_ptr<DataInput>(new DataInput(buffer, len, this, pool));
+  return DataInput(buffer, len, this, pool);
 }
 
 PdxInstanceFactory CacheImpl::createPdxInstanceFactory(

--- a/cppcache/src/CacheImpl.cpp
+++ b/cppcache/src/CacheImpl.cpp
@@ -724,18 +724,14 @@ void CacheImpl::processMarker() {
       if (const auto tcrHARegion =
               std::dynamic_pointer_cast<ThinClientHARegion>(q.int_id_)) {
         auto regionMsg = new TcrMessageClientMarker(
-            std::unique_ptr<DataOutput>(
-                new DataOutput(this->getCache()->createDataOutput())),
-            true);
+            new DataOutput(createDataOutput()), true);
         tcrHARegion->receiveNotification(regionMsg);
         for (const auto& iter : tcrHARegion->subregions(true)) {
           if (!iter->isDestroyed()) {
             if (const auto subregion =
                     std::dynamic_pointer_cast<ThinClientHARegion>(iter)) {
               regionMsg = new TcrMessageClientMarker(
-                  std::unique_ptr<DataOutput>(
-                      new DataOutput(this->getCache()->createDataOutput())),
-                  true);
+                  new DataOutput(createDataOutput()), true);
               subregion->receiveNotification(regionMsg);
             }
           }

--- a/cppcache/src/CacheImpl.cpp
+++ b/cppcache/src/CacheImpl.cpp
@@ -724,14 +724,18 @@ void CacheImpl::processMarker() {
       if (const auto tcrHARegion =
               std::dynamic_pointer_cast<ThinClientHARegion>(q.int_id_)) {
         auto regionMsg = new TcrMessageClientMarker(
-            std::unique_ptr<DataOutput>(new DataOutput(this->getCache()->createDataOutput())), true);
+            std::unique_ptr<DataOutput>(
+                new DataOutput(this->getCache()->createDataOutput())),
+            true);
         tcrHARegion->receiveNotification(regionMsg);
         for (const auto& iter : tcrHARegion->subregions(true)) {
           if (!iter->isDestroyed()) {
             if (const auto subregion =
                     std::dynamic_pointer_cast<ThinClientHARegion>(iter)) {
               regionMsg = new TcrMessageClientMarker(
-                  std::unique_ptr<DataOutput>(new DataOutput(this->getCache()->createDataOutput())), true);
+                  std::unique_ptr<DataOutput>(
+                      new DataOutput(this->getCache()->createDataOutput())),
+                  true);
               subregion->receiveNotification(regionMsg);
             }
           }
@@ -812,7 +816,7 @@ DataOutput CacheImpl::createDataOutput() const {
   return CacheImpl::createDataOutput(nullptr);
 }
 
-DataOutput CacheImpl::createDataOutput(Pool *pool) const {
+DataOutput CacheImpl::createDataOutput(Pool* pool) const {
   if (!pool) {
     pool = this->getPoolManager().getDefaultPool().get();
   }
@@ -820,14 +824,12 @@ DataOutput CacheImpl::createDataOutput(Pool *pool) const {
   return DataOutput(this, pool);
 }
 
-DataInput CacheImpl::createDataInput(const uint8_t* buffer,
-                                                      size_t len) const {
+DataInput CacheImpl::createDataInput(const uint8_t* buffer, size_t len) const {
   return CacheImpl::createDataInput(buffer, len, nullptr);
 }
 
-DataInput CacheImpl::createDataInput(const uint8_t* buffer,
-                                                      size_t len,
-                                                      Pool* pool) const {
+DataInput CacheImpl::createDataInput(const uint8_t* buffer, size_t len,
+                                     Pool* pool) const {
   if (!pool) {
     pool = this->getPoolManager().getDefaultPool().get();
   }

--- a/cppcache/src/CacheImpl.hpp
+++ b/cppcache/src/CacheImpl.hpp
@@ -293,9 +293,9 @@ class APACHE_GEODE_EXPORT CacheImpl : private NonCopyable,
     return *(m_statisticsManager.get());
   }
 
-  virtual std::unique_ptr<DataOutput> createDataOutput() const;
+  virtual DataOutput createDataOutput() const;
 
-  virtual std::unique_ptr<DataOutput> createDataOutput(Pool* pool) const;
+  virtual DataOutput createDataOutput(Pool *pool) const;
 
   virtual DataInput createDataInput(const uint8_t* buffer,
                                                      size_t len) const;

--- a/cppcache/src/CacheImpl.hpp
+++ b/cppcache/src/CacheImpl.hpp
@@ -297,10 +297,10 @@ class APACHE_GEODE_EXPORT CacheImpl : private NonCopyable,
 
   virtual std::unique_ptr<DataOutput> createDataOutput(Pool* pool) const;
 
-  virtual std::unique_ptr<DataInput> createDataInput(const uint8_t* buffer,
+  virtual DataInput createDataInput(const uint8_t* buffer,
                                                      size_t len) const;
 
-  virtual std::unique_ptr<DataInput> createDataInput(const uint8_t* buffer,
+  virtual DataInput createDataInput(const uint8_t* buffer,
                                                      size_t len,
                                                      Pool* pool) const;
 

--- a/cppcache/src/CacheImpl.hpp
+++ b/cppcache/src/CacheImpl.hpp
@@ -295,14 +295,12 @@ class APACHE_GEODE_EXPORT CacheImpl : private NonCopyable,
 
   virtual DataOutput createDataOutput() const;
 
-  virtual DataOutput createDataOutput(Pool *pool) const;
+  virtual DataOutput createDataOutput(Pool* pool) const;
 
-  virtual DataInput createDataInput(const uint8_t* buffer,
-                                                     size_t len) const;
+  virtual DataInput createDataInput(const uint8_t* buffer, size_t len) const;
 
-  virtual DataInput createDataInput(const uint8_t* buffer,
-                                                     size_t len,
-                                                     Pool* pool) const;
+  virtual DataInput createDataInput(const uint8_t* buffer, size_t len,
+                                    Pool* pool) const;
 
   PdxInstanceFactory createPdxInstanceFactory(
       const std::string& className) const;

--- a/cppcache/src/CacheTransactionManagerImpl.cpp
+++ b/cppcache/src/CacheTransactionManagerImpl.cpp
@@ -59,7 +59,8 @@ void CacheTransactionManagerImpl::commit() {
         GF_CACHE_ILLEGAL_STATE_EXCEPTION);
   }
 
-  TcrMessageCommit request(std::unique_ptr<DataOutput>(new DataOutput(m_cache->createDataOutput())));
+  TcrMessageCommit request(
+      std::unique_ptr<DataOutput>(new DataOutput(m_cache->createDataOutput())));
   TcrMessageReply reply(true, nullptr);
 
   auto tcr_dm = getDM();
@@ -270,7 +271,8 @@ void CacheTransactionManagerImpl::rollback() {
 }
 
 GfErrType CacheTransactionManagerImpl::rollback(TXState*, bool) {
-  TcrMessageRollback request(std::unique_ptr<DataOutput>(new DataOutput(m_cache->getCache()->createDataOutput())));
+  TcrMessageRollback request(std::unique_ptr<DataOutput>(
+      new DataOutput(m_cache->getCache()->createDataOutput())));
   TcrMessageReply reply(true, nullptr);
   GfErrType err = GF_NOERR;
   ThinClientPoolDM* tcr_dm = getDM();

--- a/cppcache/src/CacheTransactionManagerImpl.cpp
+++ b/cppcache/src/CacheTransactionManagerImpl.cpp
@@ -59,8 +59,7 @@ void CacheTransactionManagerImpl::commit() {
         GF_CACHE_ILLEGAL_STATE_EXCEPTION);
   }
 
-  TcrMessageCommit request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_cache->createDataOutput())));
+  TcrMessageCommit request(new DataOutput(m_cache->createDataOutput()));
   TcrMessageReply reply(true, nullptr);
 
   auto tcr_dm = getDM();
@@ -271,8 +270,8 @@ void CacheTransactionManagerImpl::rollback() {
 }
 
 GfErrType CacheTransactionManagerImpl::rollback(TXState*, bool) {
-  TcrMessageRollback request(std::unique_ptr<DataOutput>(
-      new DataOutput(m_cache->getCache()->createDataOutput())));
+  TcrMessageRollback request(
+      new DataOutput(m_cache->getCache()->createDataOutput()));
   TcrMessageReply reply(true, nullptr);
   GfErrType err = GF_NOERR;
   ThinClientPoolDM* tcr_dm = getDM();

--- a/cppcache/src/CacheTransactionManagerImpl.cpp
+++ b/cppcache/src/CacheTransactionManagerImpl.cpp
@@ -59,7 +59,7 @@ void CacheTransactionManagerImpl::commit() {
         GF_CACHE_ILLEGAL_STATE_EXCEPTION);
   }
 
-  TcrMessageCommit request(m_cache->createDataOutput());
+  TcrMessageCommit request(std::unique_ptr<DataOutput>(new DataOutput(m_cache->createDataOutput())));
   TcrMessageReply reply(true, nullptr);
 
   auto tcr_dm = getDM();
@@ -270,7 +270,7 @@ void CacheTransactionManagerImpl::rollback() {
 }
 
 GfErrType CacheTransactionManagerImpl::rollback(TXState*, bool) {
-  TcrMessageRollback request(m_cache->getCache()->createDataOutput());
+  TcrMessageRollback request(std::unique_ptr<DataOutput>(new DataOutput(m_cache->getCache()->createDataOutput())));
   TcrMessageReply reply(true, nullptr);
   GfErrType err = GF_NOERR;
   ThinClientPoolDM* tcr_dm = getDM();

--- a/cppcache/src/ClientMetadataService.cpp
+++ b/cppcache/src/ClientMetadataService.cpp
@@ -129,10 +129,10 @@ void ClientMetadataService::getClientPRMetadata(const char* regionFullPath) {
   std::shared_ptr<ClientMetadata> newCptr = nullptr;
 
   if (cptr == nullptr) {
-    TcrMessageGetClientPartitionAttributes request(tcrdm->getConnectionManager()
+    TcrMessageGetClientPartitionAttributes request(std::unique_ptr<DataOutput>(new DataOutput(tcrdm->getConnectionManager()
                                                        .getCacheImpl()
                                                        ->getCache()
-                                                       ->createDataOutput(),
+                                                       ->createDataOutput())),
                                                    regionFullPath);
     GfErrType err = tcrdm->sendSyncRequest(request, reply);
     if (err == GF_NOERR &&
@@ -186,9 +186,9 @@ std::shared_ptr<ClientMetadata> ClientMetadataService::SendClientPRMetadata(
     throw IllegalArgumentException(
         "ClientMetaData: pool cast to ThinClientPoolDM failed");
   }
-  TcrMessageGetClientPrMetadata request(tcrdm->getConnectionManager()
+  TcrMessageGetClientPrMetadata request(std::unique_ptr<DataOutput>(new DataOutput(tcrdm->getConnectionManager()
                                             .getCacheImpl()
-                                            ->createDataOutput(),
+                                            ->createDataOutput())),
                                         regionPath);
   TcrMessageReply reply(true, nullptr);
   // send this message to server and get metadata from server.

--- a/cppcache/src/ClientMetadataService.cpp
+++ b/cppcache/src/ClientMetadataService.cpp
@@ -130,10 +130,10 @@ void ClientMetadataService::getClientPRMetadata(const char* regionFullPath) {
 
   if (cptr == nullptr) {
     TcrMessageGetClientPartitionAttributes request(
-        std::unique_ptr<DataOutput>(new DataOutput(tcrdm->getConnectionManager()
-                                                       .getCacheImpl()
-                                                       ->getCache()
-                                                       ->createDataOutput())),
+        new DataOutput(tcrdm->getConnectionManager()
+                           .getCacheImpl()
+                           ->getCache()
+                           ->createDataOutput()),
         regionFullPath);
     GfErrType err = tcrdm->sendSyncRequest(request, reply);
     if (err == GF_NOERR &&
@@ -188,8 +188,8 @@ std::shared_ptr<ClientMetadata> ClientMetadataService::SendClientPRMetadata(
         "ClientMetaData: pool cast to ThinClientPoolDM failed");
   }
   TcrMessageGetClientPrMetadata request(
-      std::unique_ptr<DataOutput>(new DataOutput(
-          tcrdm->getConnectionManager().getCacheImpl()->createDataOutput())),
+      new DataOutput(
+          tcrdm->getConnectionManager().getCacheImpl()->createDataOutput()),
       regionPath);
   TcrMessageReply reply(true, nullptr);
   // send this message to server and get metadata from server.
@@ -199,7 +199,8 @@ std::shared_ptr<ClientMetadata> ClientMetadataService::SendClientPRMetadata(
   GfErrType err = tcrdm->sendSyncRequest(request, reply);
   if (err == GF_NOERR &&
       reply.getMessageType() == TcrMessage::RESPONSE_CLIENT_PR_METADATA) {
-    region = tcrdm->getConnectionManager().getCacheImpl()->getRegion(regionPath);
+    region =
+        tcrdm->getConnectionManager().getCacheImpl()->getRegion(regionPath);
     if (region != nullptr) {
       LocalRegion* lregion = dynamic_cast<LocalRegion*>(region.get());
       lregion->getRegionStats()->incMetaDataRefreshCount();

--- a/cppcache/src/ClientMetadataService.cpp
+++ b/cppcache/src/ClientMetadataService.cpp
@@ -129,11 +129,12 @@ void ClientMetadataService::getClientPRMetadata(const char* regionFullPath) {
   std::shared_ptr<ClientMetadata> newCptr = nullptr;
 
   if (cptr == nullptr) {
-    TcrMessageGetClientPartitionAttributes request(std::unique_ptr<DataOutput>(new DataOutput(tcrdm->getConnectionManager()
+    TcrMessageGetClientPartitionAttributes request(
+        std::unique_ptr<DataOutput>(new DataOutput(tcrdm->getConnectionManager()
                                                        .getCacheImpl()
                                                        ->getCache()
                                                        ->createDataOutput())),
-                                                   regionFullPath);
+        regionFullPath);
     GfErrType err = tcrdm->sendSyncRequest(request, reply);
     if (err == GF_NOERR &&
         reply.getMessageType() ==
@@ -186,10 +187,10 @@ std::shared_ptr<ClientMetadata> ClientMetadataService::SendClientPRMetadata(
     throw IllegalArgumentException(
         "ClientMetaData: pool cast to ThinClientPoolDM failed");
   }
-  TcrMessageGetClientPrMetadata request(std::unique_ptr<DataOutput>(new DataOutput(tcrdm->getConnectionManager()
-                                            .getCacheImpl()
-                                            ->createDataOutput())),
-                                        regionPath);
+  TcrMessageGetClientPrMetadata request(
+      std::unique_ptr<DataOutput>(new DataOutput(
+          tcrdm->getConnectionManager().getCacheImpl()->createDataOutput())),
+      regionPath);
   TcrMessageReply reply(true, nullptr);
   // send this message to server and get metadata from server.
   LOGFINE("Now sending GET_CLIENT_PR_METADATA for getting from server: %s",

--- a/cppcache/src/CqEventImpl.cpp
+++ b/cppcache/src/CqEventImpl.cpp
@@ -21,10 +21,8 @@
 #include "TcrMessage.hpp"
 
 using namespace apache::geode::client;
-CqEventImpl::CqEventImpl(std::shared_ptr<CqQuery>& cQuery,
-                         CqOperation baseOp,
-                         CqOperation cqOp,
-                         std::shared_ptr<CacheableKey>& key,
+CqEventImpl::CqEventImpl(std::shared_ptr<CqQuery>& cQuery, CqOperation baseOp,
+                         CqOperation cqOp, std::shared_ptr<CacheableKey>& key,
                          std::shared_ptr<Cacheable>& value,
                          ThinClientBaseDM* tcrdm,
                          std::shared_ptr<CacheableBytes> deltaBytes,
@@ -42,41 +40,35 @@ CqEventImpl::CqEventImpl(std::shared_ptr<CqQuery>& cQuery,
 }
 std::shared_ptr<CqQuery> CqEventImpl::getCq() const { return m_cQuery; }
 
-CqOperation CqEventImpl::getBaseOperation() const {
-  return m_baseOp;
-}
+CqOperation CqEventImpl::getBaseOperation() const { return m_baseOp; }
 
 /**
  * Get the the operation on the query results. Supported operations include
  * update, create, and destroy.
  */
-CqOperation CqEventImpl::getQueryOperation() const {
-  return m_queryOp;
-}
+CqOperation CqEventImpl::getQueryOperation() const { return m_queryOp; }
 
 /**
  * Get the key relating to the event.
  * @return Object key.
- */ std::shared_ptr<CacheableKey>
-CqEventImpl::getKey() const {
+ */
+std::shared_ptr<CacheableKey> CqEventImpl::getKey() const {
   return m_key;
 }
 /**
  * Get the new value of the modification.
  *  If there is no new value because this is a delete, then
  *  return null.
- */ std::shared_ptr<Cacheable>
-CqEventImpl::getNewValue() const {
+ */
+std::shared_ptr<Cacheable> CqEventImpl::getNewValue() const {
   if (m_deltaValue == nullptr) {
     return m_newValue;
   } else {
     // Get full object for delta
     TcrMessageRequestEventValue fullObjectMsg(
-        std::unique_ptr<DataOutput>(
-            new DataOutput(m_tcrdm->getConnectionManager()
-                               .getCacheImpl()
-                               ->getCache()
-                               ->createDataOutput())),
+        new DataOutput(m_tcrdm->getConnectionManager()
+                           .getCacheImpl()
+                           ->createDataOutput()),
         m_eventId);
     TcrMessageReply reply(true, nullptr);
     ThinClientPoolHADM* poolHADM = dynamic_cast<ThinClientPoolHADM*>(m_tcrdm);

--- a/cppcache/src/CqEventImpl.cpp
+++ b/cppcache/src/CqEventImpl.cpp
@@ -71,10 +71,10 @@ CqEventImpl::getNewValue() const {
     return m_newValue;
   } else {
     // Get full object for delta
-    TcrMessageRequestEventValue fullObjectMsg(m_tcrdm->getConnectionManager()
+    TcrMessageRequestEventValue fullObjectMsg(std::unique_ptr<DataOutput>(new DataOutput(m_tcrdm->getConnectionManager()
                                                   .getCacheImpl()
                                                   ->getCache()
-                                                  ->createDataOutput(),
+                                                  ->createDataOutput())),
                                               m_eventId);
     TcrMessageReply reply(true, nullptr);
     ThinClientPoolHADM* poolHADM = dynamic_cast<ThinClientPoolHADM*>(m_tcrdm);

--- a/cppcache/src/CqEventImpl.cpp
+++ b/cppcache/src/CqEventImpl.cpp
@@ -71,11 +71,13 @@ CqEventImpl::getNewValue() const {
     return m_newValue;
   } else {
     // Get full object for delta
-    TcrMessageRequestEventValue fullObjectMsg(std::unique_ptr<DataOutput>(new DataOutput(m_tcrdm->getConnectionManager()
-                                                  .getCacheImpl()
-                                                  ->getCache()
-                                                  ->createDataOutput())),
-                                              m_eventId);
+    TcrMessageRequestEventValue fullObjectMsg(
+        std::unique_ptr<DataOutput>(
+            new DataOutput(m_tcrdm->getConnectionManager()
+                               .getCacheImpl()
+                               ->getCache()
+                               ->createDataOutput())),
+        m_eventId);
     TcrMessageReply reply(true, nullptr);
     ThinClientPoolHADM* poolHADM = dynamic_cast<ThinClientPoolHADM*>(m_tcrdm);
     GfErrType err = GF_NOTCON;

--- a/cppcache/src/CqQueryImpl.cpp
+++ b/cppcache/src/CqQueryImpl.cpp
@@ -258,13 +258,13 @@ GfErrType CqQueryImpl::execute(TcrEndpoint* endpoint) {
 
   LOGFINE("Executing CQ [%s]", m_cqName.c_str());
 
-  TcrMessageExecuteCq request(std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
-                                  ->getConnectionManager()
-                                  .getCacheImpl()
-                                  ->getCache()
-                                  ->createDataOutput())),
-                              m_cqName, m_queryString, CqState::RUNNING,
-                              isDurable(), m_tccdm);
+  TcrMessageExecuteCq request(
+      std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
+                                                     ->getConnectionManager()
+                                                     .getCacheImpl()
+                                                     ->getCache()
+                                                     ->createDataOutput())),
+      m_cqName, m_queryString, CqState::RUNNING, isDurable(), m_tccdm);
   TcrMessageReply reply(true, m_tccdm);
 
   GfErrType err = GF_NOERR;
@@ -328,13 +328,13 @@ bool CqQueryImpl::executeCq(TcrMessage::MsgType) {
   }
 
   LOGDEBUG("CqQueryImpl::executeCq");
-  TcrMessageExecuteCq msg(std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
-                              ->getConnectionManager()
-                              .getCacheImpl()
-                              ->getCache()
-                              ->createDataOutput())),
-                          m_cqName, m_queryString, CqState::RUNNING,
-                          isDurable(), m_tccdm);
+  TcrMessageExecuteCq msg(
+      std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
+                                                     ->getConnectionManager()
+                                                     .getCacheImpl()
+                                                     ->getCache()
+                                                     ->createDataOutput())),
+      m_cqName, m_queryString, CqState::RUNNING, isDurable(), m_tccdm);
   TcrMessageReply reply(true, m_tccdm);
 
   GfErrType err = GF_NOERR;
@@ -380,13 +380,13 @@ std::shared_ptr<CqResults> CqQueryImpl::executeWithInitialResults(
         "CqQuery::executeWithInitialResults: cq is already running");
   }
   // QueryResult values;
-  TcrMessageExecuteCqWithIr msg(std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
-                                    ->getConnectionManager()
-                                    .getCacheImpl()
-                                    ->getCache()
-                                    ->createDataOutput())),
-                                m_cqName, m_queryString, CqState::RUNNING,
-                                isDurable(), m_tccdm);
+  TcrMessageExecuteCqWithIr msg(
+      std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
+                                                     ->getConnectionManager()
+                                                     .getCacheImpl()
+                                                     ->getCache()
+                                                     ->createDataOutput())),
+      m_cqName, m_queryString, CqState::RUNNING, isDurable(), m_tccdm);
 
   TcrMessageReply reply(true, m_tccdm);
   auto resultCollector =
@@ -473,20 +473,22 @@ void CqQueryImpl::sendStopOrClose(TcrMessage::MsgType requestType) {
   TcrMessageReply reply(true, m_tccdm);
 
   if (requestType == TcrMessage::STOPCQ_MSG_TYPE) {
-    TcrMessageStopCQ msg(std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
-                             ->getConnectionManager()
-                             .getCacheImpl()
-                             ->getCache()
-                             ->createDataOutput())),
-                         m_cqName, std::chrono::milliseconds(-1), m_tccdm);
+    TcrMessageStopCQ msg(
+        std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
+                                                       ->getConnectionManager()
+                                                       .getCacheImpl()
+                                                       ->getCache()
+                                                       ->createDataOutput())),
+        m_cqName, std::chrono::milliseconds(-1), m_tccdm);
     err = m_tccdm->sendSyncRequest(msg, reply);
   } else if (requestType == TcrMessage::CLOSECQ_MSG_TYPE) {
-    TcrMessageCloseCQ msg(std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
-                              ->getConnectionManager()
-                              .getCacheImpl()
-                              ->getCache()
-                              ->createDataOutput())),
-                          m_cqName, std::chrono::milliseconds(-1), m_tccdm);
+    TcrMessageCloseCQ msg(
+        std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
+                                                       ->getConnectionManager()
+                                                       .getCacheImpl()
+                                                       ->getCache()
+                                                       ->createDataOutput())),
+        m_cqName, std::chrono::milliseconds(-1), m_tccdm);
     err = m_tccdm->sendSyncRequest(msg, reply);
   }
 

--- a/cppcache/src/CqQueryImpl.cpp
+++ b/cppcache/src/CqQueryImpl.cpp
@@ -258,11 +258,11 @@ GfErrType CqQueryImpl::execute(TcrEndpoint* endpoint) {
 
   LOGFINE("Executing CQ [%s]", m_cqName.c_str());
 
-  TcrMessageExecuteCq request(m_cqService->getDM()
+  TcrMessageExecuteCq request(std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
                                   ->getConnectionManager()
                                   .getCacheImpl()
                                   ->getCache()
-                                  ->createDataOutput(),
+                                  ->createDataOutput())),
                               m_cqName, m_queryString, CqState::RUNNING,
                               isDurable(), m_tccdm);
   TcrMessageReply reply(true, m_tccdm);
@@ -328,11 +328,11 @@ bool CqQueryImpl::executeCq(TcrMessage::MsgType) {
   }
 
   LOGDEBUG("CqQueryImpl::executeCq");
-  TcrMessageExecuteCq msg(m_cqService->getDM()
+  TcrMessageExecuteCq msg(std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
                               ->getConnectionManager()
                               .getCacheImpl()
                               ->getCache()
-                              ->createDataOutput(),
+                              ->createDataOutput())),
                           m_cqName, m_queryString, CqState::RUNNING,
                           isDurable(), m_tccdm);
   TcrMessageReply reply(true, m_tccdm);
@@ -380,11 +380,11 @@ std::shared_ptr<CqResults> CqQueryImpl::executeWithInitialResults(
         "CqQuery::executeWithInitialResults: cq is already running");
   }
   // QueryResult values;
-  TcrMessageExecuteCqWithIr msg(m_cqService->getDM()
+  TcrMessageExecuteCqWithIr msg(std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
                                     ->getConnectionManager()
                                     .getCacheImpl()
                                     ->getCache()
-                                    ->createDataOutput(),
+                                    ->createDataOutput())),
                                 m_cqName, m_queryString, CqState::RUNNING,
                                 isDurable(), m_tccdm);
 
@@ -473,19 +473,19 @@ void CqQueryImpl::sendStopOrClose(TcrMessage::MsgType requestType) {
   TcrMessageReply reply(true, m_tccdm);
 
   if (requestType == TcrMessage::STOPCQ_MSG_TYPE) {
-    TcrMessageStopCQ msg(m_cqService->getDM()
+    TcrMessageStopCQ msg(std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
                              ->getConnectionManager()
                              .getCacheImpl()
                              ->getCache()
-                             ->createDataOutput(),
+                             ->createDataOutput())),
                          m_cqName, std::chrono::milliseconds(-1), m_tccdm);
     err = m_tccdm->sendSyncRequest(msg, reply);
   } else if (requestType == TcrMessage::CLOSECQ_MSG_TYPE) {
-    TcrMessageCloseCQ msg(m_cqService->getDM()
+    TcrMessageCloseCQ msg(std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
                               ->getConnectionManager()
                               .getCacheImpl()
                               ->getCache()
-                              ->createDataOutput(),
+                              ->createDataOutput())),
                           m_cqName, std::chrono::milliseconds(-1), m_tccdm);
     err = m_tccdm->sendSyncRequest(msg, reply);
   }

--- a/cppcache/src/CqQueryImpl.cpp
+++ b/cppcache/src/CqQueryImpl.cpp
@@ -258,13 +258,12 @@ GfErrType CqQueryImpl::execute(TcrEndpoint* endpoint) {
 
   LOGFINE("Executing CQ [%s]", m_cqName.c_str());
 
-  TcrMessageExecuteCq request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
-                                                     ->getConnectionManager()
-                                                     .getCacheImpl()
-                                                     ->getCache()
-                                                     ->createDataOutput())),
-      m_cqName, m_queryString, CqState::RUNNING, isDurable(), m_tccdm);
+  TcrMessageExecuteCq request(new DataOutput(m_cqService->getDM()
+                                                 ->getConnectionManager()
+                                                 .getCacheImpl()
+                                                 ->createDataOutput()),
+                              m_cqName, m_queryString, CqState::RUNNING,
+                              isDurable(), m_tccdm);
   TcrMessageReply reply(true, m_tccdm);
 
   GfErrType err = GF_NOERR;
@@ -328,13 +327,12 @@ bool CqQueryImpl::executeCq(TcrMessage::MsgType) {
   }
 
   LOGDEBUG("CqQueryImpl::executeCq");
-  TcrMessageExecuteCq msg(
-      std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
-                                                     ->getConnectionManager()
-                                                     .getCacheImpl()
-                                                     ->getCache()
-                                                     ->createDataOutput())),
-      m_cqName, m_queryString, CqState::RUNNING, isDurable(), m_tccdm);
+  TcrMessageExecuteCq msg(new DataOutput(m_cqService->getDM()
+                                             ->getConnectionManager()
+                                             .getCacheImpl()
+                                             ->createDataOutput()),
+                          m_cqName, m_queryString, CqState::RUNNING,
+                          isDurable(), m_tccdm);
   TcrMessageReply reply(true, m_tccdm);
 
   GfErrType err = GF_NOERR;
@@ -380,13 +378,12 @@ std::shared_ptr<CqResults> CqQueryImpl::executeWithInitialResults(
         "CqQuery::executeWithInitialResults: cq is already running");
   }
   // QueryResult values;
-  TcrMessageExecuteCqWithIr msg(
-      std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
-                                                     ->getConnectionManager()
-                                                     .getCacheImpl()
-                                                     ->getCache()
-                                                     ->createDataOutput())),
-      m_cqName, m_queryString, CqState::RUNNING, isDurable(), m_tccdm);
+  TcrMessageExecuteCqWithIr msg(new DataOutput(m_cqService->getDM()
+                                                   ->getConnectionManager()
+                                                   .getCacheImpl()
+                                                   ->createDataOutput()),
+                                m_cqName, m_queryString, CqState::RUNNING,
+                                isDurable(), m_tccdm);
 
   TcrMessageReply reply(true, m_tccdm);
   auto resultCollector =
@@ -473,22 +470,18 @@ void CqQueryImpl::sendStopOrClose(TcrMessage::MsgType requestType) {
   TcrMessageReply reply(true, m_tccdm);
 
   if (requestType == TcrMessage::STOPCQ_MSG_TYPE) {
-    TcrMessageStopCQ msg(
-        std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
-                                                       ->getConnectionManager()
-                                                       .getCacheImpl()
-                                                       ->getCache()
-                                                       ->createDataOutput())),
-        m_cqName, std::chrono::milliseconds(-1), m_tccdm);
+    TcrMessageStopCQ msg(new DataOutput(m_cqService->getDM()
+                                            ->getConnectionManager()
+                                            .getCacheImpl()
+                                            ->createDataOutput()),
+                         m_cqName, std::chrono::milliseconds(-1), m_tccdm);
     err = m_tccdm->sendSyncRequest(msg, reply);
   } else if (requestType == TcrMessage::CLOSECQ_MSG_TYPE) {
-    TcrMessageCloseCQ msg(
-        std::unique_ptr<DataOutput>(new DataOutput(m_cqService->getDM()
-                                                       ->getConnectionManager()
-                                                       .getCacheImpl()
-                                                       ->getCache()
-                                                       ->createDataOutput())),
-        m_cqName, std::chrono::milliseconds(-1), m_tccdm);
+    TcrMessageCloseCQ msg(new DataOutput(m_cqService->getDM()
+                                             ->getConnectionManager()
+                                             .getCacheImpl()
+                                             ->createDataOutput()),
+                          m_cqName, std::chrono::milliseconds(-1), m_tccdm);
     err = m_tccdm->sendSyncRequest(msg, reply);
   }
 

--- a/cppcache/src/CqService.cpp
+++ b/cppcache/src/CqService.cpp
@@ -569,12 +569,10 @@ CqOperation CqService::getOperation(int eventType) {
  * cqs.
  */
 std::shared_ptr<CacheableArrayList> CqService::getAllDurableCqsFromServer() {
-  TcrMessageGetDurableCqs msg(
-      std::unique_ptr<DataOutput>(new DataOutput(m_tccdm->getConnectionManager()
-                                                     .getCacheImpl()
-                                                     ->getCache()
-                                                     ->createDataOutput())),
-      m_tccdm);
+  TcrMessageGetDurableCqs msg(new DataOutput(m_tccdm->getConnectionManager()
+                                                 .getCacheImpl()
+                                                 ->createDataOutput()),
+                              m_tccdm);
   TcrMessageReply reply(true, m_tccdm);
 
   // intialize the chunked response hadler for durable cqs list

--- a/cppcache/src/CqService.cpp
+++ b/cppcache/src/CqService.cpp
@@ -569,10 +569,10 @@ CqOperation CqService::getOperation(int eventType) {
  * cqs.
  */
 std::shared_ptr<CacheableArrayList> CqService::getAllDurableCqsFromServer() {
-  TcrMessageGetDurableCqs msg(m_tccdm->getConnectionManager()
+  TcrMessageGetDurableCqs msg(std::unique_ptr<DataOutput>(new DataOutput(m_tccdm->getConnectionManager()
                                   .getCacheImpl()
                                   ->getCache()
-                                  ->createDataOutput(),
+                                  ->createDataOutput())),
                               m_tccdm);
   TcrMessageReply reply(true, m_tccdm);
 

--- a/cppcache/src/CqService.cpp
+++ b/cppcache/src/CqService.cpp
@@ -569,11 +569,12 @@ CqOperation CqService::getOperation(int eventType) {
  * cqs.
  */
 std::shared_ptr<CacheableArrayList> CqService::getAllDurableCqsFromServer() {
-  TcrMessageGetDurableCqs msg(std::unique_ptr<DataOutput>(new DataOutput(m_tccdm->getConnectionManager()
-                                  .getCacheImpl()
-                                  ->getCache()
-                                  ->createDataOutput())),
-                              m_tccdm);
+  TcrMessageGetDurableCqs msg(
+      std::unique_ptr<DataOutput>(new DataOutput(m_tccdm->getConnectionManager()
+                                                     .getCacheImpl()
+                                                     ->getCache()
+                                                     ->createDataOutput())),
+      m_tccdm);
   TcrMessageReply reply(true, m_tccdm);
 
   // intialize the chunked response hadler for durable cqs list

--- a/cppcache/src/DataInput.cpp
+++ b/cppcache/src/DataInput.cpp
@@ -28,10 +28,10 @@ namespace apache {
 namespace geode {
 namespace client {
 
-DataInput::DataInput(const uint8_t* m_buffer, size_t len,
+DataInput::DataInput(const uint8_t* buffer, size_t len,
                      const CacheImpl* cache, Pool* pool)
-    : m_buf(m_buffer),
-      m_bufHead(m_buffer),
+    : m_buf(buffer),
+      m_bufHead(buffer),
       m_bufLength(len),
       m_pool(pool),
       m_cache(cache) {}

--- a/cppcache/src/DataOutput.cpp
+++ b/cppcache/src/DataOutput.cpp
@@ -115,8 +115,8 @@ ACE_TSS<TSSDataOutput> TSSDataOutput::s_tssDataOutput;
 
 DataOutput::DataOutput(const CacheImpl* cache, Pool* pool)
     : m_size(0), m_haveBigBuffer(false), m_cache(cache), m_pool(pool) {
-  m_bytes.reset(DataOutput::checkoutBuffer(&m_size));
-  m_buf = m_bytes.get();
+  m_bytes = DataOutput::checkoutBuffer(&m_size);
+  m_buf = m_bytes;
 }
 
 uint8_t* DataOutput::checkoutBuffer(size_t* size) {

--- a/cppcache/src/DataOutput.cpp
+++ b/cppcache/src/DataOutput.cpp
@@ -115,7 +115,8 @@ ACE_TSS<TSSDataOutput> TSSDataOutput::s_tssDataOutput;
 
 DataOutput::DataOutput(const CacheImpl* cache, Pool* pool)
     : m_size(0), m_haveBigBuffer(false), m_cache(cache), m_pool(pool) {
-  m_buf = m_bytes = DataOutput::checkoutBuffer(&m_size);
+  m_bytes.reset(DataOutput::checkoutBuffer(&m_size));
+  m_buf = m_bytes.get();
 }
 
 uint8_t* DataOutput::checkoutBuffer(size_t* size) {

--- a/cppcache/src/DataOutput.cpp
+++ b/cppcache/src/DataOutput.cpp
@@ -115,8 +115,8 @@ ACE_TSS<TSSDataOutput> TSSDataOutput::s_tssDataOutput;
 
 DataOutput::DataOutput(const CacheImpl* cache, Pool* pool)
     : m_size(0), m_haveBigBuffer(false), m_cache(cache), m_pool(pool) {
-  m_bytes = DataOutput::checkoutBuffer(&m_size);
-  m_buf = m_bytes;
+  m_bytes.reset(DataOutput::checkoutBuffer(&m_size));
+  m_buf = m_bytes.get();
 }
 
 uint8_t* DataOutput::checkoutBuffer(size_t* size) {

--- a/cppcache/src/ExecutionImpl.cpp
+++ b/cppcache/src/ExecutionImpl.cpp
@@ -375,8 +375,9 @@ GfErrType ExecutionImpl::getFuncAttributes(const std::string& func,
   // do TCR GET_FUNCTION_ATTRIBUTES
   LOGDEBUG("Tcrmessage request GET_FUNCTION_ATTRIBUTES ");
   TcrMessageGetFunctionAttributes request(
-          std::unique_ptr<DataOutput>(new DataOutput(tcrdm->getConnectionManager().getCacheImpl()->createDataOutput())), func,
-      tcrdm);
+      std::unique_ptr<DataOutput>(new DataOutput(
+          tcrdm->getConnectionManager().getCacheImpl()->createDataOutput())),
+      func, tcrdm);
   TcrMessageReply reply(true, tcrdm);
   err = tcrdm->sendSyncRequest(request, reply);
   if (err != GF_NOERR) {
@@ -489,11 +490,12 @@ std::shared_ptr<CacheableVector> ExecutionImpl::executeOnPool(
 
   while (attempt <= retryAttempts) {
     std::string funcName(func);
-    TcrMessageExecuteFunction msg(std::unique_ptr<DataOutput>(new DataOutput(tcrdm->getConnectionManager()
-                                      .getCacheImpl()
-                                      ->getCache()
-                                      ->createDataOutput())),
-                                  funcName, m_args, getResult, tcrdm, timeout);
+    TcrMessageExecuteFunction msg(
+        std::unique_ptr<DataOutput>(new DataOutput(tcrdm->getConnectionManager()
+                                                       .getCacheImpl()
+                                                       ->getCache()
+                                                       ->createDataOutput())),
+        funcName, m_args, getResult, tcrdm, timeout);
     TcrMessageReply reply(true, tcrdm);
     ChunkedFunctionExecutionResponse* resultCollector(
         new ChunkedFunctionExecutionResponse(reply, (getResult & 2) == 2,

--- a/cppcache/src/ExecutionImpl.cpp
+++ b/cppcache/src/ExecutionImpl.cpp
@@ -375,8 +375,8 @@ GfErrType ExecutionImpl::getFuncAttributes(const std::string& func,
   // do TCR GET_FUNCTION_ATTRIBUTES
   LOGDEBUG("Tcrmessage request GET_FUNCTION_ATTRIBUTES ");
   TcrMessageGetFunctionAttributes request(
-      std::unique_ptr<DataOutput>(new DataOutput(
-          tcrdm->getConnectionManager().getCacheImpl()->createDataOutput())),
+      new DataOutput(
+          tcrdm->getConnectionManager().getCacheImpl()->createDataOutput()),
       func, tcrdm);
   TcrMessageReply reply(true, tcrdm);
   err = tcrdm->sendSyncRequest(request, reply);
@@ -491,10 +491,8 @@ std::shared_ptr<CacheableVector> ExecutionImpl::executeOnPool(
   while (attempt <= retryAttempts) {
     std::string funcName(func);
     TcrMessageExecuteFunction msg(
-        std::unique_ptr<DataOutput>(new DataOutput(tcrdm->getConnectionManager()
-                                                       .getCacheImpl()
-                                                       ->getCache()
-                                                       ->createDataOutput())),
+        new DataOutput(
+            tcrdm->getConnectionManager().getCacheImpl()->createDataOutput()),
         funcName, m_args, getResult, tcrdm, timeout);
     TcrMessageReply reply(true, tcrdm);
     ChunkedFunctionExecutionResponse* resultCollector(

--- a/cppcache/src/ExecutionImpl.cpp
+++ b/cppcache/src/ExecutionImpl.cpp
@@ -375,7 +375,7 @@ GfErrType ExecutionImpl::getFuncAttributes(const std::string& func,
   // do TCR GET_FUNCTION_ATTRIBUTES
   LOGDEBUG("Tcrmessage request GET_FUNCTION_ATTRIBUTES ");
   TcrMessageGetFunctionAttributes request(
-      tcrdm->getConnectionManager().getCacheImpl()->createDataOutput(), func,
+          std::unique_ptr<DataOutput>(new DataOutput(tcrdm->getConnectionManager().getCacheImpl()->createDataOutput())), func,
       tcrdm);
   TcrMessageReply reply(true, tcrdm);
   err = tcrdm->sendSyncRequest(request, reply);
@@ -489,10 +489,10 @@ std::shared_ptr<CacheableVector> ExecutionImpl::executeOnPool(
 
   while (attempt <= retryAttempts) {
     std::string funcName(func);
-    TcrMessageExecuteFunction msg(tcrdm->getConnectionManager()
+    TcrMessageExecuteFunction msg(std::unique_ptr<DataOutput>(new DataOutput(tcrdm->getConnectionManager()
                                       .getCacheImpl()
                                       ->getCache()
-                                      ->createDataOutput(),
+                                      ->createDataOutput())),
                                   funcName, m_args, getResult, tcrdm, timeout);
     TcrMessageReply reply(true, tcrdm);
     ChunkedFunctionExecutionResponse* resultCollector(

--- a/cppcache/src/InternalCacheTransactionManager2PCImpl.cpp
+++ b/cppcache/src/InternalCacheTransactionManager2PCImpl.cpp
@@ -61,11 +61,8 @@ void InternalCacheTransactionManager2PCImpl::prepare() {
     }
 
     TcrMessageTxSynchronization requestCommitBefore(
-        std::unique_ptr<DataOutput>(
-            new DataOutput(tcr_dm->getConnectionManager()
-                               .getCacheImpl()
-                               ->getCache()
-                               ->createDataOutput())),
+        new DataOutput(
+            tcr_dm->getConnectionManager().getCacheImpl()->createDataOutput()),
         BEFORE_COMMIT, txState->getTransactionId().getId(), STATUS_COMMITTED);
 
     TcrMessageReply replyCommitBefore(true, nullptr);
@@ -102,8 +99,7 @@ void InternalCacheTransactionManager2PCImpl::prepare() {
       }
     }
   } catch (const Exception& ex) {
-    LOGERROR("Unexpected exception during commit in prepare %s",
-             ex.what());
+    LOGERROR("Unexpected exception during commit in prepare %s", ex.what());
     throw ex;
   }
 }
@@ -161,11 +157,8 @@ void InternalCacheTransactionManager2PCImpl::afterCompletion(int32_t status) {
     TXCleaner txCleaner(this);
 
     TcrMessageTxSynchronization requestCommitAfter(
-        std::unique_ptr<DataOutput>(
-            new DataOutput(tcr_dm->getConnectionManager()
-                               .getCacheImpl()
-                               ->getCache()
-                               ->createDataOutput())),
+        new DataOutput(
+            tcr_dm->getConnectionManager().getCacheImpl()->createDataOutput()),
         AFTER_COMMIT, txState->getTransactionId().getId(), status);
 
     TcrMessageReply replyCommitAfter(true, nullptr);

--- a/cppcache/src/InternalCacheTransactionManager2PCImpl.cpp
+++ b/cppcache/src/InternalCacheTransactionManager2PCImpl.cpp
@@ -61,10 +61,10 @@ void InternalCacheTransactionManager2PCImpl::prepare() {
     }
 
     TcrMessageTxSynchronization requestCommitBefore(
-        tcr_dm->getConnectionManager()
+            std::unique_ptr<DataOutput>(new DataOutput(tcr_dm->getConnectionManager()
             .getCacheImpl()
             ->getCache()
-            ->createDataOutput(),
+            ->createDataOutput())),
         BEFORE_COMMIT, txState->getTransactionId().getId(), STATUS_COMMITTED);
 
     TcrMessageReply replyCommitBefore(true, nullptr);
@@ -160,10 +160,10 @@ void InternalCacheTransactionManager2PCImpl::afterCompletion(int32_t status) {
     TXCleaner txCleaner(this);
 
     TcrMessageTxSynchronization requestCommitAfter(
-        tcr_dm->getConnectionManager()
+            std::unique_ptr<DataOutput>(new DataOutput(tcr_dm->getConnectionManager()
             .getCacheImpl()
             ->getCache()
-            ->createDataOutput(),
+            ->createDataOutput())),
         AFTER_COMMIT, txState->getTransactionId().getId(), status);
 
     TcrMessageReply replyCommitAfter(true, nullptr);

--- a/cppcache/src/InternalCacheTransactionManager2PCImpl.cpp
+++ b/cppcache/src/InternalCacheTransactionManager2PCImpl.cpp
@@ -61,10 +61,11 @@ void InternalCacheTransactionManager2PCImpl::prepare() {
     }
 
     TcrMessageTxSynchronization requestCommitBefore(
-            std::unique_ptr<DataOutput>(new DataOutput(tcr_dm->getConnectionManager()
-            .getCacheImpl()
-            ->getCache()
-            ->createDataOutput())),
+        std::unique_ptr<DataOutput>(
+            new DataOutput(tcr_dm->getConnectionManager()
+                               .getCacheImpl()
+                               ->getCache()
+                               ->createDataOutput())),
         BEFORE_COMMIT, txState->getTransactionId().getId(), STATUS_COMMITTED);
 
     TcrMessageReply replyCommitBefore(true, nullptr);
@@ -160,10 +161,11 @@ void InternalCacheTransactionManager2PCImpl::afterCompletion(int32_t status) {
     TXCleaner txCleaner(this);
 
     TcrMessageTxSynchronization requestCommitAfter(
-            std::unique_ptr<DataOutput>(new DataOutput(tcr_dm->getConnectionManager()
-            .getCacheImpl()
-            ->getCache()
-            ->createDataOutput())),
+        std::unique_ptr<DataOutput>(
+            new DataOutput(tcr_dm->getConnectionManager()
+                               .getCacheImpl()
+                               ->getCache()
+                               ->createDataOutput())),
         AFTER_COMMIT, txState->getTransactionId().getId(), status);
 
     TcrMessageReply replyCommitAfter(true, nullptr);

--- a/cppcache/src/LocalRegion.cpp
+++ b/cppcache/src/LocalRegion.cpp
@@ -1369,9 +1369,9 @@ class RemoveActions {
     GfErrType err = GF_NOERR;
     if (!allowNULLValue && m_region.getAttributes().getCachingEnabled()) {
       m_region.getEntry(key, valuePtr);
-      std::unique_ptr<DataOutput> out1 =
+      DataOutput out1 =
           m_region.getCacheImpl()->getCache()->createDataOutput();
-      std::unique_ptr<DataOutput> out2 =
+      DataOutput out2 =
           m_region.getCacheImpl()->getCache()->createDataOutput();
 
       if (valuePtr != nullptr && value != nullptr) {
@@ -1380,14 +1380,14 @@ class RemoveActions {
           err = GF_ENOENT;
           return err;
         }
-        valuePtr->toData(*out1);
-        value->toData(*out2);
-        if (out1->getBufferLength() != out2->getBufferLength()) {
+        valuePtr->toData(out1);
+        value->toData(out2);
+        if (out1.getBufferLength() != out2.getBufferLength()) {
           err = GF_ENOENT;
           return err;
         }
-        if (memcmp(out1->getBuffer(), out2->getBuffer(),
-                   out1->getBufferLength()) != 0) {
+        if (memcmp(out1.getBuffer(), out2.getBuffer(),
+                   out1.getBufferLength()) != 0) {
           err = GF_ENOENT;
           return err;
         }
@@ -1426,9 +1426,9 @@ class RemoveActions {
     GfErrType err = GF_NOERR;
     if (!allowNULLValue && cachingEnabled) {
       m_region.getEntry(key, valuePtr);
-      std::unique_ptr<DataOutput> out1 =
+      DataOutput out1 =
           m_region.getCacheImpl()->getCache()->createDataOutput();
-      std::unique_ptr<DataOutput> out2 =
+      DataOutput out2 =
           m_region.getCacheImpl()->getCache()->createDataOutput();
       if (valuePtr != nullptr && value != nullptr) {
         if (valuePtr->classId() != value->classId() ||
@@ -1436,14 +1436,14 @@ class RemoveActions {
           err = GF_ENOENT;
           return err;
         }
-        valuePtr->toData(*out1);
-        value->toData(*out2);
-        if (out1->getBufferLength() != out2->getBufferLength()) {
+        valuePtr->toData(out1);
+        value->toData(out2);
+        if (out1.getBufferLength() != out2.getBufferLength()) {
           err = GF_ENOENT;
           return err;
         }
-        if (memcmp(out1->getBuffer(), out2->getBuffer(),
-                   out1->getBufferLength()) != 0) {
+        if (memcmp(out1.getBuffer(), out2.getBuffer(),
+                   out1.getBufferLength()) != 0) {
           err = GF_ENOENT;
           return err;
         }

--- a/cppcache/src/LocalRegion.cpp
+++ b/cppcache/src/LocalRegion.cpp
@@ -1369,8 +1369,8 @@ class RemoveActions {
     GfErrType err = GF_NOERR;
     if (!allowNULLValue && m_region.getAttributes().getCachingEnabled()) {
       m_region.getEntry(key, valuePtr);
-      DataOutput out1 = m_region.getCacheImpl()->getCache()->createDataOutput();
-      DataOutput out2 = m_region.getCacheImpl()->getCache()->createDataOutput();
+      DataOutput out1 = m_region.getCacheImpl()->createDataOutput();
+      DataOutput out2 = m_region.getCacheImpl()->createDataOutput();
 
       if (valuePtr != nullptr && value != nullptr) {
         if (valuePtr->classId() != value->classId() ||
@@ -1424,8 +1424,8 @@ class RemoveActions {
     GfErrType err = GF_NOERR;
     if (!allowNULLValue && cachingEnabled) {
       m_region.getEntry(key, valuePtr);
-      DataOutput out1 = m_region.getCacheImpl()->getCache()->createDataOutput();
-      DataOutput out2 = m_region.getCacheImpl()->getCache()->createDataOutput();
+      DataOutput out1 = m_region.getCacheImpl()->createDataOutput();
+      DataOutput out2 = m_region.getCacheImpl()->createDataOutput();
       if (valuePtr != nullptr && value != nullptr) {
         if (valuePtr->classId() != value->classId() ||
             valuePtr->typeId() != value->typeId()) {

--- a/cppcache/src/LocalRegion.cpp
+++ b/cppcache/src/LocalRegion.cpp
@@ -1369,10 +1369,8 @@ class RemoveActions {
     GfErrType err = GF_NOERR;
     if (!allowNULLValue && m_region.getAttributes().getCachingEnabled()) {
       m_region.getEntry(key, valuePtr);
-      DataOutput out1 =
-          m_region.getCacheImpl()->getCache()->createDataOutput();
-      DataOutput out2 =
-          m_region.getCacheImpl()->getCache()->createDataOutput();
+      DataOutput out1 = m_region.getCacheImpl()->getCache()->createDataOutput();
+      DataOutput out2 = m_region.getCacheImpl()->getCache()->createDataOutput();
 
       if (valuePtr != nullptr && value != nullptr) {
         if (valuePtr->classId() != value->classId() ||
@@ -1426,10 +1424,8 @@ class RemoveActions {
     GfErrType err = GF_NOERR;
     if (!allowNULLValue && cachingEnabled) {
       m_region.getEntry(key, valuePtr);
-      DataOutput out1 =
-          m_region.getCacheImpl()->getCache()->createDataOutput();
-      DataOutput out2 =
-          m_region.getCacheImpl()->getCache()->createDataOutput();
+      DataOutput out1 = m_region.getCacheImpl()->getCache()->createDataOutput();
+      DataOutput out2 = m_region.getCacheImpl()->getCache()->createDataOutput();
       if (valuePtr != nullptr && value != nullptr) {
         if (valuePtr->classId() != value->classId() ||
             valuePtr->typeId() != value->typeId()) {

--- a/cppcache/src/PdxInstanceFactory.cpp
+++ b/cppcache/src/PdxInstanceFactory.cpp
@@ -49,7 +49,8 @@ std::shared_ptr<PdxInstance> PdxInstanceFactory::create() {
   m_created = true;
 
   // Forces registration of PdxType
-  PdxHelper::serializePdx(*m_cacheImpl.createDataOutput(), pi);
+  auto dataOutput = m_cacheImpl.createDataOutput();
+  PdxHelper::serializePdx(dataOutput, pi);
 
   return pi;
 }

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -1405,8 +1405,7 @@ void PdxInstanceImpl::toDataMutable(PdxWriter& writer) {
       }
       if (value != nullptr) {
         writeField(writer, currPf->getFieldName(), currPf->getTypeId(), value);
-        position =
-            getNextFieldPosition(dataInput, static_cast<int>(i) + 1, pt);
+        position = getNextFieldPosition(dataInput, static_cast<int>(i) + 1, pt);
       } else {
         if (currPf->IsVariableLengthType()) {
           // need to add offset

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -700,23 +700,23 @@ int32_t PdxInstanceImpl::hashcode() const {
       case PdxFieldTypes::DOUBLE_ARRAY:
       case PdxFieldTypes::STRING_ARRAY:
       case PdxFieldTypes::ARRAY_OF_BYTE_ARRAYS: {
-        int retH = getRawHashCode(pt, pField, *dataInput);
+        int retH = getRawHashCode(pt, pField, dataInput);
         if (retH != 0) hashCode = 31 * hashCode + retH;
         break;
       }
       case PdxFieldTypes::OBJECT: {
-        setOffsetForObject(*dataInput, pt, pField->getSequenceId());
+        setOffsetForObject(dataInput, pt, pField->getSequenceId());
         std::shared_ptr<Cacheable> object = nullptr;
-        dataInput->readObject(object);
+        dataInput.readObject(object);
         if (object != nullptr) {
           hashCode = 31 * hashCode + deepArrayHashCode(object);
         }
         break;
       }
       case PdxFieldTypes::OBJECT_ARRAY: {
-        setOffsetForObject(*dataInput, pt, pField->getSequenceId());
+        setOffsetForObject(dataInput, pt, pField->getSequenceId());
         auto objectArray = CacheableObjectArray::create();
-        objectArray->fromData(*dataInput);
+        objectArray->fromData(dataInput);
         hashCode =
             31 * hashCode +
             ((objectArray != nullptr) ? deepArrayHashCode(objectArray) : 0);
@@ -775,109 +775,109 @@ bool PdxInstanceImpl::hasField(const std::string& fieldname) {
 
 bool PdxInstanceImpl::getBooleanField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readBoolean();
+  return dataInput.readBoolean();
 }
 
 int8_t PdxInstanceImpl::getByteField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->read();
+  return dataInput.read();
 }
 
 int16_t PdxInstanceImpl::getShortField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readInt16();
+  return dataInput.readInt16();
 }
 
 int32_t PdxInstanceImpl::getIntField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readInt32();
+  return dataInput.readInt32();
 }
 
 int64_t PdxInstanceImpl::getLongField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readInt64();
+  return dataInput.readInt64();
 }
 
 float PdxInstanceImpl::getFloatField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readFloat();
+  return dataInput.readFloat();
 }
 
 double PdxInstanceImpl::getDoubleField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readDouble();
+  return dataInput.readDouble();
 }
 
 char16_t PdxInstanceImpl::getCharField(const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readInt16();
+  return dataInput.readInt16();
 }
 
 std::string PdxInstanceImpl::getStringField(
     const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readString();
+  return dataInput.readString();
 }
 
 std::vector<bool> PdxInstanceImpl::getBooleanArrayField(
     const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readBooleanArray();
+  return dataInput.readBooleanArray();
 }
 
 std::vector<int8_t> PdxInstanceImpl::getByteArrayField(
     const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readByteArray();
+  return dataInput.readByteArray();
 }
 
 std::vector<int16_t> PdxInstanceImpl::getShortArrayField(
     const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readShortArray();
+  return dataInput.readShortArray();
 }
 
 std::vector<int32_t> PdxInstanceImpl::getIntArrayField(
     const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readIntArray();
+  return dataInput.readIntArray();
 }
 
 std::vector<int64_t> PdxInstanceImpl::getLongArrayField(
     const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readLongArray();
+  return dataInput.readLongArray();
 }
 
 std::vector<float> PdxInstanceImpl::getFloatArrayField(
     const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readFloatArray();
+  return dataInput.readFloatArray();
 }
 
 std::vector<double> PdxInstanceImpl::getDoubleArrayField(
     const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readDoubleArray();
+  return dataInput.readDoubleArray();
 }
 
 std::vector<char16_t> PdxInstanceImpl::getCharArrayField(
     const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readCharArray();
+  return dataInput.readCharArray();
 }
 
 std::vector<std::string> PdxInstanceImpl::getStringArrayField(
     const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
-  return dataInput->readStringArray();
+  return dataInput.readStringArray();
 }
 
 std::shared_ptr<CacheableDate> PdxInstanceImpl::getCacheableDateField(
     const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
   auto value = CacheableDate::create();
-  value->fromData(*dataInput);
+  value->fromData(dataInput);
   return value;
 }
 
@@ -885,7 +885,7 @@ std::shared_ptr<Cacheable> PdxInstanceImpl::getCacheableField(
     const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
   std::shared_ptr<Cacheable> value;
-  dataInput->readObject(value);
+  dataInput.readObject(value);
   return value;
 }
 std::shared_ptr<CacheableObjectArray>
@@ -893,7 +893,7 @@ PdxInstanceImpl::getCacheableObjectArrayField(
     const std::string& fieldname) const {
   auto dataInput = getDataInputForField(fieldname);
   auto value = CacheableObjectArray::create();
-  value->fromData(*dataInput);
+  value->fromData(dataInput);
   return value;
 }
 
@@ -901,7 +901,7 @@ void PdxInstanceImpl::getField(const std::string& fieldname, int8_t*** value,
                                int32_t& arrayLength,
                                int32_t*& elementLength) const {
   auto dataInput = getDataInputForField(fieldname);
-  dataInput->readArrayOfByteArrays(value, arrayLength, &elementLength);
+  dataInput.readArrayOfByteArrays(value, arrayLength, &elementLength);
 }
 
 std::string PdxInstanceImpl::toString() const {
@@ -1108,7 +1108,7 @@ std::shared_ptr<PdxSerializable> PdxInstanceImpl::getObject() {
   int64_t sampleStartNanos =
       m_enableTimeStatistics ? Utils::startStatOpTime() : 0;
   //[ToDo] do we have to call incPdxDeSerialization here?
-  auto ret = PdxHelper::deserializePdx(*dataInput, m_typeId, m_bufferLength);
+  auto ret = PdxHelper::deserializePdx(dataInput, m_typeId, m_bufferLength);
 
   if (m_enableTimeStatistics) {
     Utils::updateStatOpTime(m_cacheStats.getStat(),
@@ -1218,8 +1218,8 @@ bool PdxInstanceImpl::operator==(const CacheableKey& other) const {
       case PdxFieldTypes::DOUBLE_ARRAY:
       case PdxFieldTypes::STRING_ARRAY:
       case PdxFieldTypes::ARRAY_OF_BYTE_ARRAYS: {
-        if (!compareRawBytes(*otherPdx, myPdxType, myPFT, *myDataInput,
-                             otherPdxType, otherPFT, *otherDataInput)) {
+        if (!compareRawBytes(*otherPdx, myPdxType, myPFT, myDataInput,
+                             otherPdxType, otherPFT, otherDataInput)) {
           return false;
         }
         break;
@@ -1228,14 +1228,14 @@ bool PdxInstanceImpl::operator==(const CacheableKey& other) const {
         std::shared_ptr<Cacheable> object = nullptr;
         std::shared_ptr<Cacheable> otherObject = nullptr;
         if (!myPFT->equals(m_DefaultPdxFieldType)) {
-          setOffsetForObject(*myDataInput, myPdxType, myPFT->getSequenceId());
-          myDataInput->readObject(object);
+          setOffsetForObject(myDataInput, myPdxType, myPFT->getSequenceId());
+          myDataInput.readObject(object);
         }
 
         if (!otherPFT->equals(m_DefaultPdxFieldType)) {
-          otherPdx->setOffsetForObject(*otherDataInput, otherPdxType,
+          otherPdx->setOffsetForObject(otherDataInput, otherPdxType,
                                        otherPFT->getSequenceId());
-          otherDataInput->readObject(otherObject);
+          otherDataInput.readObject(otherObject);
         }
 
         if (object != nullptr) {
@@ -1252,14 +1252,14 @@ bool PdxInstanceImpl::operator==(const CacheableKey& other) const {
         auto objectArray = CacheableObjectArray::create();
 
         if (!myPFT->equals(m_DefaultPdxFieldType)) {
-          setOffsetForObject(*myDataInput, myPdxType, myPFT->getSequenceId());
-          objectArray->fromData(*myDataInput);
+          setOffsetForObject(myDataInput, myPdxType, myPFT->getSequenceId());
+          objectArray->fromData(myDataInput);
         }
 
         if (!otherPFT->equals(m_DefaultPdxFieldType)) {
-          otherPdx->setOffsetForObject(*otherDataInput, otherPdxType,
+          otherPdx->setOffsetForObject(otherDataInput, otherPdxType,
                                        otherPFT->getSequenceId());
-          otherObjectArray->fromData(*otherDataInput);
+          otherObjectArray->fromData(otherDataInput);
         }
         if (!deepArrayEquals(objectArray, otherObjectArray)) {
           return false;
@@ -1406,7 +1406,7 @@ void PdxInstanceImpl::toDataMutable(PdxWriter& writer) {
       if (value != nullptr) {
         writeField(writer, currPf->getFieldName(), currPf->getTypeId(), value);
         position =
-            getNextFieldPosition(*dataInput, static_cast<int>(i) + 1, pt);
+            getNextFieldPosition(dataInput, static_cast<int>(i) + 1, pt);
       } else {
         if (currPf->IsVariableLengthType()) {
           // need to add offset
@@ -1414,8 +1414,8 @@ void PdxInstanceImpl::toDataMutable(PdxWriter& writer) {
         }
         // write raw byte array...
         nextFieldPosition =
-            getNextFieldPosition(*dataInput, static_cast<int>(i) + 1, pt);
-        writeUnmodifieldField(*dataInput, position, nextFieldPosition,
+            getNextFieldPosition(dataInput, static_cast<int>(i) + 1, pt);
+        writeUnmodifieldField(dataInput, position, nextFieldPosition,
                               static_cast<PdxLocalWriter&>(writer));
         position = nextFieldPosition;  // mark next field;
       }
@@ -2015,7 +2015,7 @@ PdxTypeRegistry& PdxInstanceImpl::getPdxTypeRegistry() const {
   return m_pdxTypeRegistry;
 }
 
-std::unique_ptr<DataInput> PdxInstanceImpl::getDataInputForField(
+DataInput PdxInstanceImpl::getDataInputForField(
     const std::string& fieldname) const {
   auto pt = getPdxType();
   auto pft = pt->getPdxField(fieldname);
@@ -2025,10 +2025,10 @@ std::unique_ptr<DataInput> PdxInstanceImpl::getDataInputForField(
   }
 
   auto dataInput = m_cacheImpl.createDataInput(m_buffer, m_bufferLength);
-  auto pos = getOffset(*dataInput, pt, pft->getSequenceId());
+  auto pos = getOffset(dataInput, pt, pft->getSequenceId());
 
-  dataInput->reset();
-  dataInput->advanceCursor(pos);
+  dataInput.reset();
+  dataInput.advanceCursor(pos);
 
   return dataInput;
 }

--- a/cppcache/src/PdxInstanceImpl.hpp
+++ b/cppcache/src/PdxInstanceImpl.hpp
@@ -333,7 +333,7 @@ class APACHE_GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
       std::shared_ptr<CacheableHashTable> Obj,
       std::shared_ptr<CacheableHashTable> OtherObj);
 
-  std::unique_ptr<DataInput> getDataInputForField(
+  DataInput getDataInputForField(
       const std::string& fieldname) const;
 
   static int8_t m_BooleanDefaultBytes[];

--- a/cppcache/src/PdxInstanceImpl.hpp
+++ b/cppcache/src/PdxInstanceImpl.hpp
@@ -333,8 +333,7 @@ class APACHE_GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
       std::shared_ptr<CacheableHashTable> Obj,
       std::shared_ptr<CacheableHashTable> OtherObj);
 
-  DataInput getDataInputForField(
-      const std::string& fieldname) const;
+  DataInput getDataInputForField(const std::string& fieldname) const;
 
   static int8_t m_BooleanDefaultBytes[];
   static int8_t m_ByteDefaultBytes[];

--- a/cppcache/src/RemoteQuery.cpp
+++ b/cppcache/src/RemoteQuery.cpp
@@ -131,12 +131,13 @@ GfErrType RemoteQuery::executeNoThrow(
            m_queryString.c_str());
   if (paramList != nullptr) {
     // QUERY_WITH_PARAMETERS
-    TcrMessageQueryWithParameters msg(std::unique_ptr<DataOutput>(new DataOutput(m_tccdm->getConnectionManager()
-                                          .getCacheImpl()
-                                          ->getCache()
-                                          ->createDataOutput())),
-                                      m_queryString, nullptr, paramList,
-                                      timeout, tcdm);
+    TcrMessageQueryWithParameters msg(
+        std::unique_ptr<DataOutput>(
+            new DataOutput(m_tccdm->getConnectionManager()
+                               .getCacheImpl()
+                               ->getCache()
+                               ->createDataOutput())),
+        m_queryString, nullptr, paramList, timeout, tcdm);
     msg.setTimeout(timeout);
     reply.setTimeout(timeout);
 
@@ -157,10 +158,11 @@ GfErrType RemoteQuery::executeNoThrow(
     }
     return err;
   } else {
-    TcrMessageQuery msg(std::unique_ptr<DataOutput>(new DataOutput(m_tccdm->getConnectionManager()
-                            .getCacheImpl()
-                            ->getCache()
-                            ->createDataOutput())),
+    TcrMessageQuery msg(std::unique_ptr<DataOutput>(
+                            new DataOutput(m_tccdm->getConnectionManager()
+                                               .getCacheImpl()
+                                               ->getCache()
+                                               ->createDataOutput())),
                         m_queryString, timeout, tcdm);
     msg.setTimeout(timeout);
     reply.setTimeout(timeout);

--- a/cppcache/src/RemoteQuery.cpp
+++ b/cppcache/src/RemoteQuery.cpp
@@ -132,11 +132,8 @@ GfErrType RemoteQuery::executeNoThrow(
   if (paramList != nullptr) {
     // QUERY_WITH_PARAMETERS
     TcrMessageQueryWithParameters msg(
-        std::unique_ptr<DataOutput>(
-            new DataOutput(m_tccdm->getConnectionManager()
-                               .getCacheImpl()
-                               ->getCache()
-                               ->createDataOutput())),
+        new DataOutput(
+            m_tccdm->getConnectionManager().getCacheImpl()->createDataOutput()),
         m_queryString, nullptr, paramList, timeout, tcdm);
     msg.setTimeout(timeout);
     reply.setTimeout(timeout);
@@ -158,12 +155,10 @@ GfErrType RemoteQuery::executeNoThrow(
     }
     return err;
   } else {
-    TcrMessageQuery msg(std::unique_ptr<DataOutput>(
-                            new DataOutput(m_tccdm->getConnectionManager()
-                                               .getCacheImpl()
-                                               ->getCache()
-                                               ->createDataOutput())),
-                        m_queryString, timeout, tcdm);
+    TcrMessageQuery msg(
+        new DataOutput(
+            m_tccdm->getConnectionManager().getCacheImpl()->createDataOutput()),
+        m_queryString, timeout, tcdm);
     msg.setTimeout(timeout);
     reply.setTimeout(timeout);
 

--- a/cppcache/src/RemoteQuery.cpp
+++ b/cppcache/src/RemoteQuery.cpp
@@ -131,10 +131,10 @@ GfErrType RemoteQuery::executeNoThrow(
            m_queryString.c_str());
   if (paramList != nullptr) {
     // QUERY_WITH_PARAMETERS
-    TcrMessageQueryWithParameters msg(m_tccdm->getConnectionManager()
+    TcrMessageQueryWithParameters msg(std::unique_ptr<DataOutput>(new DataOutput(m_tccdm->getConnectionManager()
                                           .getCacheImpl()
                                           ->getCache()
-                                          ->createDataOutput(),
+                                          ->createDataOutput())),
                                       m_queryString, nullptr, paramList,
                                       timeout, tcdm);
     msg.setTimeout(timeout);
@@ -157,10 +157,10 @@ GfErrType RemoteQuery::executeNoThrow(
     }
     return err;
   } else {
-    TcrMessageQuery msg(m_tccdm->getConnectionManager()
+    TcrMessageQuery msg(std::unique_ptr<DataOutput>(new DataOutput(m_tccdm->getConnectionManager()
                             .getCacheImpl()
                             ->getCache()
-                            ->createDataOutput(),
+                            ->createDataOutput())),
                         m_queryString, timeout, tcdm);
     msg.setTimeout(timeout);
     reply.setTimeout(timeout);

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -354,9 +354,8 @@ bool TcrConnection::InitTcrConnection(
         credentials->toData(cleartext);
       }
       challengeBytes->toData(cleartext);
-      auto ciphertext =
-          m_dh->encrypt(cleartext.getBuffer(),
-                        static_cast<int>(cleartext.getBufferLength()));
+      auto ciphertext = m_dh->encrypt(
+          cleartext.getBuffer(), static_cast<int>(cleartext.getBufferLength()));
 
       auto sendCreds = cacheImpl->createDataOutput();
       ciphertext->toData(sendCreds);

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -229,10 +229,11 @@ GfErrType TcrEndpoint::createNewConnection(
           LOGFINE("Sending update notification message to endpoint %s",
                   m_name.c_str());
           TcrMessageUpdateClientNotification updateNotificationMsg(
-                  std::unique_ptr<DataOutput>(new DataOutput(newConn->getConnectionManager()
-                  .getCacheImpl()
-                  ->getCache()
-                  ->createDataOutput())),
+              std::unique_ptr<DataOutput>(
+                  new DataOutput(newConn->getConnectionManager()
+                                     .getCacheImpl()
+                                     ->getCache()
+                                     ->createDataOutput())),
               static_cast<int32_t>(newConn->getPort()));
           newConn->send(updateNotificationMsg.getMsgData(),
                         updateNotificationMsg.getMsgLength());
@@ -307,7 +308,9 @@ void TcrEndpoint::authenticateEndpoint(TcrConnection*& conn) {
     }
 
     TcrMessageUserCredential request(
-            std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->getCache()->createDataOutput())), creds, m_baseDM);
+        std::unique_ptr<DataOutput>(
+            new DataOutput(m_cacheImpl->getCache()->createDataOutput())),
+        creds, m_baseDM);
 
     LOGDEBUG("request is created");
     TcrMessageReply reply(true, this->m_baseDM);

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -229,11 +229,9 @@ GfErrType TcrEndpoint::createNewConnection(
           LOGFINE("Sending update notification message to endpoint %s",
                   m_name.c_str());
           TcrMessageUpdateClientNotification updateNotificationMsg(
-              std::unique_ptr<DataOutput>(
-                  new DataOutput(newConn->getConnectionManager()
-                                     .getCacheImpl()
-                                     ->getCache()
-                                     ->createDataOutput())),
+              new DataOutput(newConn->getConnectionManager()
+                                 .getCacheImpl()
+                                 ->createDataOutput()),
               static_cast<int32_t>(newConn->getPort()));
           newConn->send(updateNotificationMsg.getMsgData(),
                         updateNotificationMsg.getMsgLength());
@@ -308,9 +306,7 @@ void TcrEndpoint::authenticateEndpoint(TcrConnection*& conn) {
     }
 
     TcrMessageUserCredential request(
-        std::unique_ptr<DataOutput>(
-            new DataOutput(m_cacheImpl->getCache()->createDataOutput())),
-        creds, m_baseDM);
+        new DataOutput(m_cacheImpl->createDataOutput()), creds, m_baseDM);
 
     LOGDEBUG("request is created");
     TcrMessageReply reply(true, this->m_baseDM);

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -229,10 +229,10 @@ GfErrType TcrEndpoint::createNewConnection(
           LOGFINE("Sending update notification message to endpoint %s",
                   m_name.c_str());
           TcrMessageUpdateClientNotification updateNotificationMsg(
-              newConn->getConnectionManager()
+                  std::unique_ptr<DataOutput>(new DataOutput(newConn->getConnectionManager()
                   .getCacheImpl()
                   ->getCache()
-                  ->createDataOutput(),
+                  ->createDataOutput())),
               static_cast<int32_t>(newConn->getPort()));
           newConn->send(updateNotificationMsg.getMsgData(),
                         updateNotificationMsg.getMsgLength());
@@ -307,7 +307,7 @@ void TcrEndpoint::authenticateEndpoint(TcrConnection*& conn) {
     }
 
     TcrMessageUserCredential request(
-        m_cacheImpl->getCache()->createDataOutput(), creds, m_baseDM);
+            std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->getCache()->createDataOutput())), creds, m_baseDM);
 
     LOGDEBUG("request is created");
     TcrMessageReply reply(true, this->m_baseDM);

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -55,7 +55,10 @@ const int TcrMessage::m_flag_empty = 0x01;
 const int TcrMessage::m_flag_concurrency_checks = 0x02;
 
 TcrMessagePing* TcrMessage::getPingMessage(CacheImpl* cacheImpl) {
-  static auto pingMsg = new TcrMessagePing(std::unique_ptr<DataOutput>(new DataOutput(cacheImpl->createDataOutput())), true);
+  static auto pingMsg =
+      new TcrMessagePing(std::unique_ptr<DataOutput>(
+                             new DataOutput(cacheImpl->createDataOutput())),
+                         true);
   return pingMsg;
 }
 
@@ -65,8 +68,10 @@ TcrMessage* TcrMessage::getAllEPDisMess() {
 }
 
 TcrMessage* TcrMessage::getCloseConnMessage(CacheImpl* cacheImpl) {
-  static auto closeConnMsg =
-      new TcrMessageCloseConnection(std::unique_ptr<DataOutput>(new DataOutput(cacheImpl->createDataOutput())), true);
+  static auto closeConnMsg = new TcrMessageCloseConnection(
+      std::unique_ptr<DataOutput>(
+          new DataOutput(cacheImpl->createDataOutput())),
+      true);
   return closeConnMsg;
 }
 
@@ -1160,8 +1165,8 @@ void TcrMessage::handleByteArrayResponse(
         input.advanceCursor(1);  // ignore byte
         m_deltaBytes = new int8_t[m_deltaBytesLen];
         input.readBytesOnly(m_deltaBytes, m_deltaBytesLen);
-        m_delta =
-             std::unique_ptr<DataInput>(new DataInput(m_tcdm->getConnectionManager().getCacheImpl()->createDataInput(
+        m_delta = std::unique_ptr<DataInput>(new DataInput(
+            m_tcdm->getConnectionManager().getCacheImpl()->createDataInput(
                 reinterpret_cast<const uint8_t*>(m_deltaBytes),
                 m_deltaBytesLen)));
       } else {
@@ -1284,7 +1289,7 @@ void TcrMessage::handleByteArrayResponse(
 
         bits32 = input.readInt32();  // partlen;
         input.read();                // ignore isObj;
-        input.read();  // ignore cacheable CacheableHashSet typeid
+        input.read();                // ignore cacheable CacheableHashSet typeid
 
         bits32 = input.readArrayLength();  // array length
         if (bits32 > 0) {
@@ -2786,8 +2791,9 @@ void TcrMessage::setData(const char* bytearray, int32_t len, uint16_t memId,
                          const SerializationRegistry& serializationRegistry,
                          MemberListForVersionStamp& memberListForVersionStamp) {
   if (m_request == nullptr) {
-    m_request = std::unique_ptr<DataOutput>(new DataOutput(m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput(
-        getPool())));
+    m_request = std::unique_ptr<DataOutput>(new DataOutput(
+        m_tcdm->getConnectionManager().getCacheImpl()->createDataOutput(
+            getPool())));
   }
   if (bytearray) {
     DeleteArray<const char> delByteArr(bytearray);

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -39,6 +39,8 @@
 #include "DataOutputInternal.hpp"
 #include "util/JavaModifiedUtf8.hpp"
 
+#pragma error_messages(off, SEC_UNINITIALIZED_MEM_READ)
+
 using namespace apache::geode::client;
 static const uint32_t REGULAR_EXPRESSION =
     1;  // come from Java InterestType.REGULAR_EXPRESSION
@@ -2970,3 +2972,5 @@ void TcrMessage::readHashSetForGCVersions(
     }
   }
 }
+
+#pragma error_messages(default, SEC_UNINITIALIZED_MEM_READ)

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -1848,9 +1848,9 @@ TcrMessageCloseConnection::TcrMessageCloseConnection(
   m_request->write(static_cast<int8_t>(0));  // keepalive is '0'.
 }
 
-TcrMessageClientMarker::TcrMessageClientMarker(
-    std::unique_ptr<DataOutput> dataOutput, bool decodeAll) {
-  m_request = std::move(dataOutput);
+TcrMessageClientMarker::TcrMessageClientMarker(DataOutput* dataOutput,
+                                               bool decodeAll) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::CLIENT_MARKER;
   m_decodeAll = decodeAll;
 }

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -56,9 +56,7 @@ const int TcrMessage::m_flag_concurrency_checks = 0x02;
 
 TcrMessagePing* TcrMessage::getPingMessage(CacheImpl* cacheImpl) {
   static auto pingMsg =
-      new TcrMessagePing(std::unique_ptr<DataOutput>(
-                             new DataOutput(cacheImpl->createDataOutput())),
-                         true);
+      new TcrMessagePing(new DataOutput(cacheImpl->createDataOutput()), true);
   return pingMsg;
 }
 
@@ -69,9 +67,7 @@ TcrMessage* TcrMessage::getAllEPDisMess() {
 
 TcrMessage* TcrMessage::getCloseConnMessage(CacheImpl* cacheImpl) {
   static auto closeConnMsg = new TcrMessageCloseConnection(
-      std::unique_ptr<DataOutput>(
-          new DataOutput(cacheImpl->createDataOutput())),
-      true);
+      new DataOutput(cacheImpl->createDataOutput()), true);
   return closeConnMsg;
 }
 
@@ -1377,11 +1373,11 @@ void TcrMessage::handleByteArrayResponse(
 }
 
 TcrMessageDestroyRegion::TcrMessageDestroyRegion(
-    std::unique_ptr<DataOutput> dataOutput, const Region* region,
+    DataOutput* dataOutput, const Region* region,
     const std::shared_ptr<Serializable>& aCallbackArgument,
     std::chrono::milliseconds messageResponsetimeout,
     ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::DESTROY_REGION;
   m_tcdm = connectionDM;
   m_regionName =
@@ -1413,11 +1409,11 @@ TcrMessageDestroyRegion::TcrMessageDestroyRegion(
 }
 
 TcrMessageClearRegion::TcrMessageClearRegion(
-    std::unique_ptr<DataOutput> dataOutput, const Region* region,
+    DataOutput* dataOutput, const Region* region,
     const std::shared_ptr<Serializable>& aCallbackArgument,
     std::chrono::milliseconds messageResponsetimeout,
     ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::CLEAR_REGION;
   m_tcdm = connectionDM;
   m_regionName =
@@ -1452,10 +1448,10 @@ TcrMessageClearRegion::TcrMessageClearRegion(
 }
 
 TcrMessageQuery::TcrMessageQuery(
-    std::unique_ptr<DataOutput> dataOutput, const std::string& regionName,
+    DataOutput* dataOutput, const std::string& regionName,
     std::chrono::milliseconds messageResponsetimeout,
     ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::QUERY;
   m_tcdm = connectionDM;
   m_regionName = regionName;  // this is querystri;
@@ -1478,10 +1474,10 @@ TcrMessageQuery::TcrMessageQuery(
 }
 
 TcrMessageStopCQ::TcrMessageStopCQ(
-    std::unique_ptr<DataOutput> dataOutput, const std::string& regionName,
+    DataOutput* dataOutput, const std::string& regionName,
     std::chrono::milliseconds messageResponsetimeout,
     ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::STOPCQ_MSG_TYPE;
   m_tcdm = connectionDM;
   m_regionName = regionName;  // this is querystring
@@ -1509,10 +1505,10 @@ TcrMessageStopCQ::TcrMessageStopCQ(
 }
 
 TcrMessageCloseCQ::TcrMessageCloseCQ(
-    std::unique_ptr<DataOutput> dataOutput, const std::string& regionName,
+    DataOutput* dataOutput, const std::string& regionName,
     std::chrono::milliseconds messageResponsetimeout,
     ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::CLOSECQ_MSG_TYPE;
   m_tcdm = connectionDM;
   m_regionName = regionName;  // this is querystring
@@ -1536,12 +1532,12 @@ TcrMessageCloseCQ::TcrMessageCloseCQ(
 }
 
 TcrMessageQueryWithParameters::TcrMessageQueryWithParameters(
-    std::unique_ptr<DataOutput> dataOutput, const std::string& regionName,
+    DataOutput* dataOutput, const std::string& regionName,
     const std::shared_ptr<Serializable>&,
     std::shared_ptr<CacheableVector> paramList,
     std::chrono::milliseconds messageResponsetimeout,
     ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::QUERY_WITH_PARAMETERS;
   m_tcdm = connectionDM;
   m_regionName = regionName;
@@ -1575,11 +1571,11 @@ TcrMessageQueryWithParameters::TcrMessageQueryWithParameters(
 }
 
 TcrMessageContainsKey::TcrMessageContainsKey(
-    std::unique_ptr<DataOutput> dataOutput, const Region* region,
+    DataOutput* dataOutput, const Region* region,
     const std::shared_ptr<CacheableKey>& key,
     const std::shared_ptr<Serializable>& aCallbackArgument, bool isContainsKey,
     ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::CONTAINS_KEY;
   m_tcdm = connectionDM;
   m_regionName =
@@ -1611,8 +1607,8 @@ TcrMessageContainsKey::TcrMessageContainsKey(
 }
 
 TcrMessageGetDurableCqs::TcrMessageGetDurableCqs(
-    std::unique_ptr<DataOutput> dataOutput, ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, ThinClientBaseDM* connectionDM) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::GETDURABLECQS_MSG_TYPE;
   m_tcdm = connectionDM;
   m_timeout = DEFAULT_TIMEOUT_SECONDS;
@@ -1625,11 +1621,11 @@ TcrMessageGetDurableCqs::TcrMessageGetDurableCqs(
 }
 
 TcrMessageRequest::TcrMessageRequest(
-    std::unique_ptr<DataOutput> dataOutput, const Region* region,
+    DataOutput* dataOutput, const Region* region,
     const std::shared_ptr<CacheableKey>& key,
     const std::shared_ptr<Serializable>& aCallbackArgument,
     ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::REQUEST;
   m_tcdm = connectionDM;
   m_key = key;
@@ -1663,11 +1659,11 @@ TcrMessageRequest::TcrMessageRequest(
 }
 
 TcrMessageInvalidate::TcrMessageInvalidate(
-    std::unique_ptr<DataOutput> dataOutput, const Region* region,
+    DataOutput* dataOutput, const Region* region,
     const std::shared_ptr<CacheableKey>& key,
     const std::shared_ptr<Serializable>& aCallbackArgument,
     ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::INVALIDATE;
   m_tcdm = connectionDM;
   m_key = key;
@@ -1701,12 +1697,12 @@ TcrMessageInvalidate::TcrMessageInvalidate(
 }
 
 TcrMessageDestroy::TcrMessageDestroy(
-    std::unique_ptr<DataOutput> dataOutput, const Region* region,
+    DataOutput* dataOutput, const Region* region,
     const std::shared_ptr<CacheableKey>& key,
     const std::shared_ptr<Cacheable>& value,
     const std::shared_ptr<Serializable>& aCallbackArgument,
     ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::DESTROY;
   m_tcdm = connectionDM;
   m_key = key;
@@ -1756,13 +1752,13 @@ TcrMessageDestroy::TcrMessageDestroy(
 }
 
 TcrMessagePut::TcrMessagePut(
-    std::unique_ptr<DataOutput> dataOutput, const Region* region,
+    DataOutput* dataOutput, const Region* region,
     const std::shared_ptr<CacheableKey>& key,
     const std::shared_ptr<Cacheable>& value,
     const std::shared_ptr<Serializable>& aCallbackArgument, bool isDelta,
     ThinClientBaseDM* connectionDM, bool isMetaRegion,
     bool fullValueAfterDeltaFail, const char* regionName) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   // m_securityHeaderLength = 0;
   m_isMetaRegion = isMetaRegion;
   m_msgType = TcrMessage::PUT;
@@ -1810,11 +1806,10 @@ TcrMessageReply::TcrMessageReply(bool decodeAll,
   if (connectionDM != nullptr) isSecurityOn = connectionDM->isSecurityOn();
 }
 
-TcrMessagePing::TcrMessagePing(std::unique_ptr<DataOutput> dataOutput,
-                               bool decodeAll) {
+TcrMessagePing::TcrMessagePing(DataOutput* dataOutput, bool decodeAll) {
   m_msgType = TcrMessage::PING;
   m_decodeAll = decodeAll;
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_request->writeInt(m_msgType);
   m_request->writeInt(
       (int32_t)0);  // 17 is fixed message len ...  PING only has a header.
@@ -1829,11 +1824,11 @@ TcrMessagePing::TcrMessagePing(std::unique_ptr<DataOutput> dataOutput,
   m_txId = 0;
 }
 
-TcrMessageCloseConnection::TcrMessageCloseConnection(
-    std::unique_ptr<DataOutput> dataOutput, bool decodeAll) {
+TcrMessageCloseConnection::TcrMessageCloseConnection(DataOutput* dataOutput,
+                                                     bool decodeAll) {
   m_msgType = TcrMessage::CLOSE_CONNECTION;
   m_decodeAll = decodeAll;
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_request->writeInt(m_msgType);
   m_request->writeInt((int32_t)6);
   m_request->writeInt((int32_t)1);  // Number of parts.
@@ -1856,11 +1851,11 @@ TcrMessageClientMarker::TcrMessageClientMarker(DataOutput* dataOutput,
 }
 
 TcrMessageRegisterInterestList::TcrMessageRegisterInterestList(
-    std::unique_ptr<DataOutput> dataOutput, const Region* region,
+    DataOutput* dataOutput, const Region* region,
     const std::vector<std::shared_ptr<CacheableKey>>& keys, bool isDurable,
     bool isCachingEnabled, bool receiveValues,
     InterestResultPolicy interestPolicy, ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::REGISTER_INTEREST_LIST;
   m_tcdm = connectionDM;
   m_keyList = &keys;
@@ -1909,11 +1904,11 @@ TcrMessageRegisterInterestList::TcrMessageRegisterInterestList(
 }
 
 TcrMessageUnregisterInterestList::TcrMessageUnregisterInterestList(
-    std::unique_ptr<DataOutput> dataOutput, const Region* region,
+    DataOutput* dataOutput, const Region* region,
     const std::vector<std::shared_ptr<CacheableKey>>& keys, bool isDurable,
     bool receiveValues, InterestResultPolicy interestPolicy,
     ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::UNREGISTER_INTEREST_LIST;
   m_tcdm = connectionDM;
   m_keyList = &keys;
@@ -1949,10 +1944,9 @@ TcrMessageUnregisterInterestList::TcrMessageUnregisterInterestList(
 }
 
 TcrMessageCreateRegion::TcrMessageCreateRegion(
-    std::unique_ptr<DataOutput> dataOutput, const std::string& str1,
-    const std::string& str2, bool isDurable, bool receiveValues,
-    ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, const std::string& str1, const std::string& str2,
+    bool isDurable, bool receiveValues, ThinClientBaseDM* connectionDM) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::CREATE_REGION;
   m_tcdm = connectionDM;
   m_isDurable = isDurable;
@@ -1967,11 +1961,10 @@ TcrMessageCreateRegion::TcrMessageCreateRegion(
 }
 
 TcrMessageRegisterInterest::TcrMessageRegisterInterest(
-    std::unique_ptr<DataOutput> dataOutput, const std::string& str1,
-    const std::string& str2, InterestResultPolicy interestPolicy,
-    bool isDurable, bool isCachingEnabled, bool receiveValues,
-    ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, const std::string& str1, const std::string& str2,
+    InterestResultPolicy interestPolicy, bool isDurable, bool isCachingEnabled,
+    bool receiveValues, ThinClientBaseDM* connectionDM) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::REGISTER_INTEREST;
   m_tcdm = connectionDM;
   m_isDurable = isDurable;
@@ -2004,10 +1997,10 @@ TcrMessageRegisterInterest::TcrMessageRegisterInterest(
 }
 
 TcrMessageUnregisterInterest::TcrMessageUnregisterInterest(
-    std::unique_ptr<DataOutput> dataOutput, const std::string& str1,
-    const std::string& str2, InterestResultPolicy interestPolicy,
-    bool isDurable, bool receiveValues, ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, const std::string& str1, const std::string& str2,
+    InterestResultPolicy interestPolicy, bool isDurable, bool receiveValues,
+    ThinClientBaseDM* connectionDM) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::UNREGISTER_INTEREST;
   m_tcdm = connectionDM;
   m_isDurable = isDurable;
@@ -2027,9 +2020,10 @@ TcrMessageUnregisterInterest::TcrMessageUnregisterInterest(
   m_interestPolicy = interestPolicy.ordinal;
 }
 
-TcrMessageTxSynchronization::TcrMessageTxSynchronization(
-    std::unique_ptr<DataOutput> dataOutput, int ordinal, int txid, int status) {
-  m_request = std::move(dataOutput);
+TcrMessageTxSynchronization::TcrMessageTxSynchronization(DataOutput* dataOutput,
+                                                         int ordinal, int txid,
+                                                         int status) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::TX_SYNCHRONIZATION;
 
   writeHeader(m_msgType, ordinal == 1 ? 3 : 2);
@@ -2042,9 +2036,8 @@ TcrMessageTxSynchronization::TcrMessageTxSynchronization(
   writeMessageLength();
 }
 
-TcrMessageClientReady::TcrMessageClientReady(
-    std::unique_ptr<DataOutput> dataOutput) {
-  m_request = std::move(dataOutput);
+TcrMessageClientReady::TcrMessageClientReady(DataOutput* dataOutput) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::CLIENT_READY;
 
   writeHeader(m_msgType, 1);
@@ -2053,9 +2046,9 @@ TcrMessageClientReady::TcrMessageClientReady(
   writeMessageLength();
 }
 
-TcrMessageCommit::TcrMessageCommit(std::unique_ptr<DataOutput> dataOutput) {
+TcrMessageCommit::TcrMessageCommit(DataOutput* dataOutput) {
   m_msgType = TcrMessage::COMMIT;
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   writeHeader(m_msgType, 1);
   // the server expects at least 1 part, so writing a dummy
@@ -2063,9 +2056,9 @@ TcrMessageCommit::TcrMessageCommit(std::unique_ptr<DataOutput> dataOutput) {
   writeMessageLength();
 }
 
-TcrMessageRollback::TcrMessageRollback(std::unique_ptr<DataOutput> dataOutput) {
+TcrMessageRollback::TcrMessageRollback(DataOutput* dataOutput) {
   m_msgType = TcrMessage::ROLLBACK;
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   writeHeader(m_msgType, 1);
   // the server expects at least 1 part, so writing a dummy
@@ -2073,10 +2066,9 @@ TcrMessageRollback::TcrMessageRollback(std::unique_ptr<DataOutput> dataOutput) {
   writeMessageLength();
 }
 
-TcrMessageTxFailover::TcrMessageTxFailover(
-    std::unique_ptr<DataOutput> dataOutput) {
+TcrMessageTxFailover::TcrMessageTxFailover(DataOutput* dataOutput) {
   m_msgType = TcrMessage::TX_FAILOVER;
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   writeHeader(m_msgType, 1);
   // the server expects at least 1 part, so writing a dummy
@@ -2085,10 +2077,10 @@ TcrMessageTxFailover::TcrMessageTxFailover(
 }
 
 // constructor for MAKE_PRIMARY message.
-TcrMessageMakePrimary::TcrMessageMakePrimary(
-    std::unique_ptr<DataOutput> dataOutput, bool processedMarker) {
+TcrMessageMakePrimary::TcrMessageMakePrimary(DataOutput* dataOutput,
+                                             bool processedMarker) {
   m_msgType = TcrMessage::MAKE_PRIMARY;
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   writeHeader(m_msgType, 1);
   writeBytePart(processedMarker ? 1 : 0);  // boolean processedMarker
@@ -2097,10 +2089,9 @@ TcrMessageMakePrimary::TcrMessageMakePrimary(
 
 // constructor for PERIODIC_ACK of notified eventids
 TcrMessagePeriodicAck::TcrMessagePeriodicAck(
-    std::unique_ptr<DataOutput> dataOutput,
-    const EventIdMapEntryList& entries) {
+    DataOutput* dataOutput, const EventIdMapEntryList& entries) {
   m_msgType = TcrMessage::PERIODIC_ACK;
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   uint32_t numParts = static_cast<uint32_t>(entries.size());
   GF_D_ASSERT(numParts > 0);
@@ -2117,8 +2108,7 @@ TcrMessagePeriodicAck::TcrMessagePeriodicAck(
 }
 
 TcrMessagePutAll::TcrMessagePutAll(
-    std::unique_ptr<DataOutput> dataOutput, const Region* region,
-    const HashMapOfCacheable& map,
+    DataOutput* dataOutput, const Region* region, const HashMapOfCacheable& map,
     std::chrono::milliseconds messageResponsetimeout,
     ThinClientBaseDM* connectionDM,
     const std::shared_ptr<Serializable>& aCallbackArgument) {
@@ -2126,7 +2116,7 @@ TcrMessagePutAll::TcrMessagePutAll(
   m_regionName = region->getFullPath();
   m_region = region;
   m_messageResponseTimeout = messageResponsetimeout;
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   // TODO check the number of parts in this constructor. doubt because in PUT
   // value can be nullptr also.
@@ -2187,7 +2177,7 @@ TcrMessagePutAll::TcrMessagePutAll(
 }
 
 TcrMessageRemoveAll::TcrMessageRemoveAll(
-    std::unique_ptr<DataOutput> dataOutput, const Region* region,
+    DataOutput* dataOutput, const Region* region,
     const std::vector<std::shared_ptr<CacheableKey>>& keys,
     const std::shared_ptr<Serializable>& aCallbackArgument,
     ThinClientBaseDM* connectionDM) {
@@ -2195,7 +2185,7 @@ TcrMessageRemoveAll::TcrMessageRemoveAll(
   m_tcdm = connectionDM;
   m_regionName = region->getFullPath();
   m_region = region;
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   // TODO check the number of parts in this constructor. doubt because in PUT
   // value can be nullptr also.
@@ -2232,9 +2222,9 @@ TcrMessageRemoveAll::TcrMessageRemoveAll(
 }
 
 TcrMessageUpdateClientNotification::TcrMessageUpdateClientNotification(
-    std::unique_ptr<DataOutput> dataOutput, int32_t port) {
+    DataOutput* dataOutput, int32_t port) {
   m_msgType = TcrMessage::UPDATE_CLIENT_NOTIFICATION;
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   writeHeader(m_msgType, 1);
   writeIntPart(port);
@@ -2242,7 +2232,7 @@ TcrMessageUpdateClientNotification::TcrMessageUpdateClientNotification(
 }
 
 TcrMessageGetAll::TcrMessageGetAll(
-    std::unique_ptr<DataOutput> dataOutput, const Region* region,
+    DataOutput* dataOutput, const Region* region,
     const std::vector<std::shared_ptr<CacheableKey>>* keys,
     ThinClientBaseDM* connectionDM,
     const std::shared_ptr<Serializable>& aCallbackArgument) {
@@ -2252,7 +2242,7 @@ TcrMessageGetAll::TcrMessageGetAll(
   m_callbackArgument = aCallbackArgument;
   m_regionName = region->getFullPath();
   m_region = region;
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   /*CacheableObjectArrayPtr keyArr = nullptr;
   if (keys != nullptr) {
@@ -2296,12 +2286,12 @@ void TcrMessage::InitializeGetallMsg(
   writeMessageLength();
 }
 
-TcrMessageExecuteCq::TcrMessageExecuteCq(std::unique_ptr<DataOutput> dataOutput,
+TcrMessageExecuteCq::TcrMessageExecuteCq(DataOutput* dataOutput,
                                          const std::string& str1,
                                          const std::string& str2, CqState state,
                                          bool isDurable,
                                          ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   m_msgType = TcrMessage::EXECUTECQ_MSG_TYPE;
   m_tcdm = connectionDM;
@@ -2325,10 +2315,9 @@ TcrMessageExecuteCq::TcrMessageExecuteCq(std::unique_ptr<DataOutput> dataOutput,
 }
 
 TcrMessageExecuteCqWithIr::TcrMessageExecuteCqWithIr(
-    std::unique_ptr<DataOutput> dataOutput, const std::string& str1,
-    const std::string& str2, CqState state, bool isDurable,
-    ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, const std::string& str1, const std::string& str2,
+    CqState state, bool isDurable, ThinClientBaseDM* connectionDM) {
+  m_request.reset(dataOutput);
 
   m_msgType = TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE;
   m_tcdm = connectionDM;
@@ -2352,10 +2341,10 @@ TcrMessageExecuteCqWithIr::TcrMessageExecuteCqWithIr(
 }
 
 TcrMessageExecuteFunction::TcrMessageExecuteFunction(
-    std::unique_ptr<DataOutput> dataOutput, const std::string& funcName,
+    DataOutput* dataOutput, const std::string& funcName,
     const std::shared_ptr<Cacheable>& args, uint8_t getResult,
     ThinClientBaseDM* connectionDM, std::chrono::milliseconds timeout) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   m_msgType = TcrMessage::EXECUTE_FUNCTION;
   m_tcdm = connectionDM;
@@ -2370,13 +2359,13 @@ TcrMessageExecuteFunction::TcrMessageExecuteFunction(
 }
 
 TcrMessageExecuteRegionFunction::TcrMessageExecuteRegionFunction(
-    std::unique_ptr<DataOutput> dataOutput, const std::string& funcName,
-    const Region* region, const std::shared_ptr<Cacheable>& args,
+    DataOutput* dataOutput, const std::string& funcName, const Region* region,
+    const std::shared_ptr<Cacheable>& args,
     std::shared_ptr<CacheableVector> routingObj, uint8_t getResult,
     std::shared_ptr<CacheableHashSet> failedNodes,
     std::chrono::milliseconds timeout, ThinClientBaseDM* connectionDM,
     int8_t reExecute) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   m_msgType = TcrMessage::EXECUTE_REGION_FUNCTION;
   m_tcdm = connectionDM;
@@ -2424,12 +2413,12 @@ TcrMessageExecuteRegionFunction::TcrMessageExecuteRegionFunction(
 
 TcrMessageExecuteRegionFunctionSingleHop::
     TcrMessageExecuteRegionFunctionSingleHop(
-        std::unique_ptr<DataOutput> dataOutput, const std::string& funcName,
+        DataOutput* dataOutput, const std::string& funcName,
         const Region* region, const std::shared_ptr<Cacheable>& args,
         std::shared_ptr<CacheableHashSet> routingObj, uint8_t getResult,
         std::shared_ptr<CacheableHashSet> failedNodes, bool allBuckets,
         std::chrono::milliseconds timeout, ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   m_msgType = TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP;
   m_tcdm = connectionDM;
@@ -2481,8 +2470,8 @@ TcrMessageExecuteRegionFunctionSingleHop::
 }
 
 TcrMessageGetClientPartitionAttributes::TcrMessageGetClientPartitionAttributes(
-    std::unique_ptr<DataOutput> dataOutput, const char* regionName) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, const char* regionName) {
+  m_request.reset(dataOutput);
 
   m_msgType = TcrMessage::GET_CLIENT_PARTITION_ATTRIBUTES;
   writeHeader(m_msgType, 1);
@@ -2491,8 +2480,8 @@ TcrMessageGetClientPartitionAttributes::TcrMessageGetClientPartitionAttributes(
 }
 
 TcrMessageGetClientPrMetadata::TcrMessageGetClientPrMetadata(
-    std::unique_ptr<DataOutput> dataOutput, const char* regionName) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, const char* regionName) {
+  m_request.reset(dataOutput);
 
   m_msgType = TcrMessage::GET_CLIENT_PR_METADATA;
   writeHeader(m_msgType, 1);
@@ -2500,9 +2489,8 @@ TcrMessageGetClientPrMetadata::TcrMessageGetClientPrMetadata(
   writeMessageLength();
 }
 
-TcrMessageSize::TcrMessageSize(std::unique_ptr<DataOutput> dataOutput,
-                               const char* regionName) {
-  m_request = std::move(dataOutput);
+TcrMessageSize::TcrMessageSize(DataOutput* dataOutput, const char* regionName) {
+  m_request.reset(dataOutput);
 
   m_msgType = TcrMessage::SIZE;
   writeHeader(m_msgType, 1);
@@ -2511,9 +2499,9 @@ TcrMessageSize::TcrMessageSize(std::unique_ptr<DataOutput> dataOutput,
 }
 
 TcrMessageUserCredential::TcrMessageUserCredential(
-    std::unique_ptr<DataOutput> dataOutput, std::shared_ptr<Properties> creds,
+    DataOutput* dataOutput, std::shared_ptr<Properties> creds,
     ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
 
   m_msgType = TcrMessage::USER_CREDENTIAL_MESSAGE;
   m_tcdm = connectionDM;
@@ -2534,9 +2522,8 @@ TcrMessageUserCredential::TcrMessageUserCredential(
 }
 
 TcrMessageRemoveUserAuth::TcrMessageRemoveUserAuth(
-    std::unique_ptr<DataOutput> dataOutput, bool keepAlive,
-    ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, bool keepAlive, ThinClientBaseDM* connectionDM) {
+  m_request.reset(dataOutput);
 
   m_msgType = TcrMessage::REMOVE_USER_AUTH;
   m_tcdm = connectionDM;
@@ -2641,8 +2628,8 @@ void TcrMessage::addSecurityPart(int64_t connectionId, TcrConnection* conn) {
 }
 
 TcrMessageRequestEventValue::TcrMessageRequestEventValue(
-    std::unique_ptr<DataOutput> dataOutput, std::shared_ptr<EventId> eventId) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, std::shared_ptr<EventId> eventId) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::REQUEST_EVENT_VALUE;
 
   uint32_t numOfParts = 1;
@@ -2652,9 +2639,9 @@ TcrMessageRequestEventValue::TcrMessageRequestEventValue(
 }
 
 TcrMessageGetPdxIdForType::TcrMessageGetPdxIdForType(
-    std::unique_ptr<DataOutput> dataOutput,
-    const std::shared_ptr<Cacheable>& pdxType, ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, const std::shared_ptr<Cacheable>& pdxType,
+    ThinClientBaseDM* connectionDM) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::GET_PDX_ID_FOR_TYPE;
   m_tcdm = connectionDM;
 
@@ -2669,10 +2656,9 @@ TcrMessageGetPdxIdForType::TcrMessageGetPdxIdForType(
 }
 
 TcrMessageAddPdxType::TcrMessageAddPdxType(
-    std::unique_ptr<DataOutput> dataOutput,
-    const std::shared_ptr<Cacheable>& pdxType, ThinClientBaseDM* connectionDM,
-    int32_t pdxTypeId) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, const std::shared_ptr<Cacheable>& pdxType,
+    ThinClientBaseDM* connectionDM, int32_t pdxTypeId) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::ADD_PDX_TYPE;
   m_tcdm = connectionDM;
 
@@ -2688,9 +2674,9 @@ TcrMessageAddPdxType::TcrMessageAddPdxType(
 }
 
 TcrMessageGetPdxIdForEnum::TcrMessageGetPdxIdForEnum(
-    std::unique_ptr<DataOutput> dataOutput,
-    const std::shared_ptr<Cacheable>& pdxType, ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, const std::shared_ptr<Cacheable>& pdxType,
+    ThinClientBaseDM* connectionDM) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::GET_PDX_ID_FOR_ENUM;
   m_tcdm = connectionDM;
 
@@ -2705,10 +2691,9 @@ TcrMessageGetPdxIdForEnum::TcrMessageGetPdxIdForEnum(
 }
 
 TcrMessageAddPdxEnum::TcrMessageAddPdxEnum(
-    std::unique_ptr<DataOutput> dataOutput,
-    const std::shared_ptr<Cacheable>& pdxType, ThinClientBaseDM* connectionDM,
-    int32_t pdxTypeId) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, const std::shared_ptr<Cacheable>& pdxType,
+    ThinClientBaseDM* connectionDM, int32_t pdxTypeId) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::ADD_PDX_ENUM;
   m_tcdm = connectionDM;
 
@@ -2724,9 +2709,8 @@ TcrMessageAddPdxEnum::TcrMessageAddPdxEnum(
 }
 
 TcrMessageGetPdxTypeById::TcrMessageGetPdxTypeById(
-    std::unique_ptr<DataOutput> dataOutput, int32_t typeId,
-    ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, int32_t typeId, ThinClientBaseDM* connectionDM) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::GET_PDX_TYPE_BY_ID;
   m_tcdm = connectionDM;
 
@@ -2743,9 +2727,8 @@ TcrMessageGetPdxTypeById::TcrMessageGetPdxTypeById(
 }
 
 TcrMessageGetPdxEnumById::TcrMessageGetPdxEnumById(
-    std::unique_ptr<DataOutput> dataOutput, int32_t typeId,
-    ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+    DataOutput* dataOutput, int32_t typeId, ThinClientBaseDM* connectionDM) {
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::GET_PDX_ENUM_BY_ID;
   m_tcdm = connectionDM;
 
@@ -2762,9 +2745,9 @@ TcrMessageGetPdxEnumById::TcrMessageGetPdxEnumById(
 }
 
 TcrMessageGetFunctionAttributes::TcrMessageGetFunctionAttributes(
-    std::unique_ptr<DataOutput> dataOutput, const std::string& funcName,
+    DataOutput* dataOutput, const std::string& funcName,
     ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::GET_FUNCTION_ATTRIBUTES;
   m_tcdm = connectionDM;
 
@@ -2774,10 +2757,10 @@ TcrMessageGetFunctionAttributes::TcrMessageGetFunctionAttributes(
   writeMessageLength();
 }
 
-TcrMessageKeySet::TcrMessageKeySet(std::unique_ptr<DataOutput> dataOutput,
+TcrMessageKeySet::TcrMessageKeySet(DataOutput* dataOutput,
                                    const std::string& funcName,
                                    ThinClientBaseDM* connectionDM) {
-  m_request = std::move(dataOutput);
+  m_request.reset(dataOutput);
   m_msgType = TcrMessage::KEY_SET;
   m_tcdm = connectionDM;
 

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -665,7 +665,7 @@ class APACHE_GEODE_EXPORT TcrMessage {
 class TcrMessageDestroyRegion : public TcrMessage {
  public:
   TcrMessageDestroyRegion(
-      std::unique_ptr<DataOutput> dataOutput, const Region* region,
+      DataOutput* dataOutput, const Region* region,
       const std::shared_ptr<Serializable>& aCallbackArgument,
       std::chrono::milliseconds messageResponsetimeout,
       ThinClientBaseDM* connectionDM);
@@ -677,8 +677,7 @@ class TcrMessageDestroyRegion : public TcrMessage {
 
 class TcrMessageClearRegion : public TcrMessage {
  public:
-  TcrMessageClearRegion(std::unique_ptr<DataOutput> dataOutput,
-                        const Region* region,
+  TcrMessageClearRegion(DataOutput* dataOutput, const Region* region,
                         const std::shared_ptr<Serializable>& aCallbackArgument,
                         std::chrono::milliseconds messageResponsetimeout,
                         ThinClientBaseDM* connectionDM);
@@ -690,8 +689,7 @@ class TcrMessageClearRegion : public TcrMessage {
 
 class TcrMessageQuery : public TcrMessage {
  public:
-  TcrMessageQuery(std::unique_ptr<DataOutput> dataOutput,
-                  const std::string& regionName,
+  TcrMessageQuery(DataOutput* dataOutput, const std::string& regionName,
                   std::chrono::milliseconds messageResponsetimeout,
                   ThinClientBaseDM* connectionDM);
 
@@ -702,8 +700,7 @@ class TcrMessageQuery : public TcrMessage {
 
 class TcrMessageStopCQ : public TcrMessage {
  public:
-  TcrMessageStopCQ(std::unique_ptr<DataOutput> dataOutput,
-                   const std::string& regionName,
+  TcrMessageStopCQ(DataOutput* dataOutput, const std::string& regionName,
                    std::chrono::milliseconds messageResponsetimeout,
                    ThinClientBaseDM* connectionDM);
 
@@ -714,8 +711,7 @@ class TcrMessageStopCQ : public TcrMessage {
 
 class TcrMessageCloseCQ : public TcrMessage {
  public:
-  TcrMessageCloseCQ(std::unique_ptr<DataOutput> dataOutput,
-                    const std::string& regionName,
+  TcrMessageCloseCQ(DataOutput* dataOutput, const std::string& regionName,
                     std::chrono::milliseconds messageResponsetimeout,
                     ThinClientBaseDM* connectionDM);
 
@@ -727,7 +723,7 @@ class TcrMessageCloseCQ : public TcrMessage {
 class TcrMessageQueryWithParameters : public TcrMessage {
  public:
   TcrMessageQueryWithParameters(
-      std::unique_ptr<DataOutput> dataOutput, const std::string& regionName,
+      DataOutput* dataOutput, const std::string& regionName,
       const std::shared_ptr<Serializable>& aCallbackArgument,
       std::shared_ptr<CacheableVector> paramList,
       std::chrono::milliseconds messageResponsetimeout,
@@ -740,8 +736,7 @@ class TcrMessageQueryWithParameters : public TcrMessage {
 
 class TcrMessageContainsKey : public TcrMessage {
  public:
-  TcrMessageContainsKey(std::unique_ptr<DataOutput> dataOutput,
-                        const Region* region,
+  TcrMessageContainsKey(DataOutput* dataOutput, const Region* region,
                         const std::shared_ptr<CacheableKey>& key,
                         const std::shared_ptr<Serializable>& aCallbackArgument,
                         bool isContainsKey, ThinClientBaseDM* connectionDM);
@@ -753,7 +748,7 @@ class TcrMessageContainsKey : public TcrMessage {
 
 class TcrMessageGetDurableCqs : public TcrMessage {
  public:
-  TcrMessageGetDurableCqs(std::unique_ptr<DataOutput> dataOutput,
+  TcrMessageGetDurableCqs(DataOutput* dataOutput,
                           ThinClientBaseDM* connectionDM);
 
   virtual ~TcrMessageGetDurableCqs() {}
@@ -763,8 +758,7 @@ class TcrMessageGetDurableCqs : public TcrMessage {
 
 class TcrMessageRequest : public TcrMessage {
  public:
-  TcrMessageRequest(std::unique_ptr<DataOutput> dataOutput,
-                    const Region* region,
+  TcrMessageRequest(DataOutput* dataOutput, const Region* region,
                     const std::shared_ptr<CacheableKey>& key,
                     const std::shared_ptr<Serializable>& aCallbackArgument,
                     ThinClientBaseDM* connectionDM = nullptr);
@@ -776,8 +770,7 @@ class TcrMessageRequest : public TcrMessage {
 
 class TcrMessageInvalidate : public TcrMessage {
  public:
-  TcrMessageInvalidate(std::unique_ptr<DataOutput> dataOutput,
-                       const Region* region,
+  TcrMessageInvalidate(DataOutput* dataOutput, const Region* region,
                        const std::shared_ptr<CacheableKey>& key,
                        const std::shared_ptr<Serializable>& aCallbackArgument,
                        ThinClientBaseDM* connectionDM = nullptr);
@@ -787,8 +780,7 @@ class TcrMessageInvalidate : public TcrMessage {
 
 class TcrMessageDestroy : public TcrMessage {
  public:
-  TcrMessageDestroy(std::unique_ptr<DataOutput> dataOutput,
-                    const Region* region,
+  TcrMessageDestroy(DataOutput* dataOutput, const Region* region,
                     const std::shared_ptr<CacheableKey>& key,
                     const std::shared_ptr<Cacheable>& value,
                     const std::shared_ptr<Serializable>& aCallbackArgument,
@@ -800,7 +792,7 @@ class TcrMessageDestroy : public TcrMessage {
 class TcrMessageRegisterInterestList : public TcrMessage {
  public:
   TcrMessageRegisterInterestList(
-      std::unique_ptr<DataOutput> dataOutput, const Region* region,
+      DataOutput* dataOutput, const Region* region,
       const std::vector<std::shared_ptr<CacheableKey>>& keys,
       bool isDurable = false, bool isCachingEnabled = false,
       bool receiveValues = true,
@@ -815,7 +807,7 @@ class TcrMessageRegisterInterestList : public TcrMessage {
 class TcrMessageUnregisterInterestList : public TcrMessage {
  public:
   TcrMessageUnregisterInterestList(
-      std::unique_ptr<DataOutput> dataOutput, const Region* region,
+      DataOutput* dataOutput, const Region* region,
       const std::vector<std::shared_ptr<CacheableKey>>& keys,
       bool isDurable = false, bool receiveValues = true,
       InterestResultPolicy interestPolicy = InterestResultPolicy::NONE,
@@ -828,7 +820,7 @@ class TcrMessageUnregisterInterestList : public TcrMessage {
 
 class TcrMessagePut : public TcrMessage {
  public:
-  TcrMessagePut(std::unique_ptr<DataOutput> dataOutput, const Region* region,
+  TcrMessagePut(DataOutput* dataOutput, const Region* region,
                 const std::shared_ptr<CacheableKey>& key,
                 const std::shared_ptr<Cacheable>& value,
                 const std::shared_ptr<Serializable>& aCallbackArgument,
@@ -843,9 +835,9 @@ class TcrMessagePut : public TcrMessage {
 
 class TcrMessageCreateRegion : public TcrMessage {
  public:
-  TcrMessageCreateRegion(std::unique_ptr<DataOutput> dataOutput,
-                         const std::string& str1, const std::string& str2,
-                         bool isDurable = false, bool receiveValues = true,
+  TcrMessageCreateRegion(DataOutput* dataOutput, const std::string& str1,
+                         const std::string& str2, bool isDurable = false,
+                         bool receiveValues = true,
                          ThinClientBaseDM* connectionDM = nullptr);
 
   virtual ~TcrMessageCreateRegion() {}
@@ -856,8 +848,7 @@ class TcrMessageCreateRegion : public TcrMessage {
 class TcrMessageRegisterInterest : public TcrMessage {
  public:
   TcrMessageRegisterInterest(
-      std::unique_ptr<DataOutput> dataOutput, const std::string& str1,
-      const std::string& str2,
+      DataOutput* dataOutput, const std::string& str1, const std::string& str2,
       InterestResultPolicy interestPolicy = InterestResultPolicy::NONE,
       bool isDurable = false, bool isCachingEnabled = false,
       bool receiveValues = true, ThinClientBaseDM* connectionDM = nullptr);
@@ -870,8 +861,7 @@ class TcrMessageRegisterInterest : public TcrMessage {
 class TcrMessageUnregisterInterest : public TcrMessage {
  public:
   TcrMessageUnregisterInterest(
-      std::unique_ptr<DataOutput> dataOutput, const std::string& str1,
-      const std::string& str2,
+      DataOutput* dataOutput, const std::string& str1, const std::string& str2,
       InterestResultPolicy interestPolicy = InterestResultPolicy::NONE,
       bool isDurable = false, bool receiveValues = true,
       ThinClientBaseDM* connectionDM = nullptr);
@@ -883,8 +873,8 @@ class TcrMessageUnregisterInterest : public TcrMessage {
 
 class TcrMessageTxSynchronization : public TcrMessage {
  public:
-  TcrMessageTxSynchronization(std::unique_ptr<DataOutput> dataOutput,
-                              int ordinal, int txid, int status);
+  TcrMessageTxSynchronization(DataOutput* dataOutput, int ordinal, int txid,
+                              int status);
 
   virtual ~TcrMessageTxSynchronization() {}
 
@@ -893,7 +883,7 @@ class TcrMessageTxSynchronization : public TcrMessage {
 
 class TcrMessageClientReady : public TcrMessage {
  public:
-  TcrMessageClientReady(std::unique_ptr<DataOutput> dataOutput);
+  TcrMessageClientReady(DataOutput* dataOutput);
 
   virtual ~TcrMessageClientReady() {}
 
@@ -902,7 +892,7 @@ class TcrMessageClientReady : public TcrMessage {
 
 class TcrMessageCommit : public TcrMessage {
  public:
-  TcrMessageCommit(std::unique_ptr<DataOutput> dataOutput);
+  TcrMessageCommit(DataOutput* dataOutput);
 
   virtual ~TcrMessageCommit() {}
 
@@ -911,7 +901,7 @@ class TcrMessageCommit : public TcrMessage {
 
 class TcrMessageRollback : public TcrMessage {
  public:
-  TcrMessageRollback(std::unique_ptr<DataOutput> dataOutput);
+  TcrMessageRollback(DataOutput* dataOutput);
 
   virtual ~TcrMessageRollback() {}
 
@@ -920,7 +910,7 @@ class TcrMessageRollback : public TcrMessage {
 
 class TcrMessageTxFailover : public TcrMessage {
  public:
-  TcrMessageTxFailover(std::unique_ptr<DataOutput> dataOutput);
+  TcrMessageTxFailover(DataOutput* dataOutput);
 
   virtual ~TcrMessageTxFailover() {}
 
@@ -929,8 +919,7 @@ class TcrMessageTxFailover : public TcrMessage {
 
 class TcrMessageMakePrimary : public TcrMessage {
  public:
-  TcrMessageMakePrimary(std::unique_ptr<DataOutput> dataOutput,
-                        bool processedMarker);
+  TcrMessageMakePrimary(DataOutput* dataOutput, bool processedMarker);
 
   virtual ~TcrMessageMakePrimary() {}
 
@@ -939,7 +928,7 @@ class TcrMessageMakePrimary : public TcrMessage {
 
 class TcrMessagePutAll : public TcrMessage {
  public:
-  TcrMessagePutAll(std::unique_ptr<DataOutput> dataOutput, const Region* region,
+  TcrMessagePutAll(DataOutput* dataOutput, const Region* region,
                    const HashMapOfCacheable& map,
                    std::chrono::milliseconds messageResponsetimeout,
                    ThinClientBaseDM* connectionDM,
@@ -952,8 +941,7 @@ class TcrMessagePutAll : public TcrMessage {
 
 class TcrMessageRemoveAll : public TcrMessage {
  public:
-  TcrMessageRemoveAll(std::unique_ptr<DataOutput> dataOutput,
-                      const Region* region,
+  TcrMessageRemoveAll(DataOutput* dataOutput, const Region* region,
                       const std::vector<std::shared_ptr<CacheableKey>>& keys,
                       const std::shared_ptr<Serializable>& aCallbackArgument,
                       ThinClientBaseDM* connectionDM = nullptr);
@@ -965,9 +953,8 @@ class TcrMessageRemoveAll : public TcrMessage {
 
 class TcrMessageExecuteCq : public TcrMessage {
  public:
-  TcrMessageExecuteCq(std::unique_ptr<DataOutput> dataOutput,
-                      const std::string& str1, const std::string& str2,
-                      CqState state, bool isDurable,
+  TcrMessageExecuteCq(DataOutput* dataOutput, const std::string& str1,
+                      const std::string& str2, CqState state, bool isDurable,
                       ThinClientBaseDM* connectionDM);
 
   virtual ~TcrMessageExecuteCq() {}
@@ -977,10 +964,9 @@ class TcrMessageExecuteCq : public TcrMessage {
 
 class TcrMessageExecuteCqWithIr : public TcrMessage {
  public:
-  TcrMessageExecuteCqWithIr(std::unique_ptr<DataOutput> dataOutput,
-                            const std::string& str1, const std::string& str2,
-                            CqState state, bool isDurable,
-                            ThinClientBaseDM* connectionDM);
+  TcrMessageExecuteCqWithIr(DataOutput* dataOutput, const std::string& str1,
+                            const std::string& str2, CqState state,
+                            bool isDurable, ThinClientBaseDM* connectionDM);
 
   virtual ~TcrMessageExecuteCqWithIr() {}
 
@@ -990,8 +976,8 @@ class TcrMessageExecuteCqWithIr : public TcrMessage {
 class TcrMessageExecuteRegionFunction : public TcrMessage {
  public:
   TcrMessageExecuteRegionFunction(
-      std::unique_ptr<DataOutput> dataOutput, const std::string& funcName,
-      const Region* region, const std::shared_ptr<Cacheable>& args,
+      DataOutput* dataOutput, const std::string& funcName, const Region* region,
+      const std::shared_ptr<Cacheable>& args,
       std::shared_ptr<CacheableVector> routingObj, uint8_t getResult,
       std::shared_ptr<CacheableHashSet> failedNodes,
       std::chrono::milliseconds timeout,
@@ -1005,8 +991,8 @@ class TcrMessageExecuteRegionFunction : public TcrMessage {
 class TcrMessageExecuteRegionFunctionSingleHop : public TcrMessage {
  public:
   TcrMessageExecuteRegionFunctionSingleHop(
-      std::unique_ptr<DataOutput> dataOutput, const std::string& funcName,
-      const Region* region, const std::shared_ptr<Cacheable>& args,
+      DataOutput* dataOutput, const std::string& funcName, const Region* region,
+      const std::shared_ptr<Cacheable>& args,
       std::shared_ptr<CacheableHashSet> routingObj, uint8_t getResult,
       std::shared_ptr<CacheableHashSet> failedNodes, bool allBuckets,
       std::chrono::milliseconds timeout, ThinClientBaseDM* connectionDM);
@@ -1018,7 +1004,7 @@ class TcrMessageExecuteRegionFunctionSingleHop : public TcrMessage {
 
 class TcrMessageGetClientPartitionAttributes : public TcrMessage {
  public:
-  TcrMessageGetClientPartitionAttributes(std::unique_ptr<DataOutput> dataOutput,
+  TcrMessageGetClientPartitionAttributes(DataOutput* dataOutput,
                                          const char* regionName);
 
   virtual ~TcrMessageGetClientPartitionAttributes() {}
@@ -1028,8 +1014,7 @@ class TcrMessageGetClientPartitionAttributes : public TcrMessage {
 
 class TcrMessageGetClientPrMetadata : public TcrMessage {
  public:
-  TcrMessageGetClientPrMetadata(std::unique_ptr<DataOutput> dataOutput,
-                                const char* regionName);
+  TcrMessageGetClientPrMetadata(DataOutput* dataOutput, const char* regionName);
 
   virtual ~TcrMessageGetClientPrMetadata() {}
 
@@ -1038,8 +1023,7 @@ class TcrMessageGetClientPrMetadata : public TcrMessage {
 
 class TcrMessageSize : public TcrMessage {
  public:
-  TcrMessageSize(std::unique_ptr<DataOutput> dataOutput,
-                 const char* regionName);
+  TcrMessageSize(DataOutput* dataOutput, const char* regionName);
 
   virtual ~TcrMessageSize() {}
 
@@ -1048,7 +1032,7 @@ class TcrMessageSize : public TcrMessage {
 
 class TcrMessageUserCredential : public TcrMessage {
  public:
-  TcrMessageUserCredential(std::unique_ptr<DataOutput> dataOutput,
+  TcrMessageUserCredential(DataOutput* dataOutput,
                            std::shared_ptr<Properties> creds,
                            ThinClientBaseDM* connectionDM = nullptr);
 
@@ -1059,8 +1043,8 @@ class TcrMessageUserCredential : public TcrMessage {
 
 class TcrMessageRemoveUserAuth : public TcrMessage {
  public:
-  TcrMessageRemoveUserAuth(std::unique_ptr<DataOutput> dataOutput,
-                           bool keepAlive, ThinClientBaseDM* connectionDM);
+  TcrMessageRemoveUserAuth(DataOutput* dataOutput, bool keepAlive,
+                           ThinClientBaseDM* connectionDM);
 
   virtual ~TcrMessageRemoveUserAuth() {}
 
@@ -1069,7 +1053,7 @@ class TcrMessageRemoveUserAuth : public TcrMessage {
 
 class TcrMessageGetPdxIdForType : public TcrMessage {
  public:
-  TcrMessageGetPdxIdForType(std::unique_ptr<DataOutput> dataOutput,
+  TcrMessageGetPdxIdForType(DataOutput* dataOutput,
                             const std::shared_ptr<Cacheable>& pdxType,
                             ThinClientBaseDM* connectionDM);
 
@@ -1080,7 +1064,7 @@ class TcrMessageGetPdxIdForType : public TcrMessage {
 
 class TcrMessageAddPdxType : public TcrMessage {
  public:
-  TcrMessageAddPdxType(std::unique_ptr<DataOutput> dataOutput,
+  TcrMessageAddPdxType(DataOutput* dataOutput,
                        const std::shared_ptr<Cacheable>& pdxType,
                        ThinClientBaseDM* connectionDM, int32_t pdxTypeId = 0);
 
@@ -1091,7 +1075,7 @@ class TcrMessageAddPdxType : public TcrMessage {
 
 class TcrMessageGetPdxIdForEnum : public TcrMessage {
  public:
-  TcrMessageGetPdxIdForEnum(std::unique_ptr<DataOutput> dataOutput,
+  TcrMessageGetPdxIdForEnum(DataOutput* dataOutput,
                             const std::shared_ptr<Cacheable>& pdxType,
                             ThinClientBaseDM* connectionDM);
 
@@ -1102,7 +1086,7 @@ class TcrMessageGetPdxIdForEnum : public TcrMessage {
 
 class TcrMessageAddPdxEnum : public TcrMessage {
  public:
-  TcrMessageAddPdxEnum(std::unique_ptr<DataOutput> dataOutput,
+  TcrMessageAddPdxEnum(DataOutput* dataOutput,
                        const std::shared_ptr<Cacheable>& pdxType,
                        ThinClientBaseDM* connectionDM, int32_t pdxTypeId = 0);
 
@@ -1113,8 +1097,8 @@ class TcrMessageAddPdxEnum : public TcrMessage {
 
 class TcrMessageGetPdxTypeById : public TcrMessage {
  public:
-  TcrMessageGetPdxTypeById(std::unique_ptr<DataOutput> dataOutput,
-                           int32_t typeId, ThinClientBaseDM* connectionDM);
+  TcrMessageGetPdxTypeById(DataOutput* dataOutput, int32_t typeId,
+                           ThinClientBaseDM* connectionDM);
 
   virtual ~TcrMessageGetPdxTypeById() {}
 
@@ -1123,8 +1107,8 @@ class TcrMessageGetPdxTypeById : public TcrMessage {
 
 class TcrMessageGetPdxEnumById : public TcrMessage {
  public:
-  TcrMessageGetPdxEnumById(std::unique_ptr<DataOutput> dataOutput,
-                           int32_t typeId, ThinClientBaseDM* connectionDM);
+  TcrMessageGetPdxEnumById(DataOutput* dataOutput, int32_t typeId,
+                           ThinClientBaseDM* connectionDM);
 
   virtual ~TcrMessageGetPdxEnumById() {}
 
@@ -1133,7 +1117,7 @@ class TcrMessageGetPdxEnumById : public TcrMessage {
 
 class TcrMessageGetFunctionAttributes : public TcrMessage {
  public:
-  TcrMessageGetFunctionAttributes(std::unique_ptr<DataOutput> dataOutput,
+  TcrMessageGetFunctionAttributes(DataOutput* dataOutput,
                                   const std::string& funcName,
                                   ThinClientBaseDM* connectionDM = nullptr);
 
@@ -1144,8 +1128,7 @@ class TcrMessageGetFunctionAttributes : public TcrMessage {
 
 class TcrMessageKeySet : public TcrMessage {
  public:
-  TcrMessageKeySet(std::unique_ptr<DataOutput> dataOutput,
-                   const std::string& funcName,
+  TcrMessageKeySet(DataOutput* dataOutput, const std::string& funcName,
                    ThinClientBaseDM* connectionDM = nullptr);
 
   virtual ~TcrMessageKeySet() {}
@@ -1155,7 +1138,7 @@ class TcrMessageKeySet : public TcrMessage {
 
 class TcrMessageRequestEventValue : public TcrMessage {
  public:
-  TcrMessageRequestEventValue(std::unique_ptr<DataOutput> dataOutput,
+  TcrMessageRequestEventValue(DataOutput* dataOutput,
                               std::shared_ptr<EventId> eventId);
 
   virtual ~TcrMessageRequestEventValue() {}
@@ -1165,7 +1148,7 @@ class TcrMessageRequestEventValue : public TcrMessage {
 
 class TcrMessagePeriodicAck : public TcrMessage {
  public:
-  TcrMessagePeriodicAck(std::unique_ptr<DataOutput> dataOutput,
+  TcrMessagePeriodicAck(DataOutput* dataOutput,
                         const EventIdMapEntryList& entries);
 
   virtual ~TcrMessagePeriodicAck() {}
@@ -1175,8 +1158,7 @@ class TcrMessagePeriodicAck : public TcrMessage {
 
 class TcrMessageUpdateClientNotification : public TcrMessage {
  public:
-  TcrMessageUpdateClientNotification(std::unique_ptr<DataOutput> dataOutput,
-                                     int32_t port);
+  TcrMessageUpdateClientNotification(DataOutput* dataOutput, int32_t port);
 
   virtual ~TcrMessageUpdateClientNotification() {}
 
@@ -1186,7 +1168,7 @@ class TcrMessageUpdateClientNotification : public TcrMessage {
 class TcrMessageGetAll : public TcrMessage {
  public:
   TcrMessageGetAll(
-      std::unique_ptr<DataOutput> dataOutput, const Region* region,
+      DataOutput* dataOutput, const Region* region,
       const std::vector<std::shared_ptr<CacheableKey>>* keys,
       ThinClientBaseDM* connectionDM = nullptr,
       const std::shared_ptr<Serializable>& aCallbackArgument = nullptr);
@@ -1198,8 +1180,7 @@ class TcrMessageGetAll : public TcrMessage {
 
 class TcrMessageExecuteFunction : public TcrMessage {
  public:
-  TcrMessageExecuteFunction(std::unique_ptr<DataOutput> dataOutput,
-                            const std::string& funcName,
+  TcrMessageExecuteFunction(DataOutput* dataOutput, const std::string& funcName,
                             const std::shared_ptr<Cacheable>& args,
                             uint8_t getResult, ThinClientBaseDM* connectionDM,
                             std::chrono::milliseconds timeout);
@@ -1211,7 +1192,7 @@ class TcrMessageExecuteFunction : public TcrMessage {
 
 class TcrMessagePing : public TcrMessage {
  public:
-  TcrMessagePing(std::unique_ptr<DataOutput> dataOutput, bool decodeAll);
+  TcrMessagePing(DataOutput* dataOutput, bool decodeAll);
 
   virtual ~TcrMessagePing() {}
 
@@ -1220,8 +1201,7 @@ class TcrMessagePing : public TcrMessage {
 
 class TcrMessageCloseConnection : public TcrMessage {
  public:
-  TcrMessageCloseConnection(std::unique_ptr<DataOutput> dataOutput,
-                            bool decodeAll);
+  TcrMessageCloseConnection(DataOutput* dataOutput, bool decodeAll);
 
   virtual ~TcrMessageCloseConnection() {}
 

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -1230,8 +1230,7 @@ class TcrMessageCloseConnection : public TcrMessage {
 
 class TcrMessageClientMarker : public TcrMessage {
  public:
-  TcrMessageClientMarker(std::unique_ptr<DataOutput> dataOutput,
-                         bool decodeAll);
+  TcrMessageClientMarker(DataOutput* dataOutput, bool decodeAll);
 
   virtual ~TcrMessageClientMarker() {}
 

--- a/cppcache/src/ThinClientDistributionManager.cpp
+++ b/cppcache/src/ThinClientDistributionManager.cpp
@@ -338,8 +338,9 @@ GfErrType ThinClientDistributionManager::sendUserCredentials(
   GfErrType err = GF_NOERR;
 
   TcrMessageUserCredential request(
-          std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), credentials,
-      this);
+      std::unique_ptr<DataOutput>(new DataOutput(
+          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+      credentials, this);
 
   TcrMessageReply reply(true, this);
 

--- a/cppcache/src/ThinClientDistributionManager.cpp
+++ b/cppcache/src/ThinClientDistributionManager.cpp
@@ -338,8 +338,7 @@ GfErrType ThinClientDistributionManager::sendUserCredentials(
   GfErrType err = GF_NOERR;
 
   TcrMessageUserCredential request(
-      std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->createDataOutput())),
+      new DataOutput(m_connManager.getCacheImpl()->createDataOutput()),
       credentials, this);
 
   TcrMessageReply reply(true, this);

--- a/cppcache/src/ThinClientDistributionManager.cpp
+++ b/cppcache/src/ThinClientDistributionManager.cpp
@@ -338,7 +338,7 @@ GfErrType ThinClientDistributionManager::sendUserCredentials(
   GfErrType err = GF_NOERR;
 
   TcrMessageUserCredential request(
-      m_connManager.getCacheImpl()->getCache()->createDataOutput(), credentials,
+          std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), credentials,
       this);
 
   TcrMessageReply reply(true, this);

--- a/cppcache/src/ThinClientDistributionManager.cpp
+++ b/cppcache/src/ThinClientDistributionManager.cpp
@@ -339,7 +339,7 @@ GfErrType ThinClientDistributionManager::sendUserCredentials(
 
   TcrMessageUserCredential request(
       std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+          m_connManager.getCacheImpl()->createDataOutput())),
       credentials, this);
 
   TcrMessageReply reply(true, this);

--- a/cppcache/src/ThinClientHARegion.cpp
+++ b/cppcache/src/ThinClientHARegion.cpp
@@ -166,9 +166,7 @@ GfErrType ThinClientHARegion::getNoThrow_FullObject(
     std::shared_ptr<EventId> eventId, std::shared_ptr<Cacheable>& fullObject,
     std::shared_ptr<VersionTag>& versionTag) {
   TcrMessageRequestEventValue fullObjectMsg(
-      std::unique_ptr<DataOutput>(
-          new DataOutput(m_cacheImpl->createDataOutput())),
-      eventId);
+      new DataOutput(m_cacheImpl->createDataOutput()), eventId);
   TcrMessageReply reply(true, nullptr);
 
   ThinClientPoolHADM* poolHADM = dynamic_cast<ThinClientPoolHADM*>(m_tcrdm);

--- a/cppcache/src/ThinClientHARegion.cpp
+++ b/cppcache/src/ThinClientHARegion.cpp
@@ -155,8 +155,10 @@ void ThinClientHARegion::addDisMessToQueue() {
 
     if (poolDM->m_redundancyManager->m_globalProcessedMarker &&
         !m_processedMarker) {
-      TcrMessage* regionMsg =
-          new TcrMessageClientMarker(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), true);
+      TcrMessage* regionMsg = new TcrMessageClientMarker(
+          std::unique_ptr<DataOutput>(
+              new DataOutput(m_cacheImpl->createDataOutput())),
+          true);
       receiveNotification(regionMsg);
     }
   }
@@ -165,8 +167,10 @@ void ThinClientHARegion::addDisMessToQueue() {
 GfErrType ThinClientHARegion::getNoThrow_FullObject(
     std::shared_ptr<EventId> eventId, std::shared_ptr<Cacheable>& fullObject,
     std::shared_ptr<VersionTag>& versionTag) {
-  TcrMessageRequestEventValue fullObjectMsg(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())),
-                                            eventId);
+  TcrMessageRequestEventValue fullObjectMsg(
+      std::unique_ptr<DataOutput>(
+          new DataOutput(m_cacheImpl->createDataOutput())),
+      eventId);
   TcrMessageReply reply(true, nullptr);
 
   ThinClientPoolHADM* poolHADM = dynamic_cast<ThinClientPoolHADM*>(m_tcrdm);

--- a/cppcache/src/ThinClientHARegion.cpp
+++ b/cppcache/src/ThinClientHARegion.cpp
@@ -156,7 +156,7 @@ void ThinClientHARegion::addDisMessToQueue() {
     if (poolDM->m_redundancyManager->m_globalProcessedMarker &&
         !m_processedMarker) {
       TcrMessage* regionMsg =
-          new TcrMessageClientMarker(m_cacheImpl->createDataOutput(), true);
+          new TcrMessageClientMarker(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), true);
       receiveNotification(regionMsg);
     }
   }
@@ -165,7 +165,7 @@ void ThinClientHARegion::addDisMessToQueue() {
 GfErrType ThinClientHARegion::getNoThrow_FullObject(
     std::shared_ptr<EventId> eventId, std::shared_ptr<Cacheable>& fullObject,
     std::shared_ptr<VersionTag>& versionTag) {
-  TcrMessageRequestEventValue fullObjectMsg(m_cacheImpl->createDataOutput(),
+  TcrMessageRequestEventValue fullObjectMsg(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())),
                                             eventId);
   TcrMessageReply reply(true, nullptr);
 

--- a/cppcache/src/ThinClientHARegion.cpp
+++ b/cppcache/src/ThinClientHARegion.cpp
@@ -156,9 +156,7 @@ void ThinClientHARegion::addDisMessToQueue() {
     if (poolDM->m_redundancyManager->m_globalProcessedMarker &&
         !m_processedMarker) {
       TcrMessage* regionMsg = new TcrMessageClientMarker(
-          std::unique_ptr<DataOutput>(
-              new DataOutput(m_cacheImpl->createDataOutput())),
-          true);
+          new DataOutput(m_cacheImpl->createDataOutput()), true);
       receiveNotification(regionMsg);
     }
   }

--- a/cppcache/src/ThinClientLocatorHelper.cpp
+++ b/cppcache/src/ThinClientLocatorHelper.cpp
@@ -130,15 +130,15 @@ GfErrType ThinClientLocatorHelper::getAllServers(
       /* adongre
        * SSL Enabled on Location and not in the client
        */
-      if (di->read() == REPLY_SSL_ENABLED && !sysProps.sslEnabled()) {
+      if (di.read() == REPLY_SSL_ENABLED && !sysProps.sslEnabled()) {
         LOGERROR("SSL is enabled on locator, enable SSL in client as well");
         throw AuthenticationRequiredException(
             "SSL is enabled on locator, enable SSL in client as well");
       }
-      di->rewindCursor(1);
+      di.rewindCursor(1);
 
       auto response =
-          std::static_pointer_cast<GetAllServersResponse>(di->readObject());
+          std::static_pointer_cast<GetAllServersResponse>(di.readObject());
       servers = response->getServers();
       return GF_NOERR;
     } catch (const AuthenticationRequiredException&) {
@@ -222,15 +222,15 @@ GfErrType ThinClientLocatorHelper::getEndpointForNewCallBackConn(
       /* adongre
        * ssl defect
        */
-      const auto acceptanceCode = di->read();
+      const auto acceptanceCode = di.read();
       if (acceptanceCode == REPLY_SSL_ENABLED && !sysProps.sslEnabled()) {
         LOGERROR("SSL is enabled on locator, enable SSL in client as well");
         throw AuthenticationRequiredException(
             "SSL is enabled on locator, enable SSL in client as well");
       }
-      di->rewindCursor(1);
+      di.rewindCursor(1);
       auto response =
-          std::static_pointer_cast<QueueConnectionResponse>(di->readObject());
+          std::static_pointer_cast<QueueConnectionResponse>(di.readObject());
       outEndpoint = response->getServers();
       return GF_NOERR;
     } catch (const AuthenticationRequiredException& excp) {
@@ -323,16 +323,16 @@ GfErrType ThinClientLocatorHelper::getEndpointForNewFwdConn(
       /* adongre
        * SSL is enabled on locator and not in the client
        */
-      const auto acceptanceCode = di->read();
+      const auto acceptanceCode = di.read();
       if (acceptanceCode == REPLY_SSL_ENABLED && !sysProps.sslEnabled()) {
         LOGERROR("SSL is enabled on locator, enable SSL in client as well");
         throw AuthenticationRequiredException(
             "SSL is enabled on locator, enable SSL in client as well");
       }
-      di->rewindCursor(1);
+      di.rewindCursor(1);
 
       auto response =
-          std::static_pointer_cast<ClientConnectionResponse>(di->readObject());
+          std::static_pointer_cast<ClientConnectionResponse>(di.readObject());
       response->printInfo();
       if (!response->serverFound()) {
         LOGFINE("Server not found");
@@ -412,16 +412,16 @@ GfErrType ThinClientLocatorHelper::updateLocators(
       /* adongre
        * SSL Enabled on Location and not in the client
        */
-      const auto acceptanceCode = di->read();
+      const auto acceptanceCode = di.read();
       if (acceptanceCode == REPLY_SSL_ENABLED && !sysProps.sslEnabled()) {
         LOGERROR("SSL is enabled on locator, enable SSL in client as well");
         throw AuthenticationRequiredException(
             "SSL is enabled on locator, enable SSL in client as well");
       }
-      di->rewindCursor(1);
+      di.rewindCursor(1);
 
       auto response =
-          std::static_pointer_cast<LocatorListResponse>(di->readObject());
+          std::static_pointer_cast<LocatorListResponse>(di.readObject());
       auto locators = response->getLocators();
       if (locators.size() > 0) {
         RandGen randGen;

--- a/cppcache/src/ThinClientLocatorHelper.cpp
+++ b/cppcache/src/ThinClientLocatorHelper.cpp
@@ -104,10 +104,10 @@ GfErrType ThinClientLocatorHelper::getAllServers(
       GetAllServersRequest request(serverGrp);
       auto data =
           m_poolDM->getConnectionManager().getCacheImpl()->createDataOutput();
-      data->writeInt((int32_t)1001);  // GOSSIPVERSION
-      data->writeObject(&request);
+      data.writeInt((int32_t)1001);  // GOSSIPVERSION
+      data.writeObject(&request);
       auto sentLength = conn->send(
-          (char*)(data->getBuffer()), data->getBufferLength(),
+          (char*)(data.getBuffer()), data.getBufferLength(),
           m_poolDM ? m_poolDM->getReadTimeout() : std::chrono::seconds(10));
       if (sentLength <= 0) {
         // conn->close(); delete conn; conn = nullptr;
@@ -197,10 +197,10 @@ GfErrType ThinClientLocatorHelper::getEndpointForNewCallBackConn(
                                      serverGrp);
       auto data =
           m_poolDM->getConnectionManager().getCacheImpl()->createDataOutput();
-      data->writeInt((int32_t)1001);  // GOSSIPVERSION
-      data->writeObject(&request);
+      data.writeInt((int32_t)1001);  // GOSSIPVERSION
+      data.writeObject(&request);
       auto sentLength = conn->send(
-          (char*)(data->getBuffer()), data->getBufferLength(),
+          (char*)(data.getBuffer()), data.getBufferLength(),
           m_poolDM ? m_poolDM->getReadTimeout() : sysProps.connectTimeout());
       if (sentLength <= 0) {
         // conn->close(); delete conn; conn = nullptr;
@@ -287,20 +287,20 @@ GfErrType ThinClientLocatorHelper::getEndpointForNewFwdConn(
                        sysProps.connectTimeout(), buffSize);
       auto data =
           m_poolDM->getConnectionManager().getCacheImpl()->createDataOutput();
-      data->writeInt(1001);  // GOSSIPVERSION
+      data.writeInt(1001);  // GOSSIPVERSION
       if (currentServer == nullptr) {
         LOGDEBUG("Creating ClientConnectionRequest");
         ClientConnectionRequest request(exclEndPts, serverGrp);
-        data->writeObject(&request);
+        data.writeObject(&request);
       } else {
         LOGDEBUG("Creating ClientReplacementRequest for connection: ",
                  currentServer->getEndpointObject()->name().c_str());
         ClientReplacementRequest request(
             currentServer->getEndpointObject()->name(), exclEndPts, serverGrp);
-        data->writeObject(&request);
+        data.writeObject(&request);
       }
       auto sentLength = conn->send(
-          (char*)(data->getBuffer()), data->getBufferLength(),
+          (char*)(data.getBuffer()), data.getBufferLength(),
           m_poolDM ? m_poolDM->getReadTimeout() : sysProps.connectTimeout());
       if (sentLength <= 0) {
         // conn->close();
@@ -385,10 +385,10 @@ GfErrType ThinClientLocatorHelper::updateLocators(
       LocatorListRequest request(serverGrp);
       auto data =
           m_poolDM->getConnectionManager().getCacheImpl()->createDataOutput();
-      data->writeInt((int32_t)1001);  // GOSSIPVERSION
-      data->writeObject(&request);
+      data.writeInt((int32_t)1001);  // GOSSIPVERSION
+      data.writeObject(&request);
       auto sentLength = conn->send(
-          (char*)(data->getBuffer()), data->getBufferLength(),
+          (char*)(data.getBuffer()), data.getBufferLength(),
           m_poolDM ? m_poolDM->getReadTimeout() : sysProps.connectTimeout());
       if (sentLength <= 0) {
         //  conn->close();

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -87,7 +87,7 @@ class GetAllWork : public PooledWork<GfErrType>,
         m_keys(keys),
         m_region(region),
         m_aCallbackArgument(aCallbackArgument) {
-    m_request = new TcrMessageGetAll(region->getCache().createDataOutput(),
+    m_request = new TcrMessageGetAll(std::unique_ptr<DataOutput>(new DataOutput(region->getCache().createDataOutput())),
                                      region.get(), m_keys.get(), m_poolDM,
                                      m_aCallbackArgument);
     m_reply = new TcrMessageReply(true, m_poolDM);
@@ -903,7 +903,7 @@ void ThinClientPoolDM::sendUserCacheCloseMessage(bool keepAlive) {
     UserConnectionAttributes* uca = (*it).second;
     if (uca->isAuthenticated() && uca->getEndpoint()->connected()) {
       TcrMessageRemoveUserAuth request(
-          m_connManager.getCacheImpl()->getCache()->createDataOutput(),
+              std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())),
           keepAlive, this);
       TcrMessageReply reply(true, this);
 
@@ -938,7 +938,7 @@ int32_t ThinClientPoolDM::GetPDXIdForType(
   GfErrType err = GF_NOERR;
 
   TcrMessageGetPdxIdForType request(
-      m_connManager.getCacheImpl()->getCache()->createDataOutput(), pdxType,
+          std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), pdxType,
       this);
 
   TcrMessageReply reply(true, this);
@@ -979,7 +979,7 @@ void ThinClientPoolDM::AddPdxType(std::shared_ptr<Serializable> pdxType,
   GfErrType err = GF_NOERR;
 
   TcrMessageAddPdxType request(
-      m_connManager.getCacheImpl()->getCache()->createDataOutput(), pdxType,
+      std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), pdxType,
       this, pdxTypeId);
 
   TcrMessageReply reply(true, this);
@@ -1000,7 +1000,7 @@ std::shared_ptr<Serializable> ThinClientPoolDM::GetPDXTypeById(int32_t typeId) {
   GfErrType err = GF_NOERR;
 
   TcrMessageGetPdxTypeById request(
-      m_connManager.getCacheImpl()->getCache()->createDataOutput(), typeId,
+      std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), typeId,
       this);
 
   TcrMessageReply reply(true, this);
@@ -1024,7 +1024,7 @@ int32_t ThinClientPoolDM::GetEnumValue(std::shared_ptr<Serializable> enumInfo) {
   GfErrType err = GF_NOERR;
 
   TcrMessageGetPdxIdForEnum request(
-      m_connManager.getCacheImpl()->getCache()->createDataOutput(), enumInfo,
+          std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), enumInfo,
       this);
 
   TcrMessageReply reply(true, this);
@@ -1064,7 +1064,7 @@ std::shared_ptr<Serializable> ThinClientPoolDM::GetEnum(int32_t val) {
   GfErrType err = GF_NOERR;
 
   TcrMessageGetPdxEnumById request(
-      m_connManager.getCacheImpl()->getCache()->createDataOutput(), val, this);
+      std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), val, this);
 
   TcrMessageReply reply(true, this);
 
@@ -1088,7 +1088,7 @@ void ThinClientPoolDM::AddEnum(std::shared_ptr<Serializable> enumInfo,
   GfErrType err = GF_NOERR;
 
   TcrMessageAddPdxEnum request(
-      m_connManager.getCacheImpl()->getCache()->createDataOutput(), enumInfo,
+      std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), enumInfo,
       this, enumVal);
 
   TcrMessageReply reply(true, this);
@@ -1112,7 +1112,7 @@ GfErrType ThinClientPoolDM::sendUserCredentials(
   GfErrType err = GF_NOERR;
 
   TcrMessageUserCredential request(
-      m_connManager.getCacheImpl()->getCache()->createDataOutput(), credentials,
+      std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), credentials,
       this);
 
   TcrMessageReply reply(true, this);
@@ -2343,7 +2343,7 @@ void ThinClientPoolDM::updateNotificationStats(bool isDeltaSuccess,
 GfErrType ThinClientPoolDM::doFailover(TcrConnection* conn) {
   m_manager->setStickyConnection(conn, true);
   TcrMessageTxFailover request(
-      m_connManager.getCacheImpl()->getCache()->createDataOutput());
+      std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())));
   TcrMessageReply reply(true, nullptr);
 
   GfErrType err = this->sendSyncRequest(request, reply);

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -88,9 +88,8 @@ class GetAllWork : public PooledWork<GfErrType>,
         m_region(region),
         m_aCallbackArgument(aCallbackArgument) {
     m_request = new TcrMessageGetAll(
-        std::unique_ptr<DataOutput>(
-            new DataOutput(region->getCache().createDataOutput())),
-        region.get(), m_keys.get(), m_poolDM, m_aCallbackArgument);
+        new DataOutput(region->getCache().createDataOutput()), region.get(),
+        m_keys.get(), m_poolDM, m_aCallbackArgument);
     m_reply = new TcrMessageReply(true, m_poolDM);
     if (m_poolDM->isMultiUserMode()) {
       m_userAttribute = TSSUserAttributesWrapper::s_geodeTSSUserAttributes
@@ -904,8 +903,7 @@ void ThinClientPoolDM::sendUserCacheCloseMessage(bool keepAlive) {
     UserConnectionAttributes* uca = (*it).second;
     if (uca->isAuthenticated() && uca->getEndpoint()->connected()) {
       TcrMessageRemoveUserAuth request(
-          std::unique_ptr<DataOutput>(new DataOutput(
-              m_connManager.getCacheImpl()->createDataOutput())),
+          new DataOutput(m_connManager.getCacheImpl()->createDataOutput()),
           keepAlive, this);
       TcrMessageReply reply(true, this);
 
@@ -940,9 +938,8 @@ int32_t ThinClientPoolDM::GetPDXIdForType(
   GfErrType err = GF_NOERR;
 
   TcrMessageGetPdxIdForType request(
-      std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->createDataOutput())),
-      pdxType, this);
+      new DataOutput(m_connManager.getCacheImpl()->createDataOutput()), pdxType,
+      this);
 
   TcrMessageReply reply(true, this);
 
@@ -961,8 +958,7 @@ int32_t ThinClientPoolDM::GetPDXIdForType(
 
   // need to broadcast this id to all other pool
   {
-    auto& poolManager =
-        m_connManager.getCacheImpl()->getPoolManager();
+    auto& poolManager = m_connManager.getCacheImpl()->getPoolManager();
     for (const auto& iter : poolManager.getAll()) {
       auto currPool = static_cast<ThinClientPoolDM*>(iter.second.get());
 
@@ -982,9 +978,8 @@ void ThinClientPoolDM::AddPdxType(std::shared_ptr<Serializable> pdxType,
   GfErrType err = GF_NOERR;
 
   TcrMessageAddPdxType request(
-      std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->createDataOutput())),
-      pdxType, this, pdxTypeId);
+      new DataOutput(m_connManager.getCacheImpl()->createDataOutput()), pdxType,
+      this, pdxTypeId);
 
   TcrMessageReply reply(true, this);
 
@@ -1004,9 +999,8 @@ std::shared_ptr<Serializable> ThinClientPoolDM::GetPDXTypeById(int32_t typeId) {
   GfErrType err = GF_NOERR;
 
   TcrMessageGetPdxTypeById request(
-      std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->createDataOutput())),
-      typeId, this);
+      new DataOutput(m_connManager.getCacheImpl()->createDataOutput()), typeId,
+      this);
 
   TcrMessageReply reply(true, this);
 
@@ -1029,8 +1023,7 @@ int32_t ThinClientPoolDM::GetEnumValue(std::shared_ptr<Serializable> enumInfo) {
   GfErrType err = GF_NOERR;
 
   TcrMessageGetPdxIdForEnum request(
-      std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->createDataOutput())),
+      new DataOutput(m_connManager.getCacheImpl()->createDataOutput()),
       enumInfo, this);
 
   TcrMessageReply reply(true, this);
@@ -1050,8 +1043,7 @@ int32_t ThinClientPoolDM::GetEnumValue(std::shared_ptr<Serializable> enumInfo) {
 
   // need to broadcast this id to all other pool
   {
-    auto& poolManager =
-        m_connManager.getCacheImpl()->getPoolManager();
+    auto& poolManager = m_connManager.getCacheImpl()->getPoolManager();
     for (const auto& iter : poolManager.getAll()) {
       const auto& currPool =
           std::dynamic_pointer_cast<ThinClientPoolDM>(iter.second);
@@ -1070,9 +1062,8 @@ std::shared_ptr<Serializable> ThinClientPoolDM::GetEnum(int32_t val) {
   GfErrType err = GF_NOERR;
 
   TcrMessageGetPdxEnumById request(
-      std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->createDataOutput())),
-      val, this);
+      new DataOutput(m_connManager.getCacheImpl()->createDataOutput()), val,
+      this);
 
   TcrMessageReply reply(true, this);
 
@@ -1096,8 +1087,7 @@ void ThinClientPoolDM::AddEnum(std::shared_ptr<Serializable> enumInfo,
   GfErrType err = GF_NOERR;
 
   TcrMessageAddPdxEnum request(
-      std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->createDataOutput())),
+      new DataOutput(m_connManager.getCacheImpl()->createDataOutput()),
       enumInfo, this, enumVal);
 
   TcrMessageReply reply(true, this);
@@ -1121,8 +1111,7 @@ GfErrType ThinClientPoolDM::sendUserCredentials(
   GfErrType err = GF_NOERR;
 
   TcrMessageUserCredential request(
-      std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->createDataOutput())),
+      new DataOutput(m_connManager.getCacheImpl()->createDataOutput()),
       credentials, this);
 
   TcrMessageReply reply(true, this);
@@ -1280,7 +1269,8 @@ GfErrType ThinClientPoolDM::sendSyncRequest(TcrMessage& request,
       m_clientMetadataService != nullptr) {
     GfErrType error = GF_NOERR;
 
-    auto region = m_connManager.getCacheImpl()->getRegion(request.getRegionName());
+    auto region =
+        m_connManager.getCacheImpl()->getRegion(request.getRegionName());
     auto locationMap = m_clientMetadataService->getServerToFilterMap(
         *(request.getKeys()), region, request.forPrimary());
 
@@ -1437,7 +1427,8 @@ GfErrType ThinClientPoolDM::sendSyncRequest(
       return GF_CLIENT_WAIT_TIMEOUT;
     } else if (queueErr == GF_CLIENT_WAIT_TIMEOUT_REFRESH_PRMETADATA) {
       // need to refresh meta data
-      auto region = m_connManager.getCacheImpl()->getRegion(request.getRegionName());
+      auto region =
+          m_connManager.getCacheImpl()->getRegion(request.getRegionName());
 
       if (region != nullptr) {
         LOGFINE(
@@ -1565,7 +1556,8 @@ GfErrType ThinClientPoolDM::sendSyncRequest(
             request.getKeyRef() != nullptr && reply.isFEAnotherHop()))) {
         // Need to get direct access to Region's name to avoid referencing
         // temp data and causing crashes
-        auto region = m_connManager.getCacheImpl()->getRegion(request.getRegionName());
+        auto region =
+            m_connManager.getCacheImpl()->getRegion(request.getRegionName());
 
         if (region != nullptr) {
           if (!connFound)  // max limit case then don't refresh otherwise always
@@ -2352,8 +2344,8 @@ void ThinClientPoolDM::updateNotificationStats(bool isDeltaSuccess,
 
 GfErrType ThinClientPoolDM::doFailover(TcrConnection* conn) {
   m_manager->setStickyConnection(conn, true);
-  TcrMessageTxFailover request(std::unique_ptr<DataOutput>(new DataOutput(
-      m_connManager.getCacheImpl()->createDataOutput())));
+  TcrMessageTxFailover request(
+      new DataOutput(m_connManager.getCacheImpl()->createDataOutput()));
   TcrMessageReply reply(true, nullptr);
 
   GfErrType err = this->sendSyncRequest(request, reply);
@@ -2456,7 +2448,8 @@ TcrConnection* ThinClientPoolDM::getConnectionFromQueueW(
           return nullptr;
         }
 
-        auto region = m_connManager.getCacheImpl()->getRegion(request.getRegionName());
+        auto region =
+            m_connManager.getCacheImpl()->getRegion(request.getRegionName());
         if (region != nullptr) {
           slTmp = nullptr;
           m_clientMetadataService

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -87,9 +87,10 @@ class GetAllWork : public PooledWork<GfErrType>,
         m_keys(keys),
         m_region(region),
         m_aCallbackArgument(aCallbackArgument) {
-    m_request = new TcrMessageGetAll(std::unique_ptr<DataOutput>(new DataOutput(region->getCache().createDataOutput())),
-                                     region.get(), m_keys.get(), m_poolDM,
-                                     m_aCallbackArgument);
+    m_request = new TcrMessageGetAll(
+        std::unique_ptr<DataOutput>(
+            new DataOutput(region->getCache().createDataOutput())),
+        region.get(), m_keys.get(), m_poolDM, m_aCallbackArgument);
     m_reply = new TcrMessageReply(true, m_poolDM);
     if (m_poolDM->isMultiUserMode()) {
       m_userAttribute = TSSUserAttributesWrapper::s_geodeTSSUserAttributes
@@ -903,7 +904,8 @@ void ThinClientPoolDM::sendUserCacheCloseMessage(bool keepAlive) {
     UserConnectionAttributes* uca = (*it).second;
     if (uca->isAuthenticated() && uca->getEndpoint()->connected()) {
       TcrMessageRemoveUserAuth request(
-              std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+          std::unique_ptr<DataOutput>(new DataOutput(
+              m_connManager.getCacheImpl()->getCache()->createDataOutput())),
           keepAlive, this);
       TcrMessageReply reply(true, this);
 
@@ -938,8 +940,9 @@ int32_t ThinClientPoolDM::GetPDXIdForType(
   GfErrType err = GF_NOERR;
 
   TcrMessageGetPdxIdForType request(
-          std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), pdxType,
-      this);
+      std::unique_ptr<DataOutput>(new DataOutput(
+          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+      pdxType, this);
 
   TcrMessageReply reply(true, this);
 
@@ -979,8 +982,9 @@ void ThinClientPoolDM::AddPdxType(std::shared_ptr<Serializable> pdxType,
   GfErrType err = GF_NOERR;
 
   TcrMessageAddPdxType request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), pdxType,
-      this, pdxTypeId);
+      std::unique_ptr<DataOutput>(new DataOutput(
+          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+      pdxType, this, pdxTypeId);
 
   TcrMessageReply reply(true, this);
 
@@ -1000,8 +1004,9 @@ std::shared_ptr<Serializable> ThinClientPoolDM::GetPDXTypeById(int32_t typeId) {
   GfErrType err = GF_NOERR;
 
   TcrMessageGetPdxTypeById request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), typeId,
-      this);
+      std::unique_ptr<DataOutput>(new DataOutput(
+          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+      typeId, this);
 
   TcrMessageReply reply(true, this);
 
@@ -1024,8 +1029,9 @@ int32_t ThinClientPoolDM::GetEnumValue(std::shared_ptr<Serializable> enumInfo) {
   GfErrType err = GF_NOERR;
 
   TcrMessageGetPdxIdForEnum request(
-          std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), enumInfo,
-      this);
+      std::unique_ptr<DataOutput>(new DataOutput(
+          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+      enumInfo, this);
 
   TcrMessageReply reply(true, this);
 
@@ -1064,7 +1070,9 @@ std::shared_ptr<Serializable> ThinClientPoolDM::GetEnum(int32_t val) {
   GfErrType err = GF_NOERR;
 
   TcrMessageGetPdxEnumById request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), val, this);
+      std::unique_ptr<DataOutput>(new DataOutput(
+          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+      val, this);
 
   TcrMessageReply reply(true, this);
 
@@ -1088,8 +1096,9 @@ void ThinClientPoolDM::AddEnum(std::shared_ptr<Serializable> enumInfo,
   GfErrType err = GF_NOERR;
 
   TcrMessageAddPdxEnum request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), enumInfo,
-      this, enumVal);
+      std::unique_ptr<DataOutput>(new DataOutput(
+          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+      enumInfo, this, enumVal);
 
   TcrMessageReply reply(true, this);
 
@@ -1112,8 +1121,9 @@ GfErrType ThinClientPoolDM::sendUserCredentials(
   GfErrType err = GF_NOERR;
 
   TcrMessageUserCredential request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())), credentials,
-      this);
+      std::unique_ptr<DataOutput>(new DataOutput(
+          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+      credentials, this);
 
   TcrMessageReply reply(true, this);
 
@@ -2342,8 +2352,8 @@ void ThinClientPoolDM::updateNotificationStats(bool isDeltaSuccess,
 
 GfErrType ThinClientPoolDM::doFailover(TcrConnection* conn) {
   m_manager->setStickyConnection(conn, true);
-  TcrMessageTxFailover request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_connManager.getCacheImpl()->getCache()->createDataOutput())));
+  TcrMessageTxFailover request(std::unique_ptr<DataOutput>(new DataOutput(
+      m_connManager.getCacheImpl()->getCache()->createDataOutput())));
   TcrMessageReply reply(true, nullptr);
 
   GfErrType err = this->sendSyncRequest(request, reply);

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -905,7 +905,7 @@ void ThinClientPoolDM::sendUserCacheCloseMessage(bool keepAlive) {
     if (uca->isAuthenticated() && uca->getEndpoint()->connected()) {
       TcrMessageRemoveUserAuth request(
           std::unique_ptr<DataOutput>(new DataOutput(
-              m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+              m_connManager.getCacheImpl()->createDataOutput())),
           keepAlive, this);
       TcrMessageReply reply(true, this);
 
@@ -941,7 +941,7 @@ int32_t ThinClientPoolDM::GetPDXIdForType(
 
   TcrMessageGetPdxIdForType request(
       std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+          m_connManager.getCacheImpl()->createDataOutput())),
       pdxType, this);
 
   TcrMessageReply reply(true, this);
@@ -962,7 +962,7 @@ int32_t ThinClientPoolDM::GetPDXIdForType(
   // need to broadcast this id to all other pool
   {
     auto& poolManager =
-        m_connManager.getCacheImpl()->getCache()->getPoolManager();
+        m_connManager.getCacheImpl()->getPoolManager();
     for (const auto& iter : poolManager.getAll()) {
       auto currPool = static_cast<ThinClientPoolDM*>(iter.second.get());
 
@@ -983,7 +983,7 @@ void ThinClientPoolDM::AddPdxType(std::shared_ptr<Serializable> pdxType,
 
   TcrMessageAddPdxType request(
       std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+          m_connManager.getCacheImpl()->createDataOutput())),
       pdxType, this, pdxTypeId);
 
   TcrMessageReply reply(true, this);
@@ -1005,7 +1005,7 @@ std::shared_ptr<Serializable> ThinClientPoolDM::GetPDXTypeById(int32_t typeId) {
 
   TcrMessageGetPdxTypeById request(
       std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+          m_connManager.getCacheImpl()->createDataOutput())),
       typeId, this);
 
   TcrMessageReply reply(true, this);
@@ -1030,7 +1030,7 @@ int32_t ThinClientPoolDM::GetEnumValue(std::shared_ptr<Serializable> enumInfo) {
 
   TcrMessageGetPdxIdForEnum request(
       std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+          m_connManager.getCacheImpl()->createDataOutput())),
       enumInfo, this);
 
   TcrMessageReply reply(true, this);
@@ -1051,7 +1051,7 @@ int32_t ThinClientPoolDM::GetEnumValue(std::shared_ptr<Serializable> enumInfo) {
   // need to broadcast this id to all other pool
   {
     auto& poolManager =
-        m_connManager.getCacheImpl()->getCache()->getPoolManager();
+        m_connManager.getCacheImpl()->getPoolManager();
     for (const auto& iter : poolManager.getAll()) {
       const auto& currPool =
           std::dynamic_pointer_cast<ThinClientPoolDM>(iter.second);
@@ -1071,7 +1071,7 @@ std::shared_ptr<Serializable> ThinClientPoolDM::GetEnum(int32_t val) {
 
   TcrMessageGetPdxEnumById request(
       std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+          m_connManager.getCacheImpl()->createDataOutput())),
       val, this);
 
   TcrMessageReply reply(true, this);
@@ -1097,7 +1097,7 @@ void ThinClientPoolDM::AddEnum(std::shared_ptr<Serializable> enumInfo,
 
   TcrMessageAddPdxEnum request(
       std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+          m_connManager.getCacheImpl()->createDataOutput())),
       enumInfo, this, enumVal);
 
   TcrMessageReply reply(true, this);
@@ -1122,7 +1122,7 @@ GfErrType ThinClientPoolDM::sendUserCredentials(
 
   TcrMessageUserCredential request(
       std::unique_ptr<DataOutput>(new DataOutput(
-          m_connManager.getCacheImpl()->getCache()->createDataOutput())),
+          m_connManager.getCacheImpl()->createDataOutput())),
       credentials, this);
 
   TcrMessageReply reply(true, this);
@@ -2353,7 +2353,7 @@ void ThinClientPoolDM::updateNotificationStats(bool isDeltaSuccess,
 GfErrType ThinClientPoolDM::doFailover(TcrConnection* conn) {
   m_manager->setStickyConnection(conn, true);
   TcrMessageTxFailover request(std::unique_ptr<DataOutput>(new DataOutput(
-      m_connManager.getCacheImpl()->getCache()->createDataOutput())));
+      m_connManager.getCacheImpl()->createDataOutput())));
   TcrMessageReply reply(true, nullptr);
 
   GfErrType err = this->sendSyncRequest(request, reply);

--- a/cppcache/src/ThinClientPoolDM.hpp
+++ b/cppcache/src/ThinClientPoolDM.hpp
@@ -401,10 +401,10 @@ class FunctionExecution : public PooledWork<GfErrType> {
       gua.setAuthenticatedView(m_userAttr->getAuthenticatedView());
 
     std::string funcName(m_func);
-    TcrMessageExecuteFunction request(m_poolDM->getConnectionManager()
+    TcrMessageExecuteFunction request(std::unique_ptr<DataOutput>(new DataOutput(m_poolDM->getConnectionManager()
                                           .getCacheImpl()
                                           ->getCache()
-                                          ->createDataOutput(),
+                                          ->createDataOutput())),
                                       funcName, m_args, m_getResult, m_poolDM,
                                       m_timeout);
     TcrMessageReply reply(true, m_poolDM);
@@ -494,10 +494,10 @@ class OnRegionFunctionExecution : public PooledWork<GfErrType> {
         m_region(region),
         m_allBuckets(allBuckets) {
     m_request = new TcrMessageExecuteRegionFunctionSingleHop(
-        m_poolDM->getConnectionManager()
+            std::unique_ptr<DataOutput>(new DataOutput(m_poolDM->getConnectionManager()
             .getCacheImpl()
             ->getCache()
-            ->createDataOutput(),
+            ->createDataOutput())),
         m_func, m_region, m_args, m_routingObj, m_getResult, nullptr,
         m_allBuckets, timeout, m_poolDM);
     m_reply = new TcrMessageReply(true, m_poolDM);

--- a/cppcache/src/ThinClientPoolDM.hpp
+++ b/cppcache/src/ThinClientPoolDM.hpp
@@ -401,12 +401,13 @@ class FunctionExecution : public PooledWork<GfErrType> {
       gua.setAuthenticatedView(m_userAttr->getAuthenticatedView());
 
     std::string funcName(m_func);
-    TcrMessageExecuteFunction request(std::unique_ptr<DataOutput>(new DataOutput(m_poolDM->getConnectionManager()
-                                          .getCacheImpl()
-                                          ->getCache()
-                                          ->createDataOutput())),
-                                      funcName, m_args, m_getResult, m_poolDM,
-                                      m_timeout);
+    TcrMessageExecuteFunction request(
+        std::unique_ptr<DataOutput>(
+            new DataOutput(m_poolDM->getConnectionManager()
+                               .getCacheImpl()
+                               ->getCache()
+                               ->createDataOutput())),
+        funcName, m_args, m_getResult, m_poolDM, m_timeout);
     TcrMessageReply reply(true, m_poolDM);
     ChunkedFunctionExecutionResponse* resultProcessor(
         new ChunkedFunctionExecutionResponse(reply, (m_getResult & 2) == 2,
@@ -494,10 +495,11 @@ class OnRegionFunctionExecution : public PooledWork<GfErrType> {
         m_region(region),
         m_allBuckets(allBuckets) {
     m_request = new TcrMessageExecuteRegionFunctionSingleHop(
-            std::unique_ptr<DataOutput>(new DataOutput(m_poolDM->getConnectionManager()
-            .getCacheImpl()
-            ->getCache()
-            ->createDataOutput())),
+        std::unique_ptr<DataOutput>(
+            new DataOutput(m_poolDM->getConnectionManager()
+                               .getCacheImpl()
+                               ->getCache()
+                               ->createDataOutput())),
         m_func, m_region, m_args, m_routingObj, m_getResult, nullptr,
         m_allBuckets, timeout, m_poolDM);
     m_reply = new TcrMessageReply(true, m_poolDM);

--- a/cppcache/src/ThinClientPoolDM.hpp
+++ b/cppcache/src/ThinClientPoolDM.hpp
@@ -402,11 +402,9 @@ class FunctionExecution : public PooledWork<GfErrType> {
 
     std::string funcName(m_func);
     TcrMessageExecuteFunction request(
-        std::unique_ptr<DataOutput>(
-            new DataOutput(m_poolDM->getConnectionManager()
-                               .getCacheImpl()
-                               ->getCache()
-                               ->createDataOutput())),
+        new DataOutput(m_poolDM->getConnectionManager()
+                           .getCacheImpl()
+                           ->createDataOutput()),
         funcName, m_args, m_getResult, m_poolDM, m_timeout);
     TcrMessageReply reply(true, m_poolDM);
     ChunkedFunctionExecutionResponse* resultProcessor(
@@ -495,11 +493,9 @@ class OnRegionFunctionExecution : public PooledWork<GfErrType> {
         m_region(region),
         m_allBuckets(allBuckets) {
     m_request = new TcrMessageExecuteRegionFunctionSingleHop(
-        std::unique_ptr<DataOutput>(
-            new DataOutput(m_poolDM->getConnectionManager()
-                               .getCacheImpl()
-                               ->getCache()
-                               ->createDataOutput())),
+        new DataOutput(m_poolDM->getConnectionManager()
+                           .getCacheImpl()
+                           ->createDataOutput()),
         m_func, m_region, m_args, m_routingObj, m_getResult, nullptr,
         m_allBuckets, timeout, m_poolDM);
     m_reply = new TcrMessageReply(true, m_poolDM);

--- a/cppcache/src/ThinClientRedundancyManager.cpp
+++ b/cppcache/src/ThinClientRedundancyManager.cpp
@@ -747,8 +747,8 @@ bool ThinClientRedundancyManager::readyForEvents(
     return true;
   }
 
-  TcrMessageClientReady request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())));
+  TcrMessageClientReady request(std::unique_ptr<DataOutput>(new DataOutput(
+      m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())));
   TcrMessageReply reply(true, nullptr);
 
   GfErrType err = GF_NOTCON;
@@ -790,7 +790,8 @@ bool ThinClientRedundancyManager::sendMakePrimaryMesg(TcrEndpoint* ep,
   }
   TcrMessageReply reply(false, nullptr);
   const TcrMessageMakePrimary makePrimaryRequest(
-      std::unique_ptr<DataOutput>(new DataOutput(m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())),
+      std::unique_ptr<DataOutput>(new DataOutput(
+          m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())),
       ThinClientRedundancyManager::m_sentReadyForEvents);
 
   LOGFINE("Making primary subscription endpoint %s", ep->name().c_str());
@@ -1105,8 +1106,8 @@ bool ThinClientRedundancyManager::isDurable() {
 }
 
 void ThinClientRedundancyManager::readyForEvents() {
-  TcrMessageClientReady request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())));
+  TcrMessageClientReady request(std::unique_ptr<DataOutput>(new DataOutput(
+      m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())));
   TcrMessageReply reply(true, nullptr);
   GfErrType result = GF_NOTCON;
   unsigned int epCount = 0;
@@ -1192,7 +1193,10 @@ void ThinClientRedundancyManager::doPeriodicAck() {
 
       if (endpoint != m_redundantEndpoints.end()) {
         TcrMessagePeriodicAck request(
-            std::unique_ptr<DataOutput>(new DataOutput(m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())),
+            std::unique_ptr<DataOutput>(
+                new DataOutput(m_theTcrConnManager->getCacheImpl()
+                                   ->getCache()
+                                   ->createDataOutput())),
             entries);
         TcrMessageReply reply(true, nullptr);
 

--- a/cppcache/src/ThinClientRedundancyManager.cpp
+++ b/cppcache/src/ThinClientRedundancyManager.cpp
@@ -747,8 +747,8 @@ bool ThinClientRedundancyManager::readyForEvents(
     return true;
   }
 
-  TcrMessageClientReady request(std::unique_ptr<DataOutput>(new DataOutput(
-      m_theTcrConnManager->getCacheImpl()->createDataOutput())));
+  TcrMessageClientReady request(
+      new DataOutput(m_theTcrConnManager->getCacheImpl()->createDataOutput()));
   TcrMessageReply reply(true, nullptr);
 
   GfErrType err = GF_NOTCON;
@@ -790,8 +790,7 @@ bool ThinClientRedundancyManager::sendMakePrimaryMesg(TcrEndpoint* ep,
   }
   TcrMessageReply reply(false, nullptr);
   const TcrMessageMakePrimary makePrimaryRequest(
-      std::unique_ptr<DataOutput>(new DataOutput(
-          m_theTcrConnManager->getCacheImpl()->createDataOutput())),
+      new DataOutput(m_theTcrConnManager->getCacheImpl()->createDataOutput()),
       ThinClientRedundancyManager::m_sentReadyForEvents);
 
   LOGFINE("Making primary subscription endpoint %s", ep->name().c_str());
@@ -874,7 +873,8 @@ GfErrType ThinClientRedundancyManager::sendSyncRequestCq(
     if (err != GF_NOERR || m_redundantEndpoints.empty()) {
       auto userAttr = TSSUserAttributesWrapper::s_geodeTSSUserAttributes
                           ->getUserAttributes();
-      if (userAttr != nullptr) authenticatedView = userAttr->getAuthenticatedView();
+      if (userAttr != nullptr)
+        authenticatedView = userAttr->getAuthenticatedView();
       err = maintainRedundancyLevel();
       // we continue on fatal error because MRL only tries a handshake without
       // sending a request (no params passed) so no need to check
@@ -1106,8 +1106,8 @@ bool ThinClientRedundancyManager::isDurable() {
 }
 
 void ThinClientRedundancyManager::readyForEvents() {
-  TcrMessageClientReady request(std::unique_ptr<DataOutput>(new DataOutput(
-      m_theTcrConnManager->getCacheImpl()->createDataOutput())));
+  TcrMessageClientReady request(
+      new DataOutput(m_theTcrConnManager->getCacheImpl()->createDataOutput()));
   TcrMessageReply reply(true, nullptr);
   GfErrType result = GF_NOTCON;
   unsigned int epCount = 0;
@@ -1193,10 +1193,8 @@ void ThinClientRedundancyManager::doPeriodicAck() {
 
       if (endpoint != m_redundantEndpoints.end()) {
         TcrMessagePeriodicAck request(
-            std::unique_ptr<DataOutput>(
-                new DataOutput(m_theTcrConnManager->getCacheImpl()
-                                   ->getCache()
-                                   ->createDataOutput())),
+            new DataOutput(m_theTcrConnManager->getCacheImpl()
+                               ->createDataOutput()),
             entries);
         TcrMessageReply reply(true, nullptr);
 
@@ -1261,9 +1259,9 @@ void ThinClientRedundancyManager::startPeriodicAck() {
       "notify-dupcheck-life = %ld, periodic ack is %sabled",
       m_processEventIdMapTaskId,
       (m_poolHADM ? m_poolHADM->getSubscriptionAckInterval()
-                 : props.notifyAckInterval()).count(),
+                  : props.notifyAckInterval()).count(),
       (m_poolHADM ? m_poolHADM->getSubscriptionMessageTrackingTimeout()
-                 : props.notifyDupCheckLife()).count(),
+                  : props.notifyDupCheckLife()).count(),
       m_HAenabled ? "en" : "dis");
 }
 

--- a/cppcache/src/ThinClientRedundancyManager.cpp
+++ b/cppcache/src/ThinClientRedundancyManager.cpp
@@ -748,7 +748,7 @@ bool ThinClientRedundancyManager::readyForEvents(
   }
 
   TcrMessageClientReady request(
-      m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput());
+      std::unique_ptr<DataOutput>(new DataOutput(m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())));
   TcrMessageReply reply(true, nullptr);
 
   GfErrType err = GF_NOTCON;
@@ -790,7 +790,7 @@ bool ThinClientRedundancyManager::sendMakePrimaryMesg(TcrEndpoint* ep,
   }
   TcrMessageReply reply(false, nullptr);
   const TcrMessageMakePrimary makePrimaryRequest(
-      m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput(),
+      std::unique_ptr<DataOutput>(new DataOutput(m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())),
       ThinClientRedundancyManager::m_sentReadyForEvents);
 
   LOGFINE("Making primary subscription endpoint %s", ep->name().c_str());
@@ -1106,7 +1106,7 @@ bool ThinClientRedundancyManager::isDurable() {
 
 void ThinClientRedundancyManager::readyForEvents() {
   TcrMessageClientReady request(
-      m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput());
+      std::unique_ptr<DataOutput>(new DataOutput(m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())));
   TcrMessageReply reply(true, nullptr);
   GfErrType result = GF_NOTCON;
   unsigned int epCount = 0;
@@ -1192,7 +1192,7 @@ void ThinClientRedundancyManager::doPeriodicAck() {
 
       if (endpoint != m_redundantEndpoints.end()) {
         TcrMessagePeriodicAck request(
-            m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput(),
+            std::unique_ptr<DataOutput>(new DataOutput(m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())),
             entries);
         TcrMessageReply reply(true, nullptr);
 

--- a/cppcache/src/ThinClientRedundancyManager.cpp
+++ b/cppcache/src/ThinClientRedundancyManager.cpp
@@ -748,7 +748,7 @@ bool ThinClientRedundancyManager::readyForEvents(
   }
 
   TcrMessageClientReady request(std::unique_ptr<DataOutput>(new DataOutput(
-      m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())));
+      m_theTcrConnManager->getCacheImpl()->createDataOutput())));
   TcrMessageReply reply(true, nullptr);
 
   GfErrType err = GF_NOTCON;
@@ -791,7 +791,7 @@ bool ThinClientRedundancyManager::sendMakePrimaryMesg(TcrEndpoint* ep,
   TcrMessageReply reply(false, nullptr);
   const TcrMessageMakePrimary makePrimaryRequest(
       std::unique_ptr<DataOutput>(new DataOutput(
-          m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())),
+          m_theTcrConnManager->getCacheImpl()->createDataOutput())),
       ThinClientRedundancyManager::m_sentReadyForEvents);
 
   LOGFINE("Making primary subscription endpoint %s", ep->name().c_str());
@@ -1107,7 +1107,7 @@ bool ThinClientRedundancyManager::isDurable() {
 
 void ThinClientRedundancyManager::readyForEvents() {
   TcrMessageClientReady request(std::unique_ptr<DataOutput>(new DataOutput(
-      m_theTcrConnManager->getCacheImpl()->getCache()->createDataOutput())));
+      m_theTcrConnManager->getCacheImpl()->createDataOutput())));
   TcrMessageReply reply(true, nullptr);
   GfErrType result = GF_NOTCON;
   unsigned int epCount = 0;

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -97,9 +97,10 @@ class PutAllWork : public PooledWork<GfErrType>,
         m_isPapeReceived(false)
   // UNUSED , m_aCallbackArgument(aCallbackArgument)
   {
-    m_request = new TcrMessagePutAll(std::unique_ptr<DataOutput>(new DataOutput(m_region->getCache().createDataOutput())),
-                                     m_region.get(), *m_map.get(), m_timeout,
-                                     m_poolDM, aCallbackArgument);
+    m_request = new TcrMessagePutAll(
+        std::unique_ptr<DataOutput>(
+            new DataOutput(m_region->getCache().createDataOutput())),
+        m_region.get(), *m_map.get(), m_timeout, m_poolDM, aCallbackArgument);
     m_reply = new TcrMessageReply(true, m_poolDM);
 
     // create new instanceof VCOPL
@@ -241,9 +242,10 @@ class RemoveAllWork : public PooledWork<GfErrType>,
         m_keys(keys),
         m_papException(nullptr),
         m_isPapeReceived(false) {
-    m_request = new TcrMessageRemoveAll(std::unique_ptr<DataOutput>(new DataOutput(m_region->getCache().createDataOutput())),
-                                        m_region.get(), *keys,
-                                        m_aCallbackArgument, m_poolDM);
+    m_request = new TcrMessageRemoveAll(
+        std::unique_ptr<DataOutput>(
+            new DataOutput(m_region->getCache().createDataOutput())),
+        m_region.get(), *keys, m_aCallbackArgument, m_poolDM);
     m_reply = new TcrMessageReply(true, m_poolDM);
     // create new instanceof VCOPL
     ACE_Recursive_Thread_Mutex responseLock;
@@ -736,7 +738,8 @@ std::vector<std::shared_ptr<CacheableKey>> ThinClientRegion::serverKeys() {
   CHECK_DESTROY_PENDING(TryReadGuard, Region::serverKeys);
 
   TcrMessageReply reply(true, m_tcrdm);
-  TcrMessageKeySet request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->getCache()->createDataOutput())),
+  TcrMessageKeySet request(std::unique_ptr<DataOutput>(new DataOutput(
+                               m_cacheImpl->getCache()->createDataOutput())),
                            m_fullPath, m_tcrdm);
   reply.setMessageTypeRequest(TcrMessage::KEY_SET);
   std::vector<std::shared_ptr<CacheableKey>> serverKeys;
@@ -783,8 +786,10 @@ bool ThinClientRegion::containsKeyOnServer(
   /** @brief Create message and send to bridge server */
 
   TcrMessageContainsKey request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this, keyPtr,
-      static_cast<std::shared_ptr<Serializable>>(nullptr), true, m_tcrdm);
+      std::unique_ptr<DataOutput>(
+          new DataOutput(m_cacheImpl->createDataOutput())),
+      this, keyPtr, static_cast<std::shared_ptr<Serializable>>(nullptr), true,
+      m_tcrdm);
   TcrMessageReply reply(true, m_tcrdm);
   reply.setMessageTypeRequest(TcrMessage::CONTAINS_KEY);
   err = m_tcrdm->sendSyncRequest(request, reply);
@@ -829,8 +834,10 @@ bool ThinClientRegion::containsValueForKey_remote(
   /** @brief Create message and send to bridge server */
 
   TcrMessageContainsKey request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this, keyPtr,
-      static_cast<std::shared_ptr<Serializable>>(nullptr), false, m_tcrdm);
+      std::unique_ptr<DataOutput>(
+          new DataOutput(m_cacheImpl->createDataOutput())),
+      this, keyPtr, static_cast<std::shared_ptr<Serializable>>(nullptr), false,
+      m_tcrdm);
   TcrMessageReply reply(true, m_tcrdm);
   reply.setMessageTypeRequest(TcrMessage::CONTAINS_KEY);
   err = m_tcrdm->sendSyncRequest(request, reply);
@@ -876,9 +883,10 @@ void ThinClientRegion::clear(
 
   /** @brief Create message and send to bridge server */
 
-  TcrMessageClearRegion request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this,
-                                aCallbackArgument,
-                                std::chrono::milliseconds(-1), m_tcrdm);
+  TcrMessageClearRegion request(
+      std::unique_ptr<DataOutput>(
+          new DataOutput(m_cacheImpl->createDataOutput())),
+      this, aCallbackArgument, std::chrono::milliseconds(-1), m_tcrdm);
   TcrMessageReply reply(true, m_tcrdm);
   err = m_tcrdm->sendSyncRequest(request, reply);
   if (err != GF_NOERR) GfErrTypeToException("Region::clear", err);
@@ -920,8 +928,9 @@ GfErrType ThinClientRegion::getNoThrow_remote(
 
   /** @brief Create message and send to bridge server */
 
-  TcrMessageRequest request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this, keyPtr,
-                            aCallbackArgument, m_tcrdm);
+  TcrMessageRequest request(std::unique_ptr<DataOutput>(new DataOutput(
+                                m_cacheImpl->createDataOutput())),
+                            this, keyPtr, aCallbackArgument, m_tcrdm);
   TcrMessageReply reply(true, m_tcrdm);
   err = m_tcrdm->sendSyncRequest(request, reply);
   if (err != GF_NOERR) return err;
@@ -961,8 +970,9 @@ GfErrType ThinClientRegion::invalidateNoThrow_remote(
 
   /** @brief Create message and send to bridge server */
 
-  TcrMessageInvalidate request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this, keyPtr,
-                               aCallbackArgument, m_tcrdm);
+  TcrMessageInvalidate request(std::unique_ptr<DataOutput>(new DataOutput(
+                                   m_cacheImpl->createDataOutput())),
+                               this, keyPtr, aCallbackArgument, m_tcrdm);
   TcrMessageReply reply(true, m_tcrdm);
   err = m_tcrdm->sendSyncRequest(request, reply);
   if (err != GF_NOERR) return err;
@@ -1011,8 +1021,10 @@ GfErrType ThinClientRegion::putNoThrow_remote(
     auto&& temp = std::dynamic_pointer_cast<Delta>(valuePtr);
     delta = temp && temp->hasDelta();
   }
-  TcrMessagePut request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this, keyPtr, valuePtr,
-                        aCallbackArgument, delta, m_tcrdm);
+  TcrMessagePut request(std::unique_ptr<DataOutput>(
+                            new DataOutput(m_cacheImpl->createDataOutput())),
+                        this, keyPtr, valuePtr, aCallbackArgument, delta,
+                        m_tcrdm);
   TcrMessageReply* reply = new TcrMessageReply(true, m_tcrdm);
   err = m_tcrdm->sendSyncRequest(request, *reply);
   if (delta) {
@@ -1020,9 +1032,10 @@ GfErrType ThinClientRegion::putNoThrow_remote(
         .incDeltaPut();  // Does not chcek whether success of failure..
     if (reply->getMessageType() ==
         TcrMessage::PUT_DELTA_ERROR) {  // Try without delta
-      TcrMessagePut request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this, keyPtr,
-                            valuePtr, aCallbackArgument, false, m_tcrdm, false,
-                            true);
+      TcrMessagePut request(std::unique_ptr<DataOutput>(new DataOutput(
+                                m_cacheImpl->createDataOutput())),
+                            this, keyPtr, valuePtr, aCallbackArgument, false,
+                            m_tcrdm, false, true);
       delete reply;
       reply = new TcrMessageReply(true, m_tcrdm);
       err = m_tcrdm->sendSyncRequest(request, *reply);
@@ -1073,8 +1086,9 @@ GfErrType ThinClientRegion::destroyNoThrow_remote(
   GfErrType err = GF_NOERR;
 
   // do TCR destroy
-  TcrMessageDestroy request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this, keyPtr,
-                            nullptr, aCallbackArgument, m_tcrdm);
+  TcrMessageDestroy request(std::unique_ptr<DataOutput>(new DataOutput(
+                                m_cacheImpl->createDataOutput())),
+                            this, keyPtr, nullptr, aCallbackArgument, m_tcrdm);
   TcrMessageReply reply(true, m_tcrdm);
   err = m_tcrdm->sendSyncRequest(request, reply);
   if (err != GF_NOERR) return err;
@@ -1116,8 +1130,9 @@ GfErrType ThinClientRegion::removeNoThrow_remote(
   GfErrType err = GF_NOERR;
 
   // do TCR remove
-  TcrMessageDestroy request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this, keyPtr,
-                            cvalue, aCallbackArgument, m_tcrdm);
+  TcrMessageDestroy request(std::unique_ptr<DataOutput>(new DataOutput(
+                                m_cacheImpl->createDataOutput())),
+                            this, keyPtr, cvalue, aCallbackArgument, m_tcrdm);
   TcrMessageReply reply(true, m_tcrdm);
   err = m_tcrdm->sendSyncRequest(request, reply);
   if (err != GF_NOERR) {
@@ -1158,8 +1173,9 @@ GfErrType ThinClientRegion::removeNoThrowEX_remote(
   GfErrType err = GF_NOERR;
 
   // do TCR remove
-  TcrMessageDestroy request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this, keyPtr,
-                            nullptr, aCallbackArgument, m_tcrdm);
+  TcrMessageDestroy request(std::unique_ptr<DataOutput>(new DataOutput(
+                                m_cacheImpl->createDataOutput())),
+                            this, keyPtr, nullptr, aCallbackArgument, m_tcrdm);
   TcrMessageReply reply(true, m_tcrdm);
   err = m_tcrdm->sendSyncRequest(request, reply);
   if (err != GF_NOERR) {
@@ -1221,7 +1237,9 @@ GfErrType ThinClientRegion::getAllNoThrow_remote(
   }
   // create the GET_ALL request
   TcrMessageGetAll request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this, keys, m_tcrdm,
+      std::unique_ptr<DataOutput>(
+          new DataOutput(m_cacheImpl->createDataOutput())),
+      this, keys, m_tcrdm,
       aCallbackArgument);  // now we need to initialize later
 
   TcrMessageReply reply(true, m_tcrdm);
@@ -1593,8 +1611,9 @@ GfErrType ThinClientRegion::multiHopPutAllNoThrow_remote(
   auto err = GF_NOERR;
 
   // Construct request/reply for putAll
-  TcrMessagePutAll request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this, map, timeout,
-                           m_tcrdm, aCallbackArgument);
+  TcrMessagePutAll request(std::unique_ptr<DataOutput>(
+                               new DataOutput(m_cacheImpl->createDataOutput())),
+                           this, map, timeout, m_tcrdm, aCallbackArgument);
   TcrMessageReply reply(true, m_tcrdm);
   request.setTimeout(timeout);
   reply.setTimeout(timeout);
@@ -1930,8 +1949,9 @@ GfErrType ThinClientRegion::multiHopRemoveAllNoThrow_remote(
   GfErrType err = GF_NOERR;
 
   // Construct request/reply for putAll
-  TcrMessageRemoveAll request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this, keys,
-                              aCallbackArgument, m_tcrdm);
+  TcrMessageRemoveAll request(std::unique_ptr<DataOutput>(new DataOutput(
+                                  m_cacheImpl->createDataOutput())),
+                              this, keys, aCallbackArgument, m_tcrdm);
   TcrMessageReply reply(true, m_tcrdm);
 
   ACE_Recursive_Thread_Mutex responseLock;
@@ -2007,7 +2027,9 @@ uint32_t ThinClientRegion::size_remote() {
   GfErrType err = GF_NOERR;
 
   // do TCR size
-  TcrMessageSize request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), m_fullPath.c_str());
+  TcrMessageSize request(std::unique_ptr<DataOutput>(
+                             new DataOutput(m_cacheImpl->createDataOutput())),
+                         m_fullPath.c_str());
   TcrMessageReply reply(true, m_tcrdm);
   err = m_tcrdm->sendSyncRequest(request, reply);
 
@@ -2210,9 +2232,10 @@ GfErrType ThinClientRegion::destroyRegionNoThrow_remote(
   GfErrType err = GF_NOERR;
 
   // do TCR destroyRegion
-  TcrMessageDestroyRegion request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this,
-                                  aCallbackArgument,
-                                  std::chrono::milliseconds(-1), m_tcrdm);
+  TcrMessageDestroyRegion request(
+      std::unique_ptr<DataOutput>(
+          new DataOutput(m_cacheImpl->createDataOutput())),
+      this, aCallbackArgument, std::chrono::milliseconds(-1), m_tcrdm);
   TcrMessageReply reply(true, m_tcrdm);
   err = m_tcrdm->sendSyncRequest(request, reply);
   if (err != GF_NOERR) return err;
@@ -2268,9 +2291,10 @@ GfErrType ThinClientRegion::registerKeysNoThrow(
            interestPolicy.ordinal);
 
   TcrMessageRegisterInterestList request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), this, keys, isDurable,
-      getAttributes().getCachingEnabled(), receiveValues, interestPolicy,
-      m_tcrdm);
+      std::unique_ptr<DataOutput>(
+          new DataOutput(m_cacheImpl->createDataOutput())),
+      this, keys, isDurable, getAttributes().getCachingEnabled(), receiveValues,
+      interestPolicy, m_tcrdm);
   ACE_Recursive_Thread_Mutex responseLock;
   TcrChunkedResult* resultCollector = nullptr;
   if (interestPolicy.ordinal == InterestResultPolicy::KEYS_VALUES.ordinal) {
@@ -2334,9 +2358,10 @@ GfErrType ThinClientRegion::unregisterKeysNoThrow(
     return GF_CACHE_ILLEGAL_STATE_EXCEPTION;
   }
 
-  TcrMessageUnregisterInterestList request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())),
-                                           this, keys, false, true,
-                                           InterestResultPolicy::NONE, m_tcrdm);
+  TcrMessageUnregisterInterestList request(
+      std::unique_ptr<DataOutput>(
+          new DataOutput(m_cacheImpl->createDataOutput())),
+      this, keys, false, true, InterestResultPolicy::NONE, m_tcrdm);
   err = m_tcrdm->sendSyncRequestRegisterInterest(request, reply);
   if (err == GF_NOERR /*|| err == GF_CACHE_REDUNDANCY_FAILURE*/) {
     if (attemptFailover) {
@@ -2370,9 +2395,10 @@ GfErrType ThinClientRegion::unregisterKeysNoThrowLocalDestroy(
     return GF_CACHE_ILLEGAL_STATE_EXCEPTION;
   }
 
-  TcrMessageUnregisterInterestList request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())),
-                                           this, keys, false, true,
-                                           InterestResultPolicy::NONE, m_tcrdm);
+  TcrMessageUnregisterInterestList request(
+      std::unique_ptr<DataOutput>(
+          new DataOutput(m_cacheImpl->createDataOutput())),
+      this, keys, false, true, InterestResultPolicy::NONE, m_tcrdm);
   err = m_tcrdm->sendSyncRequestRegisterInterest(request, reply);
   if (err == GF_NOERR) {
     if (attemptFailover) {
@@ -2445,9 +2471,10 @@ GfErrType ThinClientRegion::registerRegexNoThrow(
 
   // TODO:
   TcrMessageRegisterInterest request(
-      std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), m_fullPath, regex.c_str(),
-      interestPolicy, isDurable, getAttributes().getCachingEnabled(),
-      receiveValues, m_tcrdm);
+      std::unique_ptr<DataOutput>(
+          new DataOutput(m_cacheImpl->createDataOutput())),
+      m_fullPath, regex.c_str(), interestPolicy, isDurable,
+      getAttributes().getCachingEnabled(), receiveValues, m_tcrdm);
   ACE_Recursive_Thread_Mutex responseLock;
   if (reply == nullptr) {
     TcrMessageReply replyLocal(true, m_tcrdm);
@@ -2525,8 +2552,9 @@ GfErrType ThinClientRegion::unregisterRegexNoThrow(const std::string& regex,
   if (err == GF_NOERR) {
     TcrMessageReply reply(false, m_tcrdm);
     TcrMessageUnregisterInterest request(
-        std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), m_fullPath, regex,
-        InterestResultPolicy::NONE, false, true, m_tcrdm);
+        std::unique_ptr<DataOutput>(
+            new DataOutput(m_cacheImpl->createDataOutput())),
+        m_fullPath, regex, InterestResultPolicy::NONE, false, true, m_tcrdm);
     err = m_tcrdm->sendSyncRequestRegisterInterest(request, reply);
     if (err == GF_NOERR /*|| err == GF_CACHE_REDUNDANCY_FAILURE*/) {
       if (attemptFailover) {
@@ -2571,8 +2599,9 @@ GfErrType ThinClientRegion::unregisterRegexNoThrowLocalDestroy(
   if (err == GF_NOERR) {
     TcrMessageReply reply(false, m_tcrdm);
     TcrMessageUnregisterInterest request(
-        std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), m_fullPath, regex,
-        InterestResultPolicy::NONE, false, true, m_tcrdm);
+        std::unique_ptr<DataOutput>(
+            new DataOutput(m_cacheImpl->createDataOutput())),
+        m_fullPath, regex, InterestResultPolicy::NONE, false, true, m_tcrdm);
     err = m_tcrdm->sendSyncRequestRegisterInterest(request, reply);
     if (err == GF_NOERR) {
       if (attemptFailover) {
@@ -2985,12 +3014,16 @@ void ThinClientRegion::executeFunction(
     TcrMessage* msg;
     if (reExecuteForServ) {
       msg = new TcrMessageExecuteRegionFunction(
-          std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), func, this, args, routingObj,
-          getResult, failedNodes, timeout, m_tcrdm, static_cast<int8_t>(1));
+          std::unique_ptr<DataOutput>(
+              new DataOutput(m_cacheImpl->createDataOutput())),
+          func, this, args, routingObj, getResult, failedNodes, timeout,
+          m_tcrdm, static_cast<int8_t>(1));
     } else {
       msg = new TcrMessageExecuteRegionFunction(
-          std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), func, this, args, routingObj,
-          getResult, failedNodes, timeout, m_tcrdm, static_cast<int8_t>(0));
+          std::unique_ptr<DataOutput>(
+              new DataOutput(m_cacheImpl->createDataOutput())),
+          func, this, args, routingObj, getResult, failedNodes, timeout,
+          m_tcrdm, static_cast<int8_t>(0));
     }
     TcrMessageReply reply(true, m_tcrdm);
     // need to check
@@ -3082,10 +3115,11 @@ std::shared_ptr<CacheableVector> ThinClientRegion::reExecuteFunction(
 
   do {
     reExecute = false;
-    TcrMessageExecuteRegionFunction msg(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), func,
-                                        this, args, routingObj, getResult,
-                                        failedNodes, timeout, m_tcrdm,
-                                        /*reExecute*/ static_cast<int8_t>(1));
+    TcrMessageExecuteRegionFunction msg(
+        std::unique_ptr<DataOutput>(
+            new DataOutput(m_cacheImpl->createDataOutput())),
+        func, this, args, routingObj, getResult, failedNodes, timeout, m_tcrdm,
+        static_cast<int8_t>(1));
     TcrMessageReply reply(true, m_tcrdm);
     // need to check
     ChunkedFunctionExecutionResponse* resultCollector(
@@ -3252,8 +3286,10 @@ GfErrType ThinClientRegion::getFuncAttributes(const std::string& func,
 
   // do TCR GET_FUNCTION_ATTRIBUTES
   LOGDEBUG("Tcrmessage request GET_FUNCTION_ATTRIBUTES ");
-  TcrMessageGetFunctionAttributes request(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())), func,
-                                          m_tcrdm);
+  TcrMessageGetFunctionAttributes request(
+      std::unique_ptr<DataOutput>(
+          new DataOutput(m_cacheImpl->createDataOutput())),
+      func, m_tcrdm);
   TcrMessageReply reply(true, m_tcrdm);
   err = m_tcrdm->sendSyncRequest(request, reply);
   if (err != GF_NOERR) {
@@ -3281,8 +3317,10 @@ GfErrType ThinClientRegion::getFuncAttributes(const std::string& func,
 GfErrType ThinClientRegion::getNoThrow_FullObject(
     std::shared_ptr<EventId> eventId, std::shared_ptr<Cacheable>& fullObject,
     std::shared_ptr<VersionTag>& versionTag) {
-  TcrMessageRequestEventValue fullObjectMsg(std::unique_ptr<DataOutput>(new DataOutput(m_cacheImpl->createDataOutput())),
-                                            eventId);
+  TcrMessageRequestEventValue fullObjectMsg(
+      std::unique_ptr<DataOutput>(
+          new DataOutput(m_cacheImpl->createDataOutput())),
+      eventId);
   TcrMessageReply reply(true, nullptr);
 
   GfErrType err = GF_NOTCON;
@@ -3720,7 +3758,7 @@ void ChunkedGetAllResponse::reset() {
 void ChunkedGetAllResponse::handleChunk(const uint8_t* chunk, int32_t chunkLen,
                                         uint8_t isLastChunkWithSecurity,
                                         const CacheImpl* cacheImpl) {
-    auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPool());
+  auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPool());
 
   uint32_t partLen;
   if (TcrMessageHelper::readChunkPartHeader(
@@ -3839,7 +3877,7 @@ void ChunkedRemoveAllResponse::handleChunk(const uint8_t* chunk,
   uint32_t partLen;
   int8_t chunkType;
   if ((chunkType = (TcrMessageHelper::ChunkObjectType)
-          TcrMessageHelper::readChunkPartHeader(
+           TcrMessageHelper::readChunkPartHeader(
                m_msg, input, GeodeTypeIdsImpl::FixedIDByte,
                GeodeTypeIdsImpl::VersionedObjectPartList,
                "ChunkedRemoveAllResponse", partLen, isLastChunkWithSecurity)) ==
@@ -3892,8 +3930,7 @@ void ChunkedDurableCQListResponse::reset() {
 
 // handles the chunk response for GETDURABLECQS_MSG_TYPE
 void ChunkedDurableCQListResponse::handleChunk(const uint8_t* chunk,
-                                               int32_t chunkLen,
-                                               uint8_t,
+                                               int32_t chunkLen, uint8_t,
                                                const CacheImpl* cacheImpl) {
   auto input = cacheImpl->createDataInput(chunk, chunkLen, m_msg.getPool());
 
@@ -3911,7 +3948,7 @@ void ChunkedDurableCQListResponse::handleChunk(const uint8_t* chunk,
   input.advanceCursor(1);  // skip the CacheableArrayList type ID byte
 
   const auto stringParts = input.read();  // read the number of strings in the
-                                           // message this is one byte
+                                          // message this is one byte
 
   for (int i = 0; i < stringParts; i++) {
     m_resultList->push_back(

--- a/cppcache/src/statistics/StatArchiveWriter.cpp
+++ b/cppcache/src/statistics/StatArchiveWriter.cpp
@@ -42,7 +42,7 @@ using std::chrono::system_clock;
 
 StatDataOutput::StatDataOutput(CacheImpl *cacheImpl)
     : bytesWritten(0), m_fp(nullptr), closed(false) {
-  dataBuffer = cacheImpl->createDataOutput();
+  dataBuffer = std::unique_ptr<DataOutput>(new DataOutput(cacheImpl->createDataOutput()));
 }
 
 StatDataOutput::StatDataOutput(std::string filename, CacheImpl *cacheImpl) {
@@ -51,7 +51,7 @@ StatDataOutput::StatDataOutput(std::string filename, CacheImpl *cacheImpl) {
   }
 
   SerializationRegistry serializationRegistry;
-  dataBuffer = cacheImpl->createDataOutput();
+  dataBuffer = std::unique_ptr<DataOutput>(new DataOutput(cacheImpl->createDataOutput()));
   outFile = filename;
   closed = false;
   bytesWritten = 0;

--- a/cppcache/src/statistics/StatArchiveWriter.cpp
+++ b/cppcache/src/statistics/StatArchiveWriter.cpp
@@ -42,7 +42,8 @@ using std::chrono::system_clock;
 
 StatDataOutput::StatDataOutput(CacheImpl *cacheImpl)
     : bytesWritten(0), m_fp(nullptr), closed(false) {
-  dataBuffer = std::unique_ptr<DataOutput>(new DataOutput(cacheImpl->createDataOutput()));
+  dataBuffer = std::unique_ptr<DataOutput>(
+      new DataOutput(cacheImpl->createDataOutput()));
 }
 
 StatDataOutput::StatDataOutput(std::string filename, CacheImpl *cacheImpl) {
@@ -51,7 +52,8 @@ StatDataOutput::StatDataOutput(std::string filename, CacheImpl *cacheImpl) {
   }
 
   SerializationRegistry serializationRegistry;
-  dataBuffer = std::unique_ptr<DataOutput>(new DataOutput(cacheImpl->createDataOutput()));
+  dataBuffer = std::unique_ptr<DataOutput>(
+      new DataOutput(cacheImpl->createDataOutput()));
   outFile = filename;
   closed = false;
   bytesWritten = 0;

--- a/cppcache/test/TcrMessage_unittest.cpp
+++ b/cppcache/test/TcrMessage_unittest.cpp
@@ -35,7 +35,7 @@ class DataOutputUnderTest : public DataOutput {
 
  protected:
   virtual const SerializationRegistry &getSerializationRegistry()
-  const override {
+      const override {
     return m_serializationRegistry;
   }
 
@@ -70,9 +70,9 @@ TEST_F(TcrMessageTest, testConstructor1MessageDataContentWithDESTROY_REGION) {
   std::chrono::milliseconds messageResponseTimeout{1000};
   ThinClientBaseDM *connectionDM = nullptr;
 
-  TcrMessageDestroyRegion message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()), region,
-      aCallbackArgument, messageResponseTimeout, connectionDM);
+  TcrMessageDestroyRegion message(new DataOutputUnderTest(), region,
+                                  aCallbackArgument, messageResponseTimeout,
+                                  connectionDM);
 
   EXPECT_EQ(TcrMessage::DESTROY_REGION, message.getMessageType());
 
@@ -89,9 +89,9 @@ TEST_F(TcrMessageTest, testConstructor1MessageDataContentWithCLEAR_REGION) {
   std::chrono::milliseconds messageResponseTimeout{1000};
   ThinClientBaseDM *connectionDM = nullptr;
 
-  TcrMessageClearRegion message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()), region,
-      aCallbackArgument, messageResponseTimeout, connectionDM);
+  TcrMessageClearRegion message(new DataOutputUnderTest(), region,
+                                aCallbackArgument, messageResponseTimeout,
+                                connectionDM);
 
   EXPECT_MESSAGE_EQ(
       "000000240000003800000003\\h{8}"
@@ -104,9 +104,8 @@ TEST_F(TcrMessageTest, testQueryConstructorMessageDataCotent) {
   std::chrono::milliseconds messageResponseTimeout{1000};
   ThinClientBaseDM *connectionDM = nullptr;
 
-  TcrMessageCloseCQ message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "myRegionName", messageResponseTimeout, connectionDM);
+  TcrMessageCloseCQ message(new DataOutputUnderTest(), "myRegionName",
+                            messageResponseTimeout, connectionDM);
 
   EXPECT_EQ(TcrMessage::CLOSECQ_MSG_TYPE, message.getMessageType());
 
@@ -120,9 +119,8 @@ TEST_F(TcrMessageTest, testQueryConstructorWithQUERY) {
   std::chrono::milliseconds messageResponseTimeout{1000};
   ThinClientBaseDM *connectionDM = nullptr;
 
-  TcrMessageQuery message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "aRegionName", messageResponseTimeout, connectionDM);
+  TcrMessageQuery message(new DataOutputUnderTest(), "aRegionName",
+                          messageResponseTimeout, connectionDM);
 
   EXPECT_EQ(TcrMessage::QUERY, message.getMessageType());
 
@@ -136,9 +134,8 @@ TEST_F(TcrMessageTest, testQueryConstructorWithSTOPCQ_MSG_TYPE) {
   std::chrono::milliseconds messageResponseTimeout{1000};
   ThinClientBaseDM *connectionDM = nullptr;
 
-  TcrMessageStopCQ message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "aRegionName", messageResponseTimeout, connectionDM);
+  TcrMessageStopCQ message(new DataOutputUnderTest(), "aRegionName",
+                           messageResponseTimeout, connectionDM);
 
   EXPECT_EQ(TcrMessage::STOPCQ_MSG_TYPE, message.getMessageType());
 
@@ -152,9 +149,8 @@ TEST_F(TcrMessageTest, testQueryConstructorWithCLOSECQ_MSG_TYPE) {
   std::chrono::milliseconds messageResponseTimeout{1000};
   ThinClientBaseDM *connectionDM = nullptr;
 
-  TcrMessageCloseCQ message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "aRegionName", messageResponseTimeout, connectionDM);
+  TcrMessageCloseCQ message(new DataOutputUnderTest(), "aRegionName",
+                            messageResponseTimeout, connectionDM);
 
   EXPECT_EQ(TcrMessage::CLOSECQ_MSG_TYPE, message.getMessageType());
 
@@ -172,9 +168,8 @@ TEST_F(TcrMessageTest,
   auto paramList = CacheableVector::create();
 
   TcrMessageQueryWithParameters message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "aRegionName", aCallbackArgument, paramList, messageResponseTimeout,
-      connectionDM);
+      new DataOutputUnderTest(), "aRegionName", aCallbackArgument, paramList,
+      messageResponseTimeout, connectionDM);
 
   EXPECT_EQ(TcrMessage::QUERY_WITH_PARAMETERS, message.getMessageType());
 
@@ -186,8 +181,7 @@ TEST_F(TcrMessageTest,
 
 TEST_F(TcrMessageTest, testConstructorWithCONTAINS_KEY) {
   TcrMessageContainsKey message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      static_cast<const Region *>(nullptr),
+      new DataOutputUnderTest(), static_cast<const Region *>(nullptr),
       CacheableString::create(
           "mykey"),  // static_cast<const
                      // std::shared_ptr<CacheableKey>>(nullptr),
@@ -203,9 +197,8 @@ TEST_F(TcrMessageTest, testConstructorWithCONTAINS_KEY) {
 }
 
 TEST_F(TcrMessageTest, testConstructorWithGETDURABLECQS_MSG_TYPE) {
-  TcrMessageGetDurableCqs message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      static_cast<ThinClientBaseDM *>(nullptr));
+  TcrMessageGetDurableCqs message(new DataOutputUnderTest(),
+                                  static_cast<ThinClientBaseDM *>(nullptr));
 
   EXPECT_EQ(TcrMessage::GETDURABLECQS_MSG_TYPE, message.getMessageType());
 
@@ -214,8 +207,7 @@ TEST_F(TcrMessageTest, testConstructorWithGETDURABLECQS_MSG_TYPE) {
 
 TEST_F(TcrMessageTest, testConstructor2WithREQUEST) {
   TcrMessageRequest message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      static_cast<const Region *>(nullptr),
+      new DataOutputUnderTest(), static_cast<const Region *>(nullptr),
       CacheableString::create(
           "mykey"),  // static_cast<const
                      // std::shared_ptr<CacheableKey>>(nullptr),
@@ -232,8 +224,8 @@ TEST_F(TcrMessageTest, testConstructor2WithREQUEST) {
 
 TEST_F(TcrMessageTest, testConstructor2WithDESTROY) {
   TcrMessageDestroy message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      static_cast<const Region *>(nullptr), CacheableString::create("mykey"),
+      new DataOutputUnderTest(), static_cast<const Region *>(nullptr),
+      CacheableString::create("mykey"),
       static_cast<const std::shared_ptr<CacheableKey>>(nullptr),
       static_cast<const std::shared_ptr<Serializable>>(nullptr),
       static_cast<ThinClientBaseDM *>(nullptr));
@@ -249,8 +241,7 @@ TEST_F(TcrMessageTest, testConstructor2WithDESTROY) {
 
 TEST_F(TcrMessageTest, testConstructor2WithINVALIDATE) {
   TcrMessageInvalidate message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      static_cast<const Region *>(nullptr),
+      new DataOutputUnderTest(), static_cast<const Region *>(nullptr),
       CacheableString::create(
           "mykey"),  // static_cast<const
                      // std::shared_ptr<CacheableKey>>(nullptr),
@@ -268,9 +259,8 @@ TEST_F(TcrMessageTest, testConstructor2WithINVALIDATE) {
 
 TEST_F(TcrMessageTest, testConstructor3WithPUT) {
   TcrMessagePut message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      static_cast<const Region *>(nullptr), CacheableString::create("mykey"),
-      CacheableString::create("myvalue"),
+      new DataOutputUnderTest(), static_cast<const Region *>(nullptr),
+      CacheableString::create("mykey"), CacheableString::create("myvalue"),
       static_cast<const std::shared_ptr<Serializable>>(nullptr),
       false,  // isDelta
       static_cast<ThinClientBaseDM *>(nullptr),
@@ -300,8 +290,7 @@ TEST_F(TcrMessageTest, testConstructor5WithREGISTER_INTERST_LIST) {
   keys.push_back(CacheableString::create("mykey"));
 
   TcrMessageRegisterInterestList message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      static_cast<const Region *>(nullptr), keys,
+      new DataOutputUnderTest(), static_cast<const Region *>(nullptr), keys,
       false,  // isDurable
       false,  // isCacheingEnabled
       false,  // receiveValues
@@ -321,8 +310,7 @@ TEST_F(TcrMessageTest, testConstructor5WithUNREGISTER_INTERST_LIST) {
   keys.push_back(CacheableString::create("mykey"));
 
   TcrMessageUnregisterInterestList message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      static_cast<const Region *>(nullptr), keys,
+      new DataOutputUnderTest(), static_cast<const Region *>(nullptr), keys,
       false,  // isDurable
       false,  // receiveValues
       InterestResultPolicy::NONE, static_cast<ThinClientBaseDM *>(nullptr));
@@ -338,8 +326,8 @@ TEST_F(TcrMessageTest, testConstructor5WithUNREGISTER_INTERST_LIST) {
 
 TEST_F(TcrMessageTest, testConstructorGET_FUNCTION_ATTRIBUTES) {
   TcrMessageGetFunctionAttributes message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      std::string("myFunction"), static_cast<ThinClientBaseDM *>(nullptr));
+      new DataOutputUnderTest(), std::string("myFunction"),
+      static_cast<ThinClientBaseDM *>(nullptr));
 
   EXPECT_EQ(TcrMessage::GET_FUNCTION_ATTRIBUTES, message.getMessageType());
 
@@ -349,10 +337,9 @@ TEST_F(TcrMessageTest, testConstructorGET_FUNCTION_ATTRIBUTES) {
 }
 
 TEST_F(TcrMessageTest, testConstructorKEY_SET) {
-  TcrMessageKeySet message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      std::string("myFunctionKeySet"),
-      static_cast<ThinClientBaseDM *>(nullptr));
+  TcrMessageKeySet message(new DataOutputUnderTest(),
+                           std::string("myFunctionKeySet"),
+                           static_cast<ThinClientBaseDM *>(nullptr));
 
   EXPECT_EQ(TcrMessage::KEY_SET, message.getMessageType());
 
@@ -363,13 +350,12 @@ TEST_F(TcrMessageTest, testConstructorKEY_SET) {
 }
 
 TEST_F(TcrMessageTest, testConstructor6WithCREATE_REGION) {
-  TcrMessageCreateRegion message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "str1",  // TODO: what does this parameter do?!
-      "str2",  // TODO: what does this parameter do?!
-      false,  // isDurable
-      false,  // receiveValues
-      static_cast<ThinClientBaseDM *>(nullptr));
+  TcrMessageCreateRegion message(new DataOutputUnderTest(),
+                                 "str1",  // TODO: what does this parameter do?!
+                                 "str2",  // TODO: what does this parameter do?!
+                                 false,   // isDurable
+                                 false,   // receiveValues
+                                 static_cast<ThinClientBaseDM *>(nullptr));
 
   EXPECT_EQ(TcrMessage::CREATE_REGION, message.getMessageType());
 
@@ -380,7 +366,7 @@ TEST_F(TcrMessageTest, testConstructor6WithCREATE_REGION) {
 
 TEST_F(TcrMessageTest, testConstructor6WithREGISTER_INTEREST) {
   TcrMessageRegisterInterest message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
+      new DataOutputUnderTest(),
       "str1",  // TODO: what does this parameter do?!
       "str2",  // TODO: what does this parameter do?!
       InterestResultPolicy::NONE,
@@ -399,7 +385,7 @@ TEST_F(TcrMessageTest, testConstructor6WithREGISTER_INTEREST) {
 
 TEST_F(TcrMessageTest, testConstructor6WithUNREGISTER_INTEREST) {
   TcrMessageUnregisterInterest message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
+      new DataOutputUnderTest(),
       "str1",  // TODO: what does this parameter do?!
       "str2",  // TODO: what does this parameter do?!
       InterestResultPolicy::NONE,
@@ -416,9 +402,8 @@ TEST_F(TcrMessageTest, testConstructor6WithUNREGISTER_INTEREST) {
 }
 
 TEST_F(TcrMessageTest, testConstructorGET_PDX_TYPE_BY_ID) {
-  TcrMessageGetPdxTypeById message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()), 42,
-      static_cast<ThinClientBaseDM *>(nullptr));
+  TcrMessageGetPdxTypeById message(new DataOutputUnderTest(), 42,
+                                   static_cast<ThinClientBaseDM *>(nullptr));
 
   EXPECT_EQ(TcrMessage::GET_PDX_TYPE_BY_ID, message.getMessageType());
 
@@ -427,9 +412,8 @@ TEST_F(TcrMessageTest, testConstructorGET_PDX_TYPE_BY_ID) {
 }
 
 TEST_F(TcrMessageTest, testConstructorGET_PDX_ENUM_BY_ID) {
-  TcrMessageGetPdxEnumById message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()), 42,
-      static_cast<ThinClientBaseDM *>(nullptr));
+  TcrMessageGetPdxEnumById message(new DataOutputUnderTest(), 42,
+                                   static_cast<ThinClientBaseDM *>(nullptr));
 
   EXPECT_EQ(TcrMessage::GET_PDX_ENUM_BY_ID, message.getMessageType());
 
@@ -439,9 +423,8 @@ TEST_F(TcrMessageTest, testConstructorGET_PDX_ENUM_BY_ID) {
 
 TEST_F(TcrMessageTest, testConstructorGET_PDX_ID_FOR_TYPE) {
   std::shared_ptr<Cacheable> myPtr(CacheableString::createDeserializable());
-  TcrMessageGetPdxIdForType message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()), myPtr,
-      static_cast<ThinClientBaseDM *>(nullptr));
+  TcrMessageGetPdxIdForType message(new DataOutputUnderTest(), myPtr,
+                                    static_cast<ThinClientBaseDM *>(nullptr));
 
   EXPECT_EQ(TcrMessage::GET_PDX_ID_FOR_TYPE, message.getMessageType());
 
@@ -451,9 +434,8 @@ TEST_F(TcrMessageTest, testConstructorGET_PDX_ID_FOR_TYPE) {
 
 TEST_F(TcrMessageTest, testConstructorADD_PDX_TYPE) {
   std::shared_ptr<Cacheable> myPtr(CacheableString::createDeserializable());
-  TcrMessageAddPdxType message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()), myPtr,
-      static_cast<ThinClientBaseDM *>(nullptr), 42);
+  TcrMessageAddPdxType message(new DataOutputUnderTest(), myPtr,
+                               static_cast<ThinClientBaseDM *>(nullptr), 42);
 
   EXPECT_EQ(TcrMessage::ADD_PDX_TYPE, message.getMessageType());
 
@@ -464,7 +446,7 @@ TEST_F(TcrMessageTest, testConstructorADD_PDX_TYPE) {
 
 TEST_F(TcrMessageTest, testConstructorGET_PDX_ID_FOR_ENUM) {
   TcrMessageGetPdxIdForEnum message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
+      new DataOutputUnderTest(),
       static_cast<std::shared_ptr<Cacheable>>(nullptr),
       static_cast<ThinClientBaseDM *>(nullptr));
 
@@ -476,10 +458,9 @@ TEST_F(TcrMessageTest, testConstructorGET_PDX_ID_FOR_ENUM) {
 TEST_F(TcrMessageTest, testConstructorADD_PDX_ENUM) {
   std::shared_ptr<Cacheable> myPtr(CacheableString::createDeserializable());
 
-  TcrMessageAddPdxEnum message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      static_cast<std::shared_ptr<Cacheable>>(nullptr),
-      static_cast<ThinClientBaseDM *>(nullptr), 42);
+  TcrMessageAddPdxEnum message(new DataOutputUnderTest(),
+                               static_cast<std::shared_ptr<Cacheable>>(nullptr),
+                               static_cast<ThinClientBaseDM *>(nullptr), 42);
 
   EXPECT_EQ(TcrMessage::ADD_PDX_ENUM, message.getMessageType());
 
@@ -490,7 +471,7 @@ TEST_F(TcrMessageTest, testConstructorADD_PDX_ENUM) {
 
 TEST_F(TcrMessageTest, testConstructorEventId) {
   TcrMessageRequestEventValue message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
+      new DataOutputUnderTest(),
       static_cast<std::shared_ptr<EventId>>(nullptr));
 
   EXPECT_EQ(TcrMessage::REQUEST_EVENT_VALUE, message.getMessageType());
@@ -499,17 +480,15 @@ TEST_F(TcrMessageTest, testConstructorEventId) {
 }
 
 TEST_F(TcrMessageTest, testConstructorREMOVE_USER_AUTH) {
-  TcrMessageRemoveUserAuth message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()), true,
-      static_cast<ThinClientBaseDM *>(nullptr));
+  TcrMessageRemoveUserAuth message(new DataOutputUnderTest(), true,
+                                   static_cast<ThinClientBaseDM *>(nullptr));
 
   EXPECT_EQ(TcrMessage::REMOVE_USER_AUTH, message.getMessageType());
 
   EXPECT_MESSAGE_EQ("0000004E0000000600000001FFFFFFFF00000000010001", message);
 
-  TcrMessageRemoveUserAuth message2(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()), false,
-      static_cast<ThinClientBaseDM *>(nullptr));
+  TcrMessageRemoveUserAuth message2(new DataOutputUnderTest(), false,
+                                    static_cast<ThinClientBaseDM *>(nullptr));
 
   EXPECT_EQ(TcrMessage::REMOVE_USER_AUTH, message2.getMessageType());
 
@@ -518,7 +497,7 @@ TEST_F(TcrMessageTest, testConstructorREMOVE_USER_AUTH) {
 
 TEST_F(TcrMessageTest, testConstructorUSER_CREDENTIAL_MESSAGE) {
   TcrMessageUserCredential message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
+      new DataOutputUnderTest(),
       static_cast<std::shared_ptr<Properties>>(nullptr),
       static_cast<ThinClientBaseDM *>(nullptr));
 
@@ -529,9 +508,8 @@ TEST_F(TcrMessageTest, testConstructorUSER_CREDENTIAL_MESSAGE) {
 }
 
 TEST_F(TcrMessageTest, testConstructorGET_CLIENT_PARTITION_ATTRIBUTES) {
-  TcrMessageGetClientPartitionAttributes message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "testClientRegion");
+  TcrMessageGetClientPartitionAttributes message(new DataOutputUnderTest(),
+                                                 "testClientRegion");
 
   EXPECT_EQ(TcrMessage::GET_CLIENT_PARTITION_ATTRIBUTES,
             message.getMessageType());
@@ -543,9 +521,8 @@ TEST_F(TcrMessageTest, testConstructorGET_CLIENT_PARTITION_ATTRIBUTES) {
 }
 
 TEST_F(TcrMessageTest, testConstructorGET_CLIENT_PR_METADATA) {
-  TcrMessageGetClientPrMetadata message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "testClientRegionPRMETA");
+  TcrMessageGetClientPrMetadata message(new DataOutputUnderTest(),
+                                        "testClientRegionPRMETA");
 
   EXPECT_EQ(TcrMessage::GET_CLIENT_PR_METADATA, message.getMessageType());
 
@@ -555,9 +532,7 @@ TEST_F(TcrMessageTest, testConstructorGET_CLIENT_PR_METADATA) {
       message);
 }
 TEST_F(TcrMessageTest, testConstructorSIZE) {
-  TcrMessageSize message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "testClientRegionSIZE");
+  TcrMessageSize message(new DataOutputUnderTest(), "testClientRegionSIZE");
 
   EXPECT_EQ(TcrMessage::SIZE, message.getMessageType());
 
@@ -575,8 +550,8 @@ TEST_F(TcrMessageTest, testConstructorEXECUTE_REGION_FUNCTION_SINGLE_HOP) {
   std::shared_ptr<Cacheable> myPtr(CacheableString::createDeserializable());
 
   TcrMessageExecuteRegionFunctionSingleHop message(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "myFuncName", region, myPtr, myHashCachePtr, 2, myHashCachePtr,
+      new DataOutputUnderTest(), "myFuncName", region, myPtr, myHashCachePtr, 2,
+      myHashCachePtr,
       false,  // allBuckets
       std::chrono::milliseconds{1}, static_cast<ThinClientBaseDM *>(nullptr));
 
@@ -602,10 +577,9 @@ TEST_F(TcrMessageTest, testConstructorEXECUTE_REGION_FUNCTION) {
   auto myVectPtr = CacheableVector::create();
 
   TcrMessageExecuteRegionFunction testMessage(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "ExecuteRegion", region, myCacheablePtr, myVectPtr, 2, myHashCachePtr,
-      std::chrono::milliseconds{10}, static_cast<ThinClientBaseDM *>(nullptr),
-      10);
+      new DataOutputUnderTest(), "ExecuteRegion", region, myCacheablePtr,
+      myVectPtr, 2, myHashCachePtr, std::chrono::milliseconds{10},
+      static_cast<ThinClientBaseDM *>(nullptr), 10);
 
   EXPECT_EQ(TcrMessage::EXECUTE_REGION_FUNCTION, testMessage.getMessageType());
   // this message is currently blank so this should change it if the impl
@@ -626,8 +600,7 @@ TEST_F(TcrMessageTest, DISABLED_testConstructorEXECUTE_FUNCTION) {
       CacheableString::createDeserializable());
 
   TcrMessageExecuteFunction testMessage(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "ExecuteFunction", myCacheablePtr, 1,
+      new DataOutputUnderTest(), "ExecuteFunction", myCacheablePtr, 1,
       static_cast<ThinClientBaseDM *>(nullptr), std::chrono::milliseconds{10});
 
   EXPECT_EQ(TcrMessage::EXECUTE_FUNCTION, testMessage.getMessageType());
@@ -645,9 +618,8 @@ TEST_F(TcrMessageTest, testConstructorEXECUTECQ_MSG_TYPE) {
       CacheableString::createDeserializable());
 
   TcrMessageExecuteCq testMessage(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "ExecuteCQ", "select * from /somewhere", CqState::RUNNING, false,
-      static_cast<ThinClientBaseDM *>(nullptr));
+      new DataOutputUnderTest(), "ExecuteCQ", "select * from /somewhere",
+      CqState::RUNNING, false, static_cast<ThinClientBaseDM *>(nullptr));
 
   EXPECT_EQ(TcrMessage::EXECUTECQ_MSG_TYPE, testMessage.getMessageType());
 
@@ -678,10 +650,9 @@ TEST_F(TcrMessageTest, testConstructorWithGinormousQueryEXECUTECQ_MSG_TYPE) {
   }
   oss << ") and s.type in SET('AAA','BBB','CCC','DDD') limit 60000";
 
-  TcrMessageExecuteCq testMessage(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "ExecuteCQ", oss.str(), CqState::RUNNING, false,
-      static_cast<ThinClientBaseDM *>(nullptr));
+  TcrMessageExecuteCq testMessage(new DataOutputUnderTest(), "ExecuteCQ",
+                                  oss.str(), CqState::RUNNING, false,
+                                  static_cast<ThinClientBaseDM *>(nullptr));
 
   EXPECT_EQ(TcrMessage::EXECUTECQ_MSG_TYPE, testMessage.getMessageType());
 
@@ -696,9 +667,8 @@ TEST_F(TcrMessageTest, testConstructorEXECUTECQ_WITH_IR_MSG_TYPE) {
       CacheableString::createDeserializable());
 
   TcrMessageExecuteCqWithIr testMessage(
-      std::unique_ptr<DataOutputUnderTest>(new DataOutputUnderTest()),
-      "ExecuteCQWithIr", "select * from /somewhere", CqState::RUNNING, false,
-      static_cast<ThinClientBaseDM *>(nullptr));
+      new DataOutputUnderTest(), "ExecuteCQWithIr", "select * from /somewhere",
+      CqState::RUNNING, false, static_cast<ThinClientBaseDM *>(nullptr));
 
   EXPECT_EQ(TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE,
             testMessage.getMessageType());

--- a/sqliteimpl/SqLiteImpl.cpp
+++ b/sqliteimpl/SqLiteImpl.cpp
@@ -112,8 +112,7 @@ void SqLiteImpl::write(const std::shared_ptr<CacheableKey>& key,
 
   keyDataBuffer.writeObject(key);
   valueDataBuffer.writeObject(value);
-  void* keyData =
-      const_cast<uint8_t*>(keyDataBuffer.getBuffer(&keyBufferSize));
+  void* keyData = const_cast<uint8_t*>(keyDataBuffer.getBuffer(&keyBufferSize));
   void* valueData =
       const_cast<uint8_t*>(valueDataBuffer.getBuffer(&valueBufferSize));
 
@@ -131,8 +130,7 @@ std::shared_ptr<Cacheable> SqLiteImpl::read(
   auto keyDataBuffer = m_regionPtr->getCache().createDataOutput();
   size_t keyBufferSize;
   keyDataBuffer.writeObject(key);
-  void* keyData =
-      const_cast<uint8_t*>(keyDataBuffer.getBuffer(&keyBufferSize));
+  void* keyData = const_cast<uint8_t*>(keyDataBuffer.getBuffer(&keyBufferSize));
   void* valueData;
   int valueBufferSize;
 
@@ -176,8 +174,7 @@ void SqLiteImpl::destroy(const std::shared_ptr<CacheableKey>& key,
   auto keyDataBuffer = m_regionPtr->getCache().createDataOutput();
   size_t keyBufferSize;
   keyDataBuffer.writeObject(key);
-  void* keyData =
-      const_cast<uint8_t*>(keyDataBuffer.getBuffer(&keyBufferSize));
+  void* keyData = const_cast<uint8_t*>(keyDataBuffer.getBuffer(&keyBufferSize));
   if (m_sqliteHelper->removeKey(keyData, static_cast<int>(keyBufferSize)) !=
       0) {
     throw IllegalStateException("Failed to destroy the key from SQLITE.");

--- a/sqliteimpl/SqLiteImpl.cpp
+++ b/sqliteimpl/SqLiteImpl.cpp
@@ -110,12 +110,12 @@ void SqLiteImpl::write(const std::shared_ptr<CacheableKey>& key,
   auto valueDataBuffer = cache.createDataOutput();
   size_t keyBufferSize, valueBufferSize;
 
-  keyDataBuffer->writeObject(key);
-  valueDataBuffer->writeObject(value);
+  keyDataBuffer.writeObject(key);
+  valueDataBuffer.writeObject(value);
   void* keyData =
-      const_cast<uint8_t*>(keyDataBuffer->getBuffer(&keyBufferSize));
+      const_cast<uint8_t*>(keyDataBuffer.getBuffer(&keyBufferSize));
   void* valueData =
-      const_cast<uint8_t*>(valueDataBuffer->getBuffer(&valueBufferSize));
+      const_cast<uint8_t*>(valueDataBuffer.getBuffer(&valueBufferSize));
 
   if (m_sqliteHelper->insertKeyValue(keyData, static_cast<int>(keyBufferSize),
                                      valueData,
@@ -130,9 +130,9 @@ std::shared_ptr<Cacheable> SqLiteImpl::read(
   // Serialize key.
   auto keyDataBuffer = m_regionPtr->getCache().createDataOutput();
   size_t keyBufferSize;
-  keyDataBuffer->writeObject(key);
+  keyDataBuffer.writeObject(key);
   void* keyData =
-      const_cast<uint8_t*>(keyDataBuffer->getBuffer(&keyBufferSize));
+      const_cast<uint8_t*>(keyDataBuffer.getBuffer(&keyBufferSize));
   void* valueData;
   int valueBufferSize;
 
@@ -175,9 +175,9 @@ void SqLiteImpl::destroy(const std::shared_ptr<CacheableKey>& key,
   // Serialize key and value.
   auto keyDataBuffer = m_regionPtr->getCache().createDataOutput();
   size_t keyBufferSize;
-  keyDataBuffer->writeObject(key);
+  keyDataBuffer.writeObject(key);
   void* keyData =
-      const_cast<uint8_t*>(keyDataBuffer->getBuffer(&keyBufferSize));
+      const_cast<uint8_t*>(keyDataBuffer.getBuffer(&keyBufferSize));
   if (m_sqliteHelper->removeKey(keyData, static_cast<int>(keyBufferSize)) !=
       0) {
     throw IllegalStateException("Failed to destroy the key from SQLITE.");

--- a/sqliteimpl/SqLiteImpl.cpp
+++ b/sqliteimpl/SqLiteImpl.cpp
@@ -145,7 +145,7 @@ std::shared_ptr<Cacheable> SqLiteImpl::read(
   auto valueDataBuffer = m_regionPtr->getCache().createDataInput(
       reinterpret_cast<uint8_t*>(valueData), valueBufferSize);
   std::shared_ptr<Cacheable> retValue;
-  valueDataBuffer->readObject(retValue);
+  valueDataBuffer.readObject(retValue);
 
   // Free memory for serialized form of Cacheable object.
   free(valueData);


### PR DESCRIPTION
For those wondering, the `#pragma error_messages(off, SEC_UNINITIALIZED_MEM_READ)` is for Solaris static analysis complaining that a variable was ["likely uninitialized"](https://docs.oracle.com/cd/E60778_01/html/E60742/gncki.html#OSSWNgncaj).