### PR TITLE
GEODE-5259: Fix clang (xcode 10) build breaks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -92,10 +92,6 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-RawStringFormats: 
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
 ReflowComments:  true
 #SortIncludes:    true
 SortIncludes:    false

--- a/cppcache/integration-test/testThinClientCq.cpp
+++ b/cppcache/integration-test/testThinClientCq.cpp
@@ -447,7 +447,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
         std::shared_ptr<CqListener> cqLstner(new MyCqListener1026);
         cqFac.addCqListener(cqLstner);
         auto cqAttr = cqFac.create();
-        auto qry = qs->newCq((char*)"1026_MyCq", qryStr, cqAttr);
+        auto qry = qs->newCq("1026_MyCq", qryStr, cqAttr);
 
         // execute Cq Query with initial Results
         auto resultsPtr = qry->executeWithInitialResults();

--- a/cppcache/src/SerializableHelper.hpp
+++ b/cppcache/src/SerializableHelper.hpp
@@ -93,7 +93,7 @@ inline bool SerializableHelper<PdxSerializable>::equalTo(
 
 template <>
 inline bool SerializableHelper<DataSerializableInternal>::metadataEqualTo(
-    const DataSerializableInternal& lhs, const DataSerializableInternal& rhs) {
+    const DataSerializableInternal&, const DataSerializableInternal&) {
   return true;
 }
 


### PR DESCRIPTION
- Remove problematic clang-format options
- Anonymize unused parameters
- Remove unnecessary type cast