### PR TITLE
GEODE-5750: correct optype enum value

### DIFF
--- a/clicache/integration-test2/CMakeLists.txt
+++ b/clicache/integration-test2/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library( ${PROJECT_NAME} SHARED
     GeodeServerTests.cs
     CacheXml.cs
     CacheXmlTests.cs
+    CqOperationTest.cs
     RegionTest.cs
     RegionSSLTest.cs
     cache.xml

--- a/clicache/integration-test2/CqOperationTest.cs
+++ b/clicache/integration-test2/CqOperationTest.cs
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace Apache.Geode.Client.IntegrationTests
+{
+    public class MyCqListener<TKey, TResult> : ICqListener<TKey, TResult>
+    {
+        public virtual void OnEvent(CqEvent<TKey, TResult> ev)
+        {
+            Order val = ev.getNewValue() as Order;
+            TKey key = ev.getKey();
+            string operationType = "UNKNOWN";
+
+            switch (ev.getQueryOperation())
+            {
+                case CqOperation.OP_TYPE_CREATE:
+                    operationType = "CREATE";
+                    break;
+                case CqOperation.OP_TYPE_UPDATE:
+                    operationType = "UPDATE";
+                    break;
+                case CqOperation.OP_TYPE_DESTROY:
+                    operationType = "DESTROY";
+                    break;
+                default:
+                    Console.WriteLine("Unexpected operation encountered {0}", ev.getQueryOperation());
+                    break;
+            }
+
+            if (val != null)
+            {
+                Console.WriteLine("MyCqListener::OnEvent({0}) called with key {1}, value {2}", operationType, key, val.ToString());
+            }
+            else
+            {
+                Console.WriteLine("MyCqListener::OnEvent({0}) called with key {1}, value null", operationType, key);
+            }
+        }
+
+        public virtual void OnError(CqEvent<TKey, TResult> ev)
+        {
+            Console.WriteLine("MyCqListener::OnError called");
+        }
+
+        public virtual void Close()
+        {
+            Console.WriteLine("MyCqListener::close called");
+        }
+    }
+
+    [Trait("Category", "Integration")]
+    public class CqOperationTest : IDisposable
+    {
+        private readonly Cache _cacheOne;
+        private readonly GeodeServer _geodeServer;
+
+        public CqOperationTest()
+        {
+            var cacheFactory = new CacheFactory();
+
+            _cacheOne = cacheFactory.Create();
+            _geodeServer = new GeodeServer();
+        }
+
+        public void Dispose()
+        {
+            _cacheOne.Close();
+            _geodeServer.Dispose();
+        }
+
+        [Fact]
+        public void NotificationsHaveCorrectValues()
+        {
+            Assert.True(false);
+        }
+    }
+}

--- a/clicache/src/CqOperation.hpp
+++ b/clicache/src/CqOperation.hpp
@@ -27,6 +27,9 @@ namespace Apache
     {
       /// <summary>
       /// Enumerated type for CqOperation
+      /// NOTE: These values *must* match those of 
+      /// apache::geode::client::CqOperation.  If you change one, make sure to
+      /// keep things in sync!
       /// </summary>
       public enum class CqOperation
       {

--- a/clicache/src/CqOperation.hpp
+++ b/clicache/src/CqOperation.hpp
@@ -31,7 +31,7 @@ namespace Apache
       public enum class CqOperation
       {
         OP_TYPE_INVALID = -1,
-        OP_TYPE_CREATE = 0,
+        OP_TYPE_CREATE = 1,
         OP_TYPE_UPDATE = 2,
         OP_TYPE_INVALIDATE = 4,
         OP_TYPE_REGION_CLEAR = 8,

--- a/cppcache/include/geode/CqOperation.hpp
+++ b/cppcache/include/geode/CqOperation.hpp
@@ -32,6 +32,8 @@ namespace client {
 
 /**
  * Enumerated type for Operation actions.
+ * NOTE: These values *must* match those of apache::geode::client::CqOperation.
+ * if you change one, make sure to keep things in sync!
  */
 enum class CqOperation {
   OP_TYPE_INVALID = -1,

--- a/cppcache/src/TcrChunkedContext.hpp
+++ b/cppcache/src/TcrChunkedContext.hpp
@@ -1,8 +1,3 @@
-#pragma once
-
-#ifndef GEODE_TCRCHUNKEDCONTEXT_H_
-#define GEODE_TCRCHUNKEDCONTEXT_H_
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,16 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * @file TcrChunkedContext.hpp
- *
- *
- */
+
+#pragma once
+
+#ifndef GEODE_TCRCHUNKEDCONTEXT_H_
+#define GEODE_TCRCHUNKEDCONTEXT_H_
 
 #include <memory>
+#include <string>
 
 #include <ace/Semaphore.h>
-#include <string>
+
 #include "Utils.hpp"
 #include "AppDomainContext.hpp"
 


### PR DESCRIPTION
This was causing C# notification to send 1 on a CREATE event, which didn't correspond to a legal value in the CLI enum.