### PR TITLE
GEODE-5567:  Replace template parameter of std::atomic with a known trivially-copyable type

### DIFF
--- a/cppcache/include/geode/CacheStatistics.hpp
+++ b/cppcache/include/geode/CacheStatistics.hpp
@@ -49,8 +49,8 @@ class APACHE_GEODE_EXPORT CacheStatistics {
  public:
   typedef std::chrono::system_clock::time_point time_point;
 
-  CacheStatistics()
-      : m_lastAccessTime(time_point()), m_lastModifiedTime(time_point()){};
+  CacheStatistics() 
+      : m_lastAccessTime(0), m_lastModifiedTime(0) {};
   CacheStatistics(const CacheStatistics&) = delete;
   virtual ~CacheStatistics() = default;
 
@@ -101,8 +101,8 @@ class APACHE_GEODE_EXPORT CacheStatistics {
   virtual void setLastAccessedTime(time_point lat);
   virtual void setLastModifiedTime(time_point lmt);
 
-  std::atomic<time_point> m_lastAccessTime;
-  std::atomic<time_point> m_lastModifiedTime;
+  std::atomic<time_point::duration::rep> m_lastAccessTime;
+  std::atomic<time_point::duration::rep> m_lastModifiedTime;
 
   friend class LocalRegion;
 };

--- a/cppcache/src/CacheStatistics.cpp
+++ b/cppcache/src/CacheStatistics.cpp
@@ -22,19 +22,19 @@ namespace geode {
 namespace client {
 
 void CacheStatistics::setLastModifiedTime(time_point lmt) {
-  m_lastModifiedTime = lmt;
+  m_lastModifiedTime = lmt.time_since_epoch().count();
 }
 
 void CacheStatistics::setLastAccessedTime(time_point lat) {
-  m_lastAccessTime = lat;
+  m_lastAccessTime = lat.time_since_epoch().count();
 }
 
 CacheStatistics::time_point CacheStatistics::getLastModifiedTime() const {
-  return m_lastModifiedTime;
+  return time_point(std::chrono::system_clock::duration(m_lastModifiedTime));
 }
 
 CacheStatistics::time_point CacheStatistics::getLastAccessedTime() const {
-  return m_lastAccessTime;
+  return time_point(std::chrono::system_clock::duration(m_lastAccessTime));
 }
 
 }  // namespace client


### PR DESCRIPTION
…rono::time_point ctors

Co-authored-by: Ivan Godwin <igodwin@pivotal.io>