### PR TITLE
GEODE-5289: Fix build issue for testPdxMetadataCheckTest 

### DIFF
--- a/cppcache/integration-test/testPdxMetadataCheckTest.cpp
+++ b/cppcache/integration-test/testPdxMetadataCheckTest.cpp
@@ -49,7 +49,6 @@ using namespace PdxTests;
 
 #define CLIENT1 s1p1
 #define CLIENT2 s1p2
-#define CLIENT3 s2p2
 #define LOCATOR s2p2
 #define SERVER1 s2p1
 


### PR DESCRIPTION
Integration test would not build with clang.

- removed unused macro
- added newline at eof