### PR TITLE
Geode-2607: improve release artifacts

### DIFF
--- a/.cpackignore
+++ b/.cpackignore
@@ -1,5 +1,3 @@
-/docker/
-/packer/
 /.git/
 /.DS_Store
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ set(CPACK_PACKAGING_INSTALL_PREFIX "/${CPACK_PACKAGE_NAME}")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/dist/LICENSE")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "${CPACK_PACKAGE_NAME}")
 set(CPACK_GENERATOR TGZ;ZIP)
+set(CPACK_PACKAGE_CHECKSUM "SHA512")
 
 # Build a comprehensive list of things to leave out of the cpack package for our
 # source code releases.  Use .gitignore as a base, then use '.cpackignore' to


### PR DESCRIPTION
See notes in JIRA for full details.  tl;dr version: Geode includes their Docker/Packer files, so we will too, and the one-line change to CMakeLists.txt is (probably) the last thing we need for cpack.