### PR TITLE
GEODE-5626: Reject getInitialValues=true in registerAllKeys when regi…

### DIFF
--- a/cppcache/integration-test-2/CMakeLists.txt
+++ b/cppcache/integration-test-2/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(integration-test-2
   framework/GfshExecute.h
   RegionPutGetAllTest.cpp
   PdxInstanceTest.cpp
+  RegisterKeysTest.cpp
   StructTest.cpp
   EnableChunkHandlerThreadTest.cpp
   )

--- a/cppcache/integration-test-2/RegisterKeysTest.cpp
+++ b/cppcache/integration-test-2/RegisterKeysTest.cpp
@@ -1,0 +1,199 @@
+/* * Licensed to the Apache Software Foundation (ASF) under one or more *
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <geode/CacheFactory.hpp>
+#include <geode/Cache.hpp>
+#include <geode/PoolManager.hpp>
+#include <geode/RegionFactory.hpp>
+#include <geode/RegionShortcut.hpp>
+
+#include "framework/Framework.h"
+#include "framework/Gfsh.h"
+#include "framework/Cluster.h"
+
+namespace {
+
+using namespace apache::geode::client;
+
+apache::geode::client::Cache createTestCache() {
+  CacheFactory cacheFactory;
+  return cacheFactory.set("log-level", "none")
+      .set("statistic-sampling-enabled", "false")
+      .create();
+}
+
+std::shared_ptr<Region> setupCachingProxyRegion(Cache& cache) {
+  auto region = cache.createRegionFactory(RegionShortcut::CACHING_PROXY)
+                    .setPoolName("default")
+                    .create("region");
+
+  return region;
+}
+
+std::shared_ptr<Region> setupProxyRegion(Cache& cache) {
+  auto region = cache.createRegionFactory(RegionShortcut::PROXY)
+                    .setPoolName("default")
+                    .create("region");
+
+  return region;
+}
+
+/**
+ */
+TEST(RegisterKeysTest, RegisterAllWithCachingRegion) {
+  Cluster cluster{LocatorCount{1}, ServerCount{1}};
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("PARTITION")
+      .execute();
+
+  {
+    auto cache = createTestCache();
+    auto pf =
+        cache.getPoolManager().createFactory().setSubscriptionEnabled(true);
+    cluster.applyLocators(pf);
+    pf.create("default");
+    auto region = setupCachingProxyRegion(cache);
+
+    region->put("one", std::make_shared<CacheableInt16>(1));
+    region->put("two", std::make_shared<CacheableInt16>(2));
+    region->put("three", std::make_shared<CacheableInt16>(3));
+  }
+
+  {
+    auto cache2 = createTestCache();
+    auto pf =
+        cache2.getPoolManager().createFactory().setSubscriptionEnabled(true);
+    cluster.applyLocators(pf);
+    pf.create("default");
+    auto region2 = setupCachingProxyRegion(cache2);
+
+    auto&& entryBefore = region2->getEntry("one");
+    ASSERT_EQ(entryBefore, nullptr);
+
+    // 2nd parameter is getInitialValues, default is false, which leads to the
+    // first update notification being passed in with a NULL "oldValue".  Set it
+    // to true here, and verify the entry retrieved is valid, i.e. the initial
+    // value was retrieved.
+    region2->registerAllKeys(false, true);
+
+    auto&& uncastedEntry = region2->getEntry("one");
+    auto&& entryAfter =
+        std::dynamic_pointer_cast<CacheableInt16>(uncastedEntry->getValue());
+    ASSERT_NE(entryAfter, nullptr);
+    ASSERT_EQ(entryAfter->value(), 1);
+  }
+}
+
+/**
+ */
+TEST(RegisterKeysTest, RegisterAnyWithCachingRegion) {
+  Cluster cluster{LocatorCount{1}, ServerCount{1}};
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("PARTITION")
+      .execute();
+
+  {
+    auto cache = createTestCache();
+    auto pf =
+        cache.getPoolManager().createFactory().setSubscriptionEnabled(true);
+    cluster.applyLocators(pf);
+    pf.create("default");
+    auto region = setupCachingProxyRegion(cache);
+
+    region->put("one", std::make_shared<CacheableInt16>(1));
+    region->put("two", std::make_shared<CacheableInt16>(2));
+    region->put("three", std::make_shared<CacheableInt16>(3));
+
+    cache.close();
+  }
+
+  {
+    auto cache2 = createTestCache();
+    auto pf =
+        cache2.getPoolManager().createFactory().setSubscriptionEnabled(true);
+    cluster.applyLocators(pf);
+    pf.create("default");
+    auto region2 = setupCachingProxyRegion(cache2);
+    std::vector<std::shared_ptr<CacheableKey> > keys;
+    keys.push_back(std::make_shared<CacheableString>("one"));
+
+    auto&& entryBefore = region2->getEntry("one");
+    ASSERT_EQ(entryBefore, nullptr);
+
+    region2->registerKeys(keys, false, true);
+
+    auto&& entryAfterGet = std::dynamic_pointer_cast<CacheableInt16>(
+        region2->getEntry("one")->getValue());
+    ASSERT_NE(entryAfterGet, nullptr);
+    ASSERT_EQ(entryAfterGet->value(), 1);
+  }
+}
+
+/**
+ */
+TEST(RegisterKeysTest, RegisterAllWithProxyRegion) {
+  Cluster cluster{LocatorCount{1}, ServerCount{1}};
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("PARTITION")
+      .execute();
+  auto cache = createTestCache();
+  auto pf =
+      cache.getPoolManager().createFactory().setSubscriptionEnabled(true);
+  cluster.applyLocators(pf);
+  pf.create("default");
+  auto region = setupProxyRegion(cache);
+
+  EXPECT_THROW(region->registerAllKeys(false, true), IllegalStateException);
+  cache.close();
+}
+
+/**
+ */
+TEST(RegisterKeysTest, RegisterAnyWithProxyRegion) {
+  Cluster cluster{LocatorCount{1}, ServerCount{1}};
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("PARTITION")
+      .execute();
+  auto cache = createTestCache();
+  auto pf =
+      cache.getPoolManager().createFactory().setSubscriptionEnabled(true);
+  cluster.applyLocators(pf);
+  pf.create("default");
+  auto region = setupProxyRegion(cache);
+  std::vector<std::shared_ptr<CacheableKey> > keys;
+  keys.push_back(std::make_shared<CacheableInt16>(2));
+
+  EXPECT_THROW(region->registerKeys(keys, false, true), IllegalStateException);
+  cache.close();
+}
+
+}  // namespace

--- a/cppcache/integration-test-2/framework/Cluster.h
+++ b/cppcache/integration-test-2/framework/Cluster.h
@@ -182,6 +182,8 @@ class Cluster {
         initialServers_(initialServers.get()) {
     jmxManagerPort_ = Framework::getAvailablePort();
 
+    // Clean up from previous run, if any, to ensure a clean server
+    removeServerDirectory();
     start();
   }
 
@@ -208,32 +210,38 @@ class Cluster {
 
   void stop();
 
+  void removeServerDirectory() {
+    boost::filesystem::path serverDir = boost::filesystem::current_path().concat("/" + name_);
+    boost::filesystem::remove_all(serverDir);
+  }
 
-  apache::geode::client::Cache createCache(const std::unordered_map<std::string, std::string>& properties) {
+  apache::geode::client::Cache createCache() { return createCache({}); }
+
+  apache::geode::client::Cache createCache(
+      const std::unordered_map<std::string, std::string> &properties) {
     using namespace apache::geode::client;
     CacheFactory cacheFactory;
 
-    for (auto&& property : properties) {
+    for (auto &&property : properties) {
       cacheFactory.set(property.first, property.second);
     }
 
-    auto cache = cacheFactory
-            .set("log-level", "none")
-            .set("statistic-sampling-enabled", "false")
-            .create();
+    auto cache = cacheFactory.set("log-level", "none")
+                     .set("statistic-sampling-enabled", "false")
+                     .create();
 
     auto poolFactory = cache.getPoolManager().createFactory();
-    for (const auto &locator : locators_) {
-      poolFactory.addLocator(locator.getAdddress().address,
-                             locator.getAdddress().port);
-      poolFactory.create("default");
-    }
+    applyLocators(poolFactory);
+    poolFactory.create("default");
 
     return cache;
   }
 
-  apache::geode::client::Cache createCache() {
-    return createCache({});
+  void applyLocators(apache::geode::client::PoolFactory &poolFactory) {
+   for (const auto &locator : locators_) {
+     poolFactory.addLocator(locator.getAdddress().address,
+                            locator.getAdddress().port);
+   }
   }
 
   Gfsh &getGfsh() noexcept { return gfsh_; }

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -417,9 +417,18 @@ void ThinClientRegion::registerKeys(
         "Durable flag only applicable for "
         "durable clients");
   }
+  if (getInitialValues && !m_regionAttributes.getCachingEnabled()) {
+    LOGERROR(
+          "Register keys getInitialValues flag is only applicable for caching"
+          "clients");
+    throw IllegalStateException(
+        "getInitialValues flag only applicable for caching clients");
+  }
 
   InterestResultPolicy interestPolicy = InterestResultPolicy::NONE;
-  if (getInitialValues) interestPolicy = InterestResultPolicy::KEYS_VALUES;
+  if (getInitialValues) {
+    interestPolicy = InterestResultPolicy::KEYS_VALUES;
+  }
 
   LOGDEBUG("ThinClientRegion::registerKeys : interestpolicy is %d",
            interestPolicy.ordinal);
@@ -487,6 +496,14 @@ void ThinClientRegion::registerAllKeys(bool isDurable, bool getInitialValues,
         "clients");
     throw IllegalStateException(
         "Durable flag only applicable for durable clients");
+  }
+
+  if (getInitialValues && !m_regionAttributes.getCachingEnabled()) {
+    LOGERROR(
+          "Register all keys getInitialValues flag is only applicable for caching"
+          "clients");
+    throw IllegalStateException(
+        "getInitialValues flag only applicable for caching clients");
   }
 
   InterestResultPolicy interestPolicy = InterestResultPolicy::NONE;


### PR DESCRIPTION
…on is not caching.

    - Refactor Cluster class so we can apply locators separately.
    - Clean up server directories at test startup.
    - Add test cases for caching proxy and proxy regions with getInitialValues set to true

Co-authored-by: Ivan Godwin <igodwin@pivotal.io>