### PR TITLE
Fix cmake version at 3.11.4 for now, til we can figure out how 3.12

### DIFF
--- a/packer/windows/install-dependencies.ps1
+++ b/packer/windows/install-dependencies.ps1
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 choco install jdk8 -confirm
-choco install cmake.portable -confirm
+choco install cmake.portable -version 3.11.4 -confirm
 choco install git.install -confirm
 choco install activeperl -confirm
 choco install doxygen.install --allowEmptyChecksums -confirm


### PR DESCRIPTION
broke references in our .net projects

Co-authored-by: Jacob Barrett <jbarrett@pivotal.io>