### PR TITLE
GEODE-5651: Remove _GEODE_FRIEND_STD_SHARED macro

### DIFF
--- a/cppcache/include/geode/Cache.hpp
+++ b/cppcache/include/geode/Cache.hpp
@@ -264,8 +264,6 @@ class APACHE_GEODE_EXPORT Cache : public GeodeCache {
   friend class FunctionService;
   friend class CacheXmlCreation;
   friend class RegionXmlCreation;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(Cache)
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/CacheableBuiltins.hpp
+++ b/cppcache/include/geode/CacheableBuiltins.hpp
@@ -158,20 +158,17 @@ class APACHE_GEODE_EXPORT CacheableContainerType
 #pragma warning(disable : 4231)
 #endif
 
-#define _GEODE_CACHEABLE_KEY_TYPE_DEF_(p, k)                      \
-  extern const char tName_##k[];                                  \
+#define _GEODE_CACHEABLE_KEY_TYPE_DEF_(p, k)                \
+  extern const char tName_##k[];                            \
   template class CacheableKeyType<p, DSCode::k, tName_##k>; \
   typedef CacheableKeyType<p, DSCode::k, tName_##k> _##k;
 
 // use a class instead of typedef for bug #283
 #define _GEODE_CACHEABLE_KEY_TYPE_(p, k)                                \
   class APACHE_GEODE_EXPORT k : public _##k {                           \
-   protected:                                                           \
+   public:                                                              \
     inline k() : _##k() {}                                              \
     inline k(const p value) : _##k(value) {}                            \
-    _GEODE_FRIEND_STD_SHARED_PTR(k)                                     \
-                                                                        \
-   public:                                                              \
     /** Factory function registered with serialization registry. */     \
     static std::shared_ptr<Serializable> createDeserializable() {       \
       return std::make_shared<k>();                                     \
@@ -194,20 +191,17 @@ class APACHE_GEODE_EXPORT CacheableContainerType
     return k::create(value);                                            \
   }
 
-#define _GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(p, c)           \
+#define _GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(p, c)     \
   template class CacheableContainerType<p, DSCode::c>; \
   typedef CacheableContainerType<p, DSCode::c> _##c;
 
 // use a class instead of typedef for bug #283
 #define _GEODE_CACHEABLE_CONTAINER_TYPE_(p, c)                         \
   class APACHE_GEODE_EXPORT c : public _##c {                          \
-   protected:                                                          \
+   public:                                                             \
     inline c() : _##c() {}                                             \
     inline c(const int32_t n) : _##c(n) {}                             \
                                                                        \
-    _GEODE_FRIEND_STD_SHARED_PTR(c)                                    \
-                                                                       \
-   public:                                                             \
     /** Factory function registered with serialization registry. */    \
     static std::shared_ptr<Serializable> createDeserializable() {      \
       return std::make_shared<c>();                                    \
@@ -284,15 +278,15 @@ _GEODE_CACHEABLE_KEY_TYPE_(char16_t, CacheableCharacter)
 
 template <typename T, DSCode GeodeTypeId>
 class APACHE_GEODE_EXPORT CacheableArray : public DataSerializablePrimitive {
- protected:
+ public:
   inline CacheableArray() = default;
+  template <typename TT>
+  CacheableArray(TT&& value) : m_value(std::forward<TT>(value)) {}
 
+ protected:
   CacheableArray(const CacheableArray& other) = delete;
 
   CacheableArray& operator=(const CacheableArray& other) = delete;
-
-  template <typename TT>
-  CacheableArray(TT&& value) : m_value(std::forward<TT>(value)) {}
 
   virtual DSCode getDsCode() const override { return GeodeTypeId; }
 
@@ -302,8 +296,6 @@ class APACHE_GEODE_EXPORT CacheableArray : public DataSerializablePrimitive {
   }
 
  private:
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableArray)
-
   std::vector<T> m_value;
 
  public:
@@ -375,8 +367,7 @@ using CacheableDoubleArray =
  * An immutable wrapper for array of floats that can serve as
  * a distributable object for caching.
  */
-using CacheableFloatArray =
-    CacheableArray<float, DSCode::CacheableFloatArray>;
+using CacheableFloatArray = CacheableArray<float, DSCode::CacheableFloatArray>;
 
 /**
  * An immutable wrapper for array of 16-bit integers that can serve as

--- a/cppcache/include/geode/CacheableDate.hpp
+++ b/cppcache/include/geode/CacheableDate.hpp
@@ -112,7 +112,6 @@ class APACHE_GEODE_EXPORT CacheableDate : public DataSerializablePrimitive,
   /** Destructor */
   ~CacheableDate() override = default;
 
- protected:
   /** Constructor, used for deserialization. */
   CacheableDate(const time_t value = 0);
 
@@ -130,8 +129,6 @@ class APACHE_GEODE_EXPORT CacheableDate : public DataSerializablePrimitive,
   // never implemented.
   void operator=(const CacheableDate& other);
   CacheableDate(const CacheableDate& other);
-
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableDate)
 };
 
 template <>

--- a/cppcache/include/geode/CacheableEnum.hpp
+++ b/cppcache/include/geode/CacheableEnum.hpp
@@ -59,6 +59,11 @@ class APACHE_GEODE_EXPORT CacheableEnum : public DataSerializablePrimitive,
   int32_t m_hashcode;
 
  public:
+  CacheableEnum();
+
+  CacheableEnum(std::string enumClassName, std::string enumName,
+                int32_t ordinal);
+
   /** Destructor */
   ~CacheableEnum() override = default;
 
@@ -121,17 +126,12 @@ class APACHE_GEODE_EXPORT CacheableEnum : public DataSerializablePrimitive,
   virtual bool operator==(const CacheableKey& other) const override;
 
  protected:
-  CacheableEnum();
-  CacheableEnum(std::string enumClassName, std::string enumName,
-                int32_t ordinal);
   void calculateHashcode();
 
  private:
   // never implemented.
   void operator=(const CacheableEnum& other);
   CacheableEnum(const CacheableEnum& other);
-
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableEnum)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/CacheableFileName.hpp
+++ b/cppcache/include/geode/CacheableFileName.hpp
@@ -69,12 +69,12 @@ class APACHE_GEODE_EXPORT CacheableFileName : public CacheableString {
   /** return the hashcode for this key. */
   virtual int32_t hashcode() const override;
 
- protected:
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableFileName)
-
   /** Default constructor. */
-  inline CacheableFileName() : CacheableString(), m_hashcode(0) {}
+  inline CacheableFileName() : CacheableString() {}
+
   inline CacheableFileName(const std::string& value) : CacheableString(value) {}
+
+ protected:
   inline CacheableFileName(std::string&& value)
       : CacheableString(std::move(value)) {}
 
@@ -82,9 +82,6 @@ class APACHE_GEODE_EXPORT CacheableFileName : public CacheableString {
   // never implemented.
   void operator=(const CacheableFileName& other) = delete;
   CacheableFileName(const CacheableFileName& other) = delete;
-
- private:
-  mutable int m_hashcode;
 };
 
 }  // namespace client

--- a/cppcache/include/geode/CacheableKey.hpp
+++ b/cppcache/include/geode/CacheableKey.hpp
@@ -39,12 +39,10 @@ namespace client {
 /** Represents a cacheable key */
 class APACHE_GEODE_EXPORT CacheableKey : public virtual Cacheable {
  protected:
-  CacheableKey() = default;
   ~CacheableKey() override = default;
 
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableKey)
-
  public:
+  CacheableKey() = default;
   /** return true if this key matches other. */
   virtual bool operator==(const CacheableKey& other) const = 0;
 

--- a/cppcache/include/geode/CacheableObjectArray.hpp
+++ b/cppcache/include/geode/CacheableObjectArray.hpp
@@ -79,7 +79,6 @@ class APACHE_GEODE_EXPORT CacheableObjectArray
 
   virtual size_t objectSize() const override;
 
- protected:
   /** Constructor, used for deserialization. */
   inline CacheableObjectArray() : std::vector<std::shared_ptr<Cacheable>>() {}
   /** Create a vector with n elements allocated. */
@@ -90,8 +89,6 @@ class APACHE_GEODE_EXPORT CacheableObjectArray
   // never implemented.
   CacheableObjectArray& operator=(const CacheableObjectArray& other) = delete;
   CacheableObjectArray(const CacheableObjectArray& other) = delete;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableObjectArray)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/CacheableString.hpp
+++ b/cppcache/include/geode/CacheableString.hpp
@@ -44,8 +44,6 @@ class APACHE_GEODE_EXPORT CacheableString
   internal::DSCode m_type;
   mutable int m_hashcode;
 
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableString)
-
  public:
   void toData(DataOutput& output) const override;
 
@@ -113,7 +111,6 @@ class APACHE_GEODE_EXPORT CacheableString
 
   virtual size_t objectSize() const override;
 
- protected:
   /** Default constructor. */
   inline CacheableString(DSCode type = DSCode::CacheableASCIIString)
       : m_str(), m_type(type), m_hashcode(0) {}

--- a/cppcache/include/geode/CacheableUndefined.hpp
+++ b/cppcache/include/geode/CacheableUndefined.hpp
@@ -59,7 +59,6 @@ class APACHE_GEODE_EXPORT CacheableUndefined
     return std::make_shared<CacheableUndefined>();
   }
 
- protected:
   /** Constructor, used for deserialization. */
   inline CacheableUndefined() = default;
 
@@ -67,8 +66,6 @@ class APACHE_GEODE_EXPORT CacheableUndefined
   // never implemented.
   CacheableUndefined& operator=(const CacheableUndefined& other) = delete;
   CacheableUndefined(const CacheableUndefined& other) = delete;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableUndefined)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/DefaultResultCollector.hpp
+++ b/cppcache/include/geode/DefaultResultCollector.hpp
@@ -41,7 +41,7 @@ namespace client {
 class APACHE_GEODE_EXPORT DefaultResultCollector : public ResultCollector {
  public:
   DefaultResultCollector();
-  virtual ~DefaultResultCollector() noexcept;
+  virtual ~DefaultResultCollector() noexcept override;
 
   virtual std::shared_ptr<CacheableVector> getResult(
       std::chrono::milliseconds timeout =

--- a/cppcache/include/geode/PdxWrapper.hpp
+++ b/cppcache/include/geode/PdxWrapper.hpp
@@ -82,8 +82,6 @@ class APACHE_GEODE_EXPORT PdxWrapper : public PdxSerializable {
  private:
   PdxWrapper() = delete;
 
-  _GEODE_FRIEND_STD_SHARED_PTR(PdxWrapper)
-
   std::shared_ptr<void> m_userObject;
   std::string m_className;
 };

--- a/cppcache/include/geode/PersistenceManager.hpp
+++ b/cppcache/include/geode/PersistenceManager.hpp
@@ -136,7 +136,7 @@ class APACHE_GEODE_EXPORT PersistenceManager {
  protected:
   /** Region for this persistence manager.
    */
-  const std::shared_ptr<Region> m_regionPtr;
+  std::shared_ptr<Region> m_regionPtr;
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/PoolFactory.hpp
+++ b/cppcache/include/geode/PoolFactory.hpp
@@ -548,8 +548,6 @@ class APACHE_GEODE_EXPORT PoolFactory {
   friend class PoolManagerImpl;
   friend class CacheFactory;
   friend class CacheXmlCreation;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(PoolFactory)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/Properties.hpp
+++ b/cppcache/include/geode/Properties.hpp
@@ -149,13 +149,10 @@ class APACHE_GEODE_EXPORT Properties
   ~Properties() override = default;
   Properties(const Properties&) = delete;
   Properties& operator=(const Properties&) = delete;
+  Properties() = default;
 
  private:
   HashMapOfCacheable m_map;
-
-  Properties() = default;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(Properties)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/Region.hpp
+++ b/cppcache/include/geode/Region.hpp
@@ -1482,8 +1482,6 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
   virtual ~Region();
 
   CacheImpl* m_cacheImpl;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(Region)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/RegionAttributes.hpp
+++ b/cppcache/include/geode/RegionAttributes.hpp
@@ -390,8 +390,6 @@ class APACHE_GEODE_EXPORT RegionAttributes
   friend class RegionInternal;
   friend class RegionXmlCreation;
 
- private:
-  _GEODE_FRIEND_STD_SHARED_PTR(RegionAttributes)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/RegionEntry.hpp
+++ b/cppcache/include/geode/RegionEntry.hpp
@@ -86,18 +86,19 @@ class APACHE_GEODE_EXPORT RegionEntry {
   bool isDestroyed() const;
 
   /**
-   * @brief destructor
-   */
-  virtual ~RegionEntry();
-
- private:
-  /**
     * @brief constructors
     * created by region
     */
   RegionEntry(const std::shared_ptr<Region>& region,
               const std::shared_ptr<CacheableKey>& key,
               const std::shared_ptr<Cacheable>& value);
+
+  /**
+   * @brief destructor
+   */
+  virtual ~RegionEntry();
+
+ private:
   std::shared_ptr<Region> m_region;
   std::shared_ptr<CacheableKey> m_key;
   std::shared_ptr<Cacheable> m_value;
@@ -105,7 +106,6 @@ class APACHE_GEODE_EXPORT RegionEntry {
   bool m_destroyed;
   friend class RegionInternal;
 
-  _GEODE_FRIEND_STD_SHARED_PTR(RegionEntry)
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/Struct.hpp
+++ b/cppcache/include/geode/Struct.hpp
@@ -51,13 +51,15 @@ class APACHE_GEODE_EXPORT Struct
  public:
   typedef std::vector<std::shared_ptr<Serializable>>::iterator iterator;
 
+  Struct() = default;
+
   /**
    * Constructor - meant only for internal use.
    */
   Struct(StructSet* ssPtr,
          std::vector<std::shared_ptr<Serializable>>& fieldValues);
 
-  ~Struct() = default;
+  ~Struct() override = default;
 
   /**
    * Factory function for registration of <code>Struct</code>.
@@ -120,8 +122,6 @@ class APACHE_GEODE_EXPORT Struct
   }
 
  private:
-  Struct() = default;
-
   void skipClassName(DataInput& input);
 
   typedef std::unordered_map<std::string, int32_t> FieldNameToIndexMap;
@@ -129,8 +129,6 @@ class APACHE_GEODE_EXPORT Struct
   StructSet* m_parent = nullptr;
   std::vector<std::shared_ptr<Serializable>> m_fieldValues;
   FieldNameToIndexMap m_fieldNameToIndex;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(Struct)
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/TransactionId.hpp
+++ b/cppcache/include/geode/TransactionId.hpp
@@ -37,8 +37,6 @@ class APACHE_GEODE_EXPORT TransactionId {
  public:
   TransactionId();
   virtual ~TransactionId();
-
-  _GEODE_FRIEND_STD_SHARED_PTR(TransactionId)
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/internal/geode_base.hpp
+++ b/cppcache/include/geode/internal/geode_base.hpp
@@ -67,32 +67,6 @@
     x = nullptr;                    \
   }
 
-// TODO shared_ptr - Consider making con/destructors public.
-/*
- * Allows std::shared_ptr to access protected constructors and destructors.
- */
-#if defined(__clang__)
-#define _GEODE_FRIEND_STD_SHARED_PTR(_T)                               \
-  friend std::__libcpp_compressed_pair_imp<std::allocator<_T>, _T, 1>; \
-  friend std::__shared_ptr_emplace<_T, std::allocator<_T> >;           \
-  friend std::default_delete<_T>;
-#elif defined(__GNUC__) || defined(__SUNPRO_CC)
-#define _GEODE_FRIEND_STD_SHARED_PTR(_T) friend __gnu_cxx::new_allocator<_T>;
-#elif defined(_MSC_VER)
-#if defined(_MANAGED)
-#define _GEODE_FRIEND_STD_SHARED_PTR(_T) \
-  friend std::_Ref_count_obj<_T>;        \
-  friend std::_Ref_count<_T>;            \
-  friend std::_Ptr_base<_T>;             \
-  friend std::default_delete<_T>;        \
-  friend std::shared_ptr<_T>;
-#else
-#define _GEODE_FRIEND_STD_SHARED_PTR(_T) friend std::_Ref_count_obj<_T>;
-#endif
-#else
-#define _GEODE_FRIEND_STD_SHARED_PTR(_T)
-#endif
-
 #include <chrono>
 #include <string>
 

--- a/cppcache/integration-test-2/PdxInstanceTest.cpp
+++ b/cppcache/integration-test-2/PdxInstanceTest.cpp
@@ -204,10 +204,10 @@ TEST(PdxInstanceTest, testPdxInstance) {
   EXPECT_EQ(1, cachePerfStats.getPdxInstanceDeserializations())
       << "pdxInstanceDeserialization should be equal to 1.";
 
-  EXPECT_EQ(0, cachePerfStats.getPdxInstanceCreations())
+  EXPECT_TRUE(cachePerfStats.getPdxInstanceCreations() == 0)
       << "pdxInstanceCreations should be equal to 0.";
 
-  EXPECT_EQ(0, cachePerfStats.getPdxInstanceDeserializationTime())
+  EXPECT_TRUE(cachePerfStats.getPdxInstanceDeserializationTime() == 0)
       << "pdxInstanceDeserializationTime should be equal to 0.";
 
   auto pdxTypeFromPdxTypeInstance =
@@ -225,7 +225,7 @@ TEST(PdxInstanceTest, testPdxInstance) {
   EXPECT_EQ(1, cachePerfStats.getPdxInstanceDeserializations())
       << "pdxInstanceDeserialization should be equal to 1.";
 
-  EXPECT_EQ(0, cachePerfStats.getPdxInstanceCreations())
+  EXPECT_TRUE(cachePerfStats.getPdxInstanceCreations() == 0)
       << "pdxInstanceCreations should be equal to 0.";
 
   EXPECT_LT(0, cachePerfStats.getPdxInstanceDeserializationTime())
@@ -257,7 +257,7 @@ TEST(PdxInstanceTest, testPdxInstance) {
 
   EXPECT_EQ(1, cachePerfStats.getPdxInstanceDeserializations())
       << "pdxInstanceDeserialization should be equal to 1.";
-  EXPECT_EQ(0, cachePerfStats.getPdxInstanceCreations())
+  EXPECT_TRUE(cachePerfStats.getPdxInstanceCreations() == 0)
       << "pdxInstanceCreations should be equal to 0.";
   EXPECT_LT(0, cachePerfStats.getPdxInstanceDeserializationTime())
       << "pdxInstanceDeserializationTime should be greater than 0.";

--- a/cppcache/integration-test-2/framework/GfshExecute.h
+++ b/cppcache/integration-test-2/framework/GfshExecute.h
@@ -43,7 +43,7 @@ bool starts_with(const _T &input, const _T &match) {
 class GfshExecute : public Gfsh {
  public:
   GfshExecute() = default;
-  virtual ~GfshExecute() = default;
+  virtual ~GfshExecute() override = default;
 
   class Connect : public Command<void> {
    public:

--- a/cppcache/integration-test/BuiltinCacheableWrappers.hpp
+++ b/cppcache/integration-test/BuiltinCacheableWrappers.hpp
@@ -358,7 +358,7 @@ class CacheableFileNameWrapper : public CacheableWrapper {
 
   virtual uint32_t getCheckSum(const std::shared_ptr<Cacheable> object) const {
     auto&& obj = std::dynamic_pointer_cast<CacheableFileName>(object);
-    return (obj ? CacheableHelper::crc32((uint8_t*)obj->value().c_str(),
+    return (obj ? CacheableHelper::crc32(reinterpret_cast<const uint8_t*>(obj->value().c_str()),
                                          obj->length())
                 : 0);
   }
@@ -516,7 +516,7 @@ class CacheableStringWrapper : public CacheableWrapper {
     const CacheableString* obj =
         dynamic_cast<const CacheableString*>(object.get());
     return (obj != nullptr ? CacheableHelper::crc32(
-                                 (uint8_t*)obj->value().c_str(), obj->length())
+        reinterpret_cast<const uint8_t*>(obj->value().c_str()), obj->length())
                            : 0);
   }
 };
@@ -559,7 +559,7 @@ class CacheableHugeStringWrapper : public CacheableWrapper {
     const CacheableString* obj =
         dynamic_cast<const CacheableString*>(object.get());
     ASSERT(obj != nullptr, "getCheckSum: null object.");
-    return CacheableHelper::crc32((uint8_t*)obj->value().c_str(),
+    return CacheableHelper::crc32(reinterpret_cast<const uint8_t*>(obj->value().c_str()),
                                   obj->length());
   }
 };
@@ -604,7 +604,7 @@ class CacheableHugeUnicodeStringWrapper : public CacheableWrapper {
     auto&& obj = std::dynamic_pointer_cast<CacheableString>(object);
     ASSERT(obj != nullptr, "getCheckSum: null object.");
     return CacheableHelper::crc32(
-        (uint8_t*)obj->value().c_str(),
+        reinterpret_cast<const uint8_t*>(obj->value().c_str()),
         obj->length() * sizeof(std::string::value_type));
   }
 };
@@ -646,7 +646,7 @@ class CacheableUnicodeStringWrapper : public CacheableWrapper {
     auto&& obj = std::dynamic_pointer_cast<CacheableString>(object);
     ASSERT(obj != nullptr, "getCheckSum: null object.");
     return CacheableHelper::crc32(
-        (uint8_t*)obj->value().c_str(),
+        reinterpret_cast<const uint8_t*>(obj->value().c_str()),
         obj->length() * sizeof(std::string::value_type));
   }
 };
@@ -1050,7 +1050,7 @@ class CacheableStringArrayWrapper : public CacheableWrapper {
     for (int32_t index = 0; index < obj->length(); index++) {
       str = obj->operator[](index);
       checkSum ^= CacheableHelper::crc32(
-          (uint8_t*)str->value().c_str(),
+          reinterpret_cast<const uint8_t*>(str->value().c_str()),
           str->length() * sizeof(std::string::value_type));
     }
     return checkSum;
@@ -1186,7 +1186,7 @@ namespace CacheableHelper {
 
 void registerBuiltins(bool isRegisterFileName = false) {
   // Initialize the random number generator.
-  srand(getpid() + static_cast<int>(time(0)));
+  srand(getpid() + static_cast<int>(time(nullptr)));
 
   // Register the builtin cacheable keys
   CacheableWrapperFactory::registerType(DSCode::CacheableBoolean,

--- a/cppcache/integration-test/CacheHelper.cpp
+++ b/cppcache/integration-test/CacheHelper.cpp
@@ -464,12 +464,11 @@ std::shared_ptr<Pool> CacheHelper::createPool2(
     int subscriptionAckInterval, int connections) {
   auto poolFac = getCache()->getPoolManager().createFactory();
 
-  if (servers != 0)  // with explicit server list
-  {
+  if (servers) {
     addServerLocatorEPs(servers, poolFac, false);
     // do region creation with end
-  } else if (locators != 0)  // with locator
-  {
+  }
+  else if (locators) {
     addServerLocatorEPs(locators, poolFac);
     if (serverGroup) {
       poolFac.setServerGroup(serverGroup);

--- a/cppcache/integration-test/CacheHelper.hpp
+++ b/cppcache/integration-test/CacheHelper.hpp
@@ -135,7 +135,7 @@ class CacheHelper {
       const std::chrono::seconds& rttl = std::chrono::seconds::zero(),
       const std::chrono::seconds& rit = std::chrono::seconds::zero(),
       int lel = 0, ExpirationAction action = ExpirationAction::DESTROY,
-      const char* endpoints = 0, bool clientNotificationEnabled = false);
+      const char* endpoints = nullptr, bool clientNotificationEnabled = false);
 
   std::shared_ptr<Pool> createPool(
       const std::string& poolName, const char* locators,
@@ -188,7 +188,7 @@ class CacheHelper {
                                   bool poolLocators = true);
 
   std::shared_ptr<Region> createPooledRegion(
-      const char* name, bool ack, const char* locators = 0,
+      const char* name, bool ack, const char* locators = nullptr,
       const char* poolName = "__TEST_POOL1__", bool caching = true,
       bool clientNotificationEnabled = false,
       const std::chrono::seconds& ettl = std::chrono::seconds::zero(),
@@ -200,7 +200,7 @@ class CacheHelper {
       ExpirationAction action = ExpirationAction::DESTROY);
 
   std::shared_ptr<Region> createPooledRegionConcurrencyCheckDisabled(
-      const char* name, bool ack, const char* locators = 0,
+      const char* name, bool ack, const char* locators = nullptr,
       const char* poolName = "__TEST_POOL1__", bool caching = true,
       bool clientNotificationEnabled = false,
       bool concurrencyCheckEnabled = true,
@@ -222,7 +222,7 @@ class CacheHelper {
       int lel = 0, ExpirationAction action = ExpirationAction::DESTROY);
 
   std::shared_ptr<Region> createPooledRegionDiscOverFlow(
-      const char* name, bool ack, const char* locators = 0,
+      const char* name, bool ack, const char* locators = nullptr,
       const char* poolName = "__TEST_POOL1__", bool caching = true,
       bool clientNotificationEnabled = false,
       const std::chrono::seconds& ettl = std::chrono::seconds::zero(),
@@ -234,7 +234,7 @@ class CacheHelper {
       ExpirationAction action = ExpirationAction::DESTROY);
 
   std::shared_ptr<Region> createPooledRegionSticky(
-      const char* name, bool ack, const char* locators = 0,
+      const char* name, bool ack, const char* locators = nullptr,
       const char* poolName = "__TEST_POOL1__", bool caching = true,
       bool clientNotificationEnabled = false,
       const std::chrono::seconds& ettl = std::chrono::seconds::zero(),
@@ -246,7 +246,7 @@ class CacheHelper {
       ExpirationAction action = ExpirationAction::DESTROY);
 
   std::shared_ptr<Region> createPooledRegionStickySingleHop(
-      const char* name, bool ack, const char* locators = 0,
+      const char* name, bool ack, const char* locators = nullptr,
       const char* poolName = "__TEST_POOL1__", bool caching = true,
       bool clientNotificationEnabled = false,
       const std::chrono::seconds& ettl = std::chrono::seconds::zero(),

--- a/cppcache/integration-test/ThinClientDistOps.hpp
+++ b/cppcache/integration-test/ThinClientDistOps.hpp
@@ -99,13 +99,13 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (noKey) {
     sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-  } else if (val == 0) {
+  } else if (!val) {
     sprintf(buf, "Verify value for key %s does not exist in region %s", key,
             name);
   } else {
@@ -171,26 +171,6 @@ void _verifyEntry(const char* name, const char* key, const char* val,
     }
     dunit::sleep(SLEEP);
   }
-}
-
-#define verifyInvalid(x, y) _verifyInvalid(x, y, __LINE__)
-
-void _verifyInvalid(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
-  LOG("Entry invalidated.");
-}
-
-#define verifyDestroyed(x, y) _verifyDestroyed(x, y, __LINE__)
-
-void _verifyDestroyed(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
-  LOG("Entry destroyed.");
 }
 
 #define verifyEntry(x, y, z) _verifyEntry(x, y, z, __LINE__)

--- a/cppcache/integration-test/ThinClientDistOps2.hpp
+++ b/cppcache/integration-test/ThinClientDistOps2.hpp
@@ -160,7 +160,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, Client1GetAll)
     // re-create region with caching enabled
     reg0->localDestroyRegion();
     reg0 = nullptr;
-    getHelper()->createPooledRegion(regionNames[0], USE_ACK, 0,
+    getHelper()->createPooledRegion(regionNames[0], USE_ACK, nullptr,
                                     "__TEST_POOL1__", true, true);
     reg0 = getHelper()->getRegion(_regionNames[0]);
     // check for IllegalArgumentException for empty key list

--- a/cppcache/integration-test/ThinClientDurable.hpp
+++ b/cppcache/integration-test/ThinClientDurable.hpp
@@ -86,7 +86,7 @@ class OperMonitor : public CacheListener {
   OperMonitor(const char* clientName, const char* regionName)
       : m_ops(0), m_clientName(clientName), m_regionName(regionName) {}
 
-  ~OperMonitor() { m_map.clear(); }
+  ~OperMonitor() override { m_map.clear(); }
 
   void validate(size_t keyCount, int eventcount, int durableValue,
                 int nonDurableValue) {

--- a/cppcache/integration-test/ThinClientDurableFailover.hpp
+++ b/cppcache/integration-test/ThinClientDurableFailover.hpp
@@ -82,7 +82,7 @@ class OperMonitor : public CacheListener {
  public:
   OperMonitor() : m_ops(0) {}
 
-  ~OperMonitor() { m_map.clear(); }
+  ~OperMonitor() override { m_map.clear(); }
 
   void validate(size_t keyCount, int eventcount, int durableValue,
                 int nonDurableValue) {

--- a/cppcache/integration-test/ThinClientDurableInterest.hpp
+++ b/cppcache/integration-test/ThinClientDurableInterest.hpp
@@ -71,7 +71,7 @@ class OperMonitor : public CacheListener {
     LOGINFO("Inside OperMonitor %d ", m_id);
   }
 
-  ~OperMonitor() { m_map.clear(); }
+  ~OperMonitor() override { m_map.clear(); }
 
   void validate(size_t keyCount, int eventcount, int durableValue,
                 int nonDurableValue) {

--- a/cppcache/integration-test/ThinClientFailover.hpp
+++ b/cppcache/integration-test/ThinClientFailover.hpp
@@ -67,13 +67,13 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (noKey) {
     sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-  } else if (val == 0) {
+  } else if (!val) {
     sprintf(buf, "Verify value for key %s does not exist in region %s", key,
             name);
   } else {

--- a/cppcache/integration-test/ThinClientFailover2.hpp
+++ b/cppcache/integration-test/ThinClientFailover2.hpp
@@ -70,13 +70,13 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (noKey) {
     sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-  } else if (val == 0) {
+  } else if (!val) {
     sprintf(buf, "Verify value for key %s does not exist in region %s", key,
             name);
   } else {
@@ -146,7 +146,7 @@ void _verifyInvalid(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
+  _verifyEntry(name, key, nullptr, false);
   LOG("Entry invalidated.");
 }
 
@@ -156,7 +156,7 @@ void _verifyDestroyed(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
+  _verifyEntry(name, key, nullptr, true);
   LOG("Entry destroyed.");
 }
 

--- a/cppcache/integration-test/ThinClientFailover3.hpp
+++ b/cppcache/integration-test/ThinClientFailover3.hpp
@@ -68,13 +68,13 @@ CacheHelper *getHelper() {
 void _verifyEntry(const char *name, const char *key, const char *val,
                   bool noKey) {
   // Verify key and value exist in this region, in this process.
-  const char *value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char *buf =
       reinterpret_cast<char *>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (noKey) {
     sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-  } else if (val == 0) {
+  } else if (!val) {
     sprintf(buf, "Verify value for key %s does not exist in region %s", key,
             name);
   } else {

--- a/cppcache/integration-test/ThinClientFailoverInterest.hpp
+++ b/cppcache/integration-test/ThinClientFailoverInterest.hpp
@@ -67,14 +67,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {

--- a/cppcache/integration-test/ThinClientFailoverInterest2.hpp
+++ b/cppcache/integration-test/ThinClientFailoverInterest2.hpp
@@ -66,14 +66,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {

--- a/cppcache/integration-test/ThinClientFailoverInterestAllWithCache.hpp
+++ b/cppcache/integration-test/ThinClientFailoverInterestAllWithCache.hpp
@@ -71,14 +71,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {

--- a/cppcache/integration-test/ThinClientFailoverRegex.hpp
+++ b/cppcache/integration-test/ThinClientFailoverRegex.hpp
@@ -67,14 +67,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {

--- a/cppcache/integration-test/ThinClientHelper.hpp
+++ b/cppcache/integration-test/ThinClientHelper.hpp
@@ -162,14 +162,14 @@ const bool NO_ACK = false;
 void _verifyEntry(const std::string& name, const char* key, const char* val,
                   bool noKey, bool checkVal = true) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (noKey) {
     sprintf(buf, "Verify key %s does not exist in region %s", key,
             name.c_str());
-  } else if (val == 0) {
+  } else if (!val) {
     sprintf(buf, "Verify value for key %s does not exist in region %s", key,
             name.c_str());
   } else {
@@ -242,7 +242,7 @@ void _verifyInvalid(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
+  _verifyEntry(name, key, nullptr, false);
   LOG("Entry invalidated.");
 }
 
@@ -252,7 +252,7 @@ void _verifyDestroyed(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
+  _verifyEntry(name, key, nullptr, true);
   LOG("Entry destroyed.");
 }
 

--- a/cppcache/integration-test/ThinClientInterestList.hpp
+++ b/cppcache/integration-test/ThinClientInterestList.hpp
@@ -65,14 +65,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {
@@ -153,23 +153,13 @@ void _verifyEntry(const char* name, const char* key, const char* val,
   }
 }
 
-#define verifyInvalid(x, y) _verifyInvalid(x, y, __LINE__)
-
-void _verifyInvalid(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
-  LOG("Entry invalidated.");
-}
-
 #define verifyDestroyed(x, y) _verifyDestroyed(x, y, __LINE__)
 
 void _verifyDestroyed(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
+  _verifyEntry(name, key, nullptr, true);
   LOG("Entry destroyed.");
 }
 

--- a/cppcache/integration-test/ThinClientInterestList2.hpp
+++ b/cppcache/integration-test/ThinClientInterestList2.hpp
@@ -65,14 +65,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {
@@ -153,23 +153,13 @@ void _verifyEntry(const char* name, const char* key, const char* val,
   }
 }
 
-#define verifyInvalid(x, y) _verifyInvalid(x, y, __LINE__)
-
-void _verifyInvalid(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
-  LOG("Entry invalidated.");
-}
-
 #define verifyDestroyed(x, y) _verifyDestroyed(x, y, __LINE__)
 
 void _verifyDestroyed(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
+  _verifyEntry(name, key, nullptr, true);
   LOG("Entry destroyed.");
 }
 

--- a/cppcache/integration-test/ThinClientListenerWriter.hpp
+++ b/cppcache/integration-test/ThinClientListenerWriter.hpp
@@ -53,7 +53,7 @@ class SimpleCacheListener : public CacheListener {
     LOGINFO("SimpleCacheListener contructor called");
   }
 
-  virtual ~SimpleCacheListener() {}
+  virtual ~SimpleCacheListener() override {}
   int getCreates() { return m_creates; }
 
   int getClears() { return m_clears; }

--- a/cppcache/integration-test/ThinClientNotification.hpp
+++ b/cppcache/integration-test/ThinClientNotification.hpp
@@ -63,13 +63,13 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (noKey) {
     sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-  } else if (val == 0) {
+  } else if (!val) {
     sprintf(buf, "Verify value for key %s does not exist in region %s", key,
             name);
   } else {
@@ -143,7 +143,7 @@ void _verifyInvalid(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
+  _verifyEntry(name, key, nullptr, false);
   LOG("Entry invalidated.");
 }
 
@@ -153,7 +153,7 @@ void _verifyDestroyed(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
+  _verifyEntry(name, key, nullptr, true);
   LOG("Entry destroyed.");
 }
 

--- a/cppcache/integration-test/ThinClientPutAll.hpp
+++ b/cppcache/integration-test/ThinClientPutAll.hpp
@@ -73,14 +73,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {
@@ -159,26 +159,6 @@ void _verifyEntry(const char* name, const char* key, const char* val,
     }
     dunit::sleep(SLEEP);
   }
-}
-
-#define verifyInvalid(x, y) _verifyInvalid(x, y, __LINE__)
-
-void _verifyInvalid(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
-  LOG("Entry invalidated.");
-}
-
-#define verifyDestroyed(x, y) _verifyDestroyed(x, y, __LINE__)
-
-void _verifyDestroyed(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
-  LOG("Entry destroyed.");
 }
 
 #define verifyEntry(x, y, z) _verifyEntry(x, y, z, __LINE__)

--- a/cppcache/integration-test/ThinClientPutAllWithCallBack.hpp
+++ b/cppcache/integration-test/ThinClientPutAllWithCallBack.hpp
@@ -73,14 +73,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {
@@ -158,26 +158,6 @@ void _verifyEntry(const char* name, const char* key, const char* val,
     }
     dunit::sleep(SLEEP);
   }
-}
-
-#define verifyInvalid(x, y) _verifyInvalid(x, y, __LINE__)
-
-void _verifyInvalid(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
-  LOG("Entry invalidated.");
-}
-
-#define verifyDestroyed(x, y) _verifyDestroyed(x, y, __LINE__)
-
-void _verifyDestroyed(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
-  LOG("Entry destroyed.");
 }
 
 #define verifyEntry(x, y, z) _verifyEntry(x, y, z, __LINE__)

--- a/cppcache/integration-test/ThinClientPutGetAll.hpp
+++ b/cppcache/integration-test/ThinClientPutGetAll.hpp
@@ -194,7 +194,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, GetAllAfterLocalDestroyRegionOnClientTwo)
     auto reg0 = getHelper()->getRegion(_regionNames[0]);
     reg0->localDestroyRegion();
     reg0 = nullptr;
-    getHelper()->createPooledRegion(regionNames[0], USE_ACK, 0,
+    getHelper()->createPooledRegion(regionNames[0], USE_ACK, nullptr,
                                     "__TEST_POOL1__", true, true);
     reg0 = getHelper()->getRegion(_regionNames[0]);
     verifyGetAll(reg0, _nvals, 0);

--- a/cppcache/integration-test/ThinClientRIwithlocalRegionDestroy.hpp
+++ b/cppcache/integration-test/ThinClientRIwithlocalRegionDestroy.hpp
@@ -51,7 +51,7 @@ class SimpleCacheListener : public CacheListener {
 
   SimpleCacheListener() : m_totalEvents(0) {}
 
-  ~SimpleCacheListener() {}
+  ~SimpleCacheListener() override {}
 
  public:
   // The Cache Listener callbacks.

--- a/cppcache/integration-test/ThinClientRegex.hpp
+++ b/cppcache/integration-test/ThinClientRegex.hpp
@@ -64,14 +64,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {
@@ -152,26 +152,6 @@ void _verifyEntry(const char* name, const char* key, const char* val,
   }
 }
 
-#define verifyInvalid(x, y) _verifyInvalid(x, y, __LINE__)
-
-void _verifyInvalid(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
-  LOG("Entry invalidated.");
-}
-
-#define verifyDestroyed(x, y) _verifyDestroyed(x, y, __LINE__)
-
-void _verifyDestroyed(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
-  LOG("Entry destroyed.");
-}
-
 #define verifyEntry(x, y, z) _verifyEntry(x, y, z, __LINE__)
 
 void _verifyEntry(const char* name, const char* key, const char* val,
@@ -181,16 +161,6 @@ void _verifyEntry(const char* name, const char* key, const char* val,
   LOG(logmsg);
   _verifyEntry(name, key, val, false);
   LOG("Entry verified.");
-}
-
-#define verifyCreated(x, y) _verifyCreated(x, y, __LINE__)
-
-void _verifyCreated(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyCreated() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, nullptr, false, true);
-  LOG("Entry created.");
 }
 
 void createPooledRegion(const char* name, bool ackMode, const char* locators,

--- a/cppcache/integration-test/ThinClientRegex2.hpp
+++ b/cppcache/integration-test/ThinClientRegex2.hpp
@@ -65,14 +65,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {
@@ -153,26 +153,6 @@ void _verifyEntry(const char* name, const char* key, const char* val,
   }
 }
 
-#define verifyInvalid(x, y) _verifyInvalid(x, y, __LINE__)
-
-void _verifyInvalid(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
-  LOG("Entry invalidated.");
-}
-
-#define verifyDestroyed(x, y) _verifyDestroyed(x, y, __LINE__)
-
-void _verifyDestroyed(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
-  LOG("Entry destroyed.");
-}
-
 #define verifyEntry(x, y, z) _verifyEntry(x, y, z, __LINE__)
 
 void _verifyEntry(const char* name, const char* key, const char* val,
@@ -182,16 +162,6 @@ void _verifyEntry(const char* name, const char* key, const char* val,
   LOG(logmsg);
   _verifyEntry(name, key, val, false);
   LOG("Entry verified.");
-}
-
-#define verifyCreated(x, y) _verifyCreated(x, y, __LINE__)
-
-void _verifyCreated(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyCreated() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, nullptr, false, true);
-  LOG("Entry created.");
 }
 
 void createRegion(const char* name, bool ackMode,

--- a/cppcache/integration-test/ThinClientRegex3.hpp
+++ b/cppcache/integration-test/ThinClientRegex3.hpp
@@ -65,14 +65,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {
@@ -153,26 +153,6 @@ void _verifyEntry(const char* name, const char* key, const char* val,
   }
 }
 
-#define verifyInvalid(x, y) _verifyInvalid(x, y, __LINE__)
-
-void _verifyInvalid(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
-  LOG("Entry invalidated.");
-}
-
-#define verifyDestroyed(x, y) _verifyDestroyed(x, y, __LINE__)
-
-void _verifyDestroyed(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
-  LOG("Entry destroyed.");
-}
-
 #define verifyEntry(x, y, z) _verifyEntry(x, y, z, __LINE__)
 
 void _verifyEntry(const char* name, const char* key, const char* val,
@@ -182,16 +162,6 @@ void _verifyEntry(const char* name, const char* key, const char* val,
   LOG(logmsg);
   _verifyEntry(name, key, val, false);
   LOG("Entry verified.");
-}
-
-#define verifyCreated(x, y) _verifyCreated(x, y, __LINE__)
-
-void _verifyCreated(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyCreated() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, nullptr, false, true);
-  LOG("Entry created.");
 }
 
 void createRegion(const char* name, bool ackMode, const char* endpoints,

--- a/cppcache/integration-test/ThinClientSSL.hpp
+++ b/cppcache/integration-test/ThinClientSSL.hpp
@@ -72,13 +72,13 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (noKey) {
     sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-  } else if (val == 0) {
+  } else if (!val) {
     sprintf(buf, "Verify value for key %s does not exist in region %s", key,
             name);
   } else {
@@ -152,7 +152,7 @@ void _verifyInvalid(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
+  _verifyEntry(name, key, nullptr, false);
   LOG("Entry invalidated.");
 }
 
@@ -162,7 +162,7 @@ void _verifyDestroyed(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
+  _verifyEntry(name, key, nullptr, true);
   LOG("Entry destroyed.");
 }
 

--- a/cppcache/integration-test/ThinClientSSLWithPassword.hpp
+++ b/cppcache/integration-test/ThinClientSSLWithPassword.hpp
@@ -74,13 +74,13 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (noKey) {
     sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-  } else if (val == 0) {
+  } else if (!val) {
     sprintf(buf, "Verify value for key %s does not exist in region %s", key,
             name);
   } else {
@@ -154,7 +154,7 @@ void _verifyInvalid(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
+  _verifyEntry(name, key, nullptr, false);
   LOG("Entry invalidated.");
 }
 
@@ -164,7 +164,7 @@ void _verifyDestroyed(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
+  _verifyEntry(name, key, nullptr, true);
   LOG("Entry destroyed.");
 }
 

--- a/cppcache/integration-test/ThinClientTXFailover.hpp
+++ b/cppcache/integration-test/ThinClientTXFailover.hpp
@@ -68,13 +68,13 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (noKey) {
     sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-  } else if (val == 0) {
+  } else if (!val) {
     sprintf(buf, "Verify value for key %s does not exist in region %s", key,
             name);
   } else {

--- a/cppcache/integration-test/ThinClientTransactions.hpp
+++ b/cppcache/integration-test/ThinClientTransactions.hpp
@@ -89,13 +89,13 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (noKey) {
     sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-  } else if (val == 0) {
+  } else if (!val) {
     sprintf(buf, "Verify value for key %s does not exist in region %s", key,
             name);
   } else {
@@ -161,26 +161,6 @@ void _verifyEntry(const char* name, const char* key, const char* val,
     }
     dunit::sleep(SLEEP);
   }
-}
-
-#define verifyInvalid(x, y) _verifyInvalid(x, y, __LINE__)
-
-void _verifyInvalid(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
-  LOG("Entry invalidated.");
-}
-
-#define verifyDestroyed(x, y) _verifyDestroyed(x, y, __LINE__)
-
-void _verifyDestroyed(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
-  LOG("Entry destroyed.");
 }
 
 #define verifyEntry(x, y, z) _verifyEntry(x, y, z, __LINE__)

--- a/cppcache/integration-test/ThinClientTransactionsXA.hpp
+++ b/cppcache/integration-test/ThinClientTransactionsXA.hpp
@@ -87,13 +87,13 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (noKey) {
     sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-  } else if (val == 0) {
+  } else if (!val) {
     sprintf(buf, "Verify value for key %s does not exist in region %s", key,
             name);
   } else {
@@ -159,26 +159,6 @@ void _verifyEntry(const char* name, const char* key, const char* val,
     }
     dunit::sleep(SLEEP);
   }
-}
-
-#define verifyInvalid(x, y) _verifyInvalid(x, y, __LINE__)
-
-void _verifyInvalid(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
-  LOG("Entry invalidated.");
-}
-
-#define verifyDestroyed(x, y) _verifyDestroyed(x, y, __LINE__)
-
-void _verifyDestroyed(const char* name, const char* key, int line) {
-  char logmsg[1024];
-  sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
-  LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
-  LOG("Entry destroyed.");
 }
 
 #define verifyEntry(x, y, z) _verifyEntry(x, y, z, __LINE__)

--- a/cppcache/integration-test/fw_dunit.cpp
+++ b/cppcache/integration-test/fw_dunit.cpp
@@ -163,7 +163,7 @@ class NamingContextImpl : virtual public NamingContext {
   virtual int rebind(const char* key, const char* value) {
     int res = -1;
     int attempts = 10;
-    while ((res = m_context.rebind(key, value, (char*)"")) == -1 &&
+    while ((res = m_context.rebind(key, value, const_cast<char*>(""))) == -1 &&
            attempts--) {
       millisleep(10);
     }
@@ -1081,8 +1081,8 @@ ThreadLauncher::ThreadLauncher(int thrCount, Thread& thr)
       m_stopSemaphore((-1 * thrCount) + 1),
       m_cleanSemaphore(0),
       m_termSemaphore((-1 * thrCount) + 1),
-      m_startTime(0),
-      m_stopTime(0),
+      m_startTime(nullptr),
+      m_stopTime(nullptr),
       m_threadDef(thr) {
   m_threadDef.init(this);
 }
@@ -1109,10 +1109,10 @@ void ThreadLauncher::go() {
 }
 
 ThreadLauncher::~ThreadLauncher() {
-  if (m_startTime != 0) {
+  if (m_startTime) {
     delete m_startTime;
   }
-  if (m_stopTime != 0) {
+  if (m_stopTime) {
     delete m_stopTime;
   }
 }

--- a/cppcache/integration-test/testCache.cpp
+++ b/cppcache/integration-test/testCache.cpp
@@ -29,17 +29,16 @@
 using namespace apache::geode::client;
 
 BEGIN_TEST(CacheFunction)
-  char* host_name = (char*)"TESTCACHE";
   const uint32_t totalSubRegions = 3;
-  char* regionName = (char*)"TESTCACHE_ROOT_REGION";
-  char* subRegionName1 = (char*)"TESTCACHE_SUB_REGION1";
-  char* subRegionName2 = (char*)"TESTCACHE_SUB_REGION2";
-  char* subRegionName21 = (char*)"TESTCACHE_SUB_REGION21";
+  const char* regionName = "TESTCACHE_ROOT_REGION";
+  const char* subRegionName1 = "TESTCACHE_SUB_REGION1";
+  const char* subRegionName2 = "TESTCACHE_SUB_REGION2";
+  const char* subRegionName21 = "TESTCACHE_SUB_REGION21";
   std::shared_ptr<Cache> cptr;
   if (cptr != nullptr) {
     std::cout << "cptr is not null" << std::endl;
   }
-  std::cout << "create Cache with name=" << host_name
+  std::cout << "create Cache with name=TESTCACHE"
             << " and unitialized system" << std::endl;
   auto cacheFactory = CacheFactory();
   cptr = std::make_shared<Cache>(cacheFactory.create());
@@ -58,7 +57,7 @@ BEGIN_TEST(CacheFunction)
     cacheImpl->createRegion(regionName, regionAttributes, rptr);
   } catch (Exception& ex) {
     std::cout << ex.what() << std::endl;
-    ASSERT(false, (char*)"attribute create failed");
+    ASSERT(false, "attribute create failed");
   }
   std::cout << "create Sub Region with name=" << subRegionName1 << std::endl;
   std::shared_ptr<Region> subRptr1;
@@ -66,7 +65,7 @@ BEGIN_TEST(CacheFunction)
     subRptr1 = rptr->createSubregion(subRegionName1, regionAttributes);
   } catch (Exception& ex) {
     std::cout << ex.what() << std::endl;
-    ASSERT(false, (char*)"subregion create failed");
+    ASSERT(false, "subregion create failed");
   }
   std::cout << "create Sub Region with name=" << subRegionName2 << std::endl;
   std::shared_ptr<Region> subRptr2;
@@ -74,7 +73,7 @@ BEGIN_TEST(CacheFunction)
     subRptr2 = rptr->createSubregion(subRegionName2, regionAttributes);
   } catch (Exception& ex) {
     std::cout << ex.what() << std::endl;
-    ASSERT(false, (char*)"subregion create failed");
+    ASSERT(false, "subregion create failed");
   }
   std::cout << "create Sub Region with name=" << subRegionName21
             << "inside region=" << subRegionName2 << std::endl;
@@ -83,7 +82,7 @@ BEGIN_TEST(CacheFunction)
     subRptr21 = subRptr2->createSubregion(subRegionName21, regionAttributes);
   } catch (Exception& ex) {
     std::cout << ex.what() << std::endl;
-    ASSERT(false, (char*)"subregion create failed");
+    ASSERT(false, "subregion create failed");
   }
   std::vector<std::shared_ptr<Region>> vr = rptr->subregions(true);
   std::cout << "  vr.size=" << vr.size() << std::endl;
@@ -119,10 +118,10 @@ BEGIN_TEST(CacheFunction)
     region = cptr->getRegion(root.c_str());
   } catch (Exception& ex) {
     std::cout << ex.what() << std::endl;
-    ASSERT(false, (char*)"getRegion");
+    ASSERT(false, "getRegion");
   }
   if (region == nullptr) {
-    ASSERT(false, (char*)"did not find it");
+    ASSERT(false, "did not find it");
   } else {
     std::cout << "found :" << region->getName() << std::endl;
   }
@@ -131,10 +130,10 @@ BEGIN_TEST(CacheFunction)
     region = cptr->getRegion(subRegion1.c_str());
   } catch (Exception& ex) {
     std::cout << ex.what() << std::endl;
-    ASSERT(false, (char*)"getRegion");
+    ASSERT(false, "getRegion");
   }
   if (region == nullptr) {
-    ASSERT(false, (char*)"did not find it");
+    ASSERT(false, "did not find it");
   } else {
     std::cout << "found :" << region->getName() << std::endl;
   }
@@ -143,10 +142,10 @@ BEGIN_TEST(CacheFunction)
     region = cptr->getRegion(subRegion21.c_str());
   } catch (Exception& ex) {
     std::cout << ex.what() << std::endl;
-    ASSERT(false, (char*)"getRegion");
+    ASSERT(false, "getRegion");
   }
   if (region == nullptr) {
-    ASSERT(false, (char*)"did not find it");
+    ASSERT(false, "did not find it");
   } else {
     std::cout << "found :" << region->getName() << std::endl;
   }
@@ -156,10 +155,10 @@ BEGIN_TEST(CacheFunction)
     region = cptr->getRegion(subRegion21.c_str());
   } catch (Exception& ex) {
     std::cout << ex.what() << std::endl;
-    ASSERT(false, (char*)"getRegion");
+    ASSERT(false, "getRegion");
   }
   if (region == nullptr) {
-    ASSERT(false, (char*)"did not find it");
+    ASSERT(false, "did not find it");
   } else {
     std::cout << "found :" << region->getName() << std::endl;
   }
@@ -169,11 +168,11 @@ BEGIN_TEST(CacheFunction)
     region = cptr->getRegion(notExist);
   } catch (Exception& ex) {
     std::cout << ex.what() << std::endl;
-    ASSERT(false, (char*)"getRegion");
+    ASSERT(false, "getRegion");
   }
   if (region == nullptr) {
     std::cout << "not found !" << std::endl;
   } else {
-    ASSERT(false, (char*)"found it");
+    ASSERT(false, "found it");
   }
 END_TEST(CacheFunction)

--- a/cppcache/integration-test/testOverflowPutGetSqLite.cpp
+++ b/cppcache/integration-test/testOverflowPutGetSqLite.cpp
@@ -40,7 +40,7 @@ void getNumOfEntries(std::shared_ptr<Region>& regionPtr, uint32_t num) {
   auto vecValues = regionPtr->values();
   printf("Values vector size is %zd\n", vecValues.size());
   printf("Num is %d\n", num);
-  ASSERT(vecValues.size() == num, (char*)"size of value vec and num not equal");
+  ASSERT(vecValues.size() == num, "size of value vec and num not equal");
 }
 
 void setAttributes(RegionAttributes regionAttributes,
@@ -234,11 +234,11 @@ void testEntryDestroy(std::shared_ptr<Region>& regionPtr, uint32_t num) {
       regionPtr->destroy(v.at(i));
     } catch (Exception& ex) {
       std::cout << ex.what() << std::endl;
-      ASSERT(false, (char*)"entry missing");
+      ASSERT(false, "entry missing");
     }
   }
   v = regionPtr->keys();
-  ASSERT(v.size() == num - 5, (char*)"size of key vec not equal");
+  ASSERT(v.size() == num - 5, "size of key vec not equal");
 }
 
 void testEntryInvalidate(std::shared_ptr<Region>& regionPtr, uint32_t num) {
@@ -251,11 +251,11 @@ void testEntryInvalidate(std::shared_ptr<Region>& regionPtr, uint32_t num) {
       regionPtr->invalidate(v.at(i));
     } catch (Exception& ex) {
       std::cout << ex.what() << std::endl;
-      ASSERT(false, (char*)"entry missing");
+      ASSERT(false, "entry missing");
     }
   }
   v = regionPtr->keys();
-  ASSERT(v.size() == num, (char*)"size of key vec not equal");
+  ASSERT(v.size() == num, "size of key vec not equal");
 }
 
 class PutThread : public ACE_Task_Base {

--- a/cppcache/integration-test/testSerialization.cpp
+++ b/cppcache/integration-test/testSerialization.cpp
@@ -77,7 +77,8 @@ class OtherType : public DataSerializable {
   }
 
   void toData(DataOutput& output) const override {
-    output.writeBytes((uint8_t*)&m_struct, sizeof(CData));
+    // TODO: refactor - this insane
+    output.writeBytes(reinterpret_cast<const uint8_t*>(&m_struct), sizeof(CData));
     output.writeInt(m_classIdToReturn);
   }
 

--- a/cppcache/integration-test/testThinClientCq.cpp
+++ b/cppcache/integration-test/testThinClientCq.cpp
@@ -435,7 +435,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
        std::shared_ptr<CqListener> cqLstner(new MyCqListener1026);
        cqFac.addCqListener(cqLstner);
        auto cqAttr = cqFac.create();
-       auto qry = qs->newCq((char*)"1026_MyCq", qryStr, cqAttr);
+       auto qry = qs->newCq("1026_MyCq", qryStr, cqAttr);
 
        // execute Cq Query with initial Results
        auto resultsPtr = qry->executeWithInitialResults();

--- a/cppcache/integration-test/testThinClientCqDurable.cpp
+++ b/cppcache/integration-test/testThinClientCqDurable.cpp
@@ -93,22 +93,22 @@ class MyCqListener1 : public CqListener {
   static int m_cntEvents;
   void onEvent(const CqEvent& cqe) override {
     m_cntEvents++;
-    char* opStr = (char*)"Default";
+    const char* opStr = "Default";
     std::shared_ptr<CacheableInt32> value(
         std::dynamic_pointer_cast<CacheableInt32>(cqe.getNewValue()));
     std::shared_ptr<CacheableInt32> key(
         std::dynamic_pointer_cast<CacheableInt32>(cqe.getKey()));
     switch (cqe.getQueryOperation()) {
       case CqOperation::OP_TYPE_CREATE: {
-        opStr = (char*)"CREATE";
+        opStr = "CREATE";
         break;
       }
       case CqOperation::OP_TYPE_UPDATE: {
-        opStr = (char*)"UPDATE";
+        opStr = "UPDATE";
         break;
       }
       case CqOperation::OP_TYPE_DESTROY: {
-        opStr = (char*)"UPDATE";
+        opStr = "UPDATE";
         break;
       }
       default:
@@ -230,7 +230,7 @@ void RunDurableCqClient() {
 
   // create a new Cq Query
   const char* qryStr = "select * from /DistRegionAck ";
-  auto qry = qrySvcPtr->newCq((char*)"MyCq", qryStr, cqAttr, true);
+  auto qry = qrySvcPtr->newCq("MyCq", qryStr, cqAttr, true);
 
   LOGINFO("Created new CqQuery");
 

--- a/cppcache/integration-test/testThinClientCqFailover.cpp
+++ b/cppcache/integration-test/testThinClientCqFailover.cpp
@@ -214,8 +214,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
       cqFac.addCqListener(cqLstner);
       auto cqAttr = cqFac.create();
 
-      char* qryStr = (char*)"select * from /Portfolios p where p.ID != 2";
-      auto qry = qs->newCq(cqName, qryStr, cqAttr);
+      auto qry = qs->newCq(cqName, "select * from /Portfolios p where p.ID != 2", cqAttr);
       qry->execute();
 
       SLEEP(15000);
@@ -251,7 +250,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepThree2)
     for (int i = 1; i < 150; i++) {
       auto port = std::make_shared<Portfolio>(i, 150);
 
-      auto keyport = CacheableKey::create((char*)"port1-1");
+      auto keyport = CacheableKey::create("port1-1");
       regPtr0->put(keyport, port);
       SLEEP(100);  // sleep a while to allow server query to complete
     }

--- a/cppcache/integration-test/testThinClientCqHAFailover.cpp
+++ b/cppcache/integration-test/testThinClientCqHAFailover.cpp
@@ -274,7 +274,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepThree2)
     for (int i = 1; i < 150; i++) {
       auto port = std::make_shared<Portfolio>(i, 20);
 
-      auto keyport = CacheableKey::create((char*)"port1-1");
+      auto keyport = CacheableKey::create("port1-1");
       regPtr0->put(keyport, port);
       SLEEP(100);  // sleep a while to allow server query to complete
     }

--- a/cppcache/integration-test/testThinClientCqIR.cpp
+++ b/cppcache/integration-test/testThinClientCqIR.cpp
@@ -145,7 +145,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, PutData)
     for (int i = 1; i < 150; i++) {
       port = std::shared_ptr<Cacheable>(new PortfolioPdx(i, 150));
 
-      auto keyport = CacheableKey::create((char*)"port1-1");
+      auto keyport = CacheableKey::create("port1-1");
       regPtr0->put(keyport, port);
       SLEEP(100);  // sleep a while to allow server query to complete
     }
@@ -170,9 +170,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, QueryData)
     }
 
     auto cqAttr = CqAttributesFactory().create();
-
-    // char* qryStr = (char*)"select * from /Portfolios p where p.ID != 2";
-    // qry->execute();
 
     auto qryStr = "select * from /Portfolios where ID != 2";
     auto qry = qs->newCq(cqName, qryStr, cqAttr);

--- a/cppcache/integration-test/testThinClientFixedPartitionResolver.cpp
+++ b/cppcache/integration-test/testThinClientFixedPartitionResolver.cpp
@@ -38,7 +38,7 @@ using namespace apache::geode::client;
 class CustomFixedPartitionResolver1 : public FixedPartitionResolver {
  public:
   CustomFixedPartitionResolver1() {}
-  ~CustomFixedPartitionResolver1() {}
+  ~CustomFixedPartitionResolver1() override {}
   const std::string& getName() override {
     static std::string name = "CustomFixedPartitionResolver1";
     LOG("CustomFixedPartitionResolver1::getName()");
@@ -86,7 +86,7 @@ auto cptr1 = std::make_shared<CustomFixedPartitionResolver1>();
 class CustomFixedPartitionResolver2 : public FixedPartitionResolver {
  public:
   CustomFixedPartitionResolver2() {}
-  ~CustomFixedPartitionResolver2() {}
+  ~CustomFixedPartitionResolver2() override {}
   const std::string& getName() override {
     static std::string name = "CustomFixedPartitionResolver2";
     LOG("CustomFixedPartitionResolver2::getName()");
@@ -134,7 +134,7 @@ auto cptr2 = std::make_shared<CustomFixedPartitionResolver2>();
 class CustomFixedPartitionResolver3 : public FixedPartitionResolver {
  public:
   CustomFixedPartitionResolver3() {}
-  ~CustomFixedPartitionResolver3() {}
+  ~CustomFixedPartitionResolver3() override {}
   const std::string& getName() override {
     static std::string name = "CustomFixedPartitionResolver3";
     LOG("CustomFixedPartitionResolver3::getName()");

--- a/cppcache/integration-test/testThinClientHADistOps.cpp
+++ b/cppcache/integration-test/testThinClientHADistOps.cpp
@@ -88,13 +88,13 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (noKey) {
     sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-  } else if (val == 0) {
+  } else if (!val) {
     sprintf(buf, "Verify value for key %s does not exist in region %s", key,
             name);
   } else {
@@ -166,7 +166,7 @@ void _verifyInvalid(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
+  _verifyEntry(name, key, nullptr, false);
   LOG("Entry invalidated.");
 }
 
@@ -176,7 +176,7 @@ void _verifyDestroyed(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
+  _verifyEntry(name, key, nullptr, true);
   LOG("Entry destroyed.");
 }
 

--- a/cppcache/integration-test/testThinClientHAEventIDMap.cpp
+++ b/cppcache/integration-test/testThinClientHAEventIDMap.cpp
@@ -59,7 +59,7 @@ class DupChecker : public CacheListener {
  public:
   DupChecker() : m_ops(0) {}
 
-  ~DupChecker() { m_map.clear(); }
+  ~DupChecker() override { m_map.clear(); }
 
   void validate() {
     ASSERT(m_map.size() == 4, "Expected 4 keys for the region");
@@ -118,14 +118,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {

--- a/cppcache/integration-test/testThinClientHAFailover.cpp
+++ b/cppcache/integration-test/testThinClientHAFailover.cpp
@@ -87,14 +87,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {

--- a/cppcache/integration-test/testThinClientHAFailoverRegex.cpp
+++ b/cppcache/integration-test/testThinClientHAFailoverRegex.cpp
@@ -65,14 +65,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {

--- a/cppcache/integration-test/testThinClientHAMixedRedundancy.cpp
+++ b/cppcache/integration-test/testThinClientHAMixedRedundancy.cpp
@@ -70,14 +70,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {

--- a/cppcache/integration-test/testThinClientHAPeriodicAck.cpp
+++ b/cppcache/integration-test/testThinClientHAPeriodicAck.cpp
@@ -59,7 +59,7 @@ class DupChecker : public CacheListener {
  public:
   DupChecker() : m_ops(0) {}
 
-  ~DupChecker() { m_map.clear(); }
+  ~DupChecker() override { m_map.clear(); }
 
   void validate() {
     ASSERT(m_map.size() == 4, "Expected 4 keys for the region");
@@ -135,14 +135,14 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {

--- a/cppcache/integration-test/testThinClientIntResPolKeysInv.cpp
+++ b/cppcache/integration-test/testThinClientIntResPolKeysInv.cpp
@@ -58,14 +58,14 @@ CacheHelper *getHelper() {
 void _verifyEntry(const char *name, const char *key, const char *val,
                   bool noKey, bool isCreated = false) {
   // Verify key and value exist in this region, in this process.
-  const char *value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char *buf =
       reinterpret_cast<char *>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (!isCreated) {
     if (noKey) {
       sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-    } else if (val == 0) {
+    } else if (!val) {
       sprintf(buf, "Verify value for key %s does not exist in region %s", key,
               name);
     } else {
@@ -152,7 +152,7 @@ void _verifyInvalid(const char *name, const char *key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
+  _verifyEntry(name, key, nullptr, false);
   LOG("Entry invalidated.");
 }
 
@@ -160,7 +160,7 @@ void _verifyDestroyed(const char *name, const char *key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
+  _verifyEntry(name, key, nullptr, true);
   LOG("Entry destroyed.");
 }
 

--- a/cppcache/integration-test/testThinClientPartitionResolver.cpp
+++ b/cppcache/integration-test/testThinClientPartitionResolver.cpp
@@ -42,7 +42,7 @@ class CustomPartitionResolver : public PartitionResolver {
   bool called;
 
   CustomPartitionResolver() : called(false) {}
-  ~CustomPartitionResolver() {}
+  ~CustomPartitionResolver() override {}
   const std::string &getName() override {
     static std::string name = "CustomPartitionResolver";
     LOG("CustomPartitionResolver::getName()");

--- a/cppcache/integration-test/testThinClientPoolExecuteFunctionThrowsException.cpp
+++ b/cppcache/integration-test/testThinClientPoolExecuteFunctionThrowsException.cpp
@@ -46,17 +46,17 @@ const char* poolRegNames[] = {"partition_region", "PoolRegion2"};
 
 const char* serverGroup = "ServerGroup1";
 
-char* getFuncIName = (char*)"MultiGetFunctionI";
-char* putFuncIName = (char*)"MultiPutFunctionI";
-char* getFuncName = (char*)"MultiGetFunction";
-char* putFuncName = (char*)"MultiPutFunction";
-char* rjFuncName = (char*)"RegionOperationsFunction";
-char* exFuncName = (char*)"ExceptionHandlingFunction";
-char* exFuncNameSendException = (char*)"executeFunction_SendException";
-char* exFuncNamePdxType = (char*)"PdxFunctionTest";
-char* FEOnRegionPrSHOP = (char*)"FEOnRegionPrSHOP";
-char* FEOnRegionPrSHOP_OptimizeForWrite =
-    (char*)"FEOnRegionPrSHOP_OptimizeForWrite";
+const char* getFuncIName = "MultiGetFunctionI";
+const char* putFuncIName = "MultiPutFunctionI";
+const char* getFuncName = "MultiGetFunction";
+const char* putFuncName = "MultiPutFunction";
+const char* rjFuncName = "RegionOperationsFunction";
+const char* exFuncName = "ExceptionHandlingFunction";
+const char* exFuncNameSendException = "executeFunction_SendException";
+const char* exFuncNamePdxType = "PdxFunctionTest";
+const char* FEOnRegionPrSHOP = "FEOnRegionPrSHOP";
+const char* FEOnRegionPrSHOP_OptimizeForWrite =
+    "FEOnRegionPrSHOP_OptimizeForWrite";
 
 class MyResultCollector : public DefaultResultCollector {
  public:

--- a/cppcache/integration-test/testThinClientPoolExecuteHAFunction.cpp
+++ b/cppcache/integration-test/testThinClientPoolExecuteHAFunction.cpp
@@ -36,10 +36,10 @@ const char* poolName = "__TEST_POOL1__";
 
 const char* serverGroup = "ServerGroup1";
 
-char* OnServerHAExceptionFunction = (char*)"OnServerHAExceptionFunction";
-char* OnServerHAShutdownFunction = (char*)"OnServerHAShutdownFunction";
+const char* OnServerHAExceptionFunction = "OnServerHAExceptionFunction";
+const char* OnServerHAShutdownFunction = "OnServerHAShutdownFunction";
 
-char* RegionOperationsHAFunction = (char*)"RegionOperationsHAFunction";
+const char* RegionOperationsHAFunction = "RegionOperationsHAFunction";
 #define verifyGetResults()                                      \
   bool found = false;                                           \
   for (int j = 0; j < 34; j++) {                                \

--- a/cppcache/integration-test/testThinClientPoolExecuteHAFunctionPrSHOP.cpp
+++ b/cppcache/integration-test/testThinClientPoolExecuteHAFunctionPrSHOP.cpp
@@ -34,12 +34,12 @@ const char* poolName = "__TEST_POOL1__";
 
 const char* serverGroup = "ServerGroup1";
 
-char* OnServerHAExceptionFunction = (char*)"OnServerHAExceptionFunction";
-char* OnServerHAShutdownFunction = (char*)"OnServerHAShutdownFunction";
+const char* OnServerHAExceptionFunction = "OnServerHAExceptionFunction";
+const char* OnServerHAShutdownFunction = "OnServerHAShutdownFunction";
 
-char* RegionOperationsHAFunction = (char*)"RegionOperationsHAFunction";
-char* RegionOperationsHAFunctionPrSHOP =
-    (char*)"RegionOperationsHAFunctionPrSHOP";
+const char* RegionOperationsHAFunction = "RegionOperationsHAFunction";
+const char* RegionOperationsHAFunctionPrSHOP =
+    "RegionOperationsHAFunctionPrSHOP";
 #define verifyGetResults()                                      \
   bool found = false;                                           \
   for (int j = 0; j < 34; j++) {                                \
@@ -59,7 +59,7 @@ class MyResultCollector : public DefaultResultCollector {
  public:
   MyResultCollector()
       : m_endResultCount(0), m_addResultCount(0), m_getResultCount(0) {}
-  ~MyResultCollector() noexcept {}
+  ~MyResultCollector() noexcept override {}
 
   std::shared_ptr<CacheableVector> getResult(
       std::chrono::milliseconds timeout) override {

--- a/cppcache/integration-test/testThinClientRemoveOps.cpp
+++ b/cppcache/integration-test/testThinClientRemoveOps.cpp
@@ -79,13 +79,13 @@ CacheHelper* getHelper() {
 void _verifyEntry(const char* name, const char* key, const char* val,
                   bool noKey) {
   // Verify key and value exist in this region, in this process.
-  const char* value = (val == 0) ? "" : val;
+  const char* value = val ? val : "";
   char* buf =
       reinterpret_cast<char*>(malloc(1024 + strlen(key) + strlen(value)));
   ASSERT(buf, "Unable to malloc buffer for logging.");
   if (noKey) {
     sprintf(buf, "Verify key %s does not exist in region %s", key, name);
-  } else if (val == 0) {
+  } else if (!val) {
     sprintf(buf, "Verify value for key %s does not exist in region %s", key,
             name);
   } else {
@@ -157,7 +157,7 @@ void _verifyInvalid(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyInvalid() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, false);
+  _verifyEntry(name, key, nullptr, false);
   LOG("Entry invalidated.");
 }
 
@@ -165,7 +165,7 @@ void _verifyDestroyed(const char* name, const char* key, int line) {
   char logmsg[1024];
   sprintf(logmsg, "verifyDestroyed() called from %d.\n", line);
   LOG(logmsg);
-  _verifyEntry(name, key, 0, true);
+  _verifyEntry(name, key, nullptr, true);
   LOG("Entry destroyed.");
 }
 

--- a/cppcache/integration-test/testThinClientSecurityAuthenticationSetAuthInitialize.cpp
+++ b/cppcache/integration-test/testThinClientSecurityAuthenticationSetAuthInitialize.cpp
@@ -118,7 +118,7 @@ DUNIT_TASK_DEFINITION(LOCATORSERVER, CreateServer1)
         printf("Input to server cmd is -->  %s",
                cmdServerAuthenticator.c_str());
         CacheHelper::initServer(
-            1, NULL, locHostPort,
+            1, nullptr, locHostPort,
             const_cast<char*>(cmdServerAuthenticator.c_str()));
         LOG("Server1 started");
       }

--- a/cppcache/integration-test/testThinClientSecurityAuthorizationMU.cpp
+++ b/cppcache/integration-test/testThinClientSecurityAuthorizationMU.cpp
@@ -36,7 +36,7 @@ using namespace apache::geode::client;
 const char* locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 std::shared_ptr<CredentialGenerator> credentialGeneratorHandler;
-char* exFuncNameSendException = (char*)"executeFunction_SendException";
+const char* exFuncNameSendException = "executeFunction_SendException";
 
 std::string getXmlPath() {
   char xmlPath[1000] = {'\0'};

--- a/cppcache/integration-test/testXmlCacheCreationWithOverFlow.cpp
+++ b/cppcache/integration-test/testXmlCacheCreationWithOverFlow.cpp
@@ -25,7 +25,6 @@
 using namespace apache::geode::client;
 
 int testXmlCacheCreationWithOverflow() {
-  char* host_name = (char*)"XML_CACHE_CREATION_TEST";
   auto cacheFactory = CacheFactory();
   std::shared_ptr<Cache> cptr;
   const uint32_t totalSubRegionsRoot1 = 2;
@@ -34,7 +33,7 @@ int testXmlCacheCreationWithOverflow() {
   char* path = ACE_OS::getenv("TESTSRC");
   std::string directory(path);
 
-  std::cout << "create DistributedSytem with name=" << host_name << std::endl;
+  std::cout << "create DistributedSytem with name=XML_CACHE_CREATION_TEST" << std::endl;
   std::cout << "Create cache with the configurations provided in "
                "valid_overflowAttr.xml"
             << std::endl;

--- a/cppcache/integration-test/testXmlCacheCreationWithPools.cpp
+++ b/cppcache/integration-test/testXmlCacheCreationWithPools.cpp
@@ -258,11 +258,10 @@ bool checkPoolAttribs(std::shared_ptr<Pool> pool, SLIST& locators,
 }
 
 int testXmlCacheCreationWithPools() {
-  char* host_name = (char*)"XML_CACHE_CREATION_TEST";
   auto cacheFactory = CacheFactory();
   std::shared_ptr<Cache> cptr;
 
-  std::cout << "create DistributedSytem with name=" << host_name << std::endl;
+  std::cout << "create DistributedSytem with name=XML_CACHE_CREATION_TEST" << std::endl;
   std::cout
       << "Create cache with the configurations provided in valid_cache_pool.xml"
       << std::endl;

--- a/cppcache/integration-test/testXmlCacheCreationWithRefid.cpp
+++ b/cppcache/integration-test/testXmlCacheCreationWithRefid.cpp
@@ -27,14 +27,14 @@
 using namespace apache::geode::client;
 
 int testXmlCacheCreationWithRefid(const char* fileName) {
-  char* host_name = (char*)"XML_CACHE_CREATION_TEST";
   auto cacheFactory = CacheFactory();
   std::shared_ptr<Cache> cptr;
 
   char* path = ACE_OS::getenv("TESTSRC");
   std::string directory(path);
 
-  std::cout << "create DistributedSytem with name=" << host_name << std::endl;
+  std::cout << "create DistributedSytem with name=XML_CACHE_CREATION_TEST" << std::endl;
+
   std::cout << "Create cache with the configurations provided in "
                "valid_cache_refid.xml"
             << std::endl;

--- a/cppcache/integration-test/testXmlCacheInitialization.cpp
+++ b/cppcache/integration-test/testXmlCacheInitialization.cpp
@@ -43,13 +43,12 @@ using namespace test;
 using namespace std;
 
 int testXmlDeclarativeCacheCreation() {
-  char* host_name = (char*)"XML_DECLARATIVE_CACHE_CREATION_TEST";
   auto cacheFactory = CacheFactory();
   std::shared_ptr<Cache> cptr;
 
   std::string directory(ACE_OS::getenv("TESTSRC"));
 
-  std::cout << "create DistributedSytem with name=" << host_name << std::endl;
+  std::cout << "create DistributedSytem with name=XML_DECLARATIVE_CACHE_CREATION_TEST" << std::endl;
 
   try {
     const auto filePath =

--- a/cppcache/src/AdminRegion.hpp
+++ b/cppcache/src/AdminRegion.hpp
@@ -61,17 +61,14 @@ class AdminRegion : private NonCopyable,
                        const std::shared_ptr<Cacheable>& valuePtr);
   TcrConnectionManager* getConnectionManager();
 
+ public:
   AdminRegion()
       : m_distMngr(nullptr),
         m_fullPath("/__ADMIN_CLIENT_HEALTH_MONITORING__"),
         m_connectionMgr(nullptr),
         m_destroyPending(false) {}
-
   ~AdminRegion();
 
-  _GEODE_FRIEND_STD_SHARED_PTR(AdminRegion)
-
- public:
   static std::shared_ptr<AdminRegion> create(
       CacheImpl* cache, ThinClientBaseDM* distMan = nullptr);
   ACE_RW_Thread_Mutex& getRWLock();

--- a/cppcache/src/CacheTransactionManagerImpl.hpp
+++ b/cppcache/src/CacheTransactionManagerImpl.hpp
@@ -36,7 +36,7 @@ enum commitOp { BEFORE_COMMIT, AFTER_COMMIT };
 class CacheTransactionManagerImpl : public virtual CacheTransactionManager {
  public:
   CacheTransactionManagerImpl(CacheImpl* cache);
-  virtual ~CacheTransactionManagerImpl();
+  virtual ~CacheTransactionManagerImpl() override;
 
   virtual void begin() override;
   virtual void commit() override;

--- a/cppcache/src/CacheXmlParser.cpp
+++ b/cppcache/src/CacheXmlParser.cpp
@@ -84,47 +84,48 @@ extern "C" void startElementSAX2Function(void* ctx, const xmlChar* name,
       (!parser->isIllegalStateException()) &&
       (!parser->isAnyOtherException())) {
     try {
-      if (strcmp((char*)name, parser->CACHE) == 0) {
+      auto uname = reinterpret_cast<const char*>(const_cast<unsigned char*>(name));
+      if (std::strcmp(uname, parser->CACHE) == 0) {
         parser->startCache(ctx, atts);
-      } else if (strcmp((char*)name, parser->CLIENT_CACHE) == 0) {
+      } else if (strcmp(uname, parser->CLIENT_CACHE) == 0) {
         parser->startCache(ctx, atts);
-      } else if (strcmp((char*)name, parser->PDX) == 0) {
+      } else if (strcmp(uname, parser->PDX) == 0) {
         parser->startPdx(atts);
-      } else if (strcmp((char*)name, parser->REGION) == 0) {
+      } else if (strcmp(uname, parser->REGION) == 0) {
         parser->incNesting();
         parser->startRegion(atts, parser->isRootLevel());
-      } else if (strcmp((char*)name, parser->ROOT_REGION) == 0) {
+      } else if (strcmp(uname, parser->ROOT_REGION) == 0) {
         parser->incNesting();
         parser->startRegion(atts, parser->isRootLevel());
-      } else if (strcmp((char*)name, parser->REGION_ATTRIBUTES) == 0) {
+      } else if (strcmp(uname, parser->REGION_ATTRIBUTES) == 0) {
         parser->startRegionAttributes(atts);
-      } else if (strcmp((char*)name, parser->REGION_TIME_TO_LIVE) == 0) {
-      } else if (strcmp((char*)name, parser->REGION_IDLE_TIME) == 0) {
-      } else if (strcmp((char*)name, parser->ENTRY_TIME_TO_LIVE) == 0) {
-      } else if (strcmp((char*)name, parser->ENTRY_IDLE_TIME) == 0) {
-      } else if (strcmp((char*)name, parser->EXPIRATION_ATTRIBUTES) == 0) {
+      } else if (strcmp(uname, parser->REGION_TIME_TO_LIVE) == 0) {
+      } else if (strcmp(uname, parser->REGION_IDLE_TIME) == 0) {
+      } else if (strcmp(uname, parser->ENTRY_TIME_TO_LIVE) == 0) {
+      } else if (strcmp(uname, parser->ENTRY_IDLE_TIME) == 0) {
+      } else if (strcmp(uname, parser->EXPIRATION_ATTRIBUTES) == 0) {
         parser->startExpirationAttributes(atts);
-      } else if (strcmp((char*)name, parser->CACHE_LOADER) == 0) {
+      } else if (strcmp(uname, parser->CACHE_LOADER) == 0) {
         parser->startCacheLoader(atts);
-      } else if (strcmp((char*)name, parser->CACHE_WRITER) == 0) {
+      } else if (strcmp(uname, parser->CACHE_WRITER) == 0) {
         parser->startCacheWriter(atts);
-      } else if (strcmp((char*)name, parser->CACHE_LISTENER) == 0) {
+      } else if (strcmp(uname, parser->CACHE_LISTENER) == 0) {
         parser->startCacheListener(atts);
-      } else if (strcmp((char*)name, parser->PARTITION_RESOLVER) == 0) {
+      } else if (strcmp(uname, parser->PARTITION_RESOLVER) == 0) {
         parser->startPartitionResolver(atts);
-      } else if (strcmp((char*)name, parser->PERSISTENCE_MANAGER) == 0) {
+      } else if (strcmp(uname, parser->PERSISTENCE_MANAGER) == 0) {
         parser->startPersistenceManager(atts);
-      } else if (strcmp((char*)name, parser->PROPERTIES) == 0) {
-      } else if (strcmp((char*)name, parser->PROPERTY) == 0) {
+      } else if (strcmp(uname, parser->PROPERTIES) == 0) {
+      } else if (strcmp(uname, parser->PROPERTY) == 0) {
         parser->startPersistenceProperties(atts);
-      } else if (strcmp((char*)name, parser->POOL) == 0) {
+      } else if (strcmp(uname, parser->POOL) == 0) {
         parser->startPool(atts);
-      } else if (strcmp((char*)name, parser->LOCATOR) == 0) {
+      } else if (strcmp(uname, parser->LOCATOR) == 0) {
         parser->startLocator(atts);
-      } else if (strcmp((char*)name, parser->SERVER) == 0) {
+      } else if (strcmp(uname, parser->SERVER) == 0) {
         parser->startServer(atts);
       } else {
-        std::string temp((char*)name);
+        std::string temp(uname);
         std::string s = "XML:Unknown XML element \"" + temp + "\"";
         throw CacheXmlException(s.c_str());
       }
@@ -157,45 +158,46 @@ extern "C" void endElementSAX2Function(void* ctx, const xmlChar* name) {
       (!parser->isIllegalStateException()) &&
       (!parser->isAnyOtherException())) {
     try {
-      if (strcmp((char*)name, parser->CACHE) == 0) {
+      auto uname = reinterpret_cast<const char*>(const_cast<unsigned char*>(name));
+      if (strcmp(uname, parser->CACHE) == 0) {
         parser->endCache();
-      } else if (strcmp((char*)name, parser->CLIENT_CACHE) == 0) {
+      } else if (strcmp(uname, parser->CLIENT_CACHE) == 0) {
         parser->endCache();
-      } else if (strcmp((char*)name, parser->PDX) == 0) {
+      } else if (strcmp(uname, parser->PDX) == 0) {
         parser->endPdx();
-      } else if (strcmp((char*)name, parser->REGION) == 0) {
+      } else if (strcmp(uname, parser->REGION) == 0) {
         parser->endRegion(parser->isRootLevel());
         parser->decNesting();
-      } else if (strcmp((char*)name, parser->ROOT_REGION) == 0) {
+      } else if (strcmp(uname, parser->ROOT_REGION) == 0) {
         parser->endRegion(parser->isRootLevel());
         parser->decNesting();
-      } else if (strcmp((char*)name, parser->REGION_ATTRIBUTES) == 0) {
+      } else if (strcmp(uname, parser->REGION_ATTRIBUTES) == 0) {
         parser->endRegionAttributes();
-      } else if (strcmp((char*)name, parser->REGION_TIME_TO_LIVE) == 0) {
+      } else if (strcmp(uname, parser->REGION_TIME_TO_LIVE) == 0) {
         parser->endRegionTimeToLive();
-      } else if (strcmp((char*)name, parser->REGION_IDLE_TIME) == 0) {
+      } else if (strcmp(uname, parser->REGION_IDLE_TIME) == 0) {
         parser->endRegionIdleTime();
-      } else if (strcmp((char*)name, parser->ENTRY_TIME_TO_LIVE) == 0) {
+      } else if (strcmp(uname, parser->ENTRY_TIME_TO_LIVE) == 0) {
         parser->endEntryTimeToLive();
-      } else if (strcmp((char*)name, parser->ENTRY_IDLE_TIME) == 0) {
+      } else if (strcmp(uname, parser->ENTRY_IDLE_TIME) == 0) {
         parser->endEntryIdleTime();
-      } else if (strcmp((char*)name, parser->EXPIRATION_ATTRIBUTES) == 0) {
-      } else if (strcmp((char*)name, parser->CACHE_LOADER) == 0) {
-      } else if (strcmp((char*)name, parser->CACHE_WRITER) == 0) {
-      } else if (strcmp((char*)name, parser->CACHE_LISTENER) == 0) {
-      } else if (strcmp((char*)name, parser->PARTITION_RESOLVER) == 0) {
-      } else if (strcmp((char*)name, parser->PERSISTENCE_MANAGER) == 0) {
+      } else if (strcmp(uname, parser->EXPIRATION_ATTRIBUTES) == 0) {
+      } else if (strcmp(uname, parser->CACHE_LOADER) == 0) {
+      } else if (strcmp(uname, parser->CACHE_WRITER) == 0) {
+      } else if (strcmp(uname, parser->CACHE_LISTENER) == 0) {
+      } else if (strcmp(uname, parser->PARTITION_RESOLVER) == 0) {
+      } else if (strcmp(uname, parser->PERSISTENCE_MANAGER) == 0) {
         parser->endPersistenceManager();
-      } else if (strcmp((char*)name, parser->PROPERTIES) == 0) {
-      } else if (strcmp((char*)name, parser->PROPERTY) == 0) {
-      } else if (strcmp((char*)name, parser->POOL) == 0) {
+      } else if (strcmp(uname, parser->PROPERTIES) == 0) {
+      } else if (strcmp(uname, parser->PROPERTY) == 0) {
+      } else if (strcmp(uname, parser->POOL) == 0) {
         parser->endPool();
-      } else if (strcmp((char*)name, parser->LOCATOR) == 0) {
+      } else if (strcmp(uname, parser->LOCATOR) == 0) {
         // parser->endLocator();
-      } else if (strcmp((char*)name, parser->SERVER) == 0) {
+      } else if (strcmp(uname, parser->SERVER) == 0) {
         // parser->endServer();
       } else {
-        std::string temp((char*)name);
+        std::string temp(uname);
         std::string s = "XML:Unknown XML element \"" + temp + "\"";
         throw CacheXmlException(s.c_str());
       }
@@ -442,10 +444,10 @@ void CacheXmlParser::create(Cache* cache) {
 void CacheXmlParser::startCache(void*, const xmlChar** attrs) {
   int attrsCount = 0;
   if (attrs != nullptr) {
-    char* attrName;
-    char* attrValue;
-    while ((attrName = (char*)attrs[attrsCount++]) != nullptr) {
-      attrValue = (char*)attrs[attrsCount++];
+    const char* attrName;
+    const char* attrValue;
+    while ((attrName = reinterpret_cast<const char*>(attrs[attrsCount++])) != nullptr) {
+      attrValue = reinterpret_cast<const char*>(attrs[attrsCount++]);
       if (attrValue == nullptr) {
         std::string exStr = "XML: No value provided for attribute: ";
         exStr += attrName;
@@ -728,19 +730,19 @@ void CacheXmlParser::startRegion(const xmlChar** atts, bool isRoot) {
     throw CacheXmlException(s.c_str());
   }
 
-  char* regionName = nullptr;
-  char* refid = nullptr;
+  const char* regionName = nullptr;
+  const char* refid = nullptr;
 
   for (int i = 0; (atts[i] != nullptr); i++) {
     if (atts[i] != nullptr) {
-      char* name = (char*)atts[i];
+      const char* name = reinterpret_cast<const char*>(const_cast<xmlChar*>(atts[i]));
       i++;
       if (atts[i] != nullptr) {
-        char* value = (char*)atts[i];
+        const char* value = reinterpret_cast<const char*>(const_cast<xmlChar*>(atts[i]));
 
-        if (strcmp(name, "name") == 0) {
+        if (std::strcmp(name, "name") == 0) {
           regionName = value;
-        } else if (strcmp(name, "refid") == 0) {
+        } else if (std::strcmp(name, "refid") == 0) {
           refid = value;
         } else {
           std::string temp(name);
@@ -811,13 +813,13 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
       throw CacheXmlException(s.c_str());
     }
 
-    char* refid = nullptr;
+    const char* refid = nullptr;
 
     for (int i = 0; (atts[i] != nullptr); i++) {
       i++;
 
       if (atts[i] != nullptr) {
-        char* value = (char*)atts[i];
+        const char* value = reinterpret_cast<const char*>(atts[i]);
         if (strcmp(value, "") == 0) {
           std::string s =
               "XML:In the <region-attributes> element no "
@@ -827,12 +829,13 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
           throw CacheXmlException(s.c_str());
         }
 
-        if (strcmp((char*)atts[i - 1], ID) == 0) {
+        const char* prev = reinterpret_cast<const char*>(atts[i - 1]);
+        if (strcmp(prev, ID) == 0) {
           auto region =
               std::static_pointer_cast<RegionXmlCreation>(_stack.top());
-          region->setAttrId(std::string((char*)atts[i]));
-        } else if (strcmp((char*)atts[i - 1], REFID) == 0) {
-          refid = (char*)atts[i];
+          region->setAttrId(std::string(value));
+        } else if (strcmp(prev, REFID) == 0) {
+          refid = value;
         }
       }
     }
@@ -862,13 +865,14 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
     _stack.push(regionAttributesFactory);
 
     for (int i = 0; (atts[i] != nullptr); i++) {
-      if (strcmp(ID, (char*)atts[i]) == 0 ||
-          strcmp(REFID, (char*)atts[i]) == 0) {
+      auto name = reinterpret_cast<const char*>(atts[i]);
+      if (strcmp(ID, name) == 0 ||
+          strcmp(REFID, name) == 0) {
         i++;
         continue;
-      } else if (strcmp(CLIENT_NOTIFICATION_ENABLED, (char*)atts[i]) == 0) {
+      } else if (strcmp(CLIENT_NOTIFICATION_ENABLED, name) == 0) {
         i++;
-        char* client_notification_enabled = (char*)atts[i];
+        auto client_notification_enabled = reinterpret_cast<const char*>(atts[i]);
         if (strcmp("false", client_notification_enabled) == 0 ||
             strcmp("FALSE", client_notification_enabled) == 0) {
           if (m_poolFactory) {
@@ -880,30 +884,29 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
             m_poolFactory->setSubscriptionEnabled(true);
           }
         } else {
-          char* name = (char*)atts[i];
-          std::string temp(name);
+          std::string temp(client_notification_enabled);
           std::string s =
               "XML: " + temp +
-              " is not a valid value for the attribute <client-notification>\n";
+              " is not a valid name for the attribute <client-notification>\n";
           throw CacheXmlException(s.c_str());
         }
-      } else if (strcmp(INITIAL_CAPACITY, (char*)atts[i]) == 0) {
+      } else if (strcmp(INITIAL_CAPACITY, name) == 0) {
         i++;
-        char* initialCapacity = (char*)atts[i];
+        auto initialCapacity = reinterpret_cast<const char*>(atts[i]);
         regionAttributesFactory->setInitialCapacity(atoi(initialCapacity));
-      } else if (strcmp(CONCURRENCY_LEVEL, (char*)atts[i]) == 0) {
+      } else if (strcmp(CONCURRENCY_LEVEL, name) == 0) {
         i++;
-        char* concurrencyLevel = (char*)atts[i];
+        auto concurrencyLevel = reinterpret_cast<const char*>(atts[i]);
         regionAttributesFactory->setConcurrencyLevel(atoi(concurrencyLevel));
-      } else if (strcmp(LOAD_FACTOR, (char*)atts[i]) == 0) {
+      } else if (strcmp(LOAD_FACTOR, name) == 0) {
         i++;
-        char* loadFactor = (char*)atts[i];
+        auto loadFactor = reinterpret_cast<const char*>(atts[i]);
         regionAttributesFactory->setLoadFactor(
             static_cast<float>(atof(loadFactor)));  // check whether this works
-      } else if (strcmp(CACHING_ENABLED, (char*)atts[i]) == 0) {
+      } else if (strcmp(CACHING_ENABLED, name) == 0) {
         bool flag = false;
         i++;
-        char* cachingEnabled = (char*)atts[i];
+        auto cachingEnabled = reinterpret_cast<const char*>(atts[i]);
         if (strcmp("true", cachingEnabled) == 0 ||
             strcmp("TRUE", cachingEnabled) == 0) {
           flag = true;
@@ -911,24 +914,23 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
                    strcmp("FALSE", cachingEnabled) == 0) {
           flag = false;
         } else {
-          char* name = (char*)atts[i];
-          std::string temp(name);
+          std::string temp(cachingEnabled);
           std::string s =
               "XML: " + temp +
-              " is not a valid value for the attribute <caching-enabled>";
+              " is not a valid name for the attribute <caching-enabled>";
           throw CacheXmlException(s.c_str());
         }
         regionAttributesFactory->setCachingEnabled(
             flag);  // check whether this works
-      } else if (strcmp(LRU_ENTRIES_LIMIT, (char*)atts[i]) == 0) {
+      } else if (strcmp(LRU_ENTRIES_LIMIT, name) == 0) {
         i++;
-        char* lruentriesLimit = (char*)atts[i];
+        auto lruentriesLimit = reinterpret_cast<const char*>(atts[i]);
         int lruentriesLimitInt = atoi(lruentriesLimit);
         uint32_t temp = static_cast<uint32_t>(lruentriesLimitInt);
         regionAttributesFactory->setLruEntriesLimit(temp);
-      } else if (strcmp(DISK_POLICY, (char*)atts[i]) == 0) {
+      } else if (strcmp(DISK_POLICY, name) == 0) {
         i++;
-        char* diskPolicy = (char*)atts[i];
+        auto diskPolicy = reinterpret_cast<const char*>(atts[i]);
         if (strcmp(OVERFLOWS, diskPolicy) == 0) {
           regionAttributesFactory->setDiskPolicy(
               apache::geode::client::DiskPolicyType::OVERFLOWS);
@@ -938,18 +940,17 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
           regionAttributesFactory->setDiskPolicy(
               apache::geode::client::DiskPolicyType::NONE);
         } else {
-          char* name = (char*)atts[i];
-          std::string temp(name);
+          std::string temp(diskPolicy);
           std::string s =
               "XML: " + temp +
-              " is not a valid value for the attribute <disk-policy>";
+              " is not a valid name for the attribute <disk-policy>";
           throw CacheXmlException(s.c_str());
         }
-      } else if (strcmp(ENDPOINTS, (char*)atts[i]) == 0) {
+      } else if (strcmp(ENDPOINTS, name) == 0) {
         i++;
         if (m_poolFactory) {
           std::vector<std::pair<std::string, int>> endPoints(
-              parseEndPoints((char*)atts[i]));
+              parseEndPoints(name));
           std::vector<std::pair<std::string, int>>::iterator endPoint;
           for (endPoint = endPoints.begin(); endPoint != endPoints.end();
                endPoint++) {
@@ -957,15 +958,15 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
           }
         }
         isTCR = true;
-      } else if (strcmp(POOL_NAME, (char*)atts[i]) == 0) {
+      } else if (strcmp(POOL_NAME, name) == 0) {
         i++;
-        char* poolName = (char*)atts[i];
+        auto poolName = reinterpret_cast<const char*>(atts[i]);
         regionAttributesFactory->setPoolName(poolName);
         isTCR = true;
-      } else if (strcmp(CLONING_ENABLED, (char*)atts[i]) == 0) {
+      } else if (strcmp(CLONING_ENABLED, name) == 0) {
         i++;
         bool flag = false;
-        char* isClonable = (char*)atts[i];
+        auto isClonable = reinterpret_cast<const char*>(atts[i]);
 
         if (strcmp("true", isClonable) == 0 ||
             strcmp("TRUE", isClonable) == 0) {
@@ -974,8 +975,7 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
                    strcmp("FALSE", isClonable) == 0) {
           flag = false;
         } else {
-          char* name = (char*)atts[i];
-          std::string temp(name);
+          std::string temp(isClonable);
           std::string s =
               "XML: " + temp +
               " is not a valid value for the attribute <cloning-enabled>";
@@ -984,10 +984,10 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
 
         regionAttributesFactory->setCloningEnabled(flag);
         isTCR = true;
-      } else if (strcmp(CONCURRENCY_CHECKS_ENABLED, (char*)atts[i]) == 0) {
+      } else if (strcmp(CONCURRENCY_CHECKS_ENABLED, name) == 0) {
         bool flag = false;
         i++;
-        char* concurrencyChecksEnabled = (char*)atts[i];
+        auto concurrencyChecksEnabled = reinterpret_cast<const char*>(atts[i]);
         if (strcmp("true", concurrencyChecksEnabled) == 0 ||
             strcmp("TRUE", concurrencyChecksEnabled) == 0) {
           flag = true;
@@ -995,7 +995,6 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
                    strcmp("FALSE", concurrencyChecksEnabled) == 0) {
           flag = false;
         } else {
-          char* name = (char*)atts[i];
           std::string temp(name);
           std::string s = "XML: " + temp +
                           " is not a valid value for the attribute "
@@ -1015,8 +1014,7 @@ void CacheXmlParser::startRegionAttributes(const xmlChar** atts) {
 
   if (isDistributed && isTCR) {
     /* we don't allow DR+TCR at current stage according to sudhir */
-    std::string s = "XML:endpoints cannot be defined for distributed region.\n";
-    throw CacheXmlException(s.c_str());
+    throw CacheXmlException("XML:endpoints cannot be defined for distributed region.\n");
   }
 }
 
@@ -1067,18 +1065,19 @@ void CacheXmlParser::startExpirationAttributes(const xmlChar** atts) {
   std::chrono::seconds timeOutSeconds;
   ExpirationAction expire = ExpirationAction::INVALID_ACTION;
   for (int i = 0; (atts[i] != nullptr); i++) {
-    if (strcmp(TIMEOUT, (char*)atts[i]) == 0) {
+    auto name = reinterpret_cast<const char*>(atts[i]);
+    if (strcmp(TIMEOUT, name) == 0) {
       i++;
-      timeOut = std::string((char*)atts[i]);
+      timeOut = std::string(reinterpret_cast<const char*>(atts[i]));
       if (timeOut.empty()) {
         std::string s =
             "XML:Value for attribute <timeout> needs to be specified";
         throw CacheXmlException(s.c_str());
       }
       timeOutSeconds = from_string<std::chrono::seconds>(timeOut);
-    } else if (strcmp(ACTION, (char*)atts[i]) == 0) {
+    } else if (strcmp(ACTION, name) == 0) {
       i++;
-      char* action = (char*)atts[i];
+      auto action = reinterpret_cast<const char*>(atts[i]);
       if (strcmp(action, "") == 0)
 
       {
@@ -1098,14 +1097,12 @@ void CacheXmlParser::startExpirationAttributes(const xmlChar** atts) {
       } else if (strcmp(LOCAL_DESTROY, action) == 0) {
         expire = ExpirationAction::LOCAL_DESTROY;
       } else {
-        char* name = (char*)atts[i];
-        std::string temp(name);
+        std::string temp(action);
         std::string s =
             "XML: " + temp + " is not a valid value for the attribute <action>";
         throw CacheXmlException(s.c_str());
       }
     } else {
-      char* name = (char*)atts[i];
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in "
@@ -1125,7 +1122,7 @@ void CacheXmlParser::startExpirationAttributes(const xmlChar** atts) {
       std::make_shared<ExpirationAttributes>(timeOutSeconds, expire);
   if (!expireAttr) {
     throw UnknownException(
-        "CacheXmlParser::startExpirationAttributes:Out of memeory");
+        "CacheXmlParser::startExpirationAttributes:Out of memory");
   }
   expireAttr->setAction(expire);
 
@@ -1147,16 +1144,18 @@ void CacheXmlParser::startPersistenceManager(const xmlChar** atts) {
   char* libraryName = nullptr;
   char* libraryFunctionName = nullptr;
   for (int i = 0; (atts[i] != nullptr); i++) {
-    if (strcmp(LIBRARY_NAME, (char*)atts[i]) == 0) {
+    auto name = reinterpret_cast<const char*>(atts[i]);
+    if (std::strcmp(LIBRARY_NAME, name) == 0) {
       i++;
-      size_t len = strlen((char*)atts[i]) + 1;
+      auto value = reinterpret_cast<const char*>(atts[i]);
+      size_t len = strlen(value) + 1;
       libraryName = new char[len];
 
       if (libraryName == nullptr) {
         std::string s = "Memory allocation fails";
         throw CacheXmlException(s.c_str());
       }
-      ACE_OS::strncpy(libraryName, (char*)atts[i], len);
+      std::strncpy(libraryName, value, len);
 
       if (libraryName == nullptr) {
         std::string s =
@@ -1168,9 +1167,10 @@ void CacheXmlParser::startPersistenceManager(const xmlChar** atts) {
             "will be set";
         throw CacheXmlException(s.c_str());
       }
-    } else if (strcmp(LIBRARY_FUNCTION_NAME, (char*)atts[i]) == 0) {
+    } else if (std::strcmp(LIBRARY_FUNCTION_NAME, name) == 0) {
       i++;
-      size_t len = strlen((char*)atts[i]) + 1;
+      auto value = reinterpret_cast<const char*>(atts[i]);
+      size_t len = strlen(value) + 1;
       libraryFunctionName = new char[len];
 
       if (libraryFunctionName == nullptr) {
@@ -1178,15 +1178,11 @@ void CacheXmlParser::startPersistenceManager(const xmlChar** atts) {
         throw CacheXmlException(s.c_str());
       }
 
-      ACE_OS::strncpy(libraryFunctionName, (char*)atts[i], len);
+      std::strncpy(libraryFunctionName, value, len);
       if (libraryFunctionName == nullptr) {
-        std::string s =
-            "XML:Value for the <library-function-name> needs to be provided";
-        ;
-        throw CacheXmlException(s.c_str());
+        throw CacheXmlException("XML:Value for the <library-function-name> needs to be provided");
       }
     } else {
-      char* name = (char*)atts[i];
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in "
@@ -1234,29 +1230,25 @@ void CacheXmlParser::startPersistenceProperties(const xmlChar** atts) {
       m_config = Properties::create();
     }
   }
-  char* propName = nullptr;
-  char* propValue = nullptr;
+  const char* propName = nullptr;
+  const char* propValue = nullptr;
   for (int i = 0; (atts[i] != nullptr); i++) {
-    if (strcmp("name", (char*)atts[i]) == 0) {
+    auto name = reinterpret_cast<const char*>(atts[i]);
+    if (std::strcmp("name", name) == 0) {
       i++;
-      propName = (char*)atts[i];
-      if (propName == nullptr || strcmp(propName, "") == 0) {
-        std::string s =
-            "XML:Value for attribute <name> needs to be specified in the "
-            "<property>";
-        throw CacheXmlException(s.c_str());
+      propName = reinterpret_cast<const char*>(atts[i]);
+      if (propName == nullptr || std::strcmp(propName, "") == 0) {
+        throw CacheXmlException("XML:Value for attribute <name> needs to be specified in the "
+            "<property>");
       }
-    } else if (strcmp("value", (char*)atts[i]) == 0) {
+    } else if (strcmp("value", name) == 0) {
       i++;
-      propValue = (char*)atts[i];
+      propValue = reinterpret_cast<const char*>(atts[i]);
       if (propValue == nullptr || strcmp(propValue, "") == 0) {
-        std::string s =
-            "XML:Value for attribute <value> needs to be "
-            "specified in the <property>";
-        throw CacheXmlException(s.c_str());
+        throw CacheXmlException("XML:Value for attribute <value> needs to be "
+            "specified in the <property>");
       }
     } else {
-      char* name = (char*)atts[i];
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in <property>: " + temp;
@@ -1277,8 +1269,8 @@ void CacheXmlParser::startPersistenceProperties(const xmlChar** atts) {
 }
 
 void CacheXmlParser::startCacheLoader(const xmlChar** atts) {
-  char* libraryName = nullptr;
-  char* libraryFunctionName = nullptr;
+  const char* libraryName = nullptr;
+  const char* libraryFunctionName = nullptr;
   int attrsCount = 0;
   if (!atts) {
     std::string s = "XML:No attributes provided for <cache-loader>";
@@ -1292,30 +1284,26 @@ void CacheXmlParser::startCacheLoader(const xmlChar** atts) {
   }
 
   for (int i = 0; (atts[i] != nullptr); i++) {
-    if (strcmp(LIBRARY_NAME, (char*)atts[i]) == 0) {
+    auto name = reinterpret_cast<const char*>(atts[i]);
+    if (strcmp(LIBRARY_NAME, name) == 0) {
       i++;
-      libraryName = (char*)atts[i];
+      libraryName = reinterpret_cast<const char*>(atts[i]);
       if (libraryName == nullptr || strcmp(libraryName, "") == 0) {
-        std::string s =
-            "XML:The attribute <library-name> of <cache-loader> cannot be "
+        throw CacheXmlException("XML:The attribute <library-name> of <cache-loader> cannot be "
             "set "
             "to an empty string. It should either have a value or the "
             "attribute should be removed. In the latter case the default "
             "value "
-            "will be set";
-        throw CacheXmlException(s.c_str());
+            "will be set");
       }
-    } else if (strcmp(LIBRARY_FUNCTION_NAME, (char*)atts[i]) == 0) {
+    } else if (strcmp(LIBRARY_FUNCTION_NAME, name) == 0) {
       i++;
-      libraryFunctionName = (char*)atts[i];
+      libraryFunctionName = reinterpret_cast<const char*>(atts[i]);
       if (libraryFunctionName == nullptr ||
           strcmp(libraryFunctionName, "") == 0) {
-        std::string s =
-            "XML:Value for the <library-function-name> needs to be provided";
-        throw CacheXmlException(s.c_str());
+        throw CacheXmlException("XML:Value for the <library-function-name> needs to be provided");
       }
     } else {
-      char* name = (char*)atts[i];
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in <cache-loader> : " + temp;
@@ -1346,8 +1334,8 @@ void CacheXmlParser::startCacheLoader(const xmlChar** atts) {
 }
 
 void CacheXmlParser::startCacheListener(const xmlChar** atts) {
-  char* libraryName = nullptr;
-  char* libraryFunctionName = nullptr;
+  const char* libraryName = nullptr;
+  const char* libraryFunctionName = nullptr;
   int attrsCount = 0;
   if (!atts) {
     std::string s = "XML:No attributes provided for <cache-listener> ";
@@ -1361,28 +1349,24 @@ void CacheXmlParser::startCacheListener(const xmlChar** atts) {
   }
 
   for (int i = 0; (atts[i] != nullptr); i++) {
-    if (strcmp(LIBRARY_NAME, (char*)atts[i]) == 0) {
+    auto name = reinterpret_cast<const char*>(atts[i]);
+    if (strcmp(LIBRARY_NAME, name) == 0) {
       i++;
-      libraryName = (char*)atts[i];
+      libraryName = reinterpret_cast<const char*>(atts[i]);
       if (libraryName == nullptr || strcmp(libraryName, "") == 0) {
-        std::string s =
-            "XML:The attribute <library-name> of the <cache-listener> tag "
+        throw CacheXmlException("XML:The attribute <library-name> of the <cache-listener> tag "
             "cannot be set to an empty string. It should either have a value "
             "or the attribute should be removed. In the latter case the "
-            "default value will be set";
-        throw CacheXmlException(s.c_str());
+            "default value will be set");
       }
-    } else if (strcmp(LIBRARY_FUNCTION_NAME, (char*)atts[i]) == 0) {
+    } else if (strcmp(LIBRARY_FUNCTION_NAME, name) == 0) {
       i++;
-      libraryFunctionName = (char*)atts[i];
+      libraryFunctionName = reinterpret_cast<const char*>(atts[i]);
       if (libraryFunctionName == nullptr ||
           strcmp(libraryFunctionName, "") == 0) {
-        std::string s =
-            "XML:Value for <library-function-name> needs to be provided";
-        throw CacheXmlException(s.c_str());
+        throw CacheXmlException("XML:Value for <library-function-name> needs to be provided");
       }
     } else {
-      char* name = (char*)atts[i];
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in <cache-listener> : " +
@@ -1414,8 +1398,8 @@ void CacheXmlParser::startCacheListener(const xmlChar** atts) {
 }
 
 void CacheXmlParser::startPartitionResolver(const xmlChar** atts) {
-  char* libraryName = nullptr;
-  char* libraryFunctionName = nullptr;
+  const char* libraryName = nullptr;
+  const char* libraryFunctionName = nullptr;
   int attrsCount = 0;
   if (!atts) {
     std::string s = "XML:No attributes provided for <partition-resolver> ";
@@ -1430,29 +1414,25 @@ void CacheXmlParser::startPartitionResolver(const xmlChar** atts) {
   }
 
   for (int i = 0; (atts[i] != nullptr); i++) {
-    if (strcmp(LIBRARY_NAME, (char*)atts[i]) == 0) {
+    auto name = reinterpret_cast<const char*>(atts[i]);
+    if (strcmp(LIBRARY_NAME, name) == 0) {
       i++;
-      libraryName = (char*)atts[i];
+      libraryName = reinterpret_cast<const char*>(atts[i]);
       if (libraryName == nullptr || strcmp(libraryName, "") == 0) {
-        std::string s =
-            "XML:The attribute <library-name> of the <partition-resolver> "
+        throw CacheXmlException("XML:The attribute <library-name> of the <partition-resolver> "
             "tag "
             "cannot be set to an empty string. It should either have a value "
             "or the attribute should be removed. In the latter case the "
-            "default value will be set";
-        throw CacheXmlException(s.c_str());
+            "default value will be set");
       }
-    } else if (strcmp(LIBRARY_FUNCTION_NAME, (char*)atts[i]) == 0) {
+    } else if (strcmp(LIBRARY_FUNCTION_NAME, name) == 0) {
       i++;
-      libraryFunctionName = (char*)atts[i];
+      libraryFunctionName = reinterpret_cast<const char*>(atts[i]);
       if (libraryFunctionName == nullptr ||
           strcmp(libraryFunctionName, "") == 0) {
-        std::string s =
-            "XML:Value for <library-function-name> needs to be provided";
-        throw CacheXmlException(s.c_str());
+        throw CacheXmlException("XML:Value for <library-function-name> needs to be provided");
       }
     } else {
-      char* name = (char*)atts[i];
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in <partition-resolver> "
@@ -1462,9 +1442,7 @@ void CacheXmlParser::startPartitionResolver(const xmlChar** atts) {
     }
   }
   if (libraryFunctionName == nullptr || strcmp(libraryFunctionName, "") == 0) {
-    std::string s =
-        "XML:Library function name not specified in <partition-resolver> ";
-    throw CacheXmlException(s.c_str());
+    throw CacheXmlException("XML:Library function name not specified in <partition-resolver> ");
   }
 
   try {
@@ -1486,8 +1464,8 @@ void CacheXmlParser::startPartitionResolver(const xmlChar** atts) {
 }
 
 void CacheXmlParser::startCacheWriter(const xmlChar** atts) {
-  char* libraryName = nullptr;
-  char* libraryFunctionName = nullptr;
+  const char* libraryName = nullptr;
+  const char* libraryFunctionName = nullptr;
   int attrsCount = 0;
   if (!atts) {
     std::string s = "XML:No attributes provided for <cache-writer>";
@@ -1501,30 +1479,26 @@ void CacheXmlParser::startCacheWriter(const xmlChar** atts) {
   }
 
   for (int i = 0; (atts[i] != nullptr); i++) {
-    if (strcmp(LIBRARY_NAME, (char*)atts[i]) == 0) {
+    auto name = reinterpret_cast<const char*>(atts[i]);
+    if (strcmp(LIBRARY_NAME, name) == 0) {
       i++;
-      libraryName = (char*)atts[i];
+      libraryName = reinterpret_cast<const char*>(atts[i]);
       if (libraryName == nullptr || strcmp(libraryName, "") == 0) {
-        std::string s =
-            "XML:The attribute <library-name> of <cache-writer> cannot be "
+        throw CacheXmlException("XML:The attribute <library-name> of <cache-writer> cannot be "
             "set "
             "to an empty string. It should either have a value or the "
             "attribute should be removed. In the latter case the default "
             "value "
-            "will be set";
-        throw CacheXmlException(s.c_str());
+            "will be set");
       }
-    } else if (strcmp(LIBRARY_FUNCTION_NAME, (char*)atts[i]) == 0) {
+    } else if (strcmp(LIBRARY_FUNCTION_NAME, name) == 0) {
       i++;
-      libraryFunctionName = (char*)atts[i];
+      libraryFunctionName = reinterpret_cast<const char*>(atts[i]);
       if (libraryFunctionName == nullptr ||
           strcmp(libraryFunctionName, "") == 0) {
-        std::string s =
-            "XML:Value for the <library-function-name> needs to be provided";
-        throw CacheXmlException(s.c_str());
+        throw CacheXmlException("XML:Value for the <library-function-name> needs to be provided");
       }
     } else {
-      char* name = (char*)atts[i];
       std::string temp(name);
       std::string s =
           "XML:Incorrect attribute name specified in <cache-writer>: " + temp;
@@ -1532,9 +1506,7 @@ void CacheXmlParser::startCacheWriter(const xmlChar** atts) {
     }
   }
   if (strcmp(libraryFunctionName, "") == 0) {
-    std::string s =
-        "XML:Library function name not specified in the <cache-writer>";
-    throw CacheXmlException(s.c_str());
+    throw CacheXmlException("XML:Library function name not specified in the <cache-writer>");
   }
 
   try {

--- a/cppcache/src/CacheableToken.hpp
+++ b/cppcache/src/CacheableToken.hpp
@@ -76,8 +76,6 @@ class APACHE_GEODE_EXPORT CacheableToken
 
   ~CacheableToken() override = default;
 
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableToken)
-
   inline bool isInvalid() { return m_value == INVALID; }
 
   inline bool isDestroyed() { return m_value == DESTROYED; }
@@ -116,9 +114,8 @@ class APACHE_GEODE_EXPORT CacheableToken
 
   virtual size_t objectSize() const override;
 
- protected:
-  CacheableToken(TokenType value);
   CacheableToken();  // used for deserialization.
+  CacheableToken(TokenType value);
 
  private:
   // never implemented.

--- a/cppcache/src/ClientHealthStats.hpp
+++ b/cppcache/src/ClientHealthStats.hpp
@@ -57,10 +57,11 @@ class ClientHealthStats : public internal::DataSerializableFixedId_t<
   }
   ~ClientHealthStats() override = default;
 
+  ClientHealthStats();
+
  private:
   ClientHealthStats(int gets, int puts, int misses, int listCalls,
                     int numThreads, int64_t cpuTime, int cpus);
-  ClientHealthStats();
 
   int m_numGets;                // CachePerfStats.gets
   int m_numPuts;                // CachePerfStats.puts
@@ -70,8 +71,6 @@ class ClientHealthStats : public internal::DataSerializableFixedId_t<
   int64_t m_processCpuTime;     //
   int m_cpus;
   std::shared_ptr<CacheableDate> m_updateTime;  // Last updateTime
-
-  _GEODE_FRIEND_STD_SHARED_PTR(ClientHealthStats)
 };
 
 }  // namespace client

--- a/cppcache/src/ClientProxyMembershipID.cpp
+++ b/cppcache/src/ClientProxyMembershipID.cpp
@@ -18,6 +18,7 @@
 #include "ClientProxyMembershipID.hpp"
 
 #include <ctime>
+#include <iostream>
 #include <string>
 #include <memory>
 
@@ -146,7 +147,7 @@ void ClientProxyMembershipID::initObjectVars(
   }
   writeVersion(Version::getOrdinal(), m_memID);
   size_t len;
-  char* buf = (char*)m_memID.getBuffer(&len);
+  char* buf = reinterpret_cast<char*>(const_cast<uint8_t*>(m_memID.getBuffer(&len)));
   m_memIDStr.append(buf, len);
 
   char PID[15] = {0};

--- a/cppcache/src/ConcurrentEntriesMap.cpp
+++ b/cppcache/src/ConcurrentEntriesMap.cpp
@@ -31,7 +31,7 @@ ConcurrentEntriesMap::ConcurrentEntriesMap(
     : EntriesMap(std::move(entryFactory)),
       m_expiryTaskManager(expiryTaskManager),
       m_concurrency(0),
-      m_segments((MapSegment*)0),
+      m_segments(nullptr),
       m_size(0),
       m_region(region),
       m_numDestroyTrackers(0),

--- a/cppcache/src/CqQueryImpl.hpp
+++ b/cppcache/src/CqQueryImpl.hpp
@@ -273,8 +273,6 @@ class CqQueryImpl : public CqQuery,
   void sendStopOrClose(TcrMessage::MsgType requestType);
   ThinClientBaseDM* m_tccdm;
   AuthenticatedView* m_authenticatedView;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(CqQueryImpl)
 };
 
 }  // namespace client

--- a/cppcache/src/ExpMapEntry.hpp
+++ b/cppcache/src/ExpMapEntry.hpp
@@ -44,7 +44,6 @@ class APACHE_GEODE_EXPORT ExpMapEntry : public MapEntryImpl,
     }
   }
 
- protected:
   // this constructor deliberately skips touching or initializing any members
   inline explicit ExpMapEntry(bool)
       : MapEntryImpl(true), ExpEntryProperties(true) {}
@@ -62,16 +61,15 @@ class APACHE_GEODE_EXPORT ExpMapEntry : public MapEntryImpl,
 class APACHE_GEODE_EXPORT VersionedExpMapEntry : public ExpMapEntry,
                                                  public VersionStamp {
  public:
-  virtual ~VersionedExpMapEntry() {}
-
-  virtual VersionStamp& getVersionStamp() { return *this; }
-
- protected:
-  inline explicit VersionedExpMapEntry(bool) : ExpMapEntry(true) {}
-
   inline VersionedExpMapEntry(ExpiryTaskManager* expiryTaskManager,
                               const std::shared_ptr<CacheableKey>& key)
       : ExpMapEntry(expiryTaskManager, key) {}
+
+  inline explicit VersionedExpMapEntry(bool) : ExpMapEntry(true) {}
+
+  virtual ~VersionedExpMapEntry() {}
+
+  virtual VersionStamp& getVersionStamp() { return *this; }
 
  private:
   // disabled

--- a/cppcache/src/ExpiryHandler_T.hpp
+++ b/cppcache/src/ExpiryHandler_T.hpp
@@ -50,7 +50,7 @@ class APACHE_GEODE_EXPORT ExpiryHandler_T : public ACE_Event_Handler {
   ~ExpiryHandler_T() override = default;
 
   int handle_timeout(const ACE_Time_Value &tv, const void *arg) override {
-    return (this->to_handler_ == 0 ? 0 : (this->op_handler_->*to_handler_)(
+    return (this->to_handler_ == nullptr ? 0 : (this->op_handler_->*to_handler_)(
                                              tv, arg));
   }
 

--- a/cppcache/src/ExpiryTaskManager.cpp
+++ b/cppcache/src/ExpiryTaskManager.cpp
@@ -59,7 +59,7 @@ long ExpiryTaskManager::scheduleExpiryTask(ACE_Event_Handler* handler,
 
   ACE_Time_Value expTimeValue(expTime);
   ACE_Time_Value intervalValue(interval);
-  return m_reactor->schedule_timer(handler, 0, expTimeValue, intervalValue);
+  return m_reactor->schedule_timer(handler, nullptr, expTimeValue, intervalValue);
 }
 
 long ExpiryTaskManager::scheduleExpiryTask(ACE_Event_Handler* handler,
@@ -70,7 +70,7 @@ long ExpiryTaskManager::scheduleExpiryTask(ACE_Event_Handler* handler,
     m_reactor->cancel_timer(handler, 1);
   }
 
-  return m_reactor->schedule_timer(handler, 0, expTimeValue, intervalVal);
+  return m_reactor->schedule_timer(handler, nullptr, expTimeValue, intervalVal);
 }
 
 int ExpiryTaskManager::resetTask(ExpiryTaskManager::id_type id, uint32_t sec) {
@@ -79,7 +79,7 @@ int ExpiryTaskManager::resetTask(ExpiryTaskManager::id_type id, uint32_t sec) {
 }
 
 int ExpiryTaskManager::cancelTask(ExpiryTaskManager::id_type id) {
-  return m_reactor->cancel_timer(id, 0, 0);
+  return m_reactor->cancel_timer(id, nullptr, 0);
 }
 
 int ExpiryTaskManager::svc() {

--- a/cppcache/src/ExpiryTaskManager.hpp
+++ b/cppcache/src/ExpiryTaskManager.hpp
@@ -105,7 +105,7 @@ class APACHE_GEODE_EXPORT ExpiryTaskManager : public ACE_Task_Base {
         if (expired == nullptr) return 0;
       }
 
-      const void* upcall_act = 0;
+      const void* upcall_act = nullptr;
 
       // Preinvoke (handles refcount if needed, etc.)
       this->preinvoke(info, cur_time, upcall_act);
@@ -164,7 +164,7 @@ class APACHE_GEODE_EXPORT ExpiryTaskManager : public ACE_Task_Base {
       ACE_Timer_Node_T<TYPE>* expired = nullptr;
       ACE_Timer_Node_Dispatch_Info_T<TYPE> info;
       while ((expired = this->getFirstNode(cur_time, info)) != nullptr) {
-        const void* upcall_act = 0;
+        const void* upcall_act = nullptr;
         this->preinvoke(info, cur_time, upcall_act);
 
         this->upcall(info, cur_time);
@@ -258,7 +258,7 @@ class APACHE_GEODE_EXPORT ExpiryTaskManager : public ACE_Task_Base {
     ACE_Time_Value expTimeValue(expTime);
     ACE_Time_Value intervalValue(interval);
     LOGFINER("Scheduled expiration ... in %d seconds.", expTime.count());
-    return m_reactor->schedule_timer(handler, 0, expTimeValue, intervalValue);
+    return m_reactor->schedule_timer(handler, nullptr, expTimeValue, intervalValue);
   }
 
   /**

--- a/cppcache/src/FunctionServiceImpl.hpp
+++ b/cppcache/src/FunctionServiceImpl.hpp
@@ -38,15 +38,7 @@ namespace client {
 
 class APACHE_GEODE_EXPORT FunctionServiceImpl : public FunctionService {
  public:
-  /**
-   * This function is used in multiuser mode to execute function on server.
-   */
-  // virtual std::shared_ptr<Execution> onServer();
-
-  /**
-   * This function is used in multiuser mode to execute function on server.
-   */
-  // virtual std::shared_ptr<Execution> onServers();
+  FunctionServiceImpl(AuthenticatedView* authenticatedView);
 
   virtual ~FunctionServiceImpl() {}
 
@@ -54,16 +46,12 @@ class APACHE_GEODE_EXPORT FunctionServiceImpl : public FunctionService {
   FunctionServiceImpl(const FunctionService&);
   FunctionServiceImpl& operator=(const FunctionService&);
 
-  FunctionServiceImpl(AuthenticatedView* authenticatedView);
-
   static std::shared_ptr<FunctionService> getFunctionService(
       AuthenticatedView* authenticatedView);
 
   AuthenticatedView* m_authenticatedView;
 
   friend class AuthenticatedView;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(FunctionServiceImpl)
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/src/InternalCacheTransactionManager2PCImpl.hpp
+++ b/cppcache/src/InternalCacheTransactionManager2PCImpl.hpp
@@ -32,7 +32,7 @@ class InternalCacheTransactionManager2PCImpl
       public InternalCacheTransactionManager2PC {
  public:
   InternalCacheTransactionManager2PCImpl(CacheImpl* cache);
-  virtual ~InternalCacheTransactionManager2PCImpl();
+  virtual ~InternalCacheTransactionManager2PCImpl() override;
 
   virtual void prepare() override;
   virtual void commit() override;

--- a/cppcache/src/LocalRegion.hpp
+++ b/cppcache/src/LocalRegion.hpp
@@ -130,7 +130,7 @@ class APACHE_GEODE_EXPORT LocalRegion : public RegionInternal {
               RegionAttributes attributes,
               const std::shared_ptr<CacheStatistics>& stats,
               bool enableTimeStatistics = true);
-  virtual ~LocalRegion();
+  virtual ~LocalRegion() override;
 
   const std::string& getName() const override;
   const std::string& getFullPath() const override;

--- a/cppcache/src/Log.cpp
+++ b/cppcache/src/Log.cpp
@@ -110,7 +110,7 @@ static int selector(const dirent* d) {
     size_t fileHyphenPos = tempname.find_last_of('-');
     if (fileHyphenPos != std::string::npos) {
       std::string buff1 = tempname.substr(0, fileHyphenPos);
-      if (ACE_OS::strstr(filebasename.c_str(), buff1.c_str()) == 0) {
+      if (strstr(filebasename.c_str(), buff1.c_str()) == nullptr) {
         return 0;
       }
       if (fileHyphenPos != actualHyphenPos) return 0;

--- a/cppcache/src/MapEntryT.hpp
+++ b/cppcache/src/MapEntryT.hpp
@@ -126,13 +126,10 @@ class MapEntryT final : public TBase {
     return std::make_shared<MapEntryT>(expiryTaskManager, key);
   }
 
- protected:
   inline MapEntryT(const std::shared_ptr<CacheableKey>& key) : TBase(key) {}
   inline MapEntryT(ExpiryTaskManager* expiryTaskManager,
                    const std::shared_ptr<CacheableKey>& key)
       : TBase(expiryTaskManager, key) {}
-
-  _GEODE_FRIEND_STD_SHARED_PTR(MapEntryT)
 };
 
 // specialization of MapEntryT to terminate the recursive template definition

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -1043,7 +1043,7 @@ std::string PdxInstanceImpl::toString() const {
         break;
       }
       case PdxFieldTypes::ARRAY_OF_BYTE_ARRAYS: {
-        int8_t** value = 0;
+        int8_t** value = nullptr;
         int32_t arrayLength;
         int32_t* elementLength;
         getField(identityFields.at(i)->getFieldName(), &value, arrayLength,

--- a/cppcache/src/PdxLocalReader.hpp
+++ b/cppcache/src/PdxLocalReader.hpp
@@ -56,7 +56,7 @@ class PdxLocalReader : public PdxReader {
                  int32_t pdxLen,
                  std::shared_ptr<PdxTypeRegistry> pdxTypeRegistry);
 
-  virtual ~PdxLocalReader();
+  virtual ~PdxLocalReader() override;
 
   void moveStream();
 

--- a/cppcache/src/PdxReaderWithTypeCollector.hpp
+++ b/cppcache/src/PdxReaderWithTypeCollector.hpp
@@ -39,7 +39,7 @@ class PdxReaderWithTypeCollector : public PdxLocalReader {
                              std::shared_ptr<PdxType> pdxType, int pdxlen,
                              std::shared_ptr<PdxTypeRegistry> pdxTypeRegistry);
 
-  virtual ~PdxReaderWithTypeCollector();
+  virtual ~PdxReaderWithTypeCollector() override;
 
   std::shared_ptr<PdxType> getLocalType() const { return m_newPdxType; }
 

--- a/cppcache/src/PdxRemoteReader.hpp
+++ b/cppcache/src/PdxRemoteReader.hpp
@@ -38,7 +38,7 @@ class PdxRemoteReader : public PdxLocalReader {
     m_currentIndex = 0;
   }
 
-  virtual ~PdxRemoteReader();
+  virtual ~PdxRemoteReader() override;
 
   virtual char16_t readChar(const std::string& fieldName) override;
 

--- a/cppcache/src/PdxRemoteWriter.cpp
+++ b/cppcache/src/PdxRemoteWriter.cpp
@@ -35,8 +35,7 @@ PdxRemoteWriter::PdxRemoteWriter(
     : PdxLocalWriter(output, pdxType, pdxTypeRegistry),
       m_preserveDataIdx(0),
       m_currentDataIdx(-1),
-      m_remoteTolocalMapLength(0),
-      m_pdxTypeRegistry(pdxTypeRegistry) {
+      m_remoteTolocalMapLength(0) {
   m_preserveData = preservedData;
   if (m_pdxType != nullptr) {
     m_remoteTolocalMap = m_pdxType->getRemoteToLocalMap();
@@ -53,8 +52,7 @@ PdxRemoteWriter::PdxRemoteWriter(
     : PdxLocalWriter(output, nullptr, pdxClassName, pdxTypeRegistry),
       m_preserveDataIdx(0),
       m_currentDataIdx(-1),
-      m_remoteTolocalMapLength(0),
-      m_pdxTypeRegistry(pdxTypeRegistry) {
+      m_remoteTolocalMapLength(0) {
   m_preserveData = nullptr;
   if (m_pdxType != nullptr) {
     m_remoteTolocalMapLength = m_pdxType->getTotalFields();

--- a/cppcache/src/PdxRemoteWriter.hpp
+++ b/cppcache/src/PdxRemoteWriter.hpp
@@ -34,8 +34,6 @@ class PdxRemoteWriter : public PdxLocalWriter {
 
   int32_t m_remoteTolocalMapLength;
 
-  std::shared_ptr<PdxTypeRegistry> m_pdxTypeRegistry;
-
   void initialize();
   void writePreserveData();
 

--- a/cppcache/src/PdxWriterWithTypeCollector.hpp
+++ b/cppcache/src/PdxWriterWithTypeCollector.hpp
@@ -29,7 +29,6 @@ namespace client {
 
 class PdxWriterWithTypeCollector : public PdxLocalWriter {
  private:
-  std::vector<int32_t> m_offsets;
   void initialize();
 
  public:

--- a/cppcache/src/Properties.cpp
+++ b/cppcache/src/Properties.cpp
@@ -125,7 +125,7 @@ void PropertiesFile::readFile(const std::string& fileName) {
        */
       buf[len] = '\0';
       char* tmp = buf;
-      char* line = 0;
+      char* line = nullptr;
       while ((line = nextBufferLine(&tmp, buf, len)) != nullptr) {
         parseLine(line);
       }
@@ -137,7 +137,7 @@ void PropertiesFile::readFile(const std::string& fileName) {
 char* PropertiesFile::nextBufferLine(char** cursor, char* bufbegin,
                                      size_t totalLen) {
   if (static_cast<size_t>((*cursor) - bufbegin) >= totalLen) {
-    return 0;
+    return nullptr;
   }
 
   char* lineBegin = *cursor;

--- a/cppcache/src/ProxyRegion.hpp
+++ b/cppcache/src/ProxyRegion.hpp
@@ -581,8 +581,6 @@ class APACHE_GEODE_EXPORT ProxyRegion final : public Region {
   AuthenticatedView* m_authenticatedView;
   std::shared_ptr<RegionInternal> m_realRegion;
   friend class FunctionService;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(ProxyRegion)
 };
 
 }  // namespace client

--- a/cppcache/src/Queue.hpp
+++ b/cppcache/src/Queue.hpp
@@ -54,12 +54,12 @@ class APACHE_GEODE_EXPORT Queue {
   T* getUntil(uint32_t sec, uint32_t usec = 0) {
     T* mp = get();
 
-    if (mp == 0) {
+    if (mp == nullptr) {
       ACE_Time_Value interval(sec + usec / 1000000, usec % 1000000);
       ACE_Time_Value stopAt(ACE_OS::gettimeofday());
       stopAt += interval;
 
-      while (!m_closed && mp == 0 && ACE_OS::gettimeofday() < stopAt) {
+      while (!m_closed && mp == nullptr && ACE_OS::gettimeofday() < stopAt) {
         ACE_Guard<ACE_Recursive_Thread_Mutex> _guard(m_mutex);
         if (m_cond.wait(&stopAt) != -1) mp = getNoLock();
       }
@@ -131,7 +131,7 @@ class APACHE_GEODE_EXPORT Queue {
 
  private:
   inline T* getNoLock() {
-    T* mp = 0;
+    T* mp = nullptr;
 
     uint32_t queueSize = static_cast<uint32_t>(m_queue.size());
     if (queueSize > 0) {

--- a/cppcache/src/QueueConnectionRequest.cpp
+++ b/cppcache/src/QueueConnectionRequest.cpp
@@ -25,9 +25,8 @@ void QueueConnectionRequest::toData(DataOutput& output) const {
   output.writeString(m_serverGp);
   output.write(static_cast<int8_t>(DSCode::FixedIDByte));
   output.write(static_cast<int8_t>(DSCode::ClientProxyMembershipId));
-  uint32_t buffLen;
-  const char* buff = m_membershipID.getDSMemberId(buffLen);
-  output.writeBytes((uint8_t*)buff, buffLen);
+  uint32_t buffLen = 0;
+  output.writeBytes(reinterpret_cast<uint8_t*>(const_cast<char*>(m_membershipID.getDSMemberId(buffLen))), buffLen);
   output.writeInt((int32_t)1);
   output.writeInt(static_cast<int32_t>(m_redundantCopies));
   writeSetOfServerLocation(output);

--- a/cppcache/src/RegionAttributes.cpp
+++ b/cppcache/src/RegionAttributes.cpp
@@ -293,7 +293,7 @@ void writeBool(DataOutput& out, bool field) {
 void readBool(DataInput& in, bool* field) { *field = in.read() ? true : false; }
 
 void writeString(DataOutput& out, const std::string& field) {
-  out.writeBytes((int8_t*)field.c_str(),
+  out.writeBytes(reinterpret_cast<int8_t*>(const_cast<char*>(field.c_str())),
                  static_cast<uint32_t>(field.length()) + 1);
 }
 

--- a/cppcache/src/RegionInternal.hpp
+++ b/cppcache/src/RegionInternal.hpp
@@ -144,7 +144,7 @@ class RegionInternal : public Region {
   /**
    * @brief destructor
    */
-  virtual ~RegionInternal();
+  virtual ~RegionInternal() override;
   /** @brief Default implementation of Public Methods from Region
    */
   virtual void registerKeys(

--- a/cppcache/src/RegionXmlCreation.cpp
+++ b/cppcache/src/RegionXmlCreation.cpp
@@ -62,7 +62,7 @@ void RegionXmlCreation::create(std::shared_ptr<Region> parent) {
   fillIn(subRegPtr);
 }
 
-RegionXmlCreation::RegionXmlCreation(char* name, bool isRootRegion) {
+RegionXmlCreation::RegionXmlCreation(const char* name, bool isRootRegion) {
   std::string tempName(name);
   regionName = tempName;
   isRoot = isRootRegion;

--- a/cppcache/src/RegionXmlCreation.hpp
+++ b/cppcache/src/RegionXmlCreation.hpp
@@ -73,7 +73,7 @@ class APACHE_GEODE_EXPORT RegionXmlCreation {
   /**
    * Creates a new <code>RegionCreation</code> with the given name.
    */
-  RegionXmlCreation(char* name, bool isRoot = false);
+  RegionXmlCreation(const char* name, bool isRoot = false);
 
   /**
    * Adds a subregion with the given name to this region

--- a/cppcache/src/SslSockStream.hpp
+++ b/cppcache/src/SslSockStream.hpp
@@ -78,11 +78,11 @@ class SslSockStream {
 
   int connect(ACE_INET_Addr ipaddr, unsigned waitSeconds);
 
-  ssize_t recv_n(void *buf, size_t len, const ACE_Time_Value *timeout = 0,
-                 size_t *bytes_transferred = 0) const;
+  ssize_t recv_n(void *buf, size_t len, const ACE_Time_Value *timeout = nullptr,
+                 size_t *bytes_transferred = nullptr) const;
 
-  ssize_t send_n(const void *buf, size_t len, const ACE_Time_Value *timeout = 0,
-                 size_t *bytes_transferred = 0) const;
+  ssize_t send_n(const void *buf, size_t len, const ACE_Time_Value *timeout = nullptr,
+                 size_t *bytes_transferred = nullptr) const;
 
   int get_local_addr(ACE_Addr &) const;
 

--- a/cppcache/src/TcpConn.cpp
+++ b/cppcache/src/TcpConn.cpp
@@ -162,9 +162,9 @@ void TcpConn::listen(ACE_INET_Addr addr,
   int32_t retVal = 0;
   if (waitSeconds > std::chrono::microseconds::zero()) {
     ACE_Time_Value wtime(waitSeconds);
-    retVal = listener.accept(*m_io, 0, &wtime);
+    retVal = listener.accept(*m_io, nullptr, &wtime);
   } else {
-    retVal = listener.accept(*m_io, 0);
+    retVal = listener.accept(*m_io, nullptr);
   }
   if (retVal == -1) {
     char msg[256];

--- a/cppcache/src/TcpConn.hpp
+++ b/cppcache/src/TcpConn.hpp
@@ -87,7 +87,7 @@ class APACHE_GEODE_EXPORT TcpConn : public Connector {
   TcpConn(const char* ipaddr, std::chrono::microseconds waitSeconds,
           int32_t maxBuffSizePool);
 
-  virtual ~TcpConn() { close(); }
+  virtual ~TcpConn() override { close(); }
 
   // Close this tcp connection
   virtual void close() override;

--- a/cppcache/src/TcpSslConn.hpp
+++ b/cppcache/src/TcpSslConn.hpp
@@ -73,7 +73,7 @@ class TcpSslConn : public TcpConn {
 
   // TODO:  Watch out for virt dtor calling virt methods!
 
-  virtual ~TcpSslConn() {}
+  virtual ~TcpSslConn() override {}
 
   // Close this tcp connection
   void close() override;

--- a/cppcache/src/TcrConnectionManager.cpp
+++ b/cppcache/src/TcrConnectionManager.cpp
@@ -185,7 +185,7 @@ void TcrConnectionManager::close() {
 
     m_redundancyManager->close();
     delete m_redundancyManager;
-    m_redundancyManager = 0;
+    m_redundancyManager = nullptr;
 
     removeHAEndpoints();
   }

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -47,8 +47,8 @@ TcrEndpoint::TcrEndpoint(const std::string& name, CacheImpl* cacheImpl,
       m_maxConnections(cacheImpl->getDistributedSystem()
                            .getSystemProperties()
                            .connectionPoolSize()),
-      m_notifyConnection(0),
-      m_notifyReceiver(0),
+      m_notifyConnection(nullptr),
+      m_notifyReceiver(nullptr),
       m_numRegionListener(0),
       m_isQueueHosted(false),
       m_cacheImpl(cacheImpl),

--- a/cppcache/src/TcrHADistributionManager.hpp
+++ b/cppcache/src/TcrHADistributionManager.hpp
@@ -40,7 +40,7 @@ class APACHE_GEODE_EXPORT TcrHADistributionManager
   TcrHADistributionManager(ThinClientRegion* theRegion,
                            TcrConnectionManager& connManager,
                            std::shared_ptr<CacheAttributes> cacheAttributes);
-  ~TcrHADistributionManager() = default;
+  ~TcrHADistributionManager() override = default;
   TcrHADistributionManager(const TcrHADistributionManager&) = delete;
   TcrHADistributionManager& operator=(const TcrHADistributionManager&) = delete;
 

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -621,7 +621,7 @@ void TcrMessage::writeRegionPart(const std::string& regionName) {
   int32_t len = static_cast<int32_t>(regionName.length());
   m_request->writeInt(len);
   m_request->write(static_cast<int8_t>(0));  // isObject = 0
-  m_request->writeBytesOnly((int8_t*)regionName.c_str(), len);
+  m_request->writeBytesOnly(reinterpret_cast<int8_t*>(const_cast<char*>(regionName.c_str())), len);
 }
 
 void TcrMessage::writeStringPart(const std::string& str) {
@@ -896,7 +896,7 @@ void TcrMessage::handleByteArrayResponse(
     const SerializationRegistry& serializationRegistry,
     MemberListForVersionStamp& memberListForVersionStamp) {
   auto input = m_tcdm->getConnectionManager().getCacheImpl()->createDataInput(
-      (uint8_t*)bytearray, len, getPool());
+      reinterpret_cast<uint8_t*>(const_cast<char*>(bytearray)), len, getPool());
   // TODO:: this need to make sure that pool is there
   //  if(m_tcdm == nullptr)
   //  throw IllegalArgumentException("Pool is nullptr in TcrMessage");
@@ -2818,15 +2818,15 @@ const std::shared_ptr<Cacheable>& TcrMessage::getCallbackArgumentRef() const {
 }
 
 const char* TcrMessage::getMsgData() const {
-  return (char*)m_request->getBuffer();
+  return reinterpret_cast<const char*>(m_request->getBuffer());
 }
 
 const char* TcrMessage::getMsgHeader() const {
-  return (char*)m_request->getBuffer();
+  return reinterpret_cast<const char*>(m_request->getBuffer());
 }
 
 const char* TcrMessage::getMsgBody() const {
-  return (char*)m_request->getBuffer() + g_headerLen;
+  return reinterpret_cast<const char*>(m_request->getBuffer() + g_headerLen);
 }
 
 size_t TcrMessage::getMsgLength() const { return m_request->getBufferLength(); }

--- a/cppcache/src/ThinClientLocatorHelper.cpp
+++ b/cppcache/src/ThinClientLocatorHelper.cpp
@@ -107,7 +107,7 @@ GfErrType ThinClientLocatorHelper::getAllServers(
       data.writeInt((int32_t)1001);  // GOSSIPVERSION
       data.writeObject(&request);
       auto sentLength = conn->send(
-          (char*)(data.getBuffer()), data.getBufferLength(),
+          reinterpret_cast<char*>(const_cast<uint8_t*>(data.getBuffer())), data.getBufferLength(),
           m_poolDM ? m_poolDM->getReadTimeout() : std::chrono::seconds(10));
       if (sentLength <= 0) {
         // conn->close(); delete conn; conn = nullptr;
@@ -200,7 +200,7 @@ GfErrType ThinClientLocatorHelper::getEndpointForNewCallBackConn(
       data.writeInt((int32_t)1001);  // GOSSIPVERSION
       data.writeObject(&request);
       auto sentLength = conn->send(
-          (char*)(data.getBuffer()), data.getBufferLength(),
+          reinterpret_cast<char*>(const_cast<uint8_t*>(data.getBuffer())), data.getBufferLength(),
           m_poolDM ? m_poolDM->getReadTimeout() : sysProps.connectTimeout());
       if (sentLength <= 0) {
         // conn->close(); delete conn; conn = nullptr;
@@ -300,7 +300,7 @@ GfErrType ThinClientLocatorHelper::getEndpointForNewFwdConn(
         data.writeObject(&request);
       }
       auto sentLength = conn->send(
-          (char*)(data.getBuffer()), data.getBufferLength(),
+          reinterpret_cast<char*>(const_cast<uint8_t*>(data.getBuffer())), data.getBufferLength(),
           m_poolDM ? m_poolDM->getReadTimeout() : sysProps.connectTimeout());
       if (sentLength <= 0) {
         // conn->close();
@@ -388,7 +388,7 @@ GfErrType ThinClientLocatorHelper::updateLocators(
       data.writeInt((int32_t)1001);  // GOSSIPVERSION
       data.writeObject(&request);
       auto sentLength = conn->send(
-          (char*)(data.getBuffer()), data.getBufferLength(),
+          reinterpret_cast<char*>(const_cast<uint8_t*>(data.getBuffer())), data.getBufferLength(),
           m_poolDM ? m_poolDM->getReadTimeout() : sysProps.connectTimeout());
       if (sentLength <= 0) {
         //  conn->close();

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -1770,7 +1770,7 @@ void ThinClientPoolDM::reducePoolSize(int num) {
   LOGFINE("removing connection %d ,  pool-size =%d", num, m_poolSize.load());
   m_poolSize -= num;
   if (m_poolSize <= 0) {
-    if (m_cliCallbackTask != NULL) m_cliCallbackSema.release();
+    if (m_cliCallbackTask != nullptr) m_cliCallbackSema.release();
   }
 }
 GfErrType ThinClientPoolDM::createPoolConnection(

--- a/cppcache/src/ThinClientPoolDM.hpp
+++ b/cppcache/src/ThinClientPoolDM.hpp
@@ -144,8 +144,8 @@ class ThinClientPoolDM
                                  std::set<ServerLocation>& excludeServers,
                                  bool& maxConnLimit,
                                  const TcrConnection* currentServer = nullptr);
-  ThinClientLocatorHelper* getLocatorHelper() volatile {
-    return (ThinClientLocatorHelper*)m_locHelper;
+  ThinClientLocatorHelper* getLocatorHelper() {
+    return m_locHelper;
   }
   virtual void releaseThreadLocalConnection();
   virtual void setThreadLocalConnection(TcrConnection* conn);
@@ -167,7 +167,7 @@ class ThinClientPoolDM
 
   virtual void sendUserCacheCloseMessage(bool keepAlive);
 
-  virtual inline PoolStats& getStats() { return *(PoolStats*)m_stats; }
+  virtual inline PoolStats& getStats() { return *m_stats; }
 
   size_t getNumberOfEndPoints() const { return m_endpoints.current_size(); }
 
@@ -210,7 +210,7 @@ class ThinClientPoolDM
   ACE_Recursive_Thread_Mutex m_endpointsLock;
   ACE_Recursive_Thread_Mutex m_endpointSelectionLock;
   std::string m_poolName;
-  volatile PoolStats* m_stats;
+  PoolStats* m_stats;
   bool m_sticky;
   // PoolStats * m_stats;
   // PoolStatType* m_poolStatType;
@@ -306,7 +306,7 @@ class ThinClientPoolDM
 
   bool excludeServer(std::string, std::set<ServerLocation>&);
 
-  volatile ThinClientLocatorHelper* m_locHelper;
+  ThinClientLocatorHelper* m_locHelper;
 
   std::atomic<int32_t> m_poolSize;  // Actual Size of Pool
   int m_numRegions;

--- a/cppcache/src/ThinClientPoolHADM.cpp
+++ b/cppcache/src/ThinClientPoolHADM.cpp
@@ -180,7 +180,7 @@ void ThinClientPoolHADM::destroy(bool keepAlive) {
 
     m_redundancyManager->close();
     delete m_redundancyManager;
-    m_redundancyManager = 0;
+    m_redundancyManager = nullptr;
 
     m_destroyPendingHADM = true;
     ThinClientPoolDM::destroy(keepAlive);

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -346,7 +346,7 @@ ThinClientRegion::ThinClientRegion(
     const std::shared_ptr<RegionInternal>& rPtr, RegionAttributes attributes,
     const std::shared_ptr<CacheStatistics>& stats, bool shared)
     : LocalRegion(name, cacheImpl, rPtr, attributes, stats, shared),
-      m_tcrdm((ThinClientBaseDM*)0),
+      m_tcrdm(nullptr),
       m_notifyRelease(false),
       m_notificationSema(1),
       m_isMetaDataRefreshed(false) {
@@ -3689,7 +3689,7 @@ void ChunkedFunctionExecutionResponse::handleChunk(
     } else {
       result = value;
     }
-    if (m_resultCollectorLock.get() != 0) {
+    if (m_resultCollectorLock.get() != nullptr) {
       ACE_Guard<ACE_Recursive_Thread_Mutex> guard(*m_resultCollectorLock);
       m_rc->addResult(result);
     } else {

--- a/cppcache/src/ThinClientRegion.hpp
+++ b/cppcache/src/ThinClientRegion.hpp
@@ -64,7 +64,7 @@ class APACHE_GEODE_EXPORT ThinClientRegion : public LocalRegion {
                    const std::shared_ptr<CacheStatistics>& stats,
                    bool shared = false);
   virtual void initTCR();
-  virtual ~ThinClientRegion();
+  virtual ~ThinClientRegion() override;
 
   /** @brief Public Methods from Region
    */

--- a/cppcache/src/config.h.in
+++ b/cppcache/src/config.h.in
@@ -41,4 +41,11 @@
 // TODO relace with CMake checks
 #define WITH_ACE_Select_Reactor 1
 
+// ACE_Thread is a pointer on MacOS *only*
+#if defined(_MACOSX)
+#define ACE_Thread_NULL nullptr
+#else
+#define ACE_Thread_NULL 0
+#endif
+
 #endif  // GEODE_CONFIG_H_

--- a/cppcache/src/statistics/GeodeStatisticsFactory.hpp
+++ b/cppcache/src/statistics/GeodeStatisticsFactory.hpp
@@ -68,7 +68,7 @@ class GeodeStatisticsFactory : public StatisticsFactory {
 
  public:
   GeodeStatisticsFactory(StatisticsManager* statMngr);
-  ~GeodeStatisticsFactory();
+  ~GeodeStatisticsFactory() override;
 
   const std::string& getName() const override;
 

--- a/cppcache/src/statistics/HostStatSampler.cpp
+++ b/cppcache/src/statistics/HostStatSampler.cpp
@@ -81,7 +81,7 @@ int selector(const dirent* d) {
     size_t fileHyphenPos = tempname.find_last_of('-');
     if (fileHyphenPos != std::string::npos) {
       std::string buff1 = tempname.substr(0, fileHyphenPos);
-      if (ACE_OS::strstr(filebasename.c_str(), buff1.c_str()) == 0) {
+      if (ACE_OS::strstr(filebasename.c_str(), buff1.c_str()) == nullptr) {
         return 0;
       }
       if (fileHyphenPos != actualHyphenPos) return 0;
@@ -563,12 +563,12 @@ void HostStatSampler::putStatsInAdminRegion() {
             Statistics* cachePerfStats =
                 gf->findFirstStatisticsByType(cacheStatType);
             if (cachePerfStats) {
-              puts = cachePerfStats->getInt((char*)"puts");
-              gets = cachePerfStats->getInt((char*)"gets");
-              misses = cachePerfStats->getInt((char*)"misses");
-              creates = cachePerfStats->getInt((char*)"creates");
+              puts = cachePerfStats->getInt("puts");
+              gets = cachePerfStats->getInt("gets");
+              misses = cachePerfStats->getInt("misses");
+              creates = cachePerfStats->getInt("creates");
               numListeners =
-                  cachePerfStats->getInt((char*)"cacheListenerCallsCompleted");
+                  cachePerfStats->getInt("cacheListenerCallsCompleted");
               puts += creates;
             }
           }

--- a/cppcache/src/statistics/OsStatisticsImpl.cpp
+++ b/cppcache/src/statistics/OsStatisticsImpl.cpp
@@ -88,9 +88,9 @@ OsStatisticsImpl::OsStatisticsImpl(StatisticsType* typeArg,
   /* adongre
    * CID 28981: Uninitialized pointer field (UNINIT_CTOR)
    */
-  doubleStorage = (double*)0;
-  intStorage = (int32_t*)0;
-  longStorage = (int64_t*)0;
+  doubleStorage = nullptr;
+  intStorage = nullptr;
+  longStorage = nullptr;
 
   if (statsType != nullptr) {
     int32_t intCount = statsType->getIntStatCount();

--- a/cppcache/src/statistics/StatisticDescriptorImpl.hpp
+++ b/cppcache/src/statistics/StatisticDescriptorImpl.hpp
@@ -111,7 +111,7 @@ class StatisticDescriptorImpl : public StatisticDescriptor {
   /**
    * Destructor
    */
-  ~StatisticDescriptorImpl();
+  ~StatisticDescriptorImpl() override;
 
   /////////////////////////// Static Methods////////////////////////////////////
 

--- a/cppcache/src/statistics/StatisticsTypeImpl.hpp
+++ b/cppcache/src/statistics/StatisticsTypeImpl.hpp
@@ -59,7 +59,7 @@ class StatisticsTypeImpl : public StatisticsType {
   StatisticsTypeImpl(std::string name, std::string description,
                      StatisticDescriptor** stats, int32_t statsLength);
 
-  ~StatisticsTypeImpl();
+  ~StatisticsTypeImpl() override;
 
   ////////////////  StatisticsType(Base class) Methods ///////////////////
 

--- a/cppcache/test/ByteArrayTest.cpp
+++ b/cppcache/test/ByteArrayTest.cpp
@@ -21,7 +21,7 @@ using namespace apache::geode::client;
 
 TEST(ByteArrayTest, TestNoArgConstructor) {
   const ByteArray ba;
-  EXPECT_EQ(0U, ba.size()) << "Zero size for no-arg constructor";
+  EXPECT_TRUE(ba.size() == 0) << "Zero size for no-arg constructor";
   EXPECT_EQ((const uint8_t *)nullptr, (const uint8_t *)ba)
       << "Null pointer for no-arg constructor";
 }
@@ -68,7 +68,7 @@ TEST(ByteArrayTest, TestAssignmentOperator) {
 TEST(ByteArrayTest, TestFromStringForEmpty) {
   const std::string empty;
   const ByteArray ba(ByteArray::fromString(empty));
-  EXPECT_EQ(0U, ba.size()) << "Zero size for empty string";
+  EXPECT_TRUE(ba.size() == 0) << "Zero size for empty string";
   EXPECT_EQ((const uint8_t *)nullptr, (const uint8_t *)ba)
       << "Null pointer for empty string";
 }

--- a/cryptoimpl/DHImpl.cpp
+++ b/cryptoimpl/DHImpl.cpp
@@ -33,10 +33,10 @@
 #include <geode/internal/geode_globals.hpp>
 
 /*
-static DH * m_dh = NULL;
+static DH * m_dh = nullptr;
 static string m_skAlgo;
 static int    m_keySize = 0;
-static BIGNUM * m_pubKeyOther = NULL;
+static BIGNUM * m_pubKeyOther = nullptr;
 static unsigned char m_key[128] = {0};
 static std::vector<X509*> m_serverCerts;
 */
@@ -80,7 +80,7 @@ ASN1_SEQUENCE(
   *dhCtx = (void *)dhimpl;
 
   // ksPath can be null
-  if (dhimpl->m_dh != NULL || dhAlgo == NULL || strlen(dhAlgo) == 0) {
+  if (dhimpl->m_dh || !dhAlgo || strlen(dhAlgo) == 0) {
     return errorCode;
   }
 
@@ -99,15 +99,16 @@ ASN1_SEQUENCE(
 
   dhimpl->m_dh = DH_new();
 
-  const BIGNUM *pbn, *gbn;
-  DH_get0_pqg(dhimpl->m_dh, &pbn, NULL, &gbn);
-  BN_dec2bn((BIGNUM **)&pbn, dhP);
+  BIGNUM* pbn = nullptr;
+  BIGNUM* gbn = nullptr;
+  DH_get0_pqg(dhimpl->m_dh, const_cast<const BIGNUM**>(&pbn), nullptr, const_cast<const BIGNUM**>(&gbn));
+  BN_dec2bn(&pbn, dhP);
 
   LOGDH(" DHInit: P ptr is %p", pbn);
   LOGDH(" DHInit: G ptr is %p", gbn);
   LOGDH(" DHInit: length is %d", DH_get_length(dhimpl->m_dh));
 
-  BN_dec2bn((BIGNUM **)&gbn, dhG);
+  BN_dec2bn(&gbn, dhG);
 
   DH_set_length(dhimpl->m_dh, dhL);
 
@@ -130,25 +131,25 @@ ASN1_SEQUENCE(
 
   LOGDH(" Loading keystore...");
 
-  if (ksPath == NULL || strlen(ksPath) == 0) {
-    LOGDH("Property \"security-client-kspath\" 's value is NULL.");
+  if (ksPath == nullptr || strlen(ksPath) == 0) {
+    LOGDH("Property \"security-client-kspath\" 's value is nullptr.");
     return errorCode;
   }
-  FILE *keyStoreFP = NULL;
+  FILE *keyStoreFP = nullptr;
   keyStoreFP = fopen(ksPath, "r");
 
   LOGDH(" kspath is [%s]", ksPath);
   LOGDH(" keystore FILE ptr is %p", keyStoreFP);
 
   // Read from pem file and put into.
-  X509 *cert = NULL;
+  X509 *cert = nullptr;
   do {
-    cert = PEM_read_X509(keyStoreFP, NULL, NULL, NULL);
+    cert = PEM_read_X509(keyStoreFP, nullptr, nullptr, nullptr);
 
-    if (cert != NULL) {
+    if (cert != nullptr) {
       dhimpl->m_serverCerts.push_back(cert);
     }
-  } while (cert != NULL);
+  } while (cert != nullptr);
 
   LOGDH(" Total certificats imported # %zd", dhimpl->m_serverCerts.size());
 
@@ -160,9 +161,9 @@ ASN1_SEQUENCE(
 void gf_clearDhKeys(void *dhCtx) {
   DHImpl *dhimpl = reinterpret_cast<DHImpl *>(dhCtx);
 
-  if (dhimpl->m_dh != NULL) {
+  if (dhimpl->m_dh != nullptr) {
     DH_free(dhimpl->m_dh);
-    dhimpl->m_dh = NULL;
+    dhimpl->m_dh = nullptr;
   }
 
   std::vector<X509 *>::const_iterator iter;
@@ -173,9 +174,9 @@ void gf_clearDhKeys(void *dhCtx) {
 
   dhimpl->m_serverCerts.clear();
 
-  if (dhimpl->m_pubKeyOther != NULL) {
+  if (dhimpl->m_pubKeyOther != nullptr) {
     BN_free(dhimpl->m_pubKeyOther);
-    dhimpl->m_pubKeyOther = NULL;
+    dhimpl->m_pubKeyOther = nullptr;
   }
 
   memset(dhimpl->m_key, 0, 128);
@@ -189,23 +190,23 @@ unsigned char *gf_getPublicKey(void *dhCtx, int *pLen) {
   const BIGNUM *pub_key, *priv_key;
   DH_get0_key(dhimpl->m_dh, &pub_key, &priv_key);
 
-  if (pub_key == NULL || pLen == NULL) {
-    return NULL;
+  if (pub_key == nullptr || pLen == nullptr) {
+    return nullptr;
   }
 
   int numBytes = BN_num_bytes(pub_key);
 
   if (numBytes <= 0) {
-    return NULL;
+    return nullptr;
   }
 
   EVP_PKEY *evppubkey = EVP_PKEY_new();
   LOGDH(" before assign DH ptr is %p\n", dhimpl->m_dh);
   EVP_PKEY_assign_DH(evppubkey, dhimpl->m_dh);
   LOGDH(" after assign DH ptr is %p\n", dhimpl->m_dh);
-  DH_PUBKEY *dhpubkey = NULL;
+  DH_PUBKEY *dhpubkey = nullptr;
   DH_PUBKEY_set(&dhpubkey, evppubkey);
-  int len = i2d_DH_PUBKEY(dhpubkey, NULL);
+  int len = i2d_DH_PUBKEY(dhpubkey, nullptr);
   unsigned char *pubkey = new unsigned char[len];
   unsigned char *temp = pubkey;
   //
@@ -230,13 +231,13 @@ void gf_setPublicKeyOther(void *dhCtx, const unsigned char *pubkey,
                           int length) {
   DHImpl *dhimpl = reinterpret_cast<DHImpl *>(dhCtx);
 
-  if (dhimpl->m_pubKeyOther != NULL) {
+  if (dhimpl->m_pubKeyOther != nullptr) {
     BN_free(dhimpl->m_pubKeyOther);
-    dhimpl->m_pubKeyOther = NULL;
+    dhimpl->m_pubKeyOther = nullptr;
   }
 
   const unsigned char *temp = pubkey;
-  DH_PUBKEY *dhpubkey = d2i_DH_PUBKEY(NULL, &temp, length);
+  DH_PUBKEY *dhpubkey = d2i_DH_PUBKEY(nullptr, &temp, length);
   LOGDH(" setPubKeyOther: after d2i_dhpubkey ptr is %p\n", dhpubkey);
   EVP_PKEY *evppkey = DH_PUBKEY_get(dhpubkey);
   LOGDH(" setPubKeyOther: after dhpubkey get evp ptr is %p\n", evppkey);
@@ -264,7 +265,7 @@ void gf_computeSharedSecret(void *dhCtx) {
   LOGDH("DHcomputeKey DHSize is %d", DH_size(dhimpl->m_dh));
   DH_compute_key(dhimpl->m_key, dhimpl->m_pubKeyOther, dhimpl->m_dh);
   LOGDH("DHcomputeKey : Compute err(%d): %s", ERR_get_error(),
-        ERR_error_string(ERR_get_error(), NULL));
+        ERR_error_string(ERR_get_error(), nullptr));
 }
 
 int DHImpl::setSkAlgo(const char *skalgo) {
@@ -333,7 +334,7 @@ const EVP_CIPHER *DHImpl::getCipherFunc() {
     return EVP_des_ede3_cbc();
   } else {
     LOGDH("ERROR: Unsupported DH Algorithm");
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -342,8 +343,8 @@ unsigned char *gf_encryptDH(void *dhCtx, const unsigned char *cleartext,
   DHImpl *dhimpl = reinterpret_cast<DHImpl *>(dhCtx);
 
   // Validation
-  if (cleartext == NULL || len < 1 || retLen == NULL) {
-    return NULL;
+  if (cleartext == nullptr || len < 1 || retLen == nullptr) {
+    return nullptr;
   }
 
   LOGDH(" DH: gf_encryptDH using sk algo: %s, Keysize: %d",
@@ -359,23 +360,23 @@ unsigned char *gf_encryptDH(void *dhCtx, const unsigned char *cleartext,
   // init openssl cipher context
   if (dhimpl->m_skAlgo == "AES") {
     int keySize = dhimpl->m_keySize > 128 ? dhimpl->m_keySize / 8 : 16;
-    EVP_EncryptInit_ex(ctx, cipherFunc, NULL, (unsigned char *)dhimpl->m_key,
+    EVP_EncryptInit_ex(ctx, cipherFunc, nullptr, (unsigned char *)dhimpl->m_key,
                        (unsigned char *)dhimpl->m_key + keySize);
   } else if (dhimpl->m_skAlgo == "Blowfish") {
     int keySize = dhimpl->m_keySize > 128 ? dhimpl->m_keySize / 8 : 16;
-    EVP_EncryptInit_ex(ctx, cipherFunc, NULL, NULL,
+    EVP_EncryptInit_ex(ctx, cipherFunc, nullptr, nullptr,
                        (unsigned char *)dhimpl->m_key + keySize);
     EVP_CIPHER_CTX_set_key_length(ctx, keySize);
     LOGDH("DHencrypt: BF keysize is %d", keySize);
-    EVP_EncryptInit_ex(ctx, NULL, NULL, (unsigned char *)dhimpl->m_key, NULL);
+    EVP_EncryptInit_ex(ctx, nullptr, nullptr, (unsigned char *)dhimpl->m_key, nullptr);
   } else if (dhimpl->m_skAlgo == "DESede") {
-    EVP_EncryptInit_ex(ctx, cipherFunc, NULL, (unsigned char *)dhimpl->m_key,
+    EVP_EncryptInit_ex(ctx, cipherFunc, nullptr, (unsigned char *)dhimpl->m_key,
                        (unsigned char *)dhimpl->m_key + 24);
   }
 
   if (!EVP_EncryptUpdate(ctx, ciphertext, &outlen, cleartext, len)) {
-    LOGDH(" DHencrypt: enc update ret NULL");
-    return NULL;
+    LOGDH(" DHencrypt: enc update ret nullptr");
+    return nullptr;
   }
   /* Buffer passed to EVP_EncryptFinal() must be after data just
    * encrypted to avoid overwriting it.
@@ -383,8 +384,8 @@ unsigned char *gf_encryptDH(void *dhCtx, const unsigned char *cleartext,
   tmplen = 0;
 
   if (!EVP_EncryptFinal_ex(ctx, ciphertext + outlen, &tmplen)) {
-    LOGDH("DHencrypt: enc final ret NULL");
-    return NULL;
+    LOGDH("DHencrypt: enc final ret nullptr");
+    return nullptr;
   }
 
   outlen += tmplen;
@@ -402,8 +403,8 @@ unsigned char *gf_decryptDH(void *dhCtx, const unsigned char *cleartext,
   DHImpl *dhimpl = reinterpret_cast<DHImpl *>(dhCtx);
 
   // Validation
-  if (cleartext == NULL || len < 1 || retLen == NULL) {
-    return NULL;
+  if (cleartext == nullptr || len < 1 || retLen == nullptr) {
+    return nullptr;
   }
 
   LOGDH(" DH: gf_encryptDH using sk algo: %s, Keysize: %d",
@@ -419,23 +420,23 @@ unsigned char *gf_decryptDH(void *dhCtx, const unsigned char *cleartext,
   // init openssl cipher context
   if (dhimpl->m_skAlgo == "AES") {
     int keySize = dhimpl->m_keySize > 128 ? dhimpl->m_keySize / 8 : 16;
-    EVP_DecryptInit_ex(ctx, cipherFunc, NULL, (unsigned char *)dhimpl->m_key,
+    EVP_DecryptInit_ex(ctx, cipherFunc, nullptr, (unsigned char *)dhimpl->m_key,
                        (unsigned char *)dhimpl->m_key + keySize);
   } else if (dhimpl->m_skAlgo == "Blowfish") {
     int keySize = dhimpl->m_keySize > 128 ? dhimpl->m_keySize / 8 : 16;
-    EVP_DecryptInit_ex(ctx, cipherFunc, NULL, NULL,
+    EVP_DecryptInit_ex(ctx, cipherFunc, nullptr, nullptr,
                        (unsigned char *)dhimpl->m_key + keySize);
     EVP_CIPHER_CTX_set_key_length(ctx, keySize);
     LOGDH("DHencrypt: BF keysize is %d", keySize);
-    EVP_DecryptInit_ex(ctx, NULL, NULL, (unsigned char *)dhimpl->m_key, NULL);
+    EVP_DecryptInit_ex(ctx, nullptr, nullptr, (unsigned char *)dhimpl->m_key, nullptr);
   } else if (dhimpl->m_skAlgo == "DESede") {
-    EVP_DecryptInit_ex(ctx, cipherFunc, NULL, (unsigned char *)dhimpl->m_key,
+    EVP_DecryptInit_ex(ctx, cipherFunc, nullptr, (unsigned char *)dhimpl->m_key,
                        (unsigned char *)dhimpl->m_key + 24);
   }
 
   if (!EVP_DecryptUpdate(ctx, ciphertext, &outlen, cleartext, len)) {
-    LOGDH(" DHencrypt: enc update ret NULL");
-    return NULL;
+    LOGDH(" DHencrypt: enc update ret nullptr");
+    return nullptr;
   }
   /* Buffer passed to EVP_EncryptFinal() must be after data just
    * encrypted to avoid overwriting it.
@@ -443,8 +444,8 @@ unsigned char *gf_decryptDH(void *dhCtx, const unsigned char *cleartext,
   tmplen = 0;
 
   if (!EVP_DecryptFinal_ex(ctx, ciphertext + outlen, &tmplen)) {
-    LOGDH("DHencrypt: enc final ret NULL");
-    return NULL;
+    LOGDH("DHencrypt: enc final ret nullptr");
+    return nullptr;
   }
 
   outlen += tmplen;
@@ -460,7 +461,7 @@ unsigned char *gf_decryptDH(void *dhCtx, const unsigned char *cleartext,
 // std::shared_ptr<CacheableBytes> decrypt(const uint8_t * ciphertext, int len)
 // {
 //  LOGDH("DH: Used unimplemented decrypt!");
-//  return NULL;
+//  return nullptr;
 //}
 
 bool gf_verifyDH(void *dhCtx, const char *subject,
@@ -470,10 +471,10 @@ bool gf_verifyDH(void *dhCtx, const char *subject,
 
   LOGDH(" In Verify - looking for subject %s", subject);
 
-  EVP_PKEY *evpkey = NULL;
-  X509 *cert = NULL;
+  EVP_PKEY *evpkey = nullptr;
+  X509 *cert = nullptr;
 
-  char *certsubject = NULL;
+  char *certsubject = nullptr;
 
   int32_t count = static_cast<int32_t>(dhimpl->m_serverCerts.size());
   if (count == 0) {
@@ -483,7 +484,7 @@ bool gf_verifyDH(void *dhCtx, const char *subject,
 
   for (int item = 0; item < count; item++) {
     certsubject = X509_NAME_oneline(
-        X509_get_subject_name(dhimpl->m_serverCerts[item]), NULL, 0);
+        X509_get_subject_name(dhimpl->m_serverCerts[item]), nullptr, 0);
 
     // Ignore first letter for comparision, openssl adds / before subject name
     // e.g. /CN=geode1
@@ -495,7 +496,7 @@ bool gf_verifyDH(void *dhCtx, const char *subject,
     }
   }
 
-  if (evpkey == NULL || cert == NULL) {
+  if (evpkey == nullptr || cert == nullptr) {
     *reason = DH_ERR_SUBJECT_NOT_FOUND;
     LOGDH("Certificate not found!");
     return false;
@@ -503,19 +504,19 @@ bool gf_verifyDH(void *dhCtx, const char *subject,
 
   const ASN1_OBJECT *macobj;
   const X509_ALGOR *algorithm = nullptr;
-  X509_ALGOR_get0(&macobj, NULL, NULL, algorithm);
+  X509_ALGOR_get0(&macobj, nullptr, nullptr, algorithm);
   if (algorithm == nullptr) {
     LOGDH("algo is null \n");
   }
 
   const EVP_MD *signatureDigest = EVP_get_digestbyobj(macobj);
   LOGDH("after EVP_get_digestbyobj  :  err(%d): %s", ERR_get_error(),
-        ERR_error_string(ERR_get_error(), NULL));
+        ERR_error_string(ERR_get_error(), nullptr));
   EVP_MD_CTX *signatureCtx = EVP_MD_CTX_new();
 
-  int result1 = EVP_VerifyInit_ex(signatureCtx, signatureDigest, NULL);
+  int result1 = EVP_VerifyInit_ex(signatureCtx, signatureDigest, nullptr);
   LOGDH("after EVP_VerifyInit_ex ret %d : err(%d): %s", result1,
-        ERR_get_error(), ERR_error_string(ERR_get_error(), NULL));
+        ERR_get_error(), ERR_error_string(ERR_get_error(), nullptr));
   LOGDH(" Result of VerifyInit is %s \n", ERR_lib_error_string(result1));
   LOGDH(" Result of VerifyInit is %s \n", ERR_func_error_string(result1));
   LOGDH(" Result of VerifyInit is %s \n", ERR_reason_error_string(result1));
@@ -540,29 +541,29 @@ bool gf_verifyDH(void *dhCtx, const char *subject,
 }
 
 int DH_PUBKEY_set(DH_PUBKEY **x, EVP_PKEY *pkey) {
-  DH_PUBKEY *pk = NULL;
+  DH_PUBKEY *pk = nullptr;
   X509_ALGOR *a;
   ASN1_OBJECT *o;
-  unsigned char *s, *p = NULL;
+  unsigned char *s, *p = nullptr;
   int i;
-  ASN1_INTEGER *asn1int = NULL;
+  ASN1_INTEGER *asn1int = nullptr;
   DH *dh = EVP_PKEY_get1_DH(pkey);
 
-  if (x == NULL) return (0);
+  if (x == nullptr) return (0);
 
-  if ((pk = DH_PUBKEY_new()) == NULL) goto err;
+  if ((pk = DH_PUBKEY_new()) == nullptr) goto err;
   a = pk->algor;
 
   LOGDH(" key type for OBJ NID is %d", EVP_PKEY_base_id(pkey));
 
   /* set the algorithm id */
-  if ((o = OBJ_nid2obj(EVP_PKEY_base_id(pkey))) == NULL) goto err;
+  if ((o = OBJ_nid2obj(EVP_PKEY_base_id(pkey))) == nullptr) goto err;
   ASN1_OBJECT_free(a->algorithm);
   a->algorithm = o;
 
   /* Set the parameter list */
   if (EVP_PKEY_base_id(pkey) == EVP_PKEY_RSA) {
-    if ((a->parameter == NULL) || (a->parameter->type != V_ASN1_NULL)) {
+    if ((a->parameter == nullptr) || (a->parameter->type != V_ASN1_NULL)) {
       ASN1_TYPE_free(a->parameter);
       if (!(a->parameter = ASN1_TYPE_new())) {
         X509err(X509_F_X509_PUBKEY_SET, ERR_R_MALLOC_FAILURE);
@@ -573,7 +574,7 @@ int DH_PUBKEY_set(DH_PUBKEY **x, EVP_PKEY *pkey) {
   } else if (EVP_PKEY_base_id(pkey) == EVP_PKEY_DH) {
     unsigned char *pp;
     ASN1_TYPE_free(a->parameter);
-    if ((i = i2d_DHparams(dh, NULL)) <= 0) goto err;
+    if ((i = i2d_DHparams(dh, nullptr)) <= 0) goto err;
     if (!(p = reinterpret_cast<unsigned char *>(OPENSSL_malloc(i)))) {
       X509err(X509_F_X509_PUBKEY_SET, ERR_R_MALLOC_FAILURE);
       goto err;
@@ -605,9 +606,9 @@ int DH_PUBKEY_set(DH_PUBKEY **x, EVP_PKEY *pkey) {
   const BIGNUM *pub_key, *priv_key;
   DH_get0_key(dh, &pub_key, &priv_key);
 
-  asn1int = BN_to_ASN1_INTEGER(pub_key, NULL);
-  if ((i = i2d_ASN1_INTEGER(asn1int, NULL)) <= 0) goto err;
-  if ((s = reinterpret_cast<unsigned char *>(OPENSSL_malloc(i + 1))) == NULL) {
+  asn1int = BN_to_ASN1_INTEGER(pub_key, nullptr);
+  if ((i = i2d_ASN1_INTEGER(asn1int, nullptr)) <= 0) goto err;
+  if ((s = reinterpret_cast<unsigned char *>(OPENSSL_malloc(i + 1))) == nullptr) {
     X509err(X509_F_X509_PUBKEY_SET, ERR_R_MALLOC_FAILURE);
     goto err;
   }
@@ -623,47 +624,47 @@ int DH_PUBKEY_set(DH_PUBKEY **x, EVP_PKEY *pkey) {
 
   OPENSSL_free(s);
 
-  if (*x != NULL) DH_PUBKEY_free(*x);
+  if (*x != nullptr) DH_PUBKEY_free(*x);
 
   *x = pk;
 
   return 1;
 err:
-  if (asn1int != NULL) ASN1_INTEGER_free(asn1int);
-  if (pk != NULL) DH_PUBKEY_free(pk);
+  if (asn1int != nullptr) ASN1_INTEGER_free(asn1int);
+  if (pk != nullptr) DH_PUBKEY_free(pk);
   return 0;
 }
 
 EVP_PKEY *DH_PUBKEY_get(DH_PUBKEY *key) {
-  EVP_PKEY *ret = NULL;
+  EVP_PKEY *ret = nullptr;
   long j;
   const unsigned char *p;
   const unsigned char *cp;
   X509_ALGOR *a;
-  ASN1_INTEGER *asn1int = NULL;
+  ASN1_INTEGER *asn1int = nullptr;
 
-  if (key == NULL) {
-    if (asn1int != NULL) ASN1_INTEGER_free(asn1int);
-    if (ret != NULL) EVP_PKEY_free(ret);
-    return (NULL);
+  if (key == nullptr) {
+    if (asn1int != nullptr) ASN1_INTEGER_free(asn1int);
+    if (ret != nullptr) EVP_PKEY_free(ret);
+    return (nullptr);
   }
 
-  if (key->pkey != NULL) {
+  if (key->pkey != nullptr) {
     EVP_PKEY_up_ref(key->pkey);
     return (key->pkey);
   }
 
-  if (key->public_key == NULL) {
-    if (asn1int != NULL) ASN1_INTEGER_free(asn1int);
-    if (ret != NULL) EVP_PKEY_free(ret);
-    return (NULL);
+  if (key->public_key == nullptr) {
+    if (asn1int != nullptr) ASN1_INTEGER_free(asn1int);
+    if (ret != nullptr) EVP_PKEY_free(ret);
+    return (nullptr);
   }
 
-  if ((ret = EVP_PKEY_new()) == NULL) {
+  if ((ret = EVP_PKEY_new()) == nullptr) {
     X509err(X509_F_X509_PUBKEY_DECODE, ERR_R_MALLOC_FAILURE);
-    if (asn1int != NULL) ASN1_INTEGER_free(asn1int);
-    if (ret != NULL) EVP_PKEY_free(ret);
-    return (NULL);
+    if (asn1int != nullptr) ASN1_INTEGER_free(asn1int);
+    if (ret != nullptr) EVP_PKEY_free(ret);
+    return (nullptr);
   }
 
   LOGDH(" DHPUBKEY evppkey type is %d", EVP_PKEY_base_id(ret));
@@ -676,17 +677,17 @@ EVP_PKEY *DH_PUBKEY_get(DH_PUBKEY *key) {
     if (a->parameter && (a->parameter->type == V_ASN1_SEQUENCE)) {
       if ((EVP_PKEY_set1_DH(ret, DH_new())) == 0) {
         X509err(X509_F_X509_PUBKEY_DECODE, ERR_R_MALLOC_FAILURE);
-        if (asn1int != NULL) ASN1_INTEGER_free(asn1int);
-        if (ret != NULL) EVP_PKEY_free(ret);
-        return (NULL);
+        if (asn1int != nullptr) ASN1_INTEGER_free(asn1int);
+        if (ret != nullptr) EVP_PKEY_free(ret);
+        return (nullptr);
       }
       cp = p = a->parameter->value.sequence->data;
       j = a->parameter->value.sequence->length;
       DH *dh = EVP_PKEY_get1_DH(ret);
       if (!d2i_DHparams(&dh, &cp, j)) {
-        if (asn1int != NULL) ASN1_INTEGER_free(asn1int);
-        if (ret != NULL) EVP_PKEY_free(ret);
-        return (NULL);
+        if (asn1int != nullptr) ASN1_INTEGER_free(asn1int);
+        if (ret != nullptr) EVP_PKEY_free(ret);
+        return (nullptr);
       }
     }
   }
@@ -694,16 +695,16 @@ EVP_PKEY *DH_PUBKEY_get(DH_PUBKEY *key) {
   p = key->public_key->data;
   j = key->public_key->length;
 
-  asn1int = d2i_ASN1_INTEGER(NULL, &p, j);
+  asn1int = d2i_ASN1_INTEGER(nullptr, &p, j);
   LOGDH("after d2i asn1 integer ptr is %p", asn1int);
 
   DH *dh = EVP_PKEY_get1_DH(ret);
-  DH_set0_key(dh, ASN1_INTEGER_to_BN(asn1int, NULL), NULL);
+  DH_set0_key(dh, ASN1_INTEGER_to_BN(asn1int, nullptr), nullptr);
   // LOGDH(" after asn1int to bn ptr is %p", ret->pkey.dh->pub_key);
 
   key->pkey = ret;
   EVP_PKEY_up_ref(ret);
 
-  if (asn1int != NULL) ASN1_INTEGER_free(asn1int);
+  if (asn1int != nullptr) ASN1_INTEGER_free(asn1int);
   return (ret);
 }

--- a/cryptoimpl/DHImpl.hpp
+++ b/cryptoimpl/DHImpl.hpp
@@ -86,7 +86,7 @@ class DHImpl {
   const EVP_CIPHER* getCipherFunc();
   int setSkAlgo(const char* skalgo);
 
-  DHImpl() : m_dh(NULL), m_keySize(0), m_pubKeyOther(NULL) {
+  DHImpl() : m_dh(nullptr), m_keySize(0), m_pubKeyOther(nullptr) {
     /* adongre
      * CID 28924: Uninitialized scalar field (UNINIT_CTOR)
      */

--- a/cryptoimpl/SSLImpl.cpp
+++ b/cryptoimpl/SSLImpl.cpp
@@ -75,7 +75,7 @@ SSLImpl::SSLImpl(ACE_HANDLE sock, const char *pubkeyfile,
 SSLImpl::~SSLImpl() {
   ACE_Guard<ACE_Recursive_Thread_Mutex> guard(SSLImpl::s_mutex);
 
-  if (m_io != NULL) {
+  if (m_io) {
     delete m_io;
   }
 }
@@ -83,7 +83,7 @@ SSLImpl::~SSLImpl() {
 void SSLImpl::close() {
   ACE_Guard<ACE_Recursive_Thread_Mutex> guard(SSLImpl::s_mutex);
 
-  if (m_io != NULL) {
+  if (m_io) {
     m_io->close();
   }
 }
@@ -96,9 +96,9 @@ int SSLImpl::listen(ACE_INET_Addr addr, std::chrono::microseconds waitSeconds) {
   ACE_SSL_SOCK_Acceptor listener(addr, 1);
   if (waitSeconds > std::chrono::microseconds::zero()) {
     ACE_Time_Value wtime(waitSeconds);
-    return listener.accept(*m_io, 0, &wtime);
+    return listener.accept(*m_io, nullptr, &wtime);
   } else {
-    return listener.accept(*m_io, 0);
+    return listener.accept(*m_io, nullptr);
   }
 }
 

--- a/cryptoimpl/SSLImpl.hpp
+++ b/cryptoimpl/SSLImpl.hpp
@@ -58,7 +58,7 @@ class SSLImpl : public apache::geode::client::Ssl {
  public:
   SSLImpl(ACE_HANDLE sock, const char* pubkeyfile, const char* privkeyfile,
           const char* password);
-  virtual ~SSLImpl();
+  virtual ~SSLImpl() override;
 
   int setOption(int, int, void*, int) override;
   int listen(ACE_INET_Addr, std::chrono::microseconds) override;

--- a/dhimpl/DHImpl.cpp
+++ b/dhimpl/DHImpl.cpp
@@ -31,10 +31,10 @@
 #include <cctype>
 #include <cstdint>
 
-static DH *m_dh = NULL;
+static DH *m_dh = nullptr;
 static std::string m_skAlgo;
 static int m_keySize = 0;
-static BIGNUM *m_pubKeyOther = NULL;
+static BIGNUM *m_pubKeyOther = nullptr;
 static unsigned char m_key[128] = {0};
 static std::vector<X509 *> m_serverCerts;
 
@@ -65,7 +65,7 @@ ASN1_SEQUENCE(
   int errorCode = DH_ERR_NO_ERROR;  // No error;
 
   // ksPath can be null
-  if (m_dh != NULL || dhAlgo == NULL || strlen(dhAlgo) == 0) {
+  if (m_dh || !dhAlgo || strlen(dhAlgo) == 0) {
     return errorCode;
   }
 
@@ -81,15 +81,16 @@ ASN1_SEQUENCE(
 
   m_dh = DH_new();
 
-  const BIGNUM *pbn, *gbn;
-  DH_get0_pqg(m_dh, &pbn, NULL, &gbn);
-  BN_dec2bn((BIGNUM **)&pbn, dhP);
+  BIGNUM* pbn = nullptr;
+  BIGNUM* gbn = nullptr;
+  DH_get0_pqg(m_dh, const_cast<const BIGNUM**>(&pbn), nullptr, const_cast<const BIGNUM**>(&gbn));
+  BN_dec2bn(&pbn, dhP);
 
   LOGDH(" DHInit: P ptr is %p", pbn);
   LOGDH(" DHInit: G ptr is %p", gbn);
   LOGDH(" DHInit: length is %d", DH_get_length(m_dh));
 
-  BN_dec2bn((BIGNUM **)&gbn, dhP);
+  BN_dec2bn(&gbn, dhP);
 
   DH_set_length(m_dh, dhL);
 
@@ -109,25 +110,25 @@ ASN1_SEQUENCE(
 
   LOGDH(" Loading keystore...");
 
-  if (ksPath == NULL || strlen(ksPath) == 0) {
-    LOGDH("Property \"security-client-kspath\" 's value is NULL.");
+  if (ksPath == nullptr || strlen(ksPath) == 0) {
+    LOGDH("Property \"security-client-kspath\" 's value is nullptr.");
     return errorCode;
   }
-  FILE *keyStoreFP = NULL;
+  FILE *keyStoreFP = nullptr;
   keyStoreFP = fopen(ksPath, "r");
 
   LOGDH(" kspath is [%s]", ksPath);
   LOGDH(" keystore FILE ptr is %p", keyStoreFP);
 
   // Read from pem file and put into.
-  X509 *cert = NULL;
+  X509 *cert = nullptr;
   do {
-    cert = PEM_read_X509(keyStoreFP, NULL, NULL, NULL);
+    cert = PEM_read_X509(keyStoreFP, nullptr, nullptr, nullptr);
 
-    if (cert != NULL) {
+    if (cert != nullptr) {
       m_serverCerts.push_back(cert);
     }
-  } while (cert != NULL);
+  } while (cert != nullptr);
 
   LOGDH(" Total certificats imported # %zd", m_serverCerts.size());
 
@@ -137,9 +138,9 @@ ASN1_SEQUENCE(
 }
 
 void gf_clearDhKeys(void) {
-  if (m_dh != NULL) {
+  if (m_dh != nullptr) {
     DH_free(m_dh);
-    m_dh = NULL;
+    m_dh = nullptr;
   }
 
   std::vector<X509 *>::const_iterator iter;
@@ -149,9 +150,9 @@ void gf_clearDhKeys(void) {
 
   m_serverCerts.clear();
 
-  if (m_pubKeyOther != NULL) {
+  if (m_pubKeyOther != nullptr) {
     BN_free(m_pubKeyOther);
-    m_pubKeyOther = NULL;
+    m_pubKeyOther = nullptr;
   }
 
   memset(m_key, 0, 128);
@@ -163,23 +164,23 @@ unsigned char *gf_getPublicKey(int *pLen) {
   const BIGNUM *pub_key, *priv_key;
   DH_get0_key(m_dh, &pub_key, &priv_key);
 
-  if (pub_key == NULL || pLen == NULL) {
-    return NULL;
+  if (pub_key == nullptr || pLen == nullptr) {
+    return nullptr;
   }
 
   int numBytes = BN_num_bytes(pub_key);
 
   if (numBytes <= 0) {
-    return NULL;
+    return nullptr;
   }
 
   EVP_PKEY *evppubkey = EVP_PKEY_new();
   LOGDH(" before assign DH ptr is %p", m_dh);
   EVP_PKEY_assign_DH(evppubkey, m_dh);
   LOGDH(" after assign DH ptr is %p", m_dh);
-  DH_PUBKEY *dhpubkey = NULL;
+  DH_PUBKEY *dhpubkey = nullptr;
   DH_PUBKEY_set(&dhpubkey, evppubkey);
-  int len = i2d_DH_PUBKEY(dhpubkey, NULL);
+  int len = i2d_DH_PUBKEY(dhpubkey, nullptr);
   unsigned char *pubkey = new unsigned char[len];
   unsigned char *temp = pubkey;
   //
@@ -201,13 +202,13 @@ unsigned char *gf_getPublicKey(int *pLen) {
 }
 
 void gf_setPublicKeyOther(const unsigned char *pubkey, int length) {
-  if (m_pubKeyOther != NULL) {
+  if (m_pubKeyOther != nullptr) {
     BN_free(m_pubKeyOther);
-    m_pubKeyOther = NULL;
+    m_pubKeyOther = nullptr;
   }
 
   const unsigned char *temp = pubkey;
-  DH_PUBKEY *dhpubkey = d2i_DH_PUBKEY(NULL, &temp, length);
+  DH_PUBKEY *dhpubkey = d2i_DH_PUBKEY(nullptr, &temp, length);
   LOGDH(" setPubKeyOther: after d2i_dhpubkey ptr is %p", dhpubkey);
   EVP_PKEY *evppkey = DH_PUBKEY_get(dhpubkey);
   LOGDH(" setPubKeyOther: after dhpubkey get evp ptr is %p", evppkey);
@@ -236,7 +237,7 @@ void gf_computeSharedSecret() {
 #ifdef _DEBUG
   int ret = DH_compute_key(m_key, m_pubKeyOther, m_dh);
   LOGDH("DHcomputeKey ret %d : Compute err(%d): %s", ret, ERR_get_error(),
-        ERR_error_string(ERR_get_error(), NULL));
+        ERR_error_string(ERR_get_error(), nullptr));
 #endif
 }
 
@@ -306,15 +307,15 @@ const EVP_CIPHER *getCipherFunc() {
     return EVP_des_ede3_cbc();
   } else {
     LOGDH("ERROR: Unsupported DH Algorithm");
-    return NULL;
+    return nullptr;
   }
 }
 
 unsigned char *gf_encryptDH(const unsigned char *cleartext, int len,
                             int *retLen) {
   // Validation
-  if (cleartext == NULL || len < 1 || retLen == NULL) {
-    return NULL;
+  if (cleartext == nullptr || len < 1 || retLen == nullptr) {
+    return nullptr;
   }
 
   LOGDH(" DH: gf_encryptDH using sk algo: %s, Keysize: %d", m_skAlgo.c_str(),
@@ -330,23 +331,23 @@ unsigned char *gf_encryptDH(const unsigned char *cleartext, int len,
   // init openssl cipher context
   if (m_skAlgo == "AES") {
     int keySize = m_keySize > 128 ? m_keySize / 8 : 16;
-    EVP_EncryptInit_ex(ctx, cipherFunc, NULL, (unsigned char *)m_key,
+    EVP_EncryptInit_ex(ctx, cipherFunc, nullptr, (unsigned char *)m_key,
                        (unsigned char *)m_key + keySize);
   } else if (m_skAlgo == "Blowfish") {
     int keySize = m_keySize > 128 ? m_keySize / 8 : 16;
-    EVP_EncryptInit_ex(ctx, cipherFunc, NULL, NULL,
+    EVP_EncryptInit_ex(ctx, cipherFunc, nullptr, nullptr,
                        (unsigned char *)m_key + keySize);
     EVP_CIPHER_CTX_set_key_length(ctx, keySize);
     LOGDH("DHencrypt: BF keysize is %d", keySize);
-    EVP_EncryptInit_ex(ctx, NULL, NULL, (unsigned char *)m_key, NULL);
+    EVP_EncryptInit_ex(ctx, nullptr, nullptr, (unsigned char *)m_key, nullptr);
   } else if (m_skAlgo == "DESede") {
-    EVP_EncryptInit_ex(ctx, cipherFunc, NULL, (unsigned char *)m_key,
+    EVP_EncryptInit_ex(ctx, cipherFunc, nullptr, (unsigned char *)m_key,
                        (unsigned char *)m_key + 24);
   }
 
   if (!EVP_EncryptUpdate(ctx, ciphertext, &outlen, cleartext, len)) {
-    LOGDH(" DHencrypt: enc update ret NULL");
-    return NULL;
+    LOGDH(" DHencrypt: enc update ret nullptr");
+    return nullptr;
   }
   /* Buffer passed to EVP_EncryptFinal() must be after data just
    * encrypted to avoid overwriting it.
@@ -354,8 +355,8 @@ unsigned char *gf_encryptDH(const unsigned char *cleartext, int len,
   tmplen = 0;
 
   if (!EVP_EncryptFinal_ex(ctx, ciphertext + outlen, &tmplen)) {
-    LOGDH("DHencrypt: enc final ret NULL");
-    return NULL;
+    LOGDH("DHencrypt: enc final ret nullptr");
+    return nullptr;
   }
 
   outlen += tmplen;
@@ -372,7 +373,7 @@ unsigned char *gf_encryptDH(const unsigned char *cleartext, int len,
 // len)
 // {
 //  LOGDH("DH: Used unimplemented decrypt!");
-//  return NULL;
+//  return nullptr;
 //}
 
 bool gf_verifyDH(const char *subject, const unsigned char *challenge,
@@ -380,10 +381,10 @@ bool gf_verifyDH(const char *subject, const unsigned char *challenge,
                  int responseLen, int *reason) {
   LOGDH(" In Verify - looking for subject %s", subject);
 
-  EVP_PKEY *evpkey = NULL;
-  X509 *cert = NULL;
+  EVP_PKEY *evpkey = nullptr;
+  X509 *cert = nullptr;
 
-  char *certsubject = NULL;
+  char *certsubject = nullptr;
 
   int32_t count = static_cast<int32_t>(m_serverCerts.size());
   if (count == 0) {
@@ -393,7 +394,7 @@ bool gf_verifyDH(const char *subject, const unsigned char *challenge,
 
   for (int item = 0; item < count; item++) {
     certsubject =
-        X509_NAME_oneline(X509_get_subject_name(m_serverCerts[item]), NULL, 0);
+        X509_NAME_oneline(X509_get_subject_name(m_serverCerts[item]), nullptr, 0);
 
     // Ignore first letter for comparision, openssl adds / before subject name
     // e.g. /CN=geode1
@@ -405,7 +406,7 @@ bool gf_verifyDH(const char *subject, const unsigned char *challenge,
     }
   }
 
-  if (evpkey == NULL || cert == NULL) {
+  if (evpkey == nullptr || cert == nullptr) {
     *reason = DH_ERR_SUBJECT_NOT_FOUND;
     LOGDH("Certificate not found!");
     return false;
@@ -413,12 +414,12 @@ bool gf_verifyDH(const char *subject, const unsigned char *challenge,
 
   const ASN1_OBJECT *macobj;
   const X509_ALGOR *algorithm = nullptr;
-  X509_ALGOR_get0(&macobj, NULL, NULL, algorithm);
+  X509_ALGOR_get0(&macobj, nullptr, nullptr, algorithm);
 
   const EVP_MD *signatureDigest = EVP_get_digestbyobj(macobj);
   EVP_MD_CTX *signatureCtx = EVP_MD_CTX_new();
 
-  int result1 = EVP_VerifyInit_ex(signatureCtx, signatureDigest, NULL);
+  int result1 = EVP_VerifyInit_ex(signatureCtx, signatureDigest, nullptr);
   LOGDH(" Result of VerifyInit is %d", result1);
 
   int result2 = EVP_VerifyUpdate(signatureCtx, challenge, challengeLen);
@@ -439,29 +440,29 @@ bool gf_verifyDH(const char *subject, const unsigned char *challenge,
 }
 
 int DH_PUBKEY_set(DH_PUBKEY **x, EVP_PKEY *pkey) {
-  DH_PUBKEY *pk = NULL;
+  DH_PUBKEY *pk = nullptr;
   X509_ALGOR *a;
   ASN1_OBJECT *o;
-  unsigned char *s, *p = NULL;
+  unsigned char *s, *p = nullptr;
   int i;
-  ASN1_INTEGER *asn1int = NULL;
+  ASN1_INTEGER *asn1int = nullptr;
   DH *dh = EVP_PKEY_get1_DH(pkey);
 
-  if (x == NULL) return (0);
+  if (x == nullptr) return (0);
 
-  if ((pk = DH_PUBKEY_new()) == NULL) goto err;
+  if ((pk = DH_PUBKEY_new()) == nullptr) goto err;
   a = pk->algor;
 
   LOGDH(" key type for OBJ NID is %d", EVP_PKEY_base_id(pkey));
 
   /* set the algorithm id */
-  if ((o = OBJ_nid2obj(EVP_PKEY_base_id(pkey))) == NULL) goto err;
+  if ((o = OBJ_nid2obj(EVP_PKEY_base_id(pkey))) == nullptr) goto err;
   ASN1_OBJECT_free(a->algorithm);
   a->algorithm = o;
 
   /* Set the parameter list */
   if (EVP_PKEY_base_id(pkey) == EVP_PKEY_RSA) {
-    if ((a->parameter == NULL) || (a->parameter->type != V_ASN1_NULL)) {
+    if ((a->parameter == nullptr) || (a->parameter->type != V_ASN1_NULL)) {
       ASN1_TYPE_free(a->parameter);
       if (!(a->parameter = ASN1_TYPE_new())) {
         X509err(X509_F_X509_PUBKEY_SET, ERR_R_MALLOC_FAILURE);
@@ -475,7 +476,7 @@ int DH_PUBKEY_set(DH_PUBKEY **x, EVP_PKEY *pkey) {
     const BIGNUM *pub_key, *priv_key;
     DH_get0_key(dh, &pub_key, &priv_key);
     ASN1_TYPE_free(a->parameter);
-    if ((i = i2d_DHparams(dh, NULL)) <= 0) goto err;
+    if ((i = i2d_DHparams(dh, nullptr)) <= 0) goto err;
     if (!(p = reinterpret_cast<unsigned char *>(OPENSSL_malloc(i)))) {
       X509err(X509_F_X509_PUBKEY_SET, ERR_R_MALLOC_FAILURE);
       goto err;
@@ -507,9 +508,9 @@ int DH_PUBKEY_set(DH_PUBKEY **x, EVP_PKEY *pkey) {
   const BIGNUM *pub_key, *priv_key;
   DH_get0_key(dh, &pub_key, &priv_key);
 
-  asn1int = BN_to_ASN1_INTEGER(pub_key, NULL);
-  if ((i = i2d_ASN1_INTEGER(asn1int, NULL)) <= 0) goto err;
-  if ((s = reinterpret_cast<unsigned char *>(OPENSSL_malloc(i + 1))) == NULL) {
+  asn1int = BN_to_ASN1_INTEGER(pub_key, nullptr);
+  if ((i = i2d_ASN1_INTEGER(asn1int, nullptr)) <= 0) goto err;
+  if ((s = reinterpret_cast<unsigned char *>(OPENSSL_malloc(i + 1))) == nullptr) {
     X509err(X509_F_X509_PUBKEY_SET, ERR_R_MALLOC_FAILURE);
     goto err;
   }
@@ -525,46 +526,46 @@ int DH_PUBKEY_set(DH_PUBKEY **x, EVP_PKEY *pkey) {
 
   OPENSSL_free(s);
 
-  if (*x != NULL) DH_PUBKEY_free(*x);
+  if (*x != nullptr) DH_PUBKEY_free(*x);
 
   *x = pk;
 
   return 1;
 err:
-  if (asn1int != NULL) ASN1_INTEGER_free(asn1int);
-  if (pk != NULL) DH_PUBKEY_free(pk);
+  if (asn1int != nullptr) ASN1_INTEGER_free(asn1int);
+  if (pk != nullptr) DH_PUBKEY_free(pk);
   return 0;
 }
 
 EVP_PKEY *DH_PUBKEY_get(DH_PUBKEY *key) {
-  EVP_PKEY *ret = NULL;
+  EVP_PKEY *ret = nullptr;
   long j;
   const unsigned char *p;
   const unsigned char *cp;
   X509_ALGOR *a;
-  ASN1_INTEGER *asn1int = NULL;
+  ASN1_INTEGER *asn1int = nullptr;
 
-  if (key == NULL) {
+  if (key == nullptr) {
     EVP_PKEY_up_ref(key->pkey);
     return (key->pkey);
   }
 
-  if (key->pkey != NULL) {
+  if (key->pkey != nullptr) {
     EVP_PKEY_up_ref(key->pkey);
     return (key->pkey);
   }
 
-  if (key->public_key == NULL) {
-    if (asn1int != NULL) ASN1_INTEGER_free(asn1int);
-    if (ret != NULL) EVP_PKEY_free(ret);
-    return (NULL);
+  if (key->public_key == nullptr) {
+    if (asn1int != nullptr) ASN1_INTEGER_free(asn1int);
+    if (ret != nullptr) EVP_PKEY_free(ret);
+    return (nullptr);
   }
 
-  if ((ret = EVP_PKEY_new()) == NULL) {
+  if ((ret = EVP_PKEY_new()) == nullptr) {
     X509err(X509_F_X509_PUBKEY_DECODE, ERR_R_MALLOC_FAILURE);
-    if (asn1int != NULL) ASN1_INTEGER_free(asn1int);
-    if (ret != NULL) EVP_PKEY_free(ret);
-    return (NULL);
+    if (asn1int != nullptr) ASN1_INTEGER_free(asn1int);
+    if (ret != nullptr) EVP_PKEY_free(ret);
+    return (nullptr);
   }
 
   LOGDH(" DHPUBKEY evppkey type is %d", EVP_PKEY_base_id(ret));
@@ -577,17 +578,17 @@ EVP_PKEY *DH_PUBKEY_get(DH_PUBKEY *key) {
     if (a->parameter && (a->parameter->type == V_ASN1_SEQUENCE)) {
       if ((EVP_PKEY_set1_DH(ret, DH_new())) == 0) {
         X509err(X509_F_X509_PUBKEY_DECODE, ERR_R_MALLOC_FAILURE);
-        if (asn1int != NULL) ASN1_INTEGER_free(asn1int);
-        if (ret != NULL) EVP_PKEY_free(ret);
-        return (NULL);
+        if (asn1int != nullptr) ASN1_INTEGER_free(asn1int);
+        if (ret != nullptr) EVP_PKEY_free(ret);
+        return (nullptr);
       }
       cp = p = a->parameter->value.sequence->data;
       j = a->parameter->value.sequence->length;
       DH *dh = EVP_PKEY_get1_DH(ret);
       if (!d2i_DHparams(&dh, &cp, j)) {
-        if (asn1int != NULL) ASN1_INTEGER_free(asn1int);
-        if (ret != NULL) EVP_PKEY_free(ret);
-        return (NULL);
+        if (asn1int != nullptr) ASN1_INTEGER_free(asn1int);
+        if (ret != nullptr) EVP_PKEY_free(ret);
+        return (nullptr);
       }
     }
   }
@@ -595,15 +596,17 @@ EVP_PKEY *DH_PUBKEY_get(DH_PUBKEY *key) {
   p = key->public_key->data;
   j = key->public_key->length;
 
-  asn1int = d2i_ASN1_INTEGER(NULL, &p, j);
+  asn1int = d2i_ASN1_INTEGER(nullptr, &p, j);
   LOGDH("after d2i asn1 integer ptr is %p", asn1int);
 
   DH *dh = EVP_PKEY_get1_DH(ret);
-  DH_set0_key(dh, ASN1_INTEGER_to_BN(asn1int, NULL), NULL);
+  DH_set0_key(dh, ASN1_INTEGER_to_BN(asn1int, nullptr), nullptr);
 
   key->pkey = ret;
   EVP_PKEY_up_ref(key->pkey);
 
-  if (asn1int != NULL) ASN1_INTEGER_free(asn1int);
+  if (asn1int) {
+    ASN1_INTEGER_free(asn1int);
+  }
   return (ret);
 }

--- a/sqliteimpl/SqLiteHelper.cpp
+++ b/sqliteimpl/SqLiteHelper.cpp
@@ -56,7 +56,7 @@ int SqLiteHelper::createTable() {
 
   // prepare statement
   int retCode;
-  retCode = sqlite3_prepare_v2(m_dbHandle, query, -1, &stmt, 0);
+  retCode = sqlite3_prepare_v2(m_dbHandle, query, -1, &stmt, nullptr);
 
   // execute statement
   if (retCode == SQLITE_OK) retCode = sqlite3_step(stmt);
@@ -72,11 +72,11 @@ int SqLiteHelper::insertKeyValue(void *keyData, int keyDataSize,
 
   // prepare statement
   sqlite3_stmt *stmt;
-  int retCode = sqlite3_prepare_v2(m_dbHandle, query, -1, &stmt, 0);
+  int retCode = sqlite3_prepare_v2(m_dbHandle, query, -1, &stmt, nullptr);
   if (retCode == SQLITE_OK) {
     // bind parameters and execte statement
-    sqlite3_bind_blob(stmt, 1, keyData, keyDataSize, 0);
-    sqlite3_bind_blob(stmt, 2, valueData, valueDataSize, 0);
+    sqlite3_bind_blob(stmt, 1, keyData, keyDataSize, nullptr);
+    sqlite3_bind_blob(stmt, 2, valueData, valueDataSize, nullptr);
     retCode = sqlite3_step(stmt);
   }
 
@@ -91,10 +91,10 @@ int SqLiteHelper::removeKey(void *keyData, int keyDataSize) {
 
   // prepare statement
   sqlite3_stmt *stmt;
-  int retCode = sqlite3_prepare_v2(m_dbHandle, query, -1, &stmt, 0);
+  int retCode = sqlite3_prepare_v2(m_dbHandle, query, -1, &stmt, nullptr);
   if (retCode == SQLITE_OK) {
     // bind parameters and execte statement
-    sqlite3_bind_blob(stmt, 1, keyData, keyDataSize, 0);
+    sqlite3_bind_blob(stmt, 1, keyData, keyDataSize, nullptr);
     retCode = sqlite3_step(stmt);
   }
 
@@ -112,10 +112,10 @@ int SqLiteHelper::getValue(void *keyData, int keyDataSize, void *&valueData,
 
   // prepare statement
   sqlite3_stmt *stmt;
-  int retCode = sqlite3_prepare_v2(m_dbHandle, query, -1, &stmt, 0);
+  int retCode = sqlite3_prepare_v2(m_dbHandle, query, -1, &stmt, nullptr);
   if (retCode == SQLITE_OK) {
     // bind parameters and execte statement
-    sqlite3_bind_blob(stmt, 1, keyData, keyDataSize, 0);
+    sqlite3_bind_blob(stmt, 1, keyData, keyDataSize, nullptr);
     retCode = sqlite3_step(stmt);
     if (retCode == SQLITE_ROW)  // we will get only one row
     {
@@ -140,7 +140,7 @@ int SqLiteHelper::dropTable() {
   // prepare statement
   sqlite3_stmt *stmt;
   int retCode;
-  retCode = sqlite3_prepare_v2(m_dbHandle, query, -1, &stmt, 0);
+  retCode = sqlite3_prepare_v2(m_dbHandle, query, -1, &stmt, nullptr);
 
   // execute statement
   if (retCode == SQLITE_OK) retCode = sqlite3_step(stmt);
@@ -166,7 +166,7 @@ int SqLiteHelper::executePragma(const char *pragmaName, int pragmaValue) {
   // prepare statement
   sqlite3_stmt *stmt;
   int retCode;
-  retCode = sqlite3_prepare_v2(m_dbHandle, query, -1, &stmt, 0);
+  retCode = sqlite3_prepare_v2(m_dbHandle, query, -1, &stmt, nullptr);
 
   // execute PRAGMA
   if (retCode == SQLITE_OK &&

--- a/sqliteimpl/SqLiteImpl.hpp
+++ b/sqliteimpl/SqLiteImpl.hpp
@@ -137,7 +137,6 @@ class SqLiteImpl : public PersistenceManager {
  private:
   SqLiteHelper* m_sqliteHelper;
 
-  std::shared_ptr<Region> m_regionPtr;
   std::string m_regionDBFile;
   std::string m_regionDir;
   std::string m_persistanceDir;

--- a/templates/security/PkcsAuthInit.cpp
+++ b/templates/security/PkcsAuthInit.cpp
@@ -42,18 +42,18 @@ SECURITYIMPL_EXPORT AuthInitialize* createPKCSAuthInitInstance() {
 uint8_t* createSignature(EVP_PKEY* key, X509* cert,
                          const unsigned char* inputBuffer,
                          uint32_t inputBufferLen, unsigned int* signatureLen) {
-  if (key == NULL || cert == NULL || inputBuffer == NULL) {
-    return NULL;
+  if (!key || !cert || !inputBuffer) {
+    return nullptr;
   }
 
   const ASN1_OBJECT* macobj;
-  X509_ALGOR_get0(&macobj, NULL, NULL, NULL);
+  X509_ALGOR_get0(&macobj, nullptr, nullptr, nullptr);
   const EVP_MD* signatureDigest = EVP_get_digestbyobj(macobj);
 
   EVP_MD_CTX* signatureCtx = EVP_MD_CTX_new();
   uint8_t* signatureData = new uint8_t[EVP_PKEY_size(key)];
 
-  bool result = (EVP_SignInit_ex(signatureCtx, signatureDigest, NULL) &&
+  bool result = (EVP_SignInit_ex(signatureCtx, signatureDigest, nullptr) &&
                  EVP_SignUpdate(signatureCtx, inputBuffer, inputBufferLen) &&
                  EVP_SignFinal(signatureCtx, signatureData, signatureLen, key));
 
@@ -61,26 +61,26 @@ uint8_t* createSignature(EVP_PKEY* key, X509* cert,
   if (result) {
     return signatureData;
   }
-  return NULL;
+  return nullptr;
 }
 
 bool readPKCSPublicPrivateKey(FILE* keyStoreFP, const char* keyStorePassword,
                               EVP_PKEY** outPrivateKey, X509** outCertificate) {
   PKCS12* p12;
 
-  if ((keyStoreFP == NULL) || (keyStorePassword == NULL) ||
+  if (!keyStoreFP || !keyStorePassword ||
       (keyStorePassword[0] == '\0')) {
     return (false);
   }
 
-  p12 = d2i_PKCS12_fp(keyStoreFP, NULL);
+  p12 = d2i_PKCS12_fp(keyStoreFP, nullptr);
 
-  if (p12 == NULL) {
+  if (p12) {
     return (false);
   }
 
   if (!PKCS12_parse(p12, keyStorePassword, outPrivateKey, outCertificate,
-                    NULL)) {
+                    nullptr)) {
     return (false);
   }
 
@@ -117,7 +117,7 @@ std::shared_ptr<Properties> PKCSAuthInit::getCredentials(
 
   const char* keyStorePath = keyStoreptr->value().c_str();
 
-  if (keyStorePath == NULL) {
+  if (!keyStorePath) {
     throw AuthenticationFailedException(
         "PKCSAuthInit::getCredentials: "
         "key-store file path property KEYSTORE_FILE_PATH not set.");
@@ -127,7 +127,7 @@ std::shared_ptr<Properties> PKCSAuthInit::getCredentials(
 
   const char* alias = aliasptr->value().c_str();
 
-  if (alias == NULL) {
+  if (!alias) {
     throw AuthenticationFailedException(
         "PKCSAuthInit::getCredentials: "
         "key-store alias property KEYSTORE_ALIAS not set.");
@@ -137,22 +137,22 @@ std::shared_ptr<Properties> PKCSAuthInit::getCredentials(
 
   const char* keyStorePass = keyStorePassptr->value().c_str();
 
-  if (keyStorePass == NULL) {
+  if (!keyStorePass) {
     throw AuthenticationFailedException(
         "PKCSAuthInit::getCredentials: "
         "key-store password property KEYSTORE_PASSWORD not set.");
   }
 
   FILE* keyStoreFP = fopen(keyStorePath, "r");
-  if (keyStoreFP == NULL) {
+  if (!keyStoreFP) {
     char msg[1024];
     sprintf(msg, "PKCSAuthInit::getCredentials: Unable to open keystore %s",
             keyStorePath);
     throw AuthenticationFailedException(msg);
   }
 
-  EVP_PKEY* privateKey = NULL;
-  X509* cert = NULL;
+  EVP_PKEY* privateKey = nullptr;
+  X509* cert = nullptr;
 
   /* Read the Public and Private Key from keystore in file */
   if (!readPKCSPublicPrivateKey(keyStoreFP, keyStorePass, &privateKey, &cert)) {
@@ -174,7 +174,7 @@ std::shared_ptr<Properties> PKCSAuthInit::getCredentials(
       static_cast<uint32_t>(strlen(alias)), &lengthEncryptedData);
   EVP_PKEY_free(privateKey);
   X509_free(cert);
-  if (signatureData == NULL) {
+  if (signatureData == nullptr) {
     throw AuthenticationFailedException(
         "PKCSAuthInit::getCredentials: "
         "Unable to create signature");

--- a/tests/cpp/fwk/UdpIpc.cpp
+++ b/tests/cpp/fwk/UdpIpc.cpp
@@ -44,13 +44,13 @@ namespace testframework {
 
 using util::concurrent::spinlock_mutex;
 
-static UdpIpc *g_test = NULL;
+static UdpIpc *g_test = nullptr;
 
 // ----------------------------------------------------------------------------
 
 TESTTASK initialize(const char *initArgs) {
   int32_t result = FWK_SUCCESS;
-  if (g_test == NULL) {
+  if (!g_test) {
     FWKINFO("Initializing Fwk library.");
     try {
       g_test = new UdpIpc(initArgs);
@@ -67,10 +67,10 @@ TESTTASK initialize(const char *initArgs) {
 TESTTASK finalize() {
   int32_t result = FWK_SUCCESS;
   FWKINFO("Finalizing Fwk library.");
-  if (g_test != NULL) {
+  if (g_test) {
     g_test->cacheFinalize();
     delete g_test;
-    g_test = NULL;
+    g_test = nullptr;
   }
   return result;
 }
@@ -163,7 +163,7 @@ void UdpIpc::doService() {
   }
 
   char *fqdn = ACE_OS::getenv("GF_FQDN");
-  if (fqdn == NULL) {
+  if (!fqdn) {
     FWKEXCEPTION("GF_FQDN not set in the environment.");
   }
 

--- a/tests/cpp/fwk/UdpIpc.hpp
+++ b/tests/cpp/fwk/UdpIpc.hpp
@@ -70,7 +70,7 @@ class TestProcessor : public ServiceTask {
     std::string str("A result for you.");
     while (*m_run) {
       UDPMessage* msg = m_queues->getInbound();
-      if (msg != NULL) {
+      if (msg) {
         if (m_sendReply) {
           msg->setMessage(str);
           m_queues->putOutbound(msg);

--- a/tests/cpp/fwklib/ClientTask.hpp
+++ b/tests/cpp/fwklib/ClientTask.hpp
@@ -23,6 +23,7 @@
 #include <atomic>
 #include "fwklib/PerfFwk.hpp"
 #include "fwklib/FwkObjects.hpp"
+#include "config.h"
 
 #include <string>
 
@@ -112,14 +113,16 @@ class ExitTask : public ClientTask {
  public:
   ExitTask() { m_Exit = true; }
   bool doSetup(ACE_thread_t id) {
-    id = 0;
+    id = ACE_Thread_NULL;
     return true;
   }
   uint32_t doTask(ACE_thread_t id) {
-    id = 0;
+    id = ACE_Thread_NULL;
     return 0;
   }
-  void doCleanup(ACE_thread_t id) { id = 0; }
+  void doCleanup(ACE_thread_t id) {
+    id = ACE_Thread_NULL;
+  }
 };
 
 class ThreadedTask : public ClientTask {
@@ -130,7 +133,7 @@ class ThreadedTask : public ClientTask {
   ThreadedTask(FwkAction func, std::string args) : m_func(func), m_args(args) {}
 
   uint32_t doTask(ACE_thread_t id) {
-    id = 0;
+    id = ACE_Thread_NULL;
     int32_t result = m_func(m_args.c_str());
     if (result != FWK_SUCCESS) {
       failed();
@@ -141,10 +144,12 @@ class ThreadedTask : public ClientTask {
   }
 
   bool doSetup(ACE_thread_t id) {
-    id = 0;
+    id = ACE_Thread_NULL;
     return true;
   }
-  void doCleanup(ACE_thread_t id) { id = 0; }
+  void doCleanup(ACE_thread_t id) {
+    id = ACE_Thread_NULL;
+  }
 };
 
 }  // namespace testframework

--- a/tests/cpp/fwklib/FrameworkTest.cpp
+++ b/tests/cpp/fwklib/FrameworkTest.cpp
@@ -61,20 +61,20 @@ FrameworkTest::FrameworkTest(const char* initArgs) {
 }
 
 FrameworkTest::~FrameworkTest() {
-  if (m_coll != NULL) {
+  if (m_coll) {
     delete m_coll;
-    m_coll = NULL;
+    m_coll = nullptr;
   }
 
-  if (m_bbc != NULL) {
+  if (m_bbc) {
     delete m_bbc;
-    m_bbc = NULL;
+    m_bbc = nullptr;
   }
 
-  if (m_timeSync != NULL) {
+  if (m_timeSync) {
     m_timeSync->stop();
     delete m_timeSync;
-    m_timeSync = NULL;
+    m_timeSync = nullptr;
   }
 
   if (m_cache != nullptr) {
@@ -85,7 +85,7 @@ FrameworkTest::~FrameworkTest() {
 // ----------------------------------------------------------------------------
 
 const FwkRegion* FrameworkTest::getSnippet(const std::string& name) const {
-  FwkRegion* value = NULL;
+  FwkRegion* value = nullptr;
   const FwkData* data = getData(name.c_str());
   if (data) {
     value = const_cast<FwkRegion*>(data->getSnippet());
@@ -130,7 +130,7 @@ const FwkRegion* FrameworkTest::getSnippet(const std::string& name) const {
   }
   if (!endPts.empty()) {
     Attributes* atts = value->getAttributes();
-    if ((atts != NULL) && (!atts->isLocal()) && (!atts->isWithPool()) &&
+    if (atts && (!atts->isLocal()) && (!atts->isWithPool()) &&
         (!isDC) && (redundancyLevel <= 0)) {
       // atts->setEndpoints( endPts );
       FWKINFO("Setting EndPoints to: " << endPts);
@@ -167,7 +167,7 @@ std::vector<std::string> FrameworkTest::getRoundRobinEP() const {
 // ----------------------------------------------------------------------------
 
 const FwkPool* FrameworkTest::getPoolSnippet(const std::string& name) const {
-  FwkPool* value = NULL;
+  FwkPool* value = nullptr;
   const FwkData* data = getData(name.c_str());
   if (data) {
     value = const_cast<FwkPool*>(data->getPoolSnippet());

--- a/tests/cpp/fwklib/FrameworkTest.hpp
+++ b/tests/cpp/fwklib/FrameworkTest.hpp
@@ -86,14 +86,14 @@ class FrameworkTest  // Base class all test classes written for xml testing
 
   const std::string getTaskId() {
     std::string id;
-    if (m_task != NULL) {
+    if (m_task) {
       return m_task->getTaskId();
     }
     return id;
   }
 
   int32_t getWaitTime() {
-    if (m_task != NULL) {
+    if (m_task) {
       return m_task->getWaitTime();
     }
     return 0;
@@ -109,7 +109,7 @@ class FrameworkTest  // Base class all test classes written for xml testing
 
   /** brief Get std::string */
   const std::string getStringValue(const char* name) const {
-    if (m_task == NULL) {
+    if (!m_task) {
       return m_coll->getStringValue(name);
     }
     return m_task->getStringValue(name);
@@ -138,12 +138,14 @@ class FrameworkTest  // Base class all test classes written for xml testing
 
   void resetValue(const char* name) const {
     FwkData* data = const_cast<FwkData*>(getData(name));
-    if (data != NULL) data->reset();
+    if (data) {
+      data->reset();
+    }
   }
 
   /** brief Get FwkData pointer */
   const FwkData* getData(const char* name) const {
-    if (m_task == NULL) {
+    if (!m_task) {
       return m_coll->getData(name);
     }
     return m_task->getData(name);

--- a/tests/cpp/fwklib/FwkBB.hpp
+++ b/tests/cpp/fwklib/FwkBB.hpp
@@ -104,7 +104,7 @@ class FwkBBMessage {
     //        FWKINFO( "FwkBBMessage::fromMessageStream: " << data );
     char* str = const_cast<char*>(data.c_str());
     char* tag = strstr(str, BB_ID_TAG);
-    if (tag == NULL) {
+    if (!tag) {
       FWKEXCEPTION("Invalid BB message: " << data);
     }
     tag += 3;
@@ -113,7 +113,7 @@ class FwkBBMessage {
     setId(id);
 
     tag = strstr(str, BB_COMMAND_TAG);
-    if (tag == NULL) {
+    if (!tag) {
       FWKEXCEPTION("Invalid BB message: " << data);
     }
     tag += 3;
@@ -122,7 +122,7 @@ class FwkBBMessage {
     setCommand(cmd);
 
     tag = strstr(str, BB_RESULT_TAG);
-    if (tag != NULL) {
+    if (tag) {
       tag += 3;
       len = static_cast<int32_t>(strcspn(tag, "<"));
       std::string result(tag, len);
@@ -130,7 +130,7 @@ class FwkBBMessage {
     }
 
     tag = strstr(str, BB_PARAMETER_TAG);
-    while (tag != NULL) {
+    while (tag) {
       tag += 3;
       len = static_cast<int32_t>(strcspn(tag, "<"));
       std::string param(tag, len);

--- a/tests/cpp/fwklib/FwkBBServer.hpp
+++ b/tests/cpp/fwklib/FwkBBServer.hpp
@@ -157,7 +157,7 @@ class BBProcessor : public ServiceTask {
     while (*m_run) {
       try {
         UDPMessage* msg = m_queues->getInbound();
-        if (msg != NULL) {
+        if (msg) {
           // Construct the FwkBBMessage
           FwkBBMessage message;
           message.fromMessageStream(msg->what());

--- a/tests/cpp/fwklib/FwkLog.cpp
+++ b/tests/cpp/fwklib/FwkLog.cpp
@@ -29,7 +29,7 @@ const char* apache::geode::client::testframework::getNodeName() {
 }
 
 const char* apache::geode::client::testframework::dirAndFile(const char* str) {
-  if (str == NULL) {
+  if (!str) {
     return "NULL";
   }
 

--- a/tests/cpp/fwklib/FwkObjects.cpp
+++ b/tests/cpp/fwklib/FwkObjects.cpp
@@ -58,7 +58,9 @@ bool allSpace(std::string& str) {
 }
 
 int32_t traverseChildElements(const DOMNode* node) {
-  if (node == NULL) return 0;
+  if (!node) {
+    return 0;
+  }
   const DOMNode* child;
   int32_t count = 0;
   switch (node->getNodeType()) {
@@ -79,7 +81,7 @@ int32_t traverseChildElements(const DOMNode* node) {
         }
       }
       FWKINFO("------ Children of " << name);
-      for (child = node->getFirstChild(); child != NULL;
+      for (child = node->getFirstChild(); child!= nullptr;
            child = child->getNextSibling()) {
         count += traverseChildElements(child);
       }
@@ -87,7 +89,7 @@ int32_t traverseChildElements(const DOMNode* node) {
     } break;
     case DOMNode::TEXT_NODE: {
       //      DOMText * tnode = dynamic_cast< DOMText * > ( ( DOMNode * )node );
-      DOMText* tnode = (DOMText*)node;
+      const DOMText* tnode = dynamic_cast<const DOMText*>(node);
       std::string tname = XMLChToStr(tnode->getNodeName());
       std::string text = XMLChToStr(tnode->getNodeValue());
       std::string ftext = XMLChToStr(tnode->getNodeValue());
@@ -138,7 +140,7 @@ void TestDriver::fromXmlNode(const DOMNode* node) {
   //  int32_t count = traverseChildElements( node );
   //  FWKINFO( "Total of " << count << " elements." );
   DOMNode* child = node->getFirstChild();
-  while (child != NULL) {
+  while (child) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       std::string name = XMLChToStr(child->getNodeName());
       if (name == LOCALFILE_TAG) {
@@ -153,9 +155,9 @@ void TestDriver::fromXmlNode(const DOMNode* node) {
         addTest(new FwkTest(child));
       } else if (name == HOSTGROUP_TAG) {
         DOMNamedNodeMap* map = child->getAttributes();
-        if (map != NULL) {
+        if (map) {
           DOMNode* tag = map->getNamedItem(StrToXMLCh("tag"));
-          if (tag != NULL) {
+          if (tag) {
             addHostGroup(XMLChToStr(tag->getNodeValue()));
           }
         }
@@ -169,30 +171,30 @@ FwkTest::FwkTest(const DOMNode* node) : m_waitTime(0), m_timesToRun(1) {
   //  FWKINFO( "Instantiate FwkTest" );
   //  traverseChildElements( node );
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map) {
     DOMNode* nameNode = map->getNamedItem(StrToXMLCh("name"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setName(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("waitTime"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setWaitTime(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("description"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setDescription(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("timesToRun"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setTimesToRun(XMLChToStr(nameNode->getNodeValue()));
     }
   }
 
   DOMNode* child = node->getFirstChild();
-  while (child != NULL) {
+  while (child) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       addTask(new FwkTask(child));
     }
@@ -206,14 +208,14 @@ void PersistManager::addProperty(const DOMNode* node) {
   DOMNamedNodeMap* map = node->getAttributes();
   std::string name;
   std::string value;
-  if (map != NULL) {
+  if (map) {
     DOMNode* nameNode = map->getNamedItem(StrToXMLCh("name"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       name = XMLChToStr(nameNode->getNodeValue());
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("value"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       value = XMLChToStr(nameNode->getNodeValue());
     }
     m_properties->insert(name.c_str(), value.c_str());
@@ -226,7 +228,7 @@ void PersistManager::addProperties(const DOMNode* node) {
   m_properties = Properties::create();
 
   DOMNode* child = node->getFirstChild();
-  while (child != NULL) {
+  while (child) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       std::string name = XMLChToStr(child->getNodeName());
       if (name == PROPERTY_TAG) {
@@ -241,20 +243,20 @@ PersistManager::PersistManager(const DOMNode* node) {
   //  FWKINFO( "Instantiate PersistManager" );
   //  traverseChildElements( node );
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map) {
     DOMNode* nameNode = map->getNamedItem(StrToXMLCh("library"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setLibraryName(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("function"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setLibraryFunctionName(XMLChToStr(nameNode->getNodeValue()));
     }
   }
 
   DOMNode* child = node->getFirstChild();
-  while (child != NULL) {
+  while (child) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       std::string name = XMLChToStr(child->getNodeName());
       if (name == PROPERTIES_TAG) {
@@ -272,61 +274,61 @@ FwkTask::FwkTask(const DOMNode* node)
       m_parallel(false),
       m_timesRan(0),
       m_continue(false),
-      m_clientSet(NULL),
-      m_dataSet(NULL),
-      m_parent(NULL) {
+      m_clientSet(nullptr),
+      m_dataSet(nullptr),
+      m_parent(nullptr) {
   //  FWKINFO( "Instantiate FwkTask" );
   //  traverseChildElements( node );
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map) {
     DOMNode* nameNode = map->getNamedItem(StrToXMLCh("name"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setName(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("action"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setAction(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("class"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setClass(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("container"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setContainer(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("waitTime"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setWaitTime(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("timesToRun"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setTimesToRun(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("threadCount"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setThreadCount(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("parallel"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setParallel(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("continueOnError"));
-    if (nameNode != NULL) {
+    if (nameNode) {
       setContinueOnError(XMLChToStr(nameNode->getNodeValue()));
     }
   }
 
   DOMNode* child = node->getFirstChild();
-  while (child != NULL) {
+  while (child) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       std::string name = XMLChToStr(child->getNodeName());
       if (name == CLIENTSET_TAG) {
@@ -343,26 +345,26 @@ LocalFile::LocalFile(const DOMNode* node) : m_append(false) {
   //  FWKINFO( "Instantiate LocalFile" );
   //  traverseChildElements( node );
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map != nullptr) {
     DOMNode* nameNode = map->getNamedItem(StrToXMLCh("name"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setName(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("append"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setAppend(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("description"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setDescription(XMLChToStr(nameNode->getNodeValue()));
     }
   }
 
   bool done = false;
   DOMNode* child = node->getFirstChild();
-  while ((child != NULL) && !done) {
+  while ((child != nullptr) && !done) {
     if (child->getNodeType() == DOMNode::TEXT_NODE) {
       //      DOMText * tnode = dynamic_cast< DOMText * >( child );
       DOMText* tnode = (DOMText*)child;
@@ -388,9 +390,9 @@ FwkClientSet::FwkClientSet(const DOMNode* node)
   DOMNode* attNode;
   std::string name;
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map != nullptr) {
     attNode = map->getNamedItem(StrToXMLCh("name"));
-    if (attNode != NULL) {
+    if (attNode != nullptr) {
       value = XMLChToStr(attNode->getNodeValue());
     }
   }
@@ -401,32 +403,32 @@ FwkClientSet::FwkClientSet(const DOMNode* node)
   }
   setName(name);
 
-  if (map != NULL) {
+  if (map != nullptr) {
     attNode = map->getNamedItem(StrToXMLCh("exclude"));
-    if (attNode != NULL) {
+    if (attNode != nullptr) {
       setExclude(XMLChToStr(attNode->getNodeValue()));
     }
     attNode = map->getNamedItem(StrToXMLCh("count"));
-    if (attNode != NULL) {
+    if (attNode != nullptr) {
       setCount(XMLChToStr(attNode->getNodeValue()));
     }
     attNode = map->getNamedItem(StrToXMLCh("begin"));
-    if (attNode != NULL) {
+    if (attNode != nullptr) {
       setBegin(XMLChToStr(attNode->getNodeValue()));
     }
     attNode = map->getNamedItem(StrToXMLCh("hostGroup"));
-    if (attNode != NULL) {
+    if (attNode != nullptr) {
       setHostGroup(XMLChToStr(attNode->getNodeValue()));
     }
     attNode = map->getNamedItem(StrToXMLCh("remaining"));
-    if (attNode != NULL) {
+    if (attNode != nullptr) {
       setRemaining(XMLChToStr(attNode->getNodeValue()));
     }
   }
 
   int32_t childCnt = 0;
   DOMNode* child = node->getFirstChild();
-  while (child != NULL) {
+  while (child != nullptr) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       addClient(new FwkClient(child));
       childCnt++;
@@ -446,15 +448,15 @@ FwkClientSet::FwkClientSet(const DOMNode* node)
 }
 
 FwkClient::FwkClient(const DOMNode* node)
-    : m_program(NULL), m_arguments(NULL), m_remaining(false) {
+    : m_program(nullptr), m_arguments(nullptr), m_remaining(false) {
   //  FWKINFO( "Instantiate FwkClient" );
   //  traverseChildElements( node );
   std::string value;
   DOMNode* attNode;
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map != nullptr) {
     attNode = map->getNamedItem(StrToXMLCh("name"));
-    if (attNode != NULL) {
+    if (attNode != nullptr) {
       value = XMLChToStr(attNode->getNodeValue());
     }
   }
@@ -464,32 +466,32 @@ FwkClient::FwkClient(const DOMNode* node)
     setName(value);
   }
 
-  if (map != NULL) {
+  if (map != nullptr) {
     attNode = map->getNamedItem(StrToXMLCh("program"));
-    if (attNode != NULL) {
+    if (attNode != nullptr) {
       setProgram(XMLChToStr(attNode->getNodeValue()));
     }
     attNode = map->getNamedItem(StrToXMLCh("arguments"));
-    if (attNode != NULL) {
+    if (attNode != nullptr) {
       setArguments(XMLChToStr(attNode->getNodeValue()));
     }
   }
 }
 
-FwkRegion::FwkRegion(const DOMNode* node) : m_attributes(NULL) {
+FwkRegion::FwkRegion(const DOMNode* node) : m_attributes(nullptr) {
   //  FWKINFO( "Instantiate FwkRegion" );
   //  traverseChildElements( node );
   std::string name;
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map != nullptr) {
     DOMNode* nameNode = map->getNamedItem(StrToXMLCh("name"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setName(XMLChToStr(nameNode->getNodeValue()));
     }
   }
 
   DOMNode* child = node->getFirstChild();
-  while (child != NULL) {
+  while (child != nullptr) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       setAttributes(new Attributes(child));
     }
@@ -502,49 +504,49 @@ Attributes::Attributes(const DOMNode* node)
   //  FWKINFO( "Instantiate Attributes" );
   //  traverseChildElements( node );
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map != nullptr) {
     DOMNode* nameNode = map->getNamedItem(StrToXMLCh("caching-enabled"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setCachingEnabled(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("load-factor"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setLoadFactor(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("concurrency-level"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setConcurrencyLevel(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("lru-entries-limit"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setLruEntriesLimit(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("initial-capacity"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setInitialCapacity(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("pool-name"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setPoolName(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("cloning-enabled"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setCloningEnabled(XMLChToStr(nameNode->getNodeValue()));
     }
     nameNode = map->getNamedItem(StrToXMLCh("concurrency-checks-enabled"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setConcurrencyCheckEnabled(XMLChToStr(nameNode->getNodeValue()));
     }
   }
 
   DOMNode* child = node->getFirstChild();
-  while (child != NULL) {
+  while (child != nullptr) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       std::string name = XMLChToStr(child->getNodeName());
       if (name == REGIONTIMETOLIVE_TAG) {
@@ -579,7 +581,7 @@ FwkPool::FwkPool(const DOMNode* node)
   setAttributesToFactory(node);
 
   /*DOMNode * child = node->getFirstChild();
-  while ( child != NULL ) {
+  while ( child != nullptr ) {
     if ( child->getNodeType() == DOMNode::ELEMENT_NODE ) {
     }
     child = child->getNextSibling();
@@ -588,100 +590,100 @@ FwkPool::FwkPool(const DOMNode* node)
 
 void FwkPool::setAttributesToFactory(const DOMNode* node) {
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map != nullptr) {
     DOMNode* nameNode = map->getNamedItem(StrToXMLCh("name"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setName(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("free-connection-timeout"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setFreeConnectionTimeout(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("idle-timeout"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setIdleTimeout(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("load-conditioning-interval"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setLoadConditioningInterval(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("max-connections"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setMaxConnections(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("min-connections"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setMinConnections(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("ping-interval"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setPingInterval(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("read-timeout"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setReadTimeout(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("retry-attempts"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setRetryAttempts(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("server-group"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setServerGroup(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("socket-buffer-size"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setSocketBufferSize(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("subscription-ack-interval"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setSubscriptionAckInterval(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("subscription-enabled"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setSubscriptionEnabled(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode =
         map->getNamedItem(StrToXMLCh("subscription-message-tracking-timeout"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setSubscriptionMessageTrackingTimeout(
           XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("subscription-redundancy"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setSubscriptionRedundancy(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("thread-local-connections"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setThreadLocalConnections(XMLChToStr(nameNode->getNodeValue()));
     }
     nameNode = map->getNamedItem(StrToXMLCh("pr-single-hop-enabled"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setPRSingleHopEnabled(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("locators"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setLocatorsFlag(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("servers"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setServersFlag(XMLChToStr(nameNode->getNodeValue()));
     }
   }
@@ -691,14 +693,14 @@ ActionPair::ActionPair(const DOMNode* node) {
   //  FWKINFO( "Instantiate ActionPair" );
   //  traverseChildElements( node );
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map != nullptr) {
     DOMNode* nameNode = map->getNamedItem(StrToXMLCh("library"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setLibraryName(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("function"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setLibraryFunctionName(XMLChToStr(nameNode->getNodeValue()));
     }
   }
@@ -708,27 +710,27 @@ ExpiryAttributes* Attributes::getExpiryAttributes(const DOMNode* node) {
   //  FWKINFO( "Instantiate getExpiryAttributes" );
   //  traverseChildElements( node );
   DOMNode* child = node->getFirstChild();
-  while (child != NULL) {
+  while (child != nullptr) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       return new ExpiryAttributes(child);
     }
     child = child->getNextSibling();
   }
-  return NULL;
+  return nullptr;
 }
 
 ExpiryAttributes::ExpiryAttributes(const DOMNode* node) : m_timeout(0) {
   //  FWKINFO( "Instantiate ExpiryAttributes" );
   //  traverseChildElements( node );
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map != nullptr) {
     DOMNode* nameNode = map->getNamedItem(StrToXMLCh("timeout"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setTimeout(XMLChToStr(nameNode->getNodeValue()));
     }
 
     nameNode = map->getNamedItem(StrToXMLCh("action"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       setAction(XMLChToStr(nameNode->getNodeValue()));
     }
   }
@@ -739,9 +741,9 @@ FwkDataSet::FwkDataSet(const DOMNode* node) {
   //  traverseChildElements( node );
   std::string name;
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map != nullptr) {
     DOMNode* nameNode = map->getNamedItem(StrToXMLCh("name"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       name = XMLChToStr(nameNode->getNodeValue());
     }
   }
@@ -752,7 +754,7 @@ FwkDataSet::FwkDataSet(const DOMNode* node) {
   }
 
   DOMNode* child = node->getFirstChild();
-  while (child != NULL) {
+  while (child != nullptr) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       add(new FwkData(child));
     }
@@ -761,18 +763,18 @@ FwkDataSet::FwkDataSet(const DOMNode* node) {
 }
 
 FwkData::FwkData(const DOMNode* node)
-    : m_dataList(NULL),
-      m_dataOneof(NULL),
-      m_dataRange(NULL),
-      m_snippet(NULL),
-      m_dataType(DATA_TYPE_NULL) {
+    : m_dataList(nullptr),
+      m_dataOneof(nullptr),
+      m_dataRange(nullptr),
+      m_snippet(nullptr),
+      m_dataType(DATA_TYPE_nullptr) {
   //  FWKINFO( "Instantiate FwkData" );
   //  traverseChildElements( node );
   std::string name;
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map != nullptr) {
     DOMNode* nameNode = map->getNamedItem(StrToXMLCh("name"));
-    if (nameNode != NULL) {
+    if (nameNode != nullptr) {
       name = XMLChToStr(nameNode->getNodeValue());
     }
   }
@@ -783,7 +785,7 @@ FwkData::FwkData(const DOMNode* node)
   }
 
   DOMNode* child = node->getFirstChild();
-  while ((child != NULL) && (m_dataType == DATA_TYPE_NULL)) {
+  while ((child != nullptr) && (m_dataType == DATA_TYPE_nullptr)) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       name = XMLChToStr(child->getNodeName());
       if (name == LIST_TAG) {
@@ -811,21 +813,21 @@ DataRange::DataRange(const DOMNode* node) {
   //  FWKINFO( "Instantiate DataRange" );
   //  traverseChildElements( node );
   DOMNamedNodeMap* map = node->getAttributes();
-  if (map != NULL) {
+  if (map != nullptr) {
     DOMNode* attNode = map->getNamedItem(StrToXMLCh("low"));
-    if (attNode != NULL) {
+    if (attNode != nullptr) {
       setLow(XMLChToStr(attNode->getNodeValue()));
     }
     attNode = map->getNamedItem(StrToXMLCh("high"));
-    if (attNode != NULL) {
+    if (attNode != nullptr) {
       setHigh(XMLChToStr(attNode->getNodeValue()));
     }
   }
 }
 
-DataSnippet::DataSnippet(const DOMNode* node) : m_region(NULL), m_pool(NULL) {
+DataSnippet::DataSnippet(const DOMNode* node) : m_region(nullptr), m_pool(nullptr) {
   DOMNode* child = node->getFirstChild();
-  while (child != NULL) {
+  while (child != nullptr) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       std::string name = XMLChToStr(child->getNodeName());
       if (name == REGION_TAG) {
@@ -843,12 +845,12 @@ DataList::DataList(const DOMNode* node) {
   //  traverseChildElements( node );
   // for all children, process ITEM_TAG elements
   DOMNode* child = node->getFirstChild();
-  while (child != NULL) {
+  while (child != nullptr) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       std::string tag = XMLChToStr(child->getNodeName());
       if (tag == ITEM_TAG) {  // now find all TEXT_NODE children of item
         DOMNode* tchild = child->getFirstChild();
-        while (tchild != NULL) {
+        while (tchild != nullptr) {
           if (tchild->getNodeType() == DOMNode::TEXT_NODE) {
             //            DOMText * tnode = dynamic_cast< DOMText * >( tchild );
             DOMText* tnode = (DOMText*)tchild;
@@ -870,12 +872,12 @@ DataOneof::DataOneof(const DOMNode* node) {
   //  traverseChildElements( node );
   // for all children, process ITEM_TAG elements
   DOMNode* child = node->getFirstChild();
-  while (child != NULL) {
+  while (child != nullptr) {
     if (child->getNodeType() == DOMNode::ELEMENT_NODE) {
       std::string tag = XMLChToStr(child->getNodeName());
       if (tag == ITEM_TAG) {  // now find all TEXT_NODE children of item
         DOMNode* tchild = child->getFirstChild();
-        while (tchild != NULL) {
+        while (tchild != nullptr) {
           if (tchild->getNodeType() == DOMNode::TEXT_NODE) {
             //            DOMText * tnode = dynamic_cast< DOMText * >( tchild );
             DOMText* tnode = (DOMText*)tchild;
@@ -925,15 +927,15 @@ TestDriver::TestDriver(const char* xmlfile) {
   DOMImplementation* domImpl =
       DOMImplementationRegistry::getDOMImplementation(ls);
 
-  if (domImpl == NULL) {
+  if (domImpl == nullptr) {
     FWKEXCEPTION("TestDriver::fromXmlFile() Failed to instantiate domImpl.");
   }
 
   DOMLSParser* builder =
       ((DOMImplementationLS*)domImpl)
-          ->createLSParser(DOMImplementationLS::MODE_SYNCHRONOUS, 0);
+          ->createLSParser(DOMImplementationLS::MODE_SYNCHRONOUS, nullptr);
 
-  if (builder == NULL) {
+  if (builder == nullptr) {
     FWKEXCEPTION(
         "TestDriver::fromXmlFile() Failed to instantiate dom builder.");
   }
@@ -955,7 +957,7 @@ TestDriver::TestDriver(const char* xmlfile) {
   builder->getDomConfig()->setParameter(XMLUni::fgDOMErrorHandler,
                                         &errorHandler);
 
-  XERCES_CPP_NAMESPACE_QUALIFIER DOMDocument* doc = 0;
+  XERCES_CPP_NAMESPACE_QUALIFIER DOMDocument* doc = nullptr;
 
   // Does the cache file exist?
   if (ACE_OS::access(xmlfile, F_OK) == -1) {
@@ -982,7 +984,7 @@ TestDriver::TestDriver(const char* xmlfile) {
   }
 
   DOMNode* node = (DOMNode*)doc->getDocumentElement();
-  if (node != NULL) {
+  if (node != nullptr) {
     fromXmlNode(node);
   }
 
@@ -1014,13 +1016,13 @@ const FwkDataSet* FwkTask::getDataSet(const char* name) const {
 
 /** brief Get FwkData pointer */
 const FwkData* FwkTask::getData(const char* name) const {
-  const FwkData* data = NULL;
+  const FwkData* data = nullptr;
 
   if (m_dataSet) {
     data = m_dataSet->find(name);
   }
 
-  if ((data == NULL) && m_parent) {  // ask our parent
+  if ((data == nullptr) && m_parent) {  // ask our parent
     data = m_parent->getData(name);
   }
 

--- a/tests/cpp/fwklib/FwkObjects.hpp
+++ b/tests/cpp/fwklib/FwkObjects.hpp
@@ -146,7 +146,7 @@ class TFwkSet {
   /** @brief Prints collection of objects */
   void print() const {
     const FWK_OBJECT* obj = getFirst();
-    while (obj != NULL) {
+    while (obj != nullptr) {
       obj->print();
       obj = getNext(obj);
     }
@@ -156,7 +156,7 @@ class TFwkSet {
    * @param key Object key to find
    */
   const FWK_OBJECT* find(const std::string& key) const {
-    const FWK_OBJECT* obj = NULL;
+    const FWK_OBJECT* obj = nullptr;
     int32_t pos = findIdx(key);
     if (pos != -1) {
       obj = m_vec.at(pos);
@@ -166,7 +166,7 @@ class TFwkSet {
 
   /** @brief Get first object in collection */
   const FWK_OBJECT* getFirst() const {
-    const FWK_OBJECT* obj = NULL;
+    const FWK_OBJECT* obj = nullptr;
     int32_t siz = static_cast<int32_t>(m_vec.size());
     if (siz > 0) {
       return m_vec.at(0);
@@ -176,8 +176,8 @@ class TFwkSet {
 
   /** @brief Get next object in collection */
   const FWK_OBJECT* getNext(const FWK_OBJECT* prev) const {
-    const FWK_OBJECT* obj = NULL;
-    if (prev == NULL) {
+    const FWK_OBJECT* obj = nullptr;
+    if (prev == nullptr) {
       return getFirst();
     }
     int32_t siz = static_cast<int32_t>(m_vec.size());
@@ -208,13 +208,13 @@ class TFwkSet {
    * @param obj Object to add
    */
   void add(const FWK_OBJECT* obj) {
-    if (obj != NULL) {
+    if (obj != nullptr) {
       m_vec.push_back(obj);
     }
   }
 
   const FWK_OBJECT* at(int32_t idx) const {
-    if ((idx < 0) || (idx > size())) return NULL;
+    if ((idx < 0) || (idx > size())) return nullptr;
     return m_vec.at(idx);
   }
 
@@ -253,13 +253,13 @@ typedef std::vector<std::string> StringVector;
 class XMLStringConverter {
  public:
   XMLStringConverter(const char* const toTranscode) {
-    m_charForm = NULL;
+    m_charForm = nullptr;
     // Call the private transcoding method
     m_unicodeForm = XMLString::transcode(toTranscode);
   }
 
   XMLStringConverter(const XMLCh* toTranscode) {
-    m_unicodeForm = NULL;
+    m_unicodeForm = nullptr;
     m_charForm = XMLString::transcode(toTranscode);
   }
 
@@ -470,9 +470,9 @@ class FwkRegion {
  public:
   FwkRegion(const DOMNode* node);
   ~FwkRegion() {
-    if (m_attributes != NULL) {
+    if (m_attributes != nullptr) {
       delete m_attributes;
-      m_attributes = NULL;
+      m_attributes = nullptr;
     }
   }
 
@@ -640,13 +640,13 @@ class DataSnippet {
  public:
   DataSnippet(const DOMNode* node);
   ~DataSnippet() {
-    if (m_region != NULL) {
+    if (m_region != nullptr) {
       delete m_region;
-      m_region = NULL;
+      m_region = nullptr;
     }
-    if (m_pool != NULL) {
+    if (m_pool != nullptr) {
       delete m_pool;
-      m_pool = NULL;
+      m_pool = nullptr;
     }
   }
 
@@ -791,21 +791,21 @@ class FwkData : public FwkObject {
   FwkData(const DOMNode* node);
 
   ~FwkData() {
-    if (m_dataList != NULL) {
+    if (m_dataList != nullptr) {
       delete m_dataList;
-      m_dataList = NULL;
+      m_dataList = nullptr;
     }
-    if (m_dataOneof != NULL) {
+    if (m_dataOneof != nullptr) {
       delete m_dataOneof;
-      m_dataOneof = NULL;
+      m_dataOneof = nullptr;
     }
-    if (m_dataRange != NULL) {
+    if (m_dataRange != nullptr) {
       delete m_dataRange;
-      m_dataRange = NULL;
+      m_dataRange = nullptr;
     }
-    if (m_snippet != NULL) {
+    if (m_snippet != nullptr) {
       delete m_snippet;
-      m_snippet = NULL;
+      m_snippet = nullptr;
     }
   }
 
@@ -838,14 +838,14 @@ class FwkData : public FwkObject {
     if (m_dataType == DATA_TYPE_SNIPPET) {
       return m_snippet->getRegion();
     }
-    return NULL;
+    return nullptr;
   }
 
   const FwkPool* getPoolSnippet() const {
     if (m_dataType == DATA_TYPE_SNIPPET) {
       return m_snippet->getPool();
     }
-    return NULL;
+    return nullptr;
   }
 
   const std::string getValue() const {
@@ -934,18 +934,18 @@ class FwkClient : public FwkObject {
   FwkClient(const DOMNode* node);
 
   FwkClient(std::string name)
-      : m_program(NULL), m_arguments(NULL), m_remaining(false) {
+      : m_program(nullptr), m_arguments(nullptr), m_remaining(false) {
     setName(name);
   }
 
   ~FwkClient() {
-    if (m_program != NULL) {
+    if (m_program != nullptr) {
       free((void*)m_program);
-      m_program = NULL;
+      m_program = nullptr;
     }
-    if (m_arguments != NULL) {
+    if (m_arguments != nullptr) {
       free((void*)m_arguments);
-      m_arguments = NULL;
+      m_arguments = nullptr;
     }
   }
 
@@ -1051,13 +1051,13 @@ class FwkTask : public FwkObject {
   FwkTask(const DOMNode* node);
 
   ~FwkTask() {
-    if (m_clientSet != NULL) {
+    if (m_clientSet != nullptr) {
       delete m_clientSet;
-      m_clientSet = NULL;
+      m_clientSet = nullptr;
     }
-    if (m_dataSet != NULL) {
+    if (m_dataSet != nullptr) {
       delete m_dataSet;
-      m_dataSet = NULL;
+      m_dataSet = nullptr;
     }
     m_clients.clear();
   }
@@ -1127,7 +1127,7 @@ class FwkTask : public FwkObject {
 
   /** brief Get char pointer */
   const FwkRegion* getSnippet(const std::string& name) const {
-    const FwkRegion* value = NULL;
+    const FwkRegion* value = nullptr;
     const FwkData* data = getData(name.c_str());
     if (data) {
       value = data->getSnippet();
@@ -1136,7 +1136,7 @@ class FwkTask : public FwkObject {
   }
 
   const FwkPool* getPoolSnippet(const std::string& name) const {
-    const FwkPool* value = NULL;
+    const FwkPool* value = nullptr;
     const FwkData* data = getData(name.c_str());
     if (data) {
       value = data->getPoolSnippet();
@@ -1146,7 +1146,7 @@ class FwkTask : public FwkObject {
 
   void resetValue(const char* name) const {
     FwkData* data = const_cast<FwkData*>(getData(name));
-    if (data != NULL) data->reset();
+    if (data != nullptr) data->reset();
   }
 
   TaskClientIdxList* getTaskClients() { return &m_clients; }
@@ -1165,11 +1165,11 @@ class FwkTask : public FwkObject {
                      << "  TimesToRun: " << m_timesToRun << "  Threads: "
                      << m_threadCount << "  Parallel: " << m_parallel
                      << "  ContinueOnError: " << m_continue);
-    if (m_clientSet != NULL) {
+    if (m_clientSet != nullptr) {
       FWKINFO("Clients: ");
       m_clientSet->print();
     }
-    if (m_dataSet != NULL) {
+    if (m_dataSet != nullptr) {
       FWKINFO("Data: ");
       m_dataSet->print();
     }
@@ -1209,7 +1209,7 @@ class FwkTask : public FwkObject {
   }
 
   void setDataSet(FwkDataSet* dataSet) {
-    if (m_dataSet == NULL) m_dataSet = dataSet;
+    if (m_dataSet == nullptr) m_dataSet = dataSet;
   }
 
   /** @brief Add ClientSet
@@ -1217,7 +1217,7 @@ class FwkTask : public FwkObject {
    */
   void addClientSet(FwkClientSet* set) {
     const FwkClient* client = set->getFirst();
-    while (client != NULL) {
+    while (client != nullptr) {
       addClient(client);
       client = set->getNext(client);
     }
@@ -1227,14 +1227,14 @@ class FwkTask : public FwkObject {
   }
 
   void addClient(const FwkClient* client) {
-    if (m_clientSet == NULL) {
+    if (m_clientSet == nullptr) {
       m_clientSet = new FwkClientSet();
     }
     m_clientSet->add(client);
   }
 
   void addData(FwkData* data) {
-    if (m_dataSet == NULL) {
+    if (m_dataSet == nullptr) {
       m_dataSet = new FwkDataSet();
     }
     m_dataSet->add(data);
@@ -1307,7 +1307,7 @@ class FwkTest : public FwkObject {
 
   const FwkTask* getTaskById(std::string& id) {
     FwkTask* task = const_cast<FwkTask*>(m_taskSet.getFirst());
-    while (task != NULL) {
+    while (task != nullptr) {
       if (task->getTaskId() == id) {
         return task;
       }
@@ -1447,7 +1447,7 @@ class TestDriver {
     FwkClient* client = const_cast<FwkClient*>(clientSet->getFirst());
     std::string grp = clientSet->getHostGroup();
     bool remaining = clientSet->getRemaining();
-    while (client != NULL) {
+    while (client != nullptr) {
       client->setHostGroup(grp);
       client->setRemaining(remaining);
       m_clients.add(client);
@@ -1461,7 +1461,7 @@ class TestDriver {
     test->setKey(m_tests.size());
     const FwkTask* task = test->getFirst();
     int32_t cnt = 1;
-    while (task != NULL) {
+    while (task != nullptr) {
       (const_cast<FwkTask*>(task))->setKey(cnt++);
       m_tasks.add(task);
       task = test->getNext(task);
@@ -1500,7 +1500,7 @@ class TestDriver {
     }
     errno = 0;
     FILE* out = fopen(fil->getName().c_str(), mode);
-    if (out == (FILE*)0) {
+    if (!out) {
       int32_t err = errno;
       FWKEXCEPTION("Unable to open file " << fil->getName() << " with mode: "
                                           << what << " error: " << err);
@@ -1526,7 +1526,7 @@ class TestDriver {
   void writeFiles() {
     const LocalFile* fil = m_localFiles.getFirst();
     //        FILE * out = fopen( "local.files", "wb" );
-    while (fil != NULL) {
+    while (fil != nullptr) {
       writeLocalFile(fil);
       //          fprintf( out, "%s\n", fil->getName().c_str() );
       fil = m_localFiles.getNext(fil);
@@ -1538,11 +1538,11 @@ class TestDriver {
 
   const FwkTask* getTaskById(std::string id) {
     const FwkTask* task = m_tasks.getFirst();
-    while (task != NULL) {
+    while (task != nullptr) {
       if (id == task->getTaskId()) return task;
       task = m_tasks.getNext(task);
     }
-    return NULL;
+    return nullptr;
   }
 
   const StringVector& getHostGroups() { return m_hostGroups; }
@@ -1561,7 +1561,7 @@ class TestDriver {
 
   /** brief Get FwkDataSet pointer */
   const FwkDataSet* getDataSet(const char* name) const {
-    if (name == NULL) return NULL;
+    if (name == nullptr) return nullptr;
 
     std::map<std::string, FwkDataSet*>::const_iterator iter =
         m_dataSetMap.find(name);
@@ -1569,24 +1569,11 @@ class TestDriver {
     if (iter != m_dataSetMap.end()) {
       return (*iter).second;
     }
-    return NULL;
+    return nullptr;
   }
 
   /** brief Get FwkData pointer */
   const FwkData* getData(const char* name) const { return m_data.find(name); }
-
-  //      /** brief Get char pointer */
-  //      const char * getValue( const char * name ) const {
-  //        const char * value = NULL;
-  //        const FwkData * data = getData( name );
-  //        if ( data ) {
-  //          std::string val = data->getValue();
-  //          if ( !val.empty() ) {
-  //            value = val.c_str();
-  //          }
-  //        }
-  //        return value;
-  //      }
 
   /** brief Get char pointer */
   const std::string getStringValue(const char* name) const {

--- a/tests/cpp/fwklib/FwkStrCvt.hpp
+++ b/tests/cpp/fwklib/FwkStrCvt.hpp
@@ -139,11 +139,11 @@ class FwkStrCvt {
   }
 
   /** @brief gets double value */
-  double toDouble() { return ACE_OS::strtod(m_sText.c_str(), 0); };
+  double toDouble() { return ACE_OS::strtod(m_sText.c_str(), nullptr); };
 
   /** @brief gets float value */
   float toFloat() {
-    return static_cast<float>(ACE_OS::strtod(m_sText.c_str(), 0));
+    return static_cast<float>(ACE_OS::strtod(m_sText.c_str(), nullptr));
   };
 
   /** @brief gets int32_t value */
@@ -193,8 +193,10 @@ class FwkStrCvt {
 
   /** @brief gets float value */
   static float toFloat(const char* value) {
-    if (value == NULL) return 0.0;
-    return static_cast<float>(ACE_OS::strtod(value, 0));
+    if (!value) {
+      return 0.0;
+    }
+    return static_cast<float>(ACE_OS::strtod(value, nullptr));
   };
 
   /** @brief gets float value */
@@ -207,8 +209,10 @@ class FwkStrCvt {
 
   /** @brief gets double value */
   static double toDouble(const char* value) {
-    if (value == NULL) return 0.0;
-    return ACE_OS::strtod(value, 0);
+    if (!value) {
+      return 0.0;
+    }
+    return ACE_OS::strtod(value, nullptr);
   };
 
   /** @brief gets double value */
@@ -221,7 +225,9 @@ class FwkStrCvt {
 
   /** @brief gets int32_t value */
   static int32_t toInt32(const char* value) {
-    if (value == NULL) return 0;
+    if (!value) {
+      return 0;
+    }
     return ACE_OS::atoi(value);
   };
 
@@ -235,7 +241,7 @@ class FwkStrCvt {
 
   /** @brief gets uint32_t value */
   static uint32_t toUInt32(const char* value) {
-    if (value == NULL) return 0;
+    if (!value) return 0;
     return static_cast<uint32_t>(ACE_OS::atoi(value));
   };
 
@@ -258,7 +264,7 @@ class FwkStrCvt {
   /** @brief gets uint64_t value */
   static uint64_t toUInt64(const char* value) {
     uint64_t uiValue = 0;
-    if (value == NULL) return uiValue;
+    if (!value) return uiValue;
     sscanf(value, UInt64_FMT, &uiValue);
     return uiValue;
   };
@@ -274,7 +280,9 @@ class FwkStrCvt {
   /** @brief gets int64_t value */
   static int64_t toInt64(const char* value) {
     int64_t iValue = 0;
-    if (value == NULL) return iValue;
+    if (!value) {
+      return iValue;
+    }
     sscanf(value, Int64_FMT, &iValue);
     return iValue;
   };
@@ -303,7 +311,9 @@ class FwkStrCvt {
 
   /** @brief gets bool value */
   static bool toBool(const char* value) {
-    if ((value != NULL) && ((*value == 't') || (*value == 'T'))) return true;
+    if (value && ((*value == 't') || (*value == 'T'))) {
+      return true;
+    }
     return false;
   }
 

--- a/tests/cpp/fwklib/IpcHandler.cpp
+++ b/tests/cpp/fwklib/IpcHandler.cpp
@@ -53,16 +53,18 @@ IpcHandler::~IpcHandler() {
 }
 
 void IpcHandler::close() {
-  if (m_io != 0) {
+  if (m_io) {
     m_io->close();
     delete m_io;
-    m_io = 0;
+    m_io = nullptr;
   }
 }
 
 bool IpcHandler::checkPipe() {
   static ACE_Time_Value next;
-  if (m_io == NULL) return false;
+  if (!m_io) {
+    return false;
+  }
   ACE_Time_Value now = ACE_OS::gettimeofday();
   if (next < now) {
     ACE_Time_Value interval(60);
@@ -113,23 +115,23 @@ int32_t IpcHandler::readInt(int32_t waitSeconds) {
 
 char *IpcHandler::checkBuffer(int32_t len) {
   static int32_t length = 512;
-  static char *buffer = NULL;
+  static char *buffer = nullptr;
 
   if (len == -12) {
     delete[] buffer;
-    buffer = NULL;
+    buffer = nullptr;
     return buffer;
   }
 
   if (length < len) {
     length = len + 32;
-    if (buffer != NULL) {
+    if (buffer != nullptr) {
       delete[] buffer;
-      buffer = NULL;
+      buffer = nullptr;
     }
   }
 
-  if (buffer == NULL) {
+  if (buffer == nullptr) {
     buffer = new char[length];
   }
 

--- a/tests/cpp/fwklib/PaceMeter.hpp
+++ b/tests/cpp/fwklib/PaceMeter.hpp
@@ -52,7 +52,7 @@ class Waiter {
     struct timeval tv;
     tv.tv_sec = interval.sec();
     tv.tv_usec = interval.usec();
-    select(1, NULL, NULL, NULL, &tv);
+    select(1, nullptr, nullptr, nullptr, &tv);
 #endif
   }
 };

--- a/tests/cpp/fwklib/PerfFwk.cpp
+++ b/tests/cpp/fwklib/PerfFwk.cpp
@@ -23,7 +23,7 @@ using namespace apache::geode::client;
 using namespace apache::geode::client::testframework;
 using namespace apache::geode::client::testframework::perf;
 
-ACE_utsname* PerfSuite::utsname = NULL;
+ACE_utsname* PerfSuite::utsname = nullptr;
 
 // void perf::logSignals( const char * tag ) {
 //  if ( tag == NULL ) {
@@ -76,7 +76,7 @@ void perf::logSize(const char* tag) {
 
   sprintf(procFileName, "/proc/%u/status", pid);
   fil = fopen(procFileName, "rb"); /* read only */
-  if (fil == (FILE*)0) {
+  if (fil == nullptr) {
     FWKINFO("Unable to read status file.");
     return;
   }
@@ -85,7 +85,7 @@ void perf::logSize(const char* tag) {
   double vs = -1;
   double rs = -1;
   char rbuff[1024];
-  while (fgets(rbuff, 1023, fil) != 0) {
+  while (fgets(rbuff, 1023, fil)) {
     if ((ACE_OS::strncasecmp(rbuff, "VmSize:", 7) == 0) &&
         (sscanf(rbuff, "%*s %u", &val) == 1)) {
       vs = static_cast<double>(val);
@@ -100,7 +100,7 @@ void perf::logSize(const char* tag) {
   char pbuf[1024];
   sprintf(pbuf, "Size of Process %u: Size: %.4f (%.4f) Mb  RSS: %.4f (%.4f) Mb",
           pid, vs, vsizeMax, rs, rssMax);
-  if (tag == NULL) {
+  if (!tag) {
     FWKINFO(pbuf);
     FWKINFO(":CSV Size::::," << pid << "," << vs << "," << rs);
   } else {

--- a/tests/cpp/fwklib/PerfFwk.hpp
+++ b/tests/cpp/fwklib/PerfFwk.hpp
@@ -47,7 +47,7 @@ namespace client {
 namespace testframework {
 namespace perf {
 
-void logSize(const char* tag = NULL);
+void logSize(const char* tag = nullptr);
 
 inline void sleepSeconds(int32_t secs) {
   ACE_Time_Value sleepTime(secs, 0);
@@ -144,7 +144,7 @@ class Record {
   void setDate(std::string date) { m_runDate = date; }
 
   void setDate() {
-    time_t esecs = time(0);
+    time_t esecs = time(nullptr);
     struct tm* now = localtime(&esecs);
     char tmp[32];
     sprintf(tmp, "%d/%d/%d %d:%d:%d", now->tm_mon + 1, now->tm_mday,
@@ -230,35 +230,35 @@ class PerfSuite {
   PerfSuite();
 
   static inline const char* getSysName() {
-    if (utsname == NULL) {
+    if (!utsname) {
       utsname = new ACE_utsname();
       ACE_OS::uname(utsname);
     }
     return utsname->sysname;
   }
   static inline const char* getNodeName() {
-    if (utsname == NULL) {
+    if (!utsname) {
       utsname = new ACE_utsname();
       ACE_OS::uname(utsname);
     }
     return utsname->nodename;
   }
   static inline const char* getRelease() {
-    if (utsname == NULL) {
+    if (!utsname) {
       utsname = new ACE_utsname();
       ACE_OS::uname(utsname);
     }
     return utsname->release;
   }
   static inline const char* getVersion() {
-    if (utsname == NULL) {
+    if (!utsname) {
       utsname = new ACE_utsname();
       ACE_OS::uname(utsname);
     }
     return utsname->version;
   }
   static inline const char* getMachine() {
-    if (utsname == NULL) {
+    if (!utsname) {
       utsname = new ACE_utsname();
       ACE_OS::uname(utsname);
     }

--- a/tests/cpp/fwklib/QueryHelper.hpp
+++ b/tests/cpp/fwklib/QueryHelper.hpp
@@ -651,7 +651,7 @@ class QueryHelper {
   static QueryHelper* singleton;
 
   static QueryHelper& getHelper() {
-    if (singleton == NULL) {
+    if (!singleton) {
       singleton = new QueryHelper();
     }
     return *singleton;
@@ -675,7 +675,7 @@ class QueryHelper {
                                     int setSize, int numSets);
   virtual void populatePortfolioPdxData(std::shared_ptr<Region>& pregion,
                                         int setSize, int numSets,
-                                        int32_t objSize = 1, char** nm = NULL);
+                                        int32_t objSize = 1, char** nm = nullptr);
   virtual void populatePositionPdxData(std::shared_ptr<Region>& pregion,
                                        int setSize, int numSets);
   virtual void destroyPortfolioOrPositionData(std::shared_ptr<Region>& pregion,
@@ -782,7 +782,7 @@ class QueryHelper {
   int positionNumSets;
 };
 
-QueryHelper* QueryHelper::singleton = NULL;
+QueryHelper* QueryHelper::singleton = nullptr;
 
 //===========================================================================================
 
@@ -802,7 +802,7 @@ bool QueryHelper::compareTwoPositionObjects(
   Position* p1 = dynamic_cast<Position*>(pos1.get());
   Position* p2 = dynamic_cast<Position*>(pos2.get());
 
-  if (p1 == NULL || p2 == NULL) {
+  if (!p1 || !p2) {
     printf("ERROR: The object(s) passed are not of Portflio type\n");
     return false;
   }
@@ -1046,7 +1046,7 @@ bool QueryHelper::verifySS(std::shared_ptr<SelectResults>& structSet,
 
     Struct* siptr = dynamic_cast<Struct*>(ser.get());
 
-    if (siptr == NULL) {
+    if (!siptr) {
       LOGINFO("siptr is NULL \n\n");
       return false;
     }

--- a/tests/cpp/fwklib/RegionHelper.hpp
+++ b/tests/cpp/fwklib/RegionHelper.hpp
@@ -52,13 +52,13 @@ class RegionHelper {
  public:
   /** Fill in this instance of RegionHelper based on the spec named by sname.
    */
-  RegionHelper(const FrameworkTest* test) : m_region(NULL) {
+  RegionHelper(const FrameworkTest* test) : m_region(nullptr) {
     m_spec = test->getStringValue("regionSpec");
     if (m_spec.empty()) {
       FWKEXCEPTION("Failed to find regionSpec definition.");
     }
     m_region = test->getSnippet(m_spec);
-    if (m_region == NULL) {
+    if (!m_region) {
       FWKEXCEPTION("Failed to find region definition.");
     }
   }

--- a/tests/cpp/fwklib/Service.cpp
+++ b/tests/cpp/fwklib/Service.cpp
@@ -38,7 +38,7 @@ Service::Service(int32_t threadCnt)
 int32_t Service::svc() {
   while (m_run) {
     ServiceTask* task = getQ();
-    if (task != NULL) {
+    if (task) {
       try {
         task->initialize();
         task->doTask();

--- a/tests/cpp/fwklib/Service.hpp
+++ b/tests/cpp/fwklib/Service.hpp
@@ -50,7 +50,7 @@ class ServiceTask {
   SharedTaskObject* m_shared;
 
  public:
-  ServiceTask(SharedTaskObject* shared) : m_run(NULL), m_shared(shared) {}
+  ServiceTask(SharedTaskObject* shared) : m_run(nullptr), m_shared(shared) {}
 
   virtual ~ServiceTask() {}
 
@@ -120,7 +120,7 @@ class SafeQueue {
       until += ACE_OS::gettimeofday();
       ;
       int32_t res = m_cond.wait(&until);
-      if (res == -1) return NULL;
+      if (res == -1) return nullptr;
     }
     return m_queue.delete_head();
   }

--- a/tests/cpp/fwklib/TaskClient.cpp
+++ b/tests/cpp/fwklib/TaskClient.cpp
@@ -46,11 +46,11 @@ using namespace apache::geode::client::testframework;
 
 #endif  // WIN32
 
-FILE* TaskClient::m_pipe = (FILE*)0;
+FILE* TaskClient::m_pipe = nullptr;
 uint32_t TaskClient::m_refCnt = 0;
 
 void TaskClient::writePipe(const char* cmd) {
-  if (m_pipe == (FILE*)0) {
+  if (!m_pipe) {
     openPipe();
   }
   fwrite(cmd, 1, strlen(cmd), m_pipe);
@@ -64,7 +64,7 @@ void TaskClient::openPipe() {
 
   sprintf(cbuf, cmd, pid);
   m_pipe = popen(cbuf, MODE);
-  if (m_pipe == (FILE*)0) {
+  if (!m_pipe) {
     FWKEXCEPTION("Failed to open pipe, errno: " << errno);
   }
 }
@@ -79,7 +79,7 @@ void TaskClient::start() {
             m_testFile, m_logDirectory, m_port);
     writePipe(buf);
     ACE_SOCK_Stream* conn = new ACE_SOCK_Stream();
-    if (m_listener->accept(*conn, 0, new ACE_Time_Value(120)) == 0) {
+    if (m_listener->accept(*conn, nullptr, new ACE_Time_Value(120)) == 0) {
       FWKINFO("Client " << m_id << " connected.");
       m_ipc = new IpcHandler(conn);
     } else {
@@ -87,10 +87,10 @@ void TaskClient::start() {
       FWKEXCEPTION("Client " << m_id << " failed to register.");
     }
   } else {
-    if (m_program == NULL) {
+    if (!m_program) {
       FWKEXCEPTION("Program not specified for Client " << m_id);
     } else {
-      const char* args = (m_arguments == NULL) ? "" : m_arguments;
+      const char* args = m_arguments ? m_arguments : "";
       sprintf(buf, "goHost %s startClient %d %s %s %d \"%s\" \"%s\"\n", m_host,
               m_id, "none", m_logDirectory, 0, m_program, args);
       writePipe(buf);

--- a/tests/cpp/fwklib/TaskClient.hpp
+++ b/tests/cpp/fwklib/TaskClient.hpp
@@ -68,68 +68,68 @@ class TaskClient : public ACE_Task_Base {
  public:
   TaskClient(int32_t port, const char* logDir, const char* testFile,
              ACE_SOCK_Acceptor* listener, int32_t id, const char* name = " ")
-      : m_host(NULL),
+      : m_host(nullptr),
         m_port(port),
         m_logDirectory(strdup(logDir)),
         m_testFile(strdup(testFile)),
-        m_ipc(0),
+        m_ipc(nullptr),
         m_id(id),
         m_busy(false),
         m_assigned(false),
         m_name(name),
         m_listener(listener),
         m_runsTasks(true),
-        m_program(NULL),
-        m_arguments(NULL),
+        m_program(nullptr),
+        m_arguments(nullptr),
         m_hostGroup(FwkClientSet::m_defaultGroup) {
     m_refCnt++;
   }
 
   TaskClient(const char* logDir, int32_t id, const char* program,
              const char* arguments, const char* name = " ")
-      : m_host(NULL),
+      : m_host(nullptr),
         m_port(0),
         m_logDirectory(strdup(logDir)),
-        m_testFile(NULL),
-        m_ipc(0),
+        m_testFile(nullptr),
+        m_ipc(nullptr),
         m_id(id),
         m_busy(false),
         m_assigned(false),
         m_name(name),
-        m_listener(NULL),
+        m_listener(nullptr),
         m_runsTasks(false),
-        m_program((program == NULL) ? NULL : strdup(program)),
-        m_arguments((arguments == NULL) ? NULL : strdup(arguments)),
+        m_program((program == nullptr) ? nullptr : strdup(program)),
+        m_arguments((arguments == nullptr) ? nullptr : strdup(arguments)),
         m_hostGroup(FwkClientSet::m_defaultGroup) {
     m_refCnt++;
   }
 
   ~TaskClient() {
     m_refCnt--;
-    if ((m_refCnt < 1) && (m_pipe != (FILE*)0)) {
+    if ((m_refCnt < 1) && m_pipe) {
       // FWKINFO( "Closing pipe." );
       const char* pexit = "exit\n";
       writePipe(pexit);
       perf::sleepSeconds(3);
       pclose(m_pipe);
-      m_pipe = (FILE*)0;
+      m_pipe = nullptr;
       // FWKINFO( "Pipe closed." );
     }
-    if (m_host != NULL) {
+    if (m_host) {
       free(m_host);
-      m_host = NULL;
+      m_host = nullptr;
     }
-    if (m_logDirectory != NULL) {
+    if (m_logDirectory) {
       free(m_logDirectory);
-      m_logDirectory = NULL;
+      m_logDirectory = nullptr;
     }
-    if (m_testFile != NULL) {
+    if (m_testFile) {
       free(m_testFile);
-      m_testFile = NULL;
+      m_testFile = nullptr;
     }
-    if (m_ipc != NULL) {
+    if (m_ipc) {
       delete m_ipc;
-      m_ipc = NULL;
+      m_ipc = nullptr;
     }
   }
 
@@ -165,8 +165,8 @@ class TaskClient : public ACE_Task_Base {
 
   const char* getHost() { return m_host; }
   void setHost(const char* host) {
-    if (host != NULL) {
-      if (m_host != NULL) free(m_host);
+    if (host) {
+      if (m_host) free(m_host);
       m_host = strdup(host);
     }
   }

--- a/tests/cpp/fwklib/TcpIpc.cpp
+++ b/tests/cpp/fwklib/TcpIpc.cpp
@@ -110,7 +110,7 @@ bool TcpIpc::listen(int32_t waitSecs) {
   ACE_INET_Addr addr(m_ipaddr.c_str());
   ACE_SOCK_Acceptor listener(addr, 1);
 
-  if (listener.accept(*m_io, 0, new ACE_Time_Value(waitSecs)) != 0) {
+  if (listener.accept(*m_io, nullptr, new ACE_Time_Value(waitSecs)) != 0) {
     FWKSEVERE("Accept failed with errno: " << errno);
     return false;
   }
@@ -118,7 +118,7 @@ bool TcpIpc::listen(int32_t waitSecs) {
 }
 
 bool TcpIpc::accept(ACE_SOCK_Acceptor *acceptor, int32_t waitSecs) {
-  if (acceptor->accept(*m_io, 0, new ACE_Time_Value(waitSecs)) != 0) {
+  if (acceptor->accept(*m_io, nullptr, new ACE_Time_Value(waitSecs)) != 0) {
     FWKSEVERE("Accept failed with errno: " << errno);
     return false;
   }
@@ -148,17 +148,17 @@ bool TcpIpc::connect(int32_t waitSecs) {
 TcpIpc::~TcpIpc() { close(); }
 
 void TcpIpc::close() {
-  if (m_io != NULL) {
+  if (m_io != nullptr) {
     m_io->close();
     delete m_io;
-    m_io = NULL;
+    m_io = nullptr;
   }
 }
 
 int32_t TcpIpc::readBuffer(char **buffer, int32_t waitSecs) {
   ACE_Time_Value wtime(waitSecs);
   iovec buffs;
-  buffs.iov_base = NULL;
+  buffs.iov_base = nullptr;
   buffs.iov_len = 0;
   int32_t red = static_cast<int32_t>(m_io->recvv(&buffs, &wtime));
   if ((red == -1) && ((errno == ECONNRESET) || (errno == EPIPE))) {

--- a/tests/cpp/fwklib/TestClient.cpp
+++ b/tests/cpp/fwklib/TestClient.cpp
@@ -22,17 +22,17 @@ using namespace apache::geode::client;
 using namespace apache::geode::client::testframework;
 using namespace apache::geode::client::testframework::perf;
 
-TestClient* TestClient::m_instance = NULL;
+TestClient* TestClient::m_instance = nullptr;
 
 TestClient* TestClient::createTestClient(int32_t threadCnt) {
-  if (m_instance == NULL) {
+  if (!m_instance) {
     m_instance = new TestClient(threadCnt);
   }
   return m_instance;
 }
 
 TestClient* TestClient::getTestClient() {
-  if (m_instance == NULL) {
+  if (!m_instance) {
     FWKEXCEPTION(
         "TestClient is NULL, expected it to be initialized in Client.");
   }
@@ -40,9 +40,9 @@ TestClient* TestClient::getTestClient() {
 }
 
 void TestClient::destroyTestClient() {
-  if (m_instance != NULL) {
+  if (m_instance) {
     delete m_instance;
-    m_instance = NULL;
+    m_instance = nullptr;
   }
 }
 
@@ -130,7 +130,7 @@ int32_t TestClient::svc() {
   int32_t runTaskStatus;
   while (!done) {
     ClientTask* task = getQ();
-    if (task != 0) {
+    if (task) {
       if (task->mustExit()) {
         done = true;
       } else {

--- a/tests/cpp/fwklib/TestClient.hpp
+++ b/tests/cpp/fwklib/TestClient.hpp
@@ -62,7 +62,7 @@ class TestClient : public ACE_Task_Base {
   }
 
   inline ACE_Time_Value* getUntil(uint32_t seconds) {
-    ACE_Time_Value* until = 0;
+    ACE_Time_Value* until = nullptr;
     if (seconds != 0) {
       until = new ACE_Time_Value(seconds);
       *until += ACE_OS::gettimeofday();

--- a/tests/cpp/fwklib/TimeSync.cpp
+++ b/tests/cpp/fwklib/TimeSync.cpp
@@ -72,7 +72,7 @@ long long ntohl64(long long value) {
 // ----------------------------------------------------------------------------
 
 int32_t TimeSync::svc() {
-  if (m_delta == NULL) {
+  if (!m_delta) {
     sendTimeSync();
   } else {
     recvTimeSync();

--- a/tests/cpp/fwklib/TimeSync.hpp
+++ b/tests/cpp/fwklib/TimeSync.hpp
@@ -57,7 +57,7 @@ class TimeSync : public ACE_Task_Base {
   void recvTimeSync();
 
  public:
-  inline TimeSync(int32_t port, int32_t* delta = NULL, bool report = false)
+  inline TimeSync(int32_t port, int32_t* delta = nullptr, bool report = false)
       : m_delta(delta),
         m_done(false),
         m_port(port),
@@ -77,7 +77,7 @@ class TimeSync : public ACE_Task_Base {
     int64_t retVal;
     ACE_Time_Value tv = ACE_OS::gettimeofday();
     retVal = timevalMicros(tv);
-    if (m_delta != NULL) {
+    if (m_delta != nullptr) {
       retVal += *m_delta;
     }
     return retVal;

--- a/tests/cpp/fwklib/UDPIpc.cpp
+++ b/tests/cpp/fwklib/UDPIpc.cpp
@@ -59,7 +59,7 @@ bool UDPMessage::receiveFrom(ACE_SOCK_Dgram& io,
                              const ACE_Time_Value* timeout) {
   bool ok = true;
   ACE_Time_Value wait(2);
-  if (timeout == NULL) {
+  if (!timeout) {
     timeout = &wait;
   }
   iovec buffs;
@@ -270,7 +270,7 @@ void Receiver::initialize() {
         char hbuff[256];
         char* hst = &hbuff[0];
         char* fqdn = ACE_OS::getenv("GF_FQDN");
-        if (fqdn != NULL) {
+        if (fqdn) {
           hst = fqdn;
         } else {
           addr.get_host_name(hbuff, 255);
@@ -322,7 +322,7 @@ void STReceiver::initialize() {
     char hbuff[256];
     char* hst = &hbuff[0];
     char* fqdn = ACE_OS::getenv("GF_FQDN");
-    if (fqdn != NULL) {
+    if (fqdn) {
       hst = fqdn;
     } else {
       addr.get_host_name(hbuff, 255);
@@ -341,7 +341,7 @@ int32_t Responder::doTask() {
   try {
     while (*m_run) {
       UDPMessage* msg = m_queues->getOutbound();
-      if (msg != NULL) {
+      if (msg) {
         msg->send(*m_io);
         delete msg;
       }

--- a/tests/cpp/fwklib/UDPIpc.hpp
+++ b/tests/cpp/fwklib/UDPIpc.hpp
@@ -24,6 +24,7 @@
 #include "PerfFwk.hpp"
 #include "FwkLog.hpp"
 #include "GsRandom.hpp"
+#include "config.h"
 
 #include <ace/Task.h>
 #include <ace/Thread_Mutex.h>
@@ -100,7 +101,7 @@ class UDPMessage : public IPCMessage {
 
   void setSender(ACE_INET_Addr& addr) { m_sender = addr; }
 
-  bool receiveFrom(ACE_SOCK_Dgram& io, const ACE_Time_Value* timeout = NULL);
+  bool receiveFrom(ACE_SOCK_Dgram& io, const ACE_Time_Value* timeout = nullptr);
 
   bool sendTo(ACE_SOCK_Dgram& io, ACE_INET_Addr& who);
 
@@ -186,7 +187,9 @@ class UDPMessageQueues : public SharedTaskObject {
 
   UDPMessage* getOutbound() {
     UDPMessage* msg = m_outbound.dequeue();
-    if (msg != NULL) m_cntOutbound++;
+    if (msg) {
+      m_cntOutbound++;
+    }
     return msg;
   }
 
@@ -206,7 +209,8 @@ class Receiver : public ServiceTask {
 
  public:
   Receiver(UDPMessageQueues* shared, uint16_t port)
-      : ServiceTask(shared), m_basePort(port), m_listener(0), m_mutex() {
+      : ServiceTask(shared), m_basePort(port), m_mutex() {
+    m_listener = ACE_Thread_NULL;
     m_queues = dynamic_cast<UDPMessageQueues*>(m_shared);
   }
 
@@ -258,7 +262,7 @@ class Processor : public ServiceTask {
   int32_t doTask() {
     while (*m_run) {
       UDPMessage* msg = m_queues->getInbound();
-      if (msg != NULL) {
+      if (msg) {
         m_queues->putOutbound(msg);
       }
     }

--- a/tests/cpp/security/CredentialGenerator.cpp
+++ b/tests/cpp/security/CredentialGenerator.cpp
@@ -27,7 +27,7 @@ using namespace apache::geode::client::testframework::security;
 using namespace apache::geode::client;
 
 CredentialGenerator::registeredClassMap* CredentialGenerator::generatormap =
-    NULL;
+    nullptr;
 std::shared_ptr<CredentialGenerator> CredentialGenerator::create(
     std::string scheme) {
   if (generators().find(scheme) != generators().end()) {

--- a/tests/cpp/security/CredentialGenerator.hpp
+++ b/tests/cpp/security/CredentialGenerator.hpp
@@ -110,7 +110,9 @@ class CredentialGenerator {
   }
   virtual ~CredentialGenerator() {}
   bool operator==(const CredentialGenerator* other) {
-    if (other == NULL) return false;
+    if (!other) {
+      return false;
+    }
     return (m_id == other->m_id && m_name == other->m_name);
   };
 
@@ -127,7 +129,7 @@ class CredentialGenerator {
   static registeredClassMap& getRegisteredSchemes() { return generators(); }
 
   static registeredClassMap& generators() {
-    if (CredentialGenerator::generatormap == NULL) {
+    if (!CredentialGenerator::generatormap) {
       CredentialGenerator::generatormap = new registeredClassMap;
     }
     return *CredentialGenerator::generatormap;
@@ -165,10 +167,10 @@ class CredentialGenerator {
   }
 
   std::string getPublickeyfile() {
-    char* tempPath = NULL;
+    char* tempPath = nullptr;
     tempPath = ACE_OS::getenv("TESTSRC");
     std::string path = "";
-    if (tempPath == NULL) {
+    if (!tempPath) {
       tempPath = ACE_OS::getenv("BUILDDIR");
       path = std::string(tempPath) + "/framework/data";
     } else {
@@ -231,11 +233,11 @@ class CredentialGenerator {
 
   virtual void getAllowedCredentialsForOps(opCodeList& opCodes,
                                            std::shared_ptr<Properties>& p,
-                                           stringList* regionNames = NULL);
+                                           stringList* regionNames = nullptr);
 
   virtual void getDisallowedCredentialsForOps(opCodeList& opCodes,
                                               std::shared_ptr<Properties>& p,
-                                              stringList* regionNames = NULL);
+                                              stringList* regionNames = nullptr);
 
   static registeredClassMap& getRegisterdSchemes() {
     if (generators().size() == 0) {

--- a/tests/cpp/security/DummyCredentialGenerator.hpp
+++ b/tests/cpp/security/DummyCredentialGenerator.hpp
@@ -39,7 +39,7 @@ class DummyCredentialGenerator : public CredentialGenerator {
   std::string getInitArgs(std::string workingDir, bool userMode) {
     std::string additionalArgs;
     char* buildDir = ACE_OS::getenv("BUILDDIR");
-    if (buildDir != NULL && workingDir.length() == 0) {
+    if (buildDir && workingDir.length() == 0) {
       workingDir = std::string(buildDir);
       workingDir += std::string("/framework/xml/Security/");
     }
@@ -88,14 +88,14 @@ class DummyCredentialGenerator : public CredentialGenerator {
 
   void getAllowedCredentialsForOps(opCodeList& opCodes,
                                    std::shared_ptr<Properties>& p,
-                                   stringList* regionNames = NULL) {
+                                   stringList* regionNames = nullptr) {
     XmlAuthzCredentialGenerator authz(id());
     authz.getAllowedCredentials(opCodes, p, regionNames);
   }
 
   void getDisallowedCredentialsForOps(opCodeList& opCodes,
                                       std::shared_ptr<Properties>& p,
-                                      stringList* regionNames = NULL) {
+                                      stringList* regionNames = nullptr) {
     XmlAuthzCredentialGenerator authz(id());
     authz.getDisallowedCredentials(opCodes, p, regionNames);
   }

--- a/tests/cpp/security/DummyCredentialGenerator2.hpp
+++ b/tests/cpp/security/DummyCredentialGenerator2.hpp
@@ -39,7 +39,7 @@ class DummyCredentialGenerator2 : public CredentialGenerator {
   std::string getInitArgs(std::string workingDir, bool userMode) {
     std::string additionalArgs;
     char* buildDir = ACE_OS::getenv("BUILDDIR");
-    if (buildDir != NULL && workingDir.length() == 0) {
+    if (buildDir && workingDir.length() == 0) {
       workingDir = std::string(buildDir);
       workingDir += std::string("/framework/xml/Security/");
     }
@@ -87,14 +87,14 @@ class DummyCredentialGenerator2 : public CredentialGenerator {
 
   void getAllowedCredentialsForOps(opCodeList& opCodes,
                                    std::shared_ptr<Properties>& p,
-                                   stringList* regionNames = NULL) {
+                                   stringList* regionNames = nullptr) {
     XmlAuthzCredentialGenerator authz(id());
     authz.getAllowedCredentials(opCodes, p, regionNames);
   }
 
   void getDisallowedCredentialsForOps(opCodeList& opCodes,
                                       std::shared_ptr<Properties>& p,
-                                      stringList* regionNames = NULL) {
+                                      stringList* regionNames = nullptr) {
     XmlAuthzCredentialGenerator authz(id());
     authz.getDisallowedCredentials(opCodes, p, regionNames);
   }

--- a/tests/cpp/security/DummyCredentialGenerator3.hpp
+++ b/tests/cpp/security/DummyCredentialGenerator3.hpp
@@ -39,7 +39,7 @@ class DummyCredentialGenerator3 : public CredentialGenerator {
   std::string getInitArgs(std::string workingDir, bool userMode) {
     std::string additionalArgs;
     char* buildDir = ACE_OS::getenv("BUILDDIR");
-    if (buildDir != NULL && workingDir.length() == 0) {
+    if (buildDir && workingDir.length() == 0) {
       workingDir = std::string(buildDir);
       workingDir += std::string("/framework/xml/Security/");
     }
@@ -87,14 +87,14 @@ class DummyCredentialGenerator3 : public CredentialGenerator {
 
   void getAllowedCredentialsForOps(opCodeList& opCodes,
                                    std::shared_ptr<Properties>& p,
-                                   stringList* regionNames = NULL) {
+                                   stringList* regionNames = nullptr) {
     XmlAuthzCredentialGenerator authz(id());
     authz.getAllowedCredentials(opCodes, p, regionNames);
   }
 
   void getDisallowedCredentialsForOps(opCodeList& opCodes,
                                       std::shared_ptr<Properties>& p,
-                                      stringList* regionNames = NULL) {
+                                      stringList* regionNames = nullptr) {
     XmlAuthzCredentialGenerator authz(id());
     authz.getDisallowedCredentials(opCodes, p, regionNames);
   }

--- a/tests/cpp/security/LdapUserCredentialGenerator.hpp
+++ b/tests/cpp/security/LdapUserCredentialGenerator.hpp
@@ -42,7 +42,7 @@ class LdapUserCredentialGenerator : public CredentialGenerator {
   std::string getInitArgs(std::string workingDir, bool) override {
     std::string additionalArgs;
     char* buildDir = ACE_OS::getenv("BUILDDIR");
-    if (buildDir != NULL && workingDir.length() == 0) {
+    if (buildDir != nullptr && workingDir.length() == 0) {
       workingDir = std::string(buildDir);
       workingDir += std::string("/framework/xml/Security/");
     }
@@ -52,18 +52,18 @@ class LdapUserCredentialGenerator : public CredentialGenerator {
 
     char* ldapSrv = ACE_OS::getenv("LDAP_SERVER");
     additionalArgs += std::string(" --J=-Dgemfire.security-ldap-server=") +
-                      (ldapSrv != NULL ? ldapSrv : "ldap");
+                      (ldapSrv != nullptr ? ldapSrv : "ldap");
 
     char* ldapRoot = ACE_OS::getenv("LDAP_BASEDN");
     additionalArgs +=
         std::string(" --J=\\\"-Dgemfire.security-ldap-basedn=") +
-        (ldapRoot != NULL ? ldapRoot
+        (ldapRoot != nullptr ? ldapRoot
                           : "ou=ldapTesting,dc=ldap,dc=apache,dc=org") +
         "\\\"";
 
     char* ldapSSL = ACE_OS::getenv("LDAP_USESSL");
     additionalArgs += std::string(" --J=-Dgemfire.security-ldap-usessl=") +
-                      (ldapSSL != NULL ? ldapSSL : "false");
+                      (ldapSSL != nullptr ? ldapSSL : "false");
 
     return additionalArgs;
   }
@@ -102,14 +102,14 @@ class LdapUserCredentialGenerator : public CredentialGenerator {
 
   void getAllowedCredentialsForOps(opCodeList& opCodes,
                                    std::shared_ptr<Properties>& p,
-                                   stringList* regionNames = NULL) override {
+                                   stringList* regionNames = nullptr) override {
     XmlAuthzCredentialGenerator authz(id());
     authz.getAllowedCredentials(opCodes, p, regionNames);
   }
 
   void getDisallowedCredentialsForOps(opCodeList& opCodes,
                                       std::shared_ptr<Properties>& p,
-                                      stringList* regionNames = NULL) override {
+                                      stringList* regionNames = nullptr) override {
     XmlAuthzCredentialGenerator authz(id());
     authz.getDisallowedCredentials(opCodes, p, regionNames);
   }

--- a/tests/cpp/security/NoopCredentialGenerator.hpp
+++ b/tests/cpp/security/NoopCredentialGenerator.hpp
@@ -38,7 +38,7 @@ class NoopCredentialGenerator : public CredentialGenerator {
   std::string getInitArgs(std::string workingDir, bool) override {
     std::string additionalArgs;
     char* buildDir = ACE_OS::getenv("BUILDDIR");
-    if (buildDir != NULL && workingDir.length() == 0) {
+    if (buildDir && workingDir.length() == 0) {
       workingDir = std::string(buildDir);
       workingDir += std::string("/framework/xml/Security/");
     }

--- a/tests/cpp/security/PkcsAuthInit.cpp
+++ b/tests/cpp/security/PkcsAuthInit.cpp
@@ -34,7 +34,7 @@ namespace client {
 std::shared_ptr<CacheableString> convertBytesToString(const uint8_t* bytes,
                                                       int32_t length,
                                                       size_t maxLength) {
-  if (bytes != NULL) {
+  if (bytes) {
     std::string str;
     size_t totalBytes = 0;
     char byteStr[20];
@@ -61,42 +61,42 @@ SECURITY_EXPORT AuthInitialize* createPKCSAuthInitInstance() {
 uint8_t* createSignature(EVP_PKEY* key, X509* cert,
                          const unsigned char* inputBuffer,
                          uint32_t inputBufferLen, unsigned int* signatureLen) {
-  if (key == NULL || cert == NULL || inputBuffer == NULL) {
-    return NULL;
+  if (!key || !cert || !inputBuffer) {
+    return nullptr;
   }
   const ASN1_OBJECT* macobj;
   const X509_ALGOR* algorithm = nullptr;
-  X509_ALGOR_get0(&macobj, NULL, NULL, algorithm);
+  X509_ALGOR_get0(&macobj, nullptr, nullptr, algorithm);
   const EVP_MD* signatureDigest = EVP_get_digestbyobj(macobj);
   EVP_MD_CTX* signatureCtx = EVP_MD_CTX_new();
   uint8_t* signatureData = new uint8_t[EVP_PKEY_size(key)];
-  bool result = (EVP_SignInit_ex(signatureCtx, signatureDigest, NULL) &&
+  bool result = (EVP_SignInit_ex(signatureCtx, signatureDigest, nullptr) &&
                  EVP_SignUpdate(signatureCtx, inputBuffer, inputBufferLen) &&
                  EVP_SignFinal(signatureCtx, signatureData, signatureLen, key));
   EVP_MD_CTX_free(signatureCtx);
   if (result) {
     return signatureData;
   }
-  return NULL;
+  return nullptr;
 }
 
 bool readPKCSPublicPrivateKey(FILE* keyStoreFP, const char* keyStorePassword,
                               EVP_PKEY** outPrivateKey, X509** outCertificate) {
   PKCS12* p12;
 
-  if ((keyStoreFP == NULL) || (keyStorePassword == NULL) ||
+  if (!keyStoreFP || !keyStorePassword ||
       (keyStorePassword[0] == '\0')) {
     return (false);
   }
 
-  p12 = d2i_PKCS12_fp(keyStoreFP, NULL);
+  p12 = d2i_PKCS12_fp(keyStoreFP, nullptr);
 
-  if (p12 == NULL) {
+  if (!p12) {
     return (false);
   }
 
   if (!PKCS12_parse(p12, keyStorePassword, outPrivateKey, outCertificate,
-                    NULL)) {
+                    nullptr)) {
     return (false);
   }
 
@@ -132,7 +132,7 @@ std::shared_ptr<Properties> PKCSAuthInitInternal::getCredentials(
 
   const char* keyStorePath = keyStoreptr->value().c_str();
 
-  if (keyStorePath == NULL) {
+  if (!keyStorePath) {
     throw AuthenticationFailedException(
         "PKCSAuthInit::getCredentials: "
         "key-store file path property KEYSTORE_FILE_PATH not set.");
@@ -142,7 +142,7 @@ std::shared_ptr<Properties> PKCSAuthInitInternal::getCredentials(
 
   const char* alias = aliasptr->value().c_str();
 
-  if (alias == NULL) {
+  if (!alias) {
     throw AuthenticationFailedException(
         "PKCSAuthInit::getCredentials: "
         "key-store alias property KEYSTORE_ALIAS not set.");
@@ -152,22 +152,22 @@ std::shared_ptr<Properties> PKCSAuthInitInternal::getCredentials(
 
   const char* keyStorePass = keyStorePassptr->value().c_str();
 
-  if (keyStorePass == NULL) {
+  if (!keyStorePass) {
     throw AuthenticationFailedException(
         "PKCSAuthInit::getCredentials: "
         "key-store password property KEYSTORE_PASSWORD not set.");
   }
 
   FILE* keyStoreFP = fopen(keyStorePath, "r");
-  if (keyStoreFP == NULL) {
+  if (!keyStoreFP) {
     char msg[1024];
     sprintf(msg, "PKCSAuthInit::getCredentials: Unable to open keystore %s",
             keyStorePath);
     throw AuthenticationFailedException(msg);
   }
 
-  EVP_PKEY* privateKey = NULL;
-  X509* cert = NULL;
+  EVP_PKEY* privateKey = nullptr;
+  X509* cert = nullptr;
 
   /* Read the Public and Private Key from keystore in file */
   if (!readPKCSPublicPrivateKey(keyStoreFP, keyStorePass, &privateKey, &cert)) {
@@ -188,7 +188,7 @@ std::shared_ptr<Properties> PKCSAuthInitInternal::getCredentials(
       static_cast<uint32_t>(strlen(alias)), &lengthEncryptedData);
   EVP_PKEY_free(privateKey);
   X509_free(cert);
-  if (signatureData == NULL) {
+  if (!signatureData) {
     throw AuthenticationFailedException(
         "PKCSAuthInit::getCredentials: "
         "Unable to create signature");

--- a/tests/cpp/security/PkcsCredentialGenerator.hpp
+++ b/tests/cpp/security/PkcsCredentialGenerator.hpp
@@ -46,12 +46,12 @@ class PKCSCredentialGenerator : public CredentialGenerator {
     std::string additionalArgs;
     char* buildDir = ACE_OS::getenv("BUILDDIR");
 
-    if (buildDir != NULL && workingDir.length() == 0) {
+    if (buildDir && workingDir.length() == 0) {
       workingDir = std::string(buildDir);
       workingDir += std::string("/framework/xml/Security/");
     }
 
-    if (buildDir != NULL && workingDir.length() == 0) {
+    if (buildDir && workingDir.length() == 0) {
       workingDir = std::string(buildDir);
       workingDir += std::string("/framework/xml/Security/");
     }
@@ -60,7 +60,7 @@ class PKCSCredentialGenerator : public CredentialGenerator {
     additionalArgs =
         std::string(" --J=-Dgemfire.security-authz-xml-uri=") +
         std::string(workingDir) +
-        std::string(authzXmlUri != NULL ? authzXmlUri : "authz-pkcs.xml");
+        std::string(authzXmlUri ? authzXmlUri : "authz-pkcs.xml");
 
     return additionalArgs;
   }
@@ -84,10 +84,10 @@ class PKCSCredentialGenerator : public CredentialGenerator {
   void insertKeyStorePath(std::shared_ptr<Properties>& p,
                           const char* username) {
     char keystoreFilePath[1024];
-    char* tempPath = NULL;
+    char* tempPath = nullptr;
     tempPath = ACE_OS::getenv("TESTSRC");
     std::string path = "";
-    if (tempPath == NULL) {
+    if (!tempPath) {
       tempPath = ACE_OS::getenv("BUILDDIR");
       path = std::string(tempPath) + "/framework/data";
     } else {
@@ -127,7 +127,7 @@ class PKCSCredentialGenerator : public CredentialGenerator {
 
   void getAllowedCredentialsForOps(opCodeList& opCodes,
                                    std::shared_ptr<Properties>& p,
-                                   stringList* regionNames = NULL) override {
+                                   stringList* regionNames = nullptr) override {
     XmlAuthzCredentialGenerator authz(id());
     authz.getAllowedCredentials(opCodes, p, regionNames);
     const char* username = p->find("security-alias")->value().c_str();
@@ -136,7 +136,7 @@ class PKCSCredentialGenerator : public CredentialGenerator {
 
   void getDisallowedCredentialsForOps(opCodeList& opCodes,
                                       std::shared_ptr<Properties>& p,
-                                      stringList* regionNames = NULL) override {
+                                      stringList* regionNames = nullptr) override {
     XmlAuthzCredentialGenerator authz(id());
     authz.getDisallowedCredentials(opCodes, p, regionNames);
     const char* username = p->find("security-alias")->value().c_str();

--- a/tests/cpp/security/Security.cpp
+++ b/tests/cpp/security/Security.cpp
@@ -56,13 +56,13 @@ std::string REGIONSBB("Regions");
 std::string CLIENTSBB("ClientsBb");
 std::string READYCLIENTS("ReadyClients");
 
-Security *g_test = NULL;
+Security *g_test = nullptr;
 
 // ----------------------------------------------------------------------------
 
 TESTTASK initialize(const char *initArgs) {
   int32_t result = FWK_SUCCESS;
-  if (g_test == NULL) {
+  if (!g_test) {
     FWKINFO("Initializing Security library.");
     try {
       g_test = new Security(initArgs);
@@ -79,10 +79,10 @@ TESTTASK initialize(const char *initArgs) {
 TESTTASK finalize() {
   int32_t result = FWK_SUCCESS;
   FWKINFO("Finalizing Security library.");
-  if (g_test != NULL) {
+  if (g_test) {
     g_test->cacheFinalize();
     delete g_test;
-    g_test = NULL;
+    g_test = nullptr;
   }
   return result;
 }
@@ -92,7 +92,7 @@ TESTTASK finalize() {
 TESTTASK doCloseCache() {
   int32_t result = FWK_SUCCESS;
   FWKINFO("Closing cache, disconnecting from distributed system.");
-  if (g_test != NULL) {
+  if (g_test) {
     g_test->cacheFinalize();
   }
   return result;
@@ -356,12 +356,12 @@ server reports " << keys << " keys." );
 // ========================================================================
 
 void Security::clearKeys() {
-  if (m_KeysA != NULL) {
+  if (m_KeysA) {
     for (int32_t i = 0; i < m_MaxKeys; i++) {
       m_KeysA[i] = nullptr;
     }
     delete[] m_KeysA;
-    m_KeysA = NULL;
+    m_KeysA = nullptr;
     m_MaxKeys = 0;
   }
 }
@@ -433,7 +433,7 @@ int32_t Security::initValues(int32_t numKeys, int32_t siz, bool useDefault) {
     numKeys = 5000;
   }
 
-  if (m_CValue != NULL) {
+  if (m_CValue) {
     for (int32_t i = 0; i < m_MaxValues; i++) {
       m_CValue[i] = nullptr;
     }
@@ -742,7 +742,7 @@ std::shared_ptr<Region> Security::getRegionPtr(const char *reg) {
   std::shared_ptr<Region> region;
   std::string name;
 
-  if (reg == NULL) {
+  if (!reg) {
     name = getStringValue("regionName");
     if (name.empty()) {
       try {

--- a/tests/cpp/security/Security.hpp
+++ b/tests/cpp/security/Security.hpp
@@ -61,15 +61,15 @@ class Security : public FrameworkTest {
  public:
   Security(const char* initArgs)
       : FrameworkTest(initArgs),
-        m_KeysA(NULL),
+        m_KeysA(nullptr),
         m_MaxKeys(0),
         m_KeyIndexBegin(0),
         m_MaxValues(0),
-        m_CValue(NULL) {}
+        m_CValue(nullptr) {}
 
   virtual ~Security(void) {
     clearKeys();
-    m_CValue = NULL;
+    m_CValue = nullptr;
   }
 
   void onRegisterMembers(void);
@@ -102,7 +102,7 @@ class Security : public FrameworkTest {
   void clearKeys();
   void initStrKeys(int32_t low, int32_t high, const std::string& keyBase);
   int32_t initValues(int32_t num, int32_t siz = 0, bool useDefault = true);
-  std::shared_ptr<Region> getRegionPtr(const char* reg = NULL);
+  std::shared_ptr<Region> getRegionPtr(const char* reg = nullptr);
   bool checkReady(int32_t numClients);
 
   std::shared_ptr<CacheableString>* m_KeysA;

--- a/tests/cpp/security/XmlAuthzCredentialGenerator.hpp
+++ b/tests/cpp/security/XmlAuthzCredentialGenerator.hpp
@@ -70,11 +70,11 @@ class XmlAuthzCredentialGenerator {
         Writers(WArr, WArr + sizeof WArr / sizeof *WArr),
         Query(QArr, QArr + sizeof QArr / sizeof *QArr),
         QueryRegions(QRArr, QRArr + sizeof QRArr / sizeof *QRArr) {
-    m_opCode = NULL;
-    m_regionNames = NULL;
-    m_prop = NULL;
+    m_opCode = nullptr;
+    m_regionNames = nullptr;
+    m_prop = nullptr;
     /* initialize random seed: */
-    srand(static_cast<unsigned int>(time(NULL)));
+    srand(static_cast<unsigned int>(time(nullptr)));
   }
   virtual ~XmlAuthzCredentialGenerator() { ; }
 
@@ -108,9 +108,9 @@ class XmlAuthzCredentialGenerator {
   }
 
   void reset() {
-    m_opCode = NULL;
-    m_regionNames = NULL;
-    m_prop = NULL;
+    m_opCode = nullptr;
+    m_regionNames = nullptr;
+    m_prop = nullptr;
   }
 
   virtual void getDisallowedCredentials(opCodeList& opCode,
@@ -291,21 +291,6 @@ class XmlAuthzCredentialGenerator {
       role = WRITER_ROLE;
     } else if (requireQuery) {
       role = QUERY_ROLE;
-      /*
-       if( m_regionNames != NULL && m_regionNames->size() > 0 ) {
-         bool queryUsers = true;
-         for( stringList::iterator rit = m_regionNames->begin(); rit !=
-       m_regionNames->end(); rit++) {
-            if( queryUsers && std::find(QueryRegions.begin(),
-       QueryRegions.end(),(*rit)) == QueryRegions.end() ) {
-              queryUsers = false;
-            }
-         }
-         if( queryUsers ) {
-           role = QUERY_ROLE;
-         }
-       }
-       */
     }
 
     return role;

--- a/tests/cpp/testobject/EqStruct.cpp
+++ b/tests/cpp/testobject/EqStruct.cpp
@@ -23,7 +23,7 @@ using namespace testobject;
 
 EqStruct::EqStruct(int index) {
   myIndex = index;  // index
-  state = (char *)"1";
+  state = "1";
   ACE_Time_Value startTime;
   startTime = ACE_OS::gettimeofday();
   ACE_UINT64 tusec = 0;
@@ -35,48 +35,48 @@ EqStruct::EqStruct(int index) {
   availQty = 100;
   positionQty = 10.0;
   isRestricted = 1;
-  demandInd = (char *)"ASDSAD";
-  side = (char *)"16";
+  demandInd = "ASDSAD";
+  side = "16";
   orderQty = 3000;
   price = 78.9;
-  ordType = (char *)"D";
+  ordType = "D";
   stopPx = 22.3;
-  senderCompID = (char *)"dsafdsf";
-  tarCompID = (char *)"dsafsadfsaf";
-  tarSubID = (char *)"rwetwj";
-  handlInst = (char *)"M N";
-  orderID = (char *)"sample";
-  timeInForce = (char *)"4";
-  clOrdID = (char *)"sample";
-  orderCapacity = (char *)"6";
+  senderCompID = "dsafdsf";
+  tarCompID = "dsafsadfsaf";
+  tarSubID = "rwetwj";
+  handlInst = "M N";
+  orderID = "sample";
+  timeInForce = "4";
+  clOrdID = "sample";
+  orderCapacity = "6";
   cumQty = 0;
-  symbol = (char *)"MSFT";
-  symbolSfx = (char *)"0";
-  execInst = (char *)"A";
-  oldClOrdID = (char *)"";
+  symbol = "MSFT";
+  symbolSfx = "0";
+  execInst = "A";
+  oldClOrdID = "";
   pegDifference = 0.1;
-  discretionInst = (char *)"G";
+  discretionInst = "G";
   discretionOffset = 300.0;
-  financeInd = (char *)"dsagfdsa";
-  securityID = (char *)"MSFT.O";
-  targetCompID = (char *)"LBLB";
-  targetSubID = (char *)"EQUITY";
+  financeInd = "dsagfdsa";
+  securityID = "MSFT.O";
+  targetCompID = "LBLB";
+  targetSubID = "EQUITY";
   isDoneForDay = 1;
   revisionSeqNum = 140;
   replaceQty = 0;
   usedClientAvailability = 45;
-  clientAvailabilityKey = (char *)"UUUU";
+  clientAvailabilityKey = "UUUU";
   isIrregularSettlmnt = 1;
 
-  var1 = (char *)"abcdefghijklmnopqrstuvwxyz";
-  var2 = (char *)"abcdefghijklmnopqrstuvwxyz";
-  var3 = (char *)"abcdefghijklmnopqrstuvwxyz";
-  var4 = (char *)"abcdefghijklmnopqrstuvwxyz";
-  var5 = (char *)"abcdefghijklmnopqrstuvwxyz";
-  var6 = (char *)"abcdefghijklmnopqrstuvwxyz";
-  var7 = (char *)"abcdefghijklmnopqrstuvwxyz";
-  var8 = (char *)"abcdefghijklmnopqrstuvwxyz";
-  var9 = (char *)"abcdefghijklmnopqrstuvwxyz";
+  var1 = "abcdefghijklmnopqrstuvwxyz";
+  var2 = "abcdefghijklmnopqrstuvwxyz";
+  var3 = "abcdefghijklmnopqrstuvwxyz";
+  var4 = "abcdefghijklmnopqrstuvwxyz";
+  var5 = "abcdefghijklmnopqrstuvwxyz";
+  var6 = "abcdefghijklmnopqrstuvwxyz";
+  var7 = "abcdefghijklmnopqrstuvwxyz";
+  var8 = "abcdefghijklmnopqrstuvwxyz";
+  var9 = "abcdefghijklmnopqrstuvwxyz";
 }
 
 void EqStruct::toData(apache::geode::client::DataOutput &out) const {

--- a/tests/cpp/testobject/InvalidPdxUsage.cpp
+++ b/tests/cpp/testobject/InvalidPdxUsage.cpp
@@ -803,7 +803,7 @@ std::string InvalidPdxUsage::toString() const {
 bool InvalidPdxUsage::equals(PdxTests::InvalidPdxUsage& other,
                              bool isPdxReadSerialized) const {
   InvalidPdxUsage* ot = dynamic_cast<InvalidPdxUsage*>(&other);
-  if (ot == NULL) {
+  if (!ot) {
     return false;
   }
   if (ot == this) {

--- a/tests/cpp/testobject/InvalidPdxUsage.hpp
+++ b/tests/cpp/testobject/InvalidPdxUsage.hpp
@@ -69,7 +69,7 @@ class TESTOBJECT_EXPORT CharTypesWithInvalidUsage : public PdxSerializable {
     LOGDEBUG("Inside CharTypesWithInvalidUsage equals");
     CharTypesWithInvalidUsage* ot =
         dynamic_cast<CharTypesWithInvalidUsage*>(&other);
-    if (ot == NULL) {
+    if (!ot) {
       return false;
     }
     if (ot == this) {
@@ -144,7 +144,7 @@ class TESTOBJECT_EXPORT AddressWithInvalidAPIUsage : public PdxSerializable {
     LOGDEBUG("Inside AddressWithInvalidAPIUsage equals");
     AddressWithInvalidAPIUsage* ot =
         dynamic_cast<AddressWithInvalidAPIUsage*>(&other);
-    if (ot == NULL) {
+    if (!ot) {
       return false;
     }
     if (ot == this) {

--- a/tests/cpp/testobject/NestedPdxObject.cpp
+++ b/tests/cpp/testobject/NestedPdxObject.cpp
@@ -55,7 +55,7 @@ bool ChildPdx::equals(ChildPdx& other) const {
   LOGINFO("ChildPdx::equals");
   ChildPdx* ot = dynamic_cast<ChildPdx*>(&other);
   // Cacheable* ot = dynamic_cast<Cacheable*>(&other);
-  if (ot == NULL) {
+  if (!ot) {
     LOGINFO("ChildPdx::equals1");
     return false;
   }

--- a/tests/cpp/testobject/NestedPdxObject.hpp
+++ b/tests/cpp/testobject/NestedPdxObject.hpp
@@ -270,7 +270,7 @@ class TESTOBJECT_EXPORT SerializePdx : public PdxSerializable {
 
   bool equals(SerializePdx& other) const {
     SerializePdx* ot = dynamic_cast<SerializePdx*>(&other);
-    if (ot == NULL) {
+    if (ot) {
       LOGINFO("SerializePdx::equals1");
       return false;
     }

--- a/tests/cpp/testobject/NonPdxType.cpp
+++ b/tests/cpp/testobject/NonPdxType.cpp
@@ -73,7 +73,7 @@ bool PdxTests::NonPdxType::selfCheck() { return false; }
 bool PdxTests::NonPdxType::equals(PdxTests::NonPdxType& other,
                                   bool isPdxReadSerialized) const {
   NonPdxType* ot = dynamic_cast<NonPdxType*>(&other);
-  if (ot == NULL) {
+  if (!ot) {
     return false;
   }
   if (ot == this) {

--- a/tests/cpp/testobject/NonPdxType.hpp
+++ b/tests/cpp/testobject/NonPdxType.hpp
@@ -56,7 +56,7 @@ class TESTOBJECT_EXPORT NonPdxAddress {
   bool equals(NonPdxAddress& other) const {
     LOGDEBUG("Inside NonPdxAddress equals");
     NonPdxAddress* ot = dynamic_cast<NonPdxAddress*>(&other);
-    if (ot == NULL) {
+    if (!ot) {
       return false;
     }
     if (ot == this) {

--- a/tests/cpp/testobject/PdxClassV1.cpp
+++ b/tests/cpp/testobject/PdxClassV1.cpp
@@ -248,11 +248,11 @@ bool PdxType3V1::m_useWeakHashMap = false;
 PdxType3V1::PdxType3V1() {
   m_i1 = 1;
   m_i2 = 21;
-  m_str1 = (char *)"common";
+  m_str1 = "common";
   m_i3 = 31;
   m_i4 = 41;
   m_i5 = 0;
-  m_str2 = (char *)"0";
+  m_str2 = "0";
 }
 
 PdxType3V1::~PdxType3V1() noexcept {
@@ -676,8 +676,8 @@ TestDiffTypePdxSV1::TestDiffTypePdxSV1() {}
 
 TestDiffTypePdxSV1::TestDiffTypePdxSV1(bool init) {
   if (init) {
-    _id = (char *)"id:100";
-    _name = (char *)"HK";
+    _id = "id:100";
+    _name = "HK";
   }
 }
 
@@ -696,7 +696,7 @@ bool TestDiffTypePdxSV1::equals(const TestDiffTypePdxSV1& obj) {
 TestEqualsV1::TestEqualsV1() {
   i1 = 1;
   i2 = 0;
-  s1 = (char *)"s1";
+  s1 = "s1";
   // TODO: Uncomment it.
   // sArr = ;
   // intArr = ;

--- a/tests/cpp/testobject/PdxClassV2.cpp
+++ b/tests/cpp/testobject/PdxClassV2.cpp
@@ -217,11 +217,11 @@ bool PdxTypes3V2::m_useWeakHashMap = false;
 PdxTypes3V2::PdxTypes3V2() {
   m_i1 = 1;
   m_i2 = 21;
-  m_str1 = (char *)"common";
+  m_str1 = "common";
   m_i4 = 41;
   m_i3 = 31;
   m_i6 = 0;
-  m_str3 = (char *)"0";
+  m_str3 = "0";
 }
 
 PdxTypes3V2::~PdxTypes3V2() noexcept {
@@ -408,7 +408,7 @@ PdxTypesR2V2::PdxTypesR2V2() {
   m_i5 = 798243;
   m_i6 = 9900;
 
-  m_str1 = (char *)"0";
+  m_str1 = "0";
 }
 
 PdxTypesR2V2::~PdxTypesR2V2() noexcept {

--- a/tests/cpp/testobject/PdxClassV2.hpp
+++ b/tests/cpp/testobject/PdxClassV2.hpp
@@ -523,7 +523,7 @@ class TestPdxSerializerForV2 : public PdxSerializer {
 
     } else {
       LOGINFO("TestPdxSerializerForV2::fromdata() Invalid Class Name");
-      return NULL;
+      return nullptr;
     }
   }
 

--- a/tests/cpp/testobject/PdxType.cpp
+++ b/tests/cpp/testobject/PdxType.cpp
@@ -275,7 +275,7 @@ std::string PdxTests::PdxType::toString() const {
 bool PdxTests::PdxType::equals(PdxTests::PdxType& other,
                                bool isPdxReadSerialized) const {
   PdxType* ot = dynamic_cast<PdxType*>(&other);
-  if (ot == NULL) {
+  if (!ot) {
     return false;
   }
   if (ot == this) {

--- a/tests/cpp/testobject/PdxType.hpp
+++ b/tests/cpp/testobject/PdxType.hpp
@@ -174,7 +174,7 @@ class TESTOBJECT_EXPORT CharTypes : public PdxSerializable {
   bool equals(CharTypes& other) const {
     LOGDEBUG("Inside CharTypes equals");
     CharTypes* ot = dynamic_cast<CharTypes*>(&other);
-    if (ot == NULL) {
+    if (!ot) {
       return false;
     }
     if (ot == this) {
@@ -247,7 +247,7 @@ class TESTOBJECT_EXPORT Address : public PdxSerializable {
   bool equals(Address& other) const {
     LOGDEBUG("Inside Address equals");
     Address* ot = dynamic_cast<Address*>(&other);
-    if (ot == NULL) {
+    if (!ot) {
       return false;
     }
     if (ot == this) {

--- a/tests/cpp/testobject/PdxVersioned1.cpp
+++ b/tests/cpp/testobject/PdxVersioned1.cpp
@@ -343,7 +343,7 @@ std::string PdxTests::PdxVersioned1::toString() const {
 
 bool PdxTests::PdxVersioned1::equals(PdxTests::PdxVersioned1& other) const {
   PdxVersioned1* ot = dynamic_cast<PdxVersioned1*>(&other);
-  if (ot == NULL) {
+  if (!ot) {
     return false;
   }
   if (ot == this) {

--- a/tests/cpp/testobject/PdxVersioned2.cpp
+++ b/tests/cpp/testobject/PdxVersioned2.cpp
@@ -373,7 +373,7 @@ std::string PdxTests::PdxVersioned2::toString() const {
 
 bool PdxTests::PdxVersioned2::equals(PdxTests::PdxVersioned2& other) const {
   PdxVersioned2* ot = dynamic_cast<PdxVersioned2*>(&other);
-  if (ot == NULL) {
+  if (!ot) {
     return false;
   }
   if (ot == this) {

--- a/tests/cpp/testobject/Portfolio.cpp
+++ b/tests/cpp/testobject/Portfolio.cpp
@@ -49,15 +49,15 @@ Portfolio::Portfolio(int32_t i, uint32_t size,
   memset(newVal, 'B', size);
   newVal[size] = '\0';
   newValSize = size;
-  creationDate = CacheableDate::create(time(NULL));
-  arrayNull = NULL;
-  arrayZeroSize = NULL;
+  creationDate = CacheableDate::create(time(nullptr));
+  arrayNull = nullptr;
+  arrayZeroSize = nullptr;
 }
 
 Portfolio::~Portfolio() noexcept {
-  if (newVal != NULL) {
+  if (newVal) {
     delete[] newVal;
-    newVal = NULL;
+    newVal = nullptr;
   }
 }
 

--- a/tests/cpp/testobject/Portfolio.hpp
+++ b/tests/cpp/testobject/Portfolio.hpp
@@ -60,10 +60,10 @@ class TESTOBJECT_EXPORT Portfolio : public DataSerializable {
         pkid(nullptr),
         type(nullptr),
         status(),
-        newVal(NULL),
+        newVal(nullptr),
         creationDate(nullptr),
-        arrayNull(NULL),
-        arrayZeroSize(NULL) {}
+        arrayNull(nullptr),
+        arrayZeroSize(nullptr) {}
   Portfolio(int32_t id, uint32_t size = 0,
             std::shared_ptr<CacheableStringArray> nm = nullptr);
   ~Portfolio() noexcept override;
@@ -85,7 +85,7 @@ class TESTOBJECT_EXPORT Portfolio : public DataSerializable {
   int32_t getID() { return ID; }
   void showNames(const char* label) {
     LOGINFO(label);
-    if (names == nullptr) {
+    if (!names) {
       LOGINFO("names is NULL");
       return;
     }

--- a/tests/cpp/testobject/VariousPdxTypes.cpp
+++ b/tests/cpp/testobject/VariousPdxTypes.cpp
@@ -94,7 +94,7 @@ void PdxTypes1::fromData(PdxReader &pr) {
  *  PdxTypes2
  * *********************************************************/
 PdxTypes2::PdxTypes2() {
-  m_s1 = (char *)"one";
+  m_s1 = "one";
   m_i1 = 34324;
   m_i2 = 2144;
   m_i3 = 4645734;
@@ -153,7 +153,7 @@ void PdxTypes2::fromData(PdxReader &pr) {
  *  PdxTypes3
  * *********************************************************/
 PdxTypes3::PdxTypes3() {
-  m_s1 = (char *)"one";
+  m_s1 = "one";
   m_i1 = 34324;
   m_i2 = 2144;
   m_i3 = 4645734;
@@ -209,7 +209,7 @@ void PdxTypes3::fromData(PdxReader &pr) {
  *  PdxTypes4
  * *********************************************************/
 PdxTypes4::PdxTypes4() {
-  m_s1 = (char *)"one";
+  m_s1 = "one";
   m_i1 = 34324;
   m_i2 = 2144;
   m_i3 = 4645734;


### PR DESCRIPTION
- Make all necessary ctors public as a result of change
- Fix up all compiler errors on Mac after upgrade to XCode 9.4 toolchain.

Co-authored-by: Ivan Godwin <igodwin@pivotal.io>