### PR TITLE
GEODE-5713: fix valgrind uninitialized value

### DIFF
--- a/cppcache/src/statistics/StatArchiveWriter.cpp
+++ b/cppcache/src/statistics/StatArchiveWriter.cpp
@@ -170,9 +170,9 @@ ResourceInst::ResourceInst(int32_t idArg, Statistics *resourceArg,
                            const ResourceType *typeArg,
                            StatDataOutput *dataOutArg)
     : type(typeArg) {
-  this->id = idArg;
-  this->resource = resourceArg;
-  this->dataOut = dataOutArg;
+  id = idArg;
+  resource = resourceArg;
+  dataOut = dataOutArg;
   int32_t cnt = type->getNumOfDescriptors();
   archivedStatValues = new int64_t[cnt];
   // initialize to zero
@@ -198,31 +198,32 @@ int64_t ResourceInst::getStatValue(StatisticDescriptor *f) {
 void ResourceInst::writeSample() {
   bool wroteInstId = false;
   bool checkForChange = true;
-  StatisticDescriptor **stats = this->type->getStats();
+  StatisticDescriptor **stats = type->getStats();
   GF_D_ASSERT(stats != nullptr);
   GF_D_ASSERT(*stats != nullptr);
-  if (this->resource->isClosed()) {
+  if (resource->isClosed()) {
     return;
   }
   if (firstTime) {
     firstTime = false;
     checkForChange = false;
   }
-  for (int32_t i = 0; i < numOfDescps; i++) {
+  auto count = type->getNumOfDescriptors();
+  for (int32_t i = 0; i < count; i++) {
     int64_t value = getStatValue(stats[i]);
     if (!checkForChange || value != archivedStatValues[i]) {
       int64_t delta = value - archivedStatValues[i];
       archivedStatValues[i] = value;
       if (!wroteInstId) {
         wroteInstId = true;
-        writeResourceInst(this->dataOut, this->id);
+        writeResourceInst(dataOut, id);
       }
-      this->dataOut->writeByte(i);
+      dataOut->writeByte(i);
       writeStatValue(stats[i], delta);
     }
   }
   if (wroteInstId) {
-    this->dataOut->writeByte(static_cast<unsigned char>(ILLEGAL_STAT_OFFSET));
+    dataOut->writeByte(static_cast<unsigned char>(ILLEGAL_STAT_OFFSET));
   }
 }
 

--- a/cppcache/src/statistics/StatArchiveWriter.cpp
+++ b/cppcache/src/statistics/StatArchiveWriter.cpp
@@ -179,7 +179,6 @@ ResourceInst::ResourceInst(int32_t idArg, Statistics *resourceArg,
   for (int32_t i = 0; i < cnt; i++) {
     archivedStatValues[i] = 0;
   }
-  numOfDescps = cnt;
   firstTime = true;
 }
 

--- a/cppcache/src/statistics/StatArchiveWriter.hpp
+++ b/cppcache/src/statistics/StatArchiveWriter.hpp
@@ -192,8 +192,6 @@ class APACHE_GEODE_EXPORT ResourceInst : private NonCopyable,
   /* This will contain the previous values of the descriptors */
   int64_t *archivedStatValues;
   StatDataOutput *dataOut;
-  /* Number of descriptors this resource instance has */
-  int32_t numOfDescps;
   /* To know whether the instance has come for the first time */
   bool firstTime;
 };

--- a/cppcache/src/statistics/StatArchiveWriter.hpp
+++ b/cppcache/src/statistics/StatArchiveWriter.hpp
@@ -192,7 +192,7 @@ class APACHE_GEODE_EXPORT ResourceInst : private NonCopyable,
   /* This will contain the previous values of the descriptors */
   int64_t *archivedStatValues;
   StatDataOutput *dataOut;
-  /* Number of descriptors this resource instnace has */
+  /* Number of descriptors this resource instance has */
   int32_t numOfDescps;
   /* To know whether the instance has come for the first time */
   bool firstTime;


### PR DESCRIPTION
When the simple example code listed in GEODE-5713 was run under Valgrind on Linux, it generated a complaint about use of an uninitialized variable in a loop in the statistics code.  This _appears_ to have been a red herring, since as far as we can tell the value in question was definitely initialized, but... cleaning things up a bit without changing semantics seems to get rid of the error message.

- replaced use of member var `numOfDescps` with a local var initialized from the contained type object
- removed (no longer used) member var `numOfDescps`
- removed gratuitous use of `this` pointer
