### PR TITLE
GEODE-5634: upgrade xunit version and add testadapter

### DIFF
--- a/clicache/integration-test2/CMakeLists.txt
+++ b/clicache/integration-test2/CMakeLists.txt
@@ -67,10 +67,11 @@ set_target_properties( ${PROJECT_NAME} PROPERTIES
   VS_DOTNET_REFERENCES "System;System.Xml;System.Web;System.Configuration"
   VS_DOTNET_REFERENCE_Microsoft.VisualStudio.TestPlatform.TestFramework "${CMAKE_BINARY_DIR}/clicache/packages/Microsoft.VisualStudio.TestPlatform.14.0.0.1/lib/net20/Microsoft.VisualStudio.TestPlatform.TestFramework.dll"
   VS_DOTNET_REFERENCE_Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions "${CMAKE_BINARY_DIR}/clicache/packages/Microsoft.VisualStudio.TestPlatform.14.0.0.1/lib/net20/Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll"
-  VS_DOTNET_REFERENCE_xunit.core "${CMAKE_BINARY_DIR}/clicache/packages/xunit.extensibility.core.2.3.1/lib/netstandard1.1/xunit.core.dll"
-  VS_DOTNET_REFERENCE_xunit.assert "${CMAKE_BINARY_DIR}/clicache/packages/xunit.assert.2.3.1/lib/netstandard1.1/xunit.assert.dll"
-  VS_DOTNET_REFERENCE_xunit.abstractions "${CMAKE_BINARY_DIR}/clicache/packages/xunit.abstractions.2.0.1/lib/net35/xunit.abstractions.dll"
-  VS_DOTNET_REFERENCE_xunit.execution.desktop "${CMAKE_BINARY_DIR}/clicache/packages/xunit.extensibility.execution.2.3.1/lib/net452/xunit.execution.desktop.dll"
+  VS_DOTNET_REFERENCE_xunit.core "${CMAKE_BINARY_DIR}/clicache/packages/xunit.extensibility.core.2.4.0/lib/netstandard1.1/xunit.core.dll"
+  VS_DOTNET_REFERENCE_xunit.assert "${CMAKE_BINARY_DIR}/clicache/packages/xunit.assert.2.4.0/lib/netstandard1.1/xunit.assert.dll"
+  VS_DOTNET_REFERENCE_xunit.abstractions "${CMAKE_BINARY_DIR}/clicache/packages/xunit.abstractions.2.0.2/lib/net35/xunit.abstractions.dll"
+  VS_DOTNET_REFERENCE_xunit.execution.desktop "${CMAKE_BINARY_DIR}/clicache/packages/xunit.extensibility.execution.2.4.0/lib/net452/xunit.execution.desktop.dll"
+  VS_DOTNET_REFERENCE_xunit.runner.visualstudio.testadapter "${CMAKE_BINARY_DIR}/clicache/packages/xunit.runner.visualstudio.2.4.0/build/_common/xunit.runner.visualstudio.testadapter.dll"
 )
 
 if(NOT "${STRONG_NAME_KEY}" STREQUAL "")

--- a/clicache/integration-test2/packages.config
+++ b/clicache/integration-test2/packages.config
@@ -17,13 +17,13 @@
 -->
 <packages>
   <package id="Microsoft.VisualStudio.TestPlatform" version="14.0.0.1" targetFramework="net452" />
-  <package id="xunit" version="2.3.1" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.1" targetFramework="net35" />
-  <package id="xunit.analyzers" version="0.8.0" targetFramework="net452" />
-  <package id="xunit.assert" version="2.3.1" targetFramework="net452" />
-  <package id="xunit.core" version="2.3.1" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net452" />
-  <package id="xunit.runner.console" version="2.3.1" targetFramework="net452" developmentDependency="true" />
-  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net452" developmentDependency="true" />
+  <package id="xunit" version="2.4.0" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.2" targetFramework="net35" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net452" />
+  <package id="xunit.assert" version="2.4.0" targetFramework="net452" />
+  <package id="xunit.core" version="2.4.0" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net452" />
+  <package id="xunit.runner.console" version="2.4.0" targetFramework="net452" developmentDependency="true" />
+  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/clicache/test2/CMakeLists.txt
+++ b/clicache/test2/CMakeLists.txt
@@ -46,10 +46,11 @@ set_target_properties( ${PROJECT_NAME} PROPERTIES
   VS_DOTNET_REFERENCES "System;System.Xml;System.Web;System.Configuration"
   VS_DOTNET_REFERENCE_Microsoft.VisualStudio.TestPlatform.TestFramework "${CMAKE_BINARY_DIR}/clicache/packages/Microsoft.VisualStudio.TestPlatform.14.0.0.1/lib/net20/Microsoft.VisualStudio.TestPlatform.TestFramework.dll"
   VS_DOTNET_REFERENCE_Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions "${CMAKE_BINARY_DIR}/clicache/packages/Microsoft.VisualStudio.TestPlatform.14.0.0.1/lib/net20/Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll"
-  VS_DOTNET_REFERENCE_xunit.core "${CMAKE_BINARY_DIR}/clicache/packages/xunit.extensibility.core.2.3.1/lib/netstandard1.1/xunit.core.dll"
-  VS_DOTNET_REFERENCE_xunit.assert "${CMAKE_BINARY_DIR}/clicache/packages/xunit.assert.2.3.1/lib/netstandard1.1/xunit.assert.dll"
-  VS_DOTNET_REFERENCE_xunit.abstractions "${CMAKE_BINARY_DIR}/clicache/packages/xunit.abstractions.2.0.1/lib/net35/xunit.abstractions.dll"
-  VS_DOTNET_REFERENCE_xunit.execution.desktop "${CMAKE_BINARY_DIR}/clicache/packages/xunit.extensibility.execution.2.3.1/lib/net452/xunit.execution.desktop.dll"
+  VS_DOTNET_REFERENCE_xunit.core "${CMAKE_BINARY_DIR}/clicache/packages/xunit.extensibility.core.2.4.0/lib/netstandard1.1/xunit.core.dll"
+  VS_DOTNET_REFERENCE_xunit.assert "${CMAKE_BINARY_DIR}/clicache/packages/xunit.assert.2.4.0/lib/netstandard1.1/xunit.assert.dll"
+  VS_DOTNET_REFERENCE_xunit.abstractions "${CMAKE_BINARY_DIR}/clicache/packages/xunit.abstractions.2.0.2/lib/net35/xunit.abstractions.dll"
+  VS_DOTNET_REFERENCE_xunit.execution.desktop "${CMAKE_BINARY_DIR}/clicache/packages/xunit.extensibility.execution.2.4.0/lib/net452/xunit.execution.desktop.dll"
+  VS_DOTNET_REFERENCE_xunit.runner.visualstudio.testadapter "${CMAKE_BINARY_DIR}/clicache/packages/xunit.runner.visualstudio.2.4.0/build/_common/xunit.runner.visualstudio.testadapter.dll"
 )
 
 if(NOT "${STRONG_NAME_KEY}" STREQUAL "")

--- a/clicache/test2/packages.config
+++ b/clicache/test2/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.VisualStudio.TestPlatform" version="14.0.0.1" targetFramework="net452" />
-  <package id="xunit" version="2.3.1" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.1" targetFramework="net35" />
-  <package id="xunit.analyzers" version="0.8.0" targetFramework="net452" />
-  <package id="xunit.assert" version="2.3.1" targetFramework="net452" />
-  <package id="xunit.core" version="2.3.1" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net452" />
-  <package id="xunit.runner.console" version="2.3.1" targetFramework="net452" developmentDependency="true" />
-  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net452" developmentDependency="true" />
+  <package id="xunit" version="2.4.0" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.2" targetFramework="net35" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net452" />
+  <package id="xunit.assert" version="2.4.0" targetFramework="net452" />
+  <package id="xunit.core" version="2.4.0" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net452" />
+  <package id="xunit.runner.console" version="2.4.0" targetFramework="net452" developmentDependency="true" />
+  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net452" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
- upgraded xunit from 2.3.1 to 2.4.0
- added new cmake reference to xunit.runner.visualstudio.testadapter

Co-authored-by: Mike Martell <mmartell@pivotal.io>