### PR TITLE
GEODE-5677: Removes _GEODE_FRIEND_STD_SHARED_PTR.

### DIFF
--- a/cppcache/include/geode/AuthInitialize.hpp
+++ b/cppcache/include/geode/AuthInitialize.hpp
@@ -48,6 +48,8 @@ class Properties;
  */
 class APACHE_GEODE_EXPORT AuthInitialize {
  public:
+  virtual ~AuthInitialize() noexcept = default;
+
   /**@brief initialize with the given set of security properties
    * and return the credentials for the client as properties.
    * @param props the set of security properties provided to the

--- a/cppcache/include/geode/Cache.hpp
+++ b/cppcache/include/geode/Cache.hpp
@@ -264,8 +264,6 @@ class APACHE_GEODE_EXPORT Cache : public GeodeCache {
   friend class FunctionService;
   friend class CacheXmlCreation;
   friend class RegionXmlCreation;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(Cache)
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/CacheableBuiltins.hpp
+++ b/cppcache/include/geode/CacheableBuiltins.hpp
@@ -158,20 +158,18 @@ class APACHE_GEODE_EXPORT CacheableContainerType
 #pragma warning(disable : 4231)
 #endif
 
-#define _GEODE_CACHEABLE_KEY_TYPE_DEF_(p, k)                      \
-  extern const char tName_##k[];                                  \
+#define _GEODE_CACHEABLE_KEY_TYPE_DEF_(p, k)                \
+  extern const char tName_##k[];                            \
   template class CacheableKeyType<p, DSCode::k, tName_##k>; \
   typedef CacheableKeyType<p, DSCode::k, tName_##k> _##k;
 
 // use a class instead of typedef for bug #283
 #define _GEODE_CACHEABLE_KEY_TYPE_(p, k)                                \
   class APACHE_GEODE_EXPORT k : public _##k {                           \
-   protected:                                                           \
+   public:                                                              \
     inline k() : _##k() {}                                              \
     inline k(const p value) : _##k(value) {}                            \
-    _GEODE_FRIEND_STD_SHARED_PTR(k)                                     \
                                                                         \
-   public:                                                              \
     /** Factory function registered with serialization registry. */     \
     static std::shared_ptr<Serializable> createDeserializable() {       \
       return std::make_shared<k>();                                     \
@@ -194,20 +192,17 @@ class APACHE_GEODE_EXPORT CacheableContainerType
     return k::create(value);                                            \
   }
 
-#define _GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(p, c)           \
+#define _GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(p, c)     \
   template class CacheableContainerType<p, DSCode::c>; \
   typedef CacheableContainerType<p, DSCode::c> _##c;
 
 // use a class instead of typedef for bug #283
 #define _GEODE_CACHEABLE_CONTAINER_TYPE_(p, c)                         \
   class APACHE_GEODE_EXPORT c : public _##c {                          \
-   protected:                                                          \
+   public:                                                             \
     inline c() : _##c() {}                                             \
     inline c(const int32_t n) : _##c(n) {}                             \
                                                                        \
-    _GEODE_FRIEND_STD_SHARED_PTR(c)                                    \
-                                                                       \
-   public:                                                             \
     /** Factory function registered with serialization registry. */    \
     static std::shared_ptr<Serializable> createDeserializable() {      \
       return std::make_shared<c>();                                    \
@@ -285,28 +280,28 @@ _GEODE_CACHEABLE_KEY_TYPE_(char16_t, CacheableCharacter)
 template <typename T, DSCode GeodeTypeId>
 class APACHE_GEODE_EXPORT CacheableArray : public DataSerializablePrimitive {
  protected:
-  inline CacheableArray() = default;
+  DSCode getDsCode() const override { return GeodeTypeId; }
 
-  CacheableArray(const CacheableArray& other) = delete;
-
-  CacheableArray& operator=(const CacheableArray& other) = delete;
-
-  template <typename TT>
-  CacheableArray(TT&& value) : m_value(std::forward<TT>(value)) {}
-
-  virtual DSCode getDsCode() const override { return GeodeTypeId; }
-
-  virtual size_t objectSize() const override {
+  size_t objectSize() const override {
     return static_cast<uint32_t>(
         apache::geode::client::serializer::objectArraySize(m_value));
   }
 
  private:
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableArray)
-
   std::vector<T> m_value;
 
  public:
+  inline CacheableArray() = default;
+
+  template <typename TT>
+  CacheableArray(TT&& value) : m_value(std::forward<TT>(value)) {}
+
+  ~CacheableArray() noexcept override = default;
+
+  CacheableArray(const CacheableArray& other) = delete;
+
+  CacheableArray& operator=(const CacheableArray& other) = delete;
+
   inline const std::vector<T>& value() const { return m_value; }
 
   inline int32_t length() const { return static_cast<int32_t>(m_value.size()); }
@@ -375,8 +370,7 @@ using CacheableDoubleArray =
  * An immutable wrapper for array of floats that can serve as
  * a distributable object for caching.
  */
-using CacheableFloatArray =
-    CacheableArray<float, DSCode::CacheableFloatArray>;
+using CacheableFloatArray = CacheableArray<float, DSCode::CacheableFloatArray>;
 
 /**
  * An immutable wrapper for array of 16-bit integers that can serve as

--- a/cppcache/include/geode/CacheableDate.hpp
+++ b/cppcache/include/geode/CacheableDate.hpp
@@ -54,6 +54,24 @@ class APACHE_GEODE_EXPORT CacheableDate : public DataSerializablePrimitive,
   typedef std::chrono::time_point<clock> time_point;
   typedef std::chrono::milliseconds duration;
 
+  /** Constructor, used for deserialization. */
+  CacheableDate(const time_t value = 0);
+
+  /**
+   * Construct from std::chrono::time_point<std::chrono::system_clock>.
+   */
+  CacheableDate(const time_point& value);
+
+  /**
+   * Construct from std::chrono::seconds since POSIX epoch.
+   */
+  CacheableDate(const duration& value);
+
+  ~CacheableDate() noexcept override = default;
+
+  void operator=(const CacheableDate& other) = delete;
+  CacheableDate(const CacheableDate& other) = delete;
+
   void toData(DataOutput& output) const override;
 
   virtual void fromData(DataInput& input) override;
@@ -108,30 +126,6 @@ class APACHE_GEODE_EXPORT CacheableDate : public DataSerializablePrimitive,
   }
 
   std::string toString() const override;
-
-  /** Destructor */
-  ~CacheableDate() override = default;
-
- protected:
-  /** Constructor, used for deserialization. */
-  CacheableDate(const time_t value = 0);
-
-  /**
-   * Construct from std::chrono::time_point<std::chrono::system_clock>.
-   */
-  CacheableDate(const time_point& value);
-
-  /**
-   * Construct from std::chrono::seconds since POSIX epoch.
-   */
-  CacheableDate(const duration& value);
-
- private:
-  // never implemented.
-  void operator=(const CacheableDate& other);
-  CacheableDate(const CacheableDate& other);
-
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableDate)
 };
 
 template <>

--- a/cppcache/include/geode/CacheableEnum.hpp
+++ b/cppcache/include/geode/CacheableEnum.hpp
@@ -59,8 +59,20 @@ class APACHE_GEODE_EXPORT CacheableEnum : public DataSerializablePrimitive,
   int32_t m_hashcode;
 
  public:
-  /** Destructor */
-  ~CacheableEnum() override = default;
+  inline CacheableEnum()
+      : m_enumClassName(nullptr),
+        m_enumName(nullptr),
+        m_ordinal(-1),
+        m_hashcode(0) {}
+  inline CacheableEnum(std::string enumClassName, std::string enumName,
+                       int32_t ordinal)
+      : m_enumClassName(std::move(enumClassName)),
+        m_enumName(std::move(enumName)),
+        m_ordinal(ordinal),
+        m_hashcode(0) {}
+  ~CacheableEnum() noexcept override = default;
+  void operator=(const CacheableEnum& other) = delete;
+  CacheableEnum(const CacheableEnum& other) = delete;
 
   /**
    * @brief creation function for enum.
@@ -80,9 +92,7 @@ class APACHE_GEODE_EXPORT CacheableEnum : public DataSerializablePrimitive,
     return size;
   }
 
-  virtual DSCode getDsCode() const override {
-    return DSCode::CacheableEnum;
-  }
+  virtual DSCode getDsCode() const override { return DSCode::CacheableEnum; }
 
   /**
    * Display this object as c string.
@@ -121,17 +131,7 @@ class APACHE_GEODE_EXPORT CacheableEnum : public DataSerializablePrimitive,
   virtual bool operator==(const CacheableKey& other) const override;
 
  protected:
-  CacheableEnum();
-  CacheableEnum(std::string enumClassName, std::string enumName,
-                int32_t ordinal);
   void calculateHashcode();
-
- private:
-  // never implemented.
-  void operator=(const CacheableEnum& other);
-  CacheableEnum(const CacheableEnum& other);
-
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableEnum)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/CacheableFileName.hpp
+++ b/cppcache/include/geode/CacheableFileName.hpp
@@ -45,6 +45,14 @@ class Serializable;
 
 class APACHE_GEODE_EXPORT CacheableFileName : public CacheableString {
  public:
+  inline CacheableFileName() = default;
+  inline CacheableFileName(const std::string& value) : CacheableString(value) {}
+  inline CacheableFileName(std::string&& value)
+      : CacheableString(std::move(value)) {}
+  ~CacheableFileName() noexcept override = default;
+  void operator=(const CacheableFileName& other) = delete;
+  CacheableFileName(const CacheableFileName& other) = delete;
+
   void toData(DataOutput& output) const override;
 
   virtual void fromData(DataInput& input) override;
@@ -68,20 +76,6 @@ class APACHE_GEODE_EXPORT CacheableFileName : public CacheableString {
 
   /** return the hashcode for this key. */
   virtual int32_t hashcode() const override;
-
- protected:
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableFileName)
-
-  /** Default constructor. */
-  inline CacheableFileName() = default;
-  inline CacheableFileName(const std::string& value) : CacheableString(value) {}
-  inline CacheableFileName(std::string&& value)
-      : CacheableString(std::move(value)) {}
-
- private:
-  // never implemented.
-  void operator=(const CacheableFileName& other) = delete;
-  CacheableFileName(const CacheableFileName& other) = delete;
 };
 
 }  // namespace client

--- a/cppcache/include/geode/CacheableKey.hpp
+++ b/cppcache/include/geode/CacheableKey.hpp
@@ -42,7 +42,6 @@ class APACHE_GEODE_EXPORT CacheableKey : public virtual Cacheable {
   CacheableKey() = default;
   ~CacheableKey() override = default;
 
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableKey)
 
  public:
   /** return true if this key matches other. */

--- a/cppcache/include/geode/CacheableObjectArray.hpp
+++ b/cppcache/include/geode/CacheableObjectArray.hpp
@@ -47,6 +47,18 @@ class APACHE_GEODE_EXPORT CacheableObjectArray
     : public internal::DataSerializablePrimitive,
       public std::vector<std::shared_ptr<Cacheable>> {
  public:
+  /** Constructor, used for deserialization. */
+  inline CacheableObjectArray() : std::vector<std::shared_ptr<Cacheable>>() {}
+
+  /** Create a vector with n elements allocated. */
+  inline CacheableObjectArray(int32_t n)
+      : std::vector<std::shared_ptr<Cacheable>>(n) {}
+
+  ~CacheableObjectArray() noexcept override = default;
+
+  CacheableObjectArray& operator=(const CacheableObjectArray& other) = delete;
+  CacheableObjectArray(const CacheableObjectArray& other) = delete;
+
   void toData(DataOutput& output) const override;
 
   virtual void fromData(DataInput& input) override;
@@ -78,20 +90,6 @@ class APACHE_GEODE_EXPORT CacheableObjectArray
   }
 
   virtual size_t objectSize() const override;
-
- protected:
-  /** Constructor, used for deserialization. */
-  inline CacheableObjectArray() : std::vector<std::shared_ptr<Cacheable>>() {}
-  /** Create a vector with n elements allocated. */
-  inline CacheableObjectArray(int32_t n)
-      : std::vector<std::shared_ptr<Cacheable>>(n) {}
-
- private:
-  // never implemented.
-  CacheableObjectArray& operator=(const CacheableObjectArray& other) = delete;
-  CacheableObjectArray(const CacheableObjectArray& other) = delete;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableObjectArray)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/CacheableUndefined.hpp
+++ b/cppcache/include/geode/CacheableUndefined.hpp
@@ -41,6 +41,11 @@ class Serializable;
 class APACHE_GEODE_EXPORT CacheableUndefined
    : public internal::DataSerializableFixedId_t<internal::DSFid::CacheableUndefined> {
  public:
+  inline CacheableUndefined() = default;
+  virtual ~CacheableUndefined() noexcept override = default;
+  CacheableUndefined& operator=(const CacheableUndefined& other) = delete;
+  CacheableUndefined(const CacheableUndefined& other) = delete;
+
   void toData(DataOutput&) const override;
 
   void fromData(DataInput&) override;
@@ -58,17 +63,6 @@ class APACHE_GEODE_EXPORT CacheableUndefined
   inline static std::shared_ptr<CacheableUndefined> create() {
     return std::make_shared<CacheableUndefined>();
   }
-
- protected:
-  /** Constructor, used for deserialization. */
-  inline CacheableUndefined() = default;
-
- private:
-  // never implemented.
-  CacheableUndefined& operator=(const CacheableUndefined& other) = delete;
-  CacheableUndefined(const CacheableUndefined& other) = delete;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(CacheableUndefined)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/CqAttributes.hpp
+++ b/cppcache/include/geode/CqAttributes.hpp
@@ -42,6 +42,8 @@ namespace client {
  */
 class APACHE_GEODE_EXPORT CqAttributes {
  public:
+  virtual ~CqAttributes() noexcept = default;
+
   /**
    * CqListeners type
    */

--- a/cppcache/include/geode/CqListener.hpp
+++ b/cppcache/include/geode/CqListener.hpp
@@ -23,14 +23,12 @@
 #include "internal/geode_globals.hpp"
 #include "CqEvent.hpp"
 
-/**
- * @file
- */
-
 namespace apache {
 namespace geode {
 namespace client {
+
 class CacheListener;
+
 /**
  * @class CqListener CqListener.hpp
  *
@@ -41,6 +39,10 @@ class CacheListener;
  */
 class APACHE_GEODE_EXPORT CqListener {
  public:
+  virtual ~CqListener() noexcept = default;
+  CqListener(const CacheListener& other) = delete;
+  void operator=(const CqListener& other) = delete;
+
   /**
    * This method is invoked when an event is occurred on the region
    * that satisfied the query condition of this CQ.
@@ -83,10 +85,6 @@ class APACHE_GEODE_EXPORT CqListener {
    */
   CqListener();
 
- private:
-  // never implemented.
-  CqListener(const CacheListener& other);
-  void operator=(const CqListener& other);
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -486,8 +486,8 @@ class APACHE_GEODE_EXPORT DataInput {
 
   virtual Cache* getCache() const;
 
-  ~DataInput() = default;
   DataInput() = delete;
+  virtual ~DataInput() noexcept = default;
   DataInput(const DataInput&) = delete;
   DataInput& operator=(const DataInput&) = delete;
   DataInput(DataInput&&) = default;

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -492,15 +492,16 @@ class APACHE_GEODE_EXPORT DataOutput {
 
   virtual Cache* getCache() const;
 
+  DataOutput() = delete;
+
   /** Destruct a DataOutput, including releasing the created buffer. */
-  ~DataOutput() {
+  virtual ~DataOutput() noexcept {
     reset();
     if (m_bytes) {
       DataOutput::checkinBuffer(m_bytes.release(), m_size);
     }
   }
 
-  DataOutput() = delete;
   DataOutput(const DataOutput&) = delete;
   DataOutput& operator=(const DataOutput&) = delete;
   DataOutput(DataOutput&&) = default;

--- a/cppcache/include/geode/PdxWrapper.hpp
+++ b/cppcache/include/geode/PdxWrapper.hpp
@@ -82,7 +82,6 @@ class APACHE_GEODE_EXPORT PdxWrapper : public PdxSerializable {
  private:
   PdxWrapper() = delete;
 
-  _GEODE_FRIEND_STD_SHARED_PTR(PdxWrapper)
 
   std::shared_ptr<void> m_userObject;
   std::string m_className;

--- a/cppcache/include/geode/PoolFactory.hpp
+++ b/cppcache/include/geode/PoolFactory.hpp
@@ -548,8 +548,6 @@ class APACHE_GEODE_EXPORT PoolFactory {
   friend class PoolManagerImpl;
   friend class CacheFactory;
   friend class CacheXmlCreation;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(PoolFactory)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/Properties.hpp
+++ b/cppcache/include/geode/Properties.hpp
@@ -58,6 +58,11 @@ class APACHE_GEODE_EXPORT Properties
     virtual ~Visitor() {}
   };
 
+  Properties() = default;
+  ~Properties() noexcept override = default;
+  Properties(const Properties&) = delete;
+  Properties& operator=(const Properties&) = delete;
+
   /**
    * Return the value for the given key, or nullptr if not found.
    *
@@ -146,16 +151,9 @@ class APACHE_GEODE_EXPORT Properties
 
   DSCode getDsCode() const override;
 
-  ~Properties() override = default;
-  Properties(const Properties&) = delete;
-  Properties& operator=(const Properties&) = delete;
 
  private:
   HashMapOfCacheable m_map;
-
-  Properties() = default;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(Properties)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/Query.hpp
+++ b/cppcache/include/geode/Query.hpp
@@ -48,6 +48,8 @@ namespace client {
  */
 class APACHE_GEODE_EXPORT Query {
  public:
+  virtual ~Query() noexcept = default;
+
   /**
    * Executes the OQL Query on the cache server and returns the results.
    *

--- a/cppcache/include/geode/Region.hpp
+++ b/cppcache/include/geode/Region.hpp
@@ -1482,8 +1482,6 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
   virtual ~Region();
 
   CacheImpl* m_cacheImpl;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(Region)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/RegionAttributes.hpp
+++ b/cppcache/include/geode/RegionAttributes.hpp
@@ -391,7 +391,6 @@ class APACHE_GEODE_EXPORT RegionAttributes
   friend class RegionXmlCreation;
 
  private:
-  _GEODE_FRIEND_STD_SHARED_PTR(RegionAttributes)
 };
 
 }  // namespace client

--- a/cppcache/include/geode/RegionEntry.hpp
+++ b/cppcache/include/geode/RegionEntry.hpp
@@ -34,6 +34,7 @@ namespace client {
 
 class RegionInternal;
 class Region;
+
 /**
  * @class RegionEntry RegionEntry.hpp
  * An object in a Region that represents an entry, i.e., a key-value pair.
@@ -49,6 +50,15 @@ class Region;
  */
 class APACHE_GEODE_EXPORT RegionEntry {
  public:
+  /**
+   * @brief constructors
+   * created by region
+   */
+  RegionEntry(const std::shared_ptr<Region>& region,
+              const std::shared_ptr<CacheableKey>& key,
+              const std::shared_ptr<Cacheable>& value);
+  virtual ~RegionEntry() noexcept;
+
   /** Returns the key for this entry.
    *
    * @return the key for this entry
@@ -85,27 +95,13 @@ class APACHE_GEODE_EXPORT RegionEntry {
    */
   bool isDestroyed() const;
 
-  /**
-   * @brief destructor
-   */
-  virtual ~RegionEntry();
-
  private:
-  /**
-    * @brief constructors
-    * created by region
-    */
-  RegionEntry(const std::shared_ptr<Region>& region,
-              const std::shared_ptr<CacheableKey>& key,
-              const std::shared_ptr<Cacheable>& value);
   std::shared_ptr<Region> m_region;
   std::shared_ptr<CacheableKey> m_key;
   std::shared_ptr<Cacheable> m_value;
   std::shared_ptr<CacheStatistics> m_statistics;
   bool m_destroyed;
   friend class RegionInternal;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(RegionEntry)
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/Struct.hpp
+++ b/cppcache/include/geode/Struct.hpp
@@ -57,6 +57,8 @@ class APACHE_GEODE_EXPORT Struct
   Struct(StructSet* ssPtr,
          std::vector<std::shared_ptr<Serializable>>& fieldValues);
 
+  Struct() = default;
+
   ~Struct() noexcept override = default;
 
   /**
@@ -120,7 +122,6 @@ class APACHE_GEODE_EXPORT Struct
   }
 
  private:
-  Struct() = default;
 
   void skipClassName(DataInput& input);
 
@@ -129,8 +130,6 @@ class APACHE_GEODE_EXPORT Struct
   StructSet* m_parent = nullptr;
   std::vector<std::shared_ptr<Serializable>> m_fieldValues;
   FieldNameToIndexMap m_fieldNameToIndex;
-
-  _GEODE_FRIEND_STD_SHARED_PTR(Struct)
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/TransactionId.hpp
+++ b/cppcache/include/geode/TransactionId.hpp
@@ -37,8 +37,6 @@ class APACHE_GEODE_EXPORT TransactionId {
  public:
   TransactionId();
   virtual ~TransactionId();
-
-  _GEODE_FRIEND_STD_SHARED_PTR(TransactionId)
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/internal/geode_base.hpp
+++ b/cppcache/include/geode/internal/geode_base.hpp
@@ -67,36 +67,6 @@
     x = nullptr;                    \
   }
 
-// TODO shared_ptr - Consider making con/destructors public.
-/*
- * Allows std::shared_ptr to access protected constructors and destructors.
- */
-#if defined(__clang__)
-#if defined(__apple_build_version__) && __apple_build_version__ >= 9020039
-#define _GEODE_FRIEND_STD_SHARED_PTR(_T) \
-  friend std::__1::__compressed_pair_elem<_T, 1, false>;
-#else
-#define _GEODE_FRIEND_STD_SHARED_PTR(_T)                               \
-  friend std::__libcpp_compressed_pair_imp<std::allocator<_T>, _T, 1>; \
-  friend std::__shared_ptr_emplace<_T, std::allocator<_T> >;           \
-  friend std::default_delete<_T>;
-#endif
-#elif defined(__GNUC__) || defined(__SUNPRO_CC)
-#define _GEODE_FRIEND_STD_SHARED_PTR(_T) friend __gnu_cxx::new_allocator<_T>;
-#elif defined(_MSC_VER)
-#if defined(_MANAGED)
-#define _GEODE_FRIEND_STD_SHARED_PTR(_T) \
-  friend std::_Ref_count_obj<_T>;        \
-  friend std::_Ref_count<_T>;            \
-  friend std::_Ptr_base<_T>;             \
-  friend std::default_delete<_T>;        \
-  friend std::shared_ptr<_T>;
-#else
-#define _GEODE_FRIEND_STD_SHARED_PTR(_T) friend std::_Ref_count_obj<_T>;
-#endif
-#else
-#define _GEODE_FRIEND_STD_SHARED_PTR(_T)
-#endif
 
 #include <chrono>
 #include <string>

--- a/cppcache/integration-test/testThinClientSecurityAuthenticationSetAuthInitialize.cpp
+++ b/cppcache/integration-test/testThinClientSecurityAuthenticationSetAuthInitialize.cpp
@@ -46,9 +46,9 @@ std::string getXmlPath() {
 #define SECURITY_PASSWORD "security-password"
 class UserPasswordAuthInit : public AuthInitialize {
  public:
-  UserPasswordAuthInit() {}
+  UserPasswordAuthInit() = default;
 
-  ~UserPasswordAuthInit() {}
+  ~UserPasswordAuthInit() noexcept override = default;
 
   std::shared_ptr<Properties> getCredentials(
       const std::shared_ptr<Properties>& securityprops,

--- a/cppcache/integration-test/testThinClientSecurityCQAuthorizationMU.cpp
+++ b/cppcache/integration-test/testThinClientSecurityCQAuthorizationMU.cpp
@@ -94,6 +94,7 @@ class MyCqListener : public CqListener {
         m_numUpdates(0),
         m_numDeletes(0),
         m_numEvents(0) {}
+  ~MyCqListener() noexcept override = default;
   inline void updateCount(const CqEvent& cqEvent) {
     printf(" in cqEvent.getQueryOperation() %d id = %d\n",
            static_cast<int>(cqEvent.getQueryOperation()), m_id);
@@ -119,15 +120,15 @@ class MyCqListener : public CqListener {
            m_numUpdates, m_numDeletes);
   }
 
-  void onEvent(const CqEvent& cqe) {
+  void onEvent(const CqEvent& cqe) override {
     LOG("MyCqListener::OnEvent called");
     updateCount(cqe);
   }
-  void onError(const CqEvent& cqe) {
+  void onError(const CqEvent& cqe) override {
     updateCount(cqe);
     LOG("MyCqListener::OnError called");
   }
-  void close() { LOG("MyCqListener::close called"); }
+  void close() override { LOG("MyCqListener::close called"); }
 };
 
 std::string getXmlPath() {

--- a/cppcache/integration-test/testThinClientSecurityDurableCQAuthorizationMU.cpp
+++ b/cppcache/integration-test/testThinClientSecurityDurableCQAuthorizationMU.cpp
@@ -94,6 +94,7 @@ class MyCqListener : public CqListener {
         m_numUpdates(0),
         m_numDeletes(0),
         m_numEvents(0) {}
+  ~MyCqListener() noexcept override = default;
   inline void updateCount(const CqEvent& cqEvent) {
     printf(" in cqEvent.getQueryOperation() %d id = %d\n",
            static_cast<int>(cqEvent.getQueryOperation()), m_id);
@@ -119,15 +120,15 @@ class MyCqListener : public CqListener {
            m_numUpdates, m_numDeletes);
   }
 
-  void onEvent(const CqEvent& cqe) {
+  void onEvent(const CqEvent& cqe) override {
     LOG("MyCqListener::OnEvent called");
     updateCount(cqe);
   }
-  void onError(const CqEvent& cqe) {
+  void onError(const CqEvent& cqe) override {
     updateCount(cqe);
     LOG("MyCqListener::OnError called");
   }
-  void close() { LOG("MyCqListener::close called"); }
+  void close() override { LOG("MyCqListener::close called"); }
 };
 
 std::string getXmlPath() {

--- a/cppcache/src/AppDomainContext.hpp
+++ b/cppcache/src/AppDomainContext.hpp
@@ -31,6 +31,8 @@ class AppDomainContext {
   typedef AppDomainContext* (*factory)();
   typedef std::function<void()> runnable;
 
+  virtual ~AppDomainContext() noexcept = default;
+
   virtual void run(runnable func) = 0;
 };
 

--- a/cppcache/src/CacheableEnum.cpp
+++ b/cppcache/src/CacheableEnum.cpp
@@ -27,19 +27,6 @@ namespace apache {
 namespace geode {
 namespace client {
 
-CacheableEnum::CacheableEnum()
-    : m_enumClassName(nullptr),
-      m_enumName(nullptr),
-      m_ordinal(-1),
-      m_hashcode(0) {}
-
-CacheableEnum::CacheableEnum(std::string enumClassName, std::string enumName,
-                             int32_t ordinal)
-    : m_enumClassName(std::move(enumClassName)),
-      m_enumName(std::move(enumName)),
-      m_ordinal(ordinal),
-      m_hashcode(0) {}
-
 void CacheableEnum::toData(apache::geode::client::DataOutput& output) const {
   int enumVal = PdxHelper::getEnumValue(
       m_enumClassName.c_str(), m_enumName.c_str(), m_ordinal,

--- a/cppcache/src/CqAttributesImpl.hpp
+++ b/cppcache/src/CqAttributesImpl.hpp
@@ -49,6 +49,8 @@ namespace client {
  */
 class APACHE_GEODE_EXPORT CqAttributesImpl : public CqAttributes {
  public:
+  ~CqAttributesImpl() noexcept override = default;
+
   listener_container_type getCqListeners() override;
 
   /**

--- a/cppcache/src/CqAttributesImpl.hpp
+++ b/cppcache/src/CqAttributesImpl.hpp
@@ -49,7 +49,7 @@ namespace client {
  */
 class APACHE_GEODE_EXPORT CqAttributesImpl : public CqAttributes {
  public:
-  ~CqAttributesImpl() noexcept override = default;
+  ~CqAttributesImpl() noexcept override {}
 
   listener_container_type getCqListeners() override;
 

--- a/cppcache/src/ExecutionImpl.hpp
+++ b/cppcache/src/ExecutionImpl.hpp
@@ -58,6 +58,7 @@ class ExecutionImpl {
         m_allServer(allServer),
         m_pool(pool),
         m_authenticatedView(authenticatedView) {}
+  virtual ~ExecutionImpl() noexcept = default;
   virtual Execution withFilter(std::shared_ptr<CacheableVector> routingObj);
   virtual Execution withArgs(std::shared_ptr<Cacheable> args);
   virtual Execution withCollector(std::shared_ptr<ResultCollector> rs);

--- a/cppcache/src/RegionEntry.cpp
+++ b/cppcache/src/RegionEntry.cpp
@@ -30,7 +30,7 @@ RegionEntry::RegionEntry(const std::shared_ptr<Region>& region,
                          const std::shared_ptr<Cacheable>& value)
     : m_region(region), m_key(key), m_value(value), m_destroyed(false) {}
 
-RegionEntry::~RegionEntry() {}
+RegionEntry::~RegionEntry() noexcept {}
 std::shared_ptr<CacheableKey> RegionEntry::getKey() { return m_key; }
 std::shared_ptr<Cacheable> RegionEntry::getValue() {
   return CacheableToken::isInvalid(m_value) ? nullptr : m_value;

--- a/cppcache/src/RemoteQuery.hpp
+++ b/cppcache/src/RemoteQuery.hpp
@@ -54,6 +54,8 @@ class APACHE_GEODE_EXPORT RemoteQuery : public Query {
               ThinClientBaseDM* tccdmptr,
               AuthenticatedView* authenticatedView = nullptr);
 
+  ~RemoteQuery() noexcept override = default;
+
   std::shared_ptr<SelectResults> execute(
       std::chrono::milliseconds timeout =
           DEFAULT_QUERY_RESPONSE_TIMEOUT) override;

--- a/cppcache/test/CacheableStringTests.cpp
+++ b/cppcache/test/CacheableStringTests.cpp
@@ -42,7 +42,7 @@ class TestDataOutput : public DataOutputInternal {
     // NOP
   }
 
-  virtual ~TestDataOutput() {
+  ~TestDataOutput() noexcept override {
     delete m_byteArray;
     m_byteArray = nullptr;
   }

--- a/cppcache/test/DataInputTest.cpp
+++ b/cppcache/test/DataInputTest.cpp
@@ -41,6 +41,7 @@ using namespace apache::geode::client;
 class DataInputUnderTest : public DataInputInternal {
  public:
   using DataInputInternal::DataInputInternal;
+  ~DataInputUnderTest() noexcept override {}
 
   virtual const SerializationRegistry &getSerializationRegistry()
       const override {
@@ -159,9 +160,7 @@ class TestDataInput {
 
 class DataInputTest : public ::testing::Test, protected ByteArrayFixture {
  public:
-  virtual ~DataInputTest() {
-    // NOP
-  }
+  ~DataInputTest() noexcept override {} 
 };
 
 TEST_F(DataInputTest, ThrowsWhenReadingInputWithSizeZero) {

--- a/cppcache/test/DataOutputTest.cpp
+++ b/cppcache/test/DataOutputTest.cpp
@@ -43,7 +43,7 @@ class TestDataOutput : public DataOutputInternal {
     // NOP
   }
 
-  virtual ~TestDataOutput() {
+  ~TestDataOutput() noexcept override {
     delete m_byteArray;
     m_byteArray = nullptr;
   }

--- a/cppcache/test/TcrMessage_unittest.cpp
+++ b/cppcache/test/TcrMessage_unittest.cpp
@@ -32,6 +32,7 @@ class DataOutputUnderTest : public DataOutput {
  public:
   using DataOutput::DataOutput;
   DataOutputUnderTest() : DataOutput(nullptr, nullptr) {}
+  ~DataOutputUnderTest() noexcept override {}
 
  protected:
   virtual const SerializationRegistry &getSerializationRegistry()

--- a/templates/security/PkcsAuthInit.hpp
+++ b/templates/security/PkcsAuthInit.hpp
@@ -66,19 +66,9 @@ namespace client {
  */
 
 class PKCSAuthInit : public AuthInitialize {
-  /**
-   * @brief public methods
-   */
  public:
-  /**
-   * @brief constructor
-   */
-  PKCSAuthInit() {}
-
-  /**
-   * @brief destructor
-   */
-  ~PKCSAuthInit() {}
+  PKCSAuthInit() = default;
+  ~PKCSAuthInit() noexcept override = default;
 
   /**@brief initialize with the given set of security properties
    * and return the credentials for the client as properties.

--- a/templates/security/UserPasswordAuthInit.hpp
+++ b/templates/security/UserPasswordAuthInit.hpp
@@ -45,19 +45,9 @@ namespace client {
  * <code>createUserPasswordAuthInitInstance</code>.
  */
 class UserPasswordAuthInit : public AuthInitialize {
-  /**
-   * @brief public methods
-   */
  public:
-  /**
-   * @brief constructor
-   */
-  UserPasswordAuthInit() {}
-
-  /**
-   * @brief destructor
-   */
-  ~UserPasswordAuthInit() {}
+  UserPasswordAuthInit() = default;
+  ~UserPasswordAuthInit() noexcept override = default;
 
   /**@brief initialize with the given set of security properties
    * and return the credentials for the client as properties.

--- a/tests/cpp/security/PkcsAuthInit.hpp
+++ b/tests/cpp/security/PkcsAuthInit.hpp
@@ -67,20 +67,10 @@ namespace client {
  */
 
 class PKCSAuthInitInternal : public AuthInitialize {
-  /**
-   * @brief public methods
-   */
  public:
-  /**
-   * @brief constructor
-   */
   PKCSAuthInitInternal(bool makeString = false)
       : m_stringCredentials(makeString) {}
-
-  /**
-   * @brief destructor
-   */
-  ~PKCSAuthInitInternal() {}
+  ~PKCSAuthInitInternal() noexcept override = default;
 
   /**@brief initialize with the given set of security properties
    * and return the credentials for the client as properties.

--- a/tests/cpp/testobject/NoopAuthInit.hpp
+++ b/tests/cpp/testobject/NoopAuthInit.hpp
@@ -44,19 +44,9 @@ namespace client {
  * <code>createNoopAuthInitInstance</code>.
  */
 class NoopAuthInit : public AuthInitialize {
-  /**
-   * @brief public methods
-   */
  public:
-  /**
-   * @brief constructor
-   */
-  NoopAuthInit() {}
-
-  /**
-   * @brief destructor
-   */
-  ~NoopAuthInit() {}
+  NoopAuthInit() = default;
+  ~NoopAuthInit() noexcept override = default;
 
   /**@brief initialize with the given set of security properties
    * and return the credentials for the client as properties.


### PR DESCRIPTION
* Make all shared_ptr bound classes have public constructors.
* Correct missing virtual destructors.
* Correct deleted functions.
* Other minor CLang 6.0 fixes.