### PR TITLE
Remove version specifier from install-ssh

### DIFF
--- a/packer/windows/install-ssh.ps1
+++ b/packer/windows/install-ssh.ps1
@@ -18,6 +18,6 @@
 $ErrorActionPreference = "Stop"
 
 write-host "Installing OpenSSH"
-choco install openssh -params '"/SSHServerFeature"' --version 0.0.24.0 -confirm
+choco install openssh -params '"/SSHServerFeature"' -confirm
 
 schtasks.exe /Create /TN init-ssh /RU SYSTEM /SC ONSTART /TR "powershell.exe -File 'C:\Program Files\Amazon\Ec2ConfigService\Scripts\init-ssh.ps1'"


### PR DESCRIPTION
Moving to latest version for Windows, to see if that helps some of the instability.

Co-authored-by: Mike Martell <mmartell@pivotal.io>