### PR TITLE
Geode-5768: Disable parallel execution of cli integration-test2

### DIFF
--- a/clicache/integration-test2/CMakeLists.txt
+++ b/clicache/integration-test2/CMakeLists.txt
@@ -36,7 +36,9 @@ add_library( ${PROJECT_NAME} SHARED
     CqOperationTest.cs
     RegionTest.cs
     RegionSSLTest.cs
+    Position.cs
     cache.xml
+    server.xml
     geode.properties
     xunit.runner.json
     packages.config
@@ -47,7 +49,7 @@ add_library( ${PROJECT_NAME} SHARED
     ServerSslKeys/server_truststore.jks
 )
 
-set_source_files_properties(cache.xml xunit.runner.json geode.properties ClientSslKeys/client_keystore.password.pem ClientSslKeys/client_truststore.pem ServerSslKeys/server_keystore.jks ServerSslKeys/server_truststore.jks PROPERTIES
+set_source_files_properties(cache.xml server.xml xunit.runner.json geode.properties ClientSslKeys/client_keystore.password.pem ClientSslKeys/client_truststore.pem ServerSslKeys/server_keystore.jks ServerSslKeys/server_truststore.jks PROPERTIES
   VS_COPY_TO_OUT_DIR Always
   VS_TOOL_OVERRIDE "None"
 )

--- a/clicache/integration-test2/CqOperationTest.cs
+++ b/clicache/integration-test2/CqOperationTest.cs
@@ -264,7 +264,7 @@ namespace Apache.Geode.Client.IntegrationTests
         [Fact]
         public void NotificationsHaveCorrectValuesDataSerializable()
         {
-            _cache.TypeRegistry.RegisterType(Position.CreateDeserializable, 2);
+            _cache.TypeRegistry.RegisterType(Position.CreateDeserializable, 22);
   
             var poolFactory = _cache.GetPoolFactory()
             .AddLocator("localhost", _geodeServer.LocatorPort);

--- a/clicache/integration-test2/GeodeServer.cs
+++ b/clicache/integration-test2/GeodeServer.cs
@@ -87,18 +87,21 @@ public class GeodeServer : IDisposable
       {
         StartInfo =
         {
-          FileName = Config.GeodeGfsh,
-          Arguments = " -e \"start locator --bind-address=localhost --port=" + LocatorPort +
-                      " --J=-Dgemfire.jmx-manager-port=" + LocatorJmxPort + " --http-service-port=0" + "\"" +
-                      " -e \"start server --bind-address=localhost --server-port=0\"" +
-                      " -e \"create region --name=" + regionName + " --type=PARTITION\"" +
-                      " -e \"create region --name=testRegion1 --type=PARTITION\"" +
-                      " -e \"create region --name=cqTestRegion --type=REPLICATE\"",
-          WindowStyle = ProcessWindowStyle.Hidden,
-          UseShellExecute = false,
-          RedirectStandardOutput = true,
-          RedirectStandardError = true,
-          CreateNoWindow = true
+
+            FileName = Config.GeodeGfsh,
+            Arguments = " -e \"start locator --name=locator1 --bind-address=localhost --port=" + LocatorPort +
+                        " --J=-Dgemfire.jmx-manager-port=" + LocatorJmxPort + " --http-service-port=0" + "\"" +
+                        " -e \"deploy --jar=..\\..\\..\\tests\\javaobject\\javaobject.jar\"" +
+                        " -e \"start server --name=server1 --bind-address=localhost --cache-xml-file=server.xml --server-port=0\"" +
+                        " -e \"start server --name=server1 --bind-address=localhost --server-port=0\"" +
+                        " -e \"create region --name=" + regionName + " --type=PARTITION\"" +
+                        " -e \"create region --name=testRegion1 --type=PARTITION\"" +
+                        " -e \"create region --name=cqTestRegion --type=REPLICATE\"",
+            WindowStyle = ProcessWindowStyle.Hidden,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
         }
       };
     }

--- a/clicache/integration-test2/GeodeServerTests.cs
+++ b/clicache/integration-test2/GeodeServerTests.cs
@@ -18,7 +18,7 @@
 using Xunit;
 
 [Trait("Category", "Integration")]
-public class GemFireServerTest
+public class GeodeServerTest
 {
     [Fact]
     public void Start()

--- a/clicache/integration-test2/Position.cs
+++ b/clicache/integration-test2/Position.cs
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace Apache.Geode.Client.IntegrationTests
+{
+  using Apache.Geode.Client;
+  public class Position
+    : IDataSerializable
+  {
+    #region Private members
+
+    private long m_avg20DaysVol;
+    private string m_bondRating;
+    private double m_convRatio;
+    private string m_country;
+    private double m_delta;
+    private long m_industry;
+    private long m_issuer;
+    private double m_mktValue;
+    private double m_qty;
+    private string m_secId;
+    private string m_secLinks;
+    private string m_secType;
+    private int m_sharesOutstanding;
+    private string m_underlyer;
+    private long m_volatility;
+    private int m_pid;
+
+    private static int m_count = 0;
+
+    #endregion
+
+    #region Private methods
+
+    private void Init()
+    {
+      m_avg20DaysVol = 0;
+      m_bondRating = "bondRatingString";
+      m_convRatio = 0.0;
+      m_country = null;
+      m_delta = 0.0;
+      m_industry = 0;
+      m_issuer = 0;
+      m_mktValue = 0.0;
+      m_qty = 0.0;
+      m_secId = null;
+      m_secLinks = null;
+      m_secType = null;
+      m_sharesOutstanding = 0;
+      m_underlyer = null;
+      m_volatility = 0;
+      m_pid = 0;
+    }
+
+    private UInt64 GetObjectSize(ISerializable obj)
+    {
+      return (obj == null ? 0 : obj.ObjectSize);
+    }
+
+    #endregion
+
+    #region Public accessors
+
+    public string SecId
+    {
+      get
+      {
+        return m_secId;
+      }
+    }
+
+    public int Id
+    {
+      get
+      {
+        return m_pid;
+      }
+    }
+
+    public int SharesOutstanding
+    {
+      get
+      {
+        return m_sharesOutstanding;
+      }
+      set
+      {
+        m_sharesOutstanding = value;
+      }
+    }
+
+    public static int Count
+    {
+      get
+      {
+        return m_count;
+      }
+      set
+      {
+        m_count = value;
+      }
+    }
+
+    public override string ToString()
+    {
+      return "Position [secId=" + m_secId + " sharesOutstanding=" + m_sharesOutstanding + " type=" + m_secType + " id=" + m_pid + "]";
+    }
+    #endregion
+
+    #region Constructors
+
+    public Position()
+    {
+      Init();
+    }
+
+    //This ctor is for a data validation test
+    public Position(Int32 iForExactVal)
+    {
+      Init();
+
+      char[] id = new char[iForExactVal + 1];
+      for (int i = 0; i <= iForExactVal; i++)
+      {
+        id[i] = 'a';
+      }
+      m_secId = id.ToString();
+      m_qty = iForExactVal % 2 == 0 ? 1000 : 100;
+      m_mktValue = m_qty * 2;
+      m_sharesOutstanding = iForExactVal;
+      m_secType = "a";
+      m_pid = iForExactVal;
+    }
+
+    public Position(string id, int shares)
+    {
+      Init();
+      m_secId = id;
+      m_qty = shares * (m_count % 2 == 0 ? 10.0 : 100.0);
+      m_mktValue = m_qty * 1.2345998;
+      m_sharesOutstanding = shares;
+      m_secType = "a";
+      m_pid = m_count++;
+    }
+
+    #endregion
+
+    #region IDataSerializable Members
+
+    public void FromData(DataInput input)
+    {
+      m_avg20DaysVol = input.ReadInt64();
+      m_bondRating = input.ReadUTF();
+      m_convRatio = input.ReadDouble();
+      m_country = input.ReadUTF();
+      m_delta = input.ReadDouble();
+      m_industry = input.ReadInt64();
+      m_issuer = input.ReadInt64();
+      m_mktValue = input.ReadDouble();
+      m_qty = input.ReadDouble();
+      m_secId = input.ReadUTF();
+      m_secLinks = input.ReadUTF();
+      m_secType = input.ReadUTF();
+      m_sharesOutstanding = input.ReadInt32();
+      m_underlyer = input.ReadUTF();
+      m_volatility = input.ReadInt64();
+      m_pid = input.ReadInt32();
+    }
+
+    public void ToData(DataOutput output)
+    {
+      output.WriteInt64(m_avg20DaysVol);
+      output.WriteUTF(m_bondRating);
+      output.WriteDouble(m_convRatio);
+      output.WriteUTF(m_country);
+      output.WriteDouble(m_delta);
+      output.WriteInt64(m_industry);
+      output.WriteInt64(m_issuer);
+      output.WriteDouble(m_mktValue);
+      output.WriteDouble(m_qty);
+      output.WriteUTF(m_secId);
+      output.WriteUTF(m_secLinks);
+      output.WriteUTF(m_secType);
+      output.WriteInt32(m_sharesOutstanding);
+      output.WriteUTF(m_underlyer);
+      output.WriteInt64(m_volatility);
+      output.WriteInt32(m_pid);
+      
+    }
+
+    public UInt64 ObjectSize
+    {
+      get
+      {
+        UInt64 objectSize = 0;
+        objectSize += (UInt64)sizeof(long);
+        objectSize += (UInt64) (m_bondRating.Length * sizeof(char));
+        objectSize += (UInt64)sizeof(double);
+        objectSize += (UInt64)(m_country.Length * sizeof(char));
+        objectSize += (UInt64)sizeof(double);
+        objectSize += (UInt64)sizeof(Int64);
+        objectSize += (UInt64)sizeof(Int64);
+        objectSize += (UInt64)sizeof(double);
+        objectSize += (UInt64)sizeof(double);
+        objectSize += (UInt64)(m_secId.Length * sizeof(char));
+        objectSize += (UInt64)(m_secLinks.Length * sizeof(char));
+        objectSize += (UInt64)(m_secType == null ? 0 : sizeof(char) * m_secType.Length);
+        objectSize += (UInt64)sizeof(Int32);
+        objectSize += (UInt64)(m_underlyer.Length * sizeof(char));
+        objectSize += (UInt64)sizeof(Int64);
+        objectSize += (UInt64)sizeof(Int32);
+        return objectSize;
+      }
+    }
+
+    #endregion
+
+    public static ISerializable CreateDeserializable()
+    {
+      return new Position();
+    }
+  }
+}

--- a/clicache/integration-test2/server.xml
+++ b/clicache/integration-test2/server.xml
@@ -19,8 +19,8 @@
 	xmlns="http://geode.apache.org/schema/cache" 
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd" version="1.0">
 	<serialization-registration>
-		<instantiator id="2">
-			<class-name>javaobject.Position</class-name>
+		<instantiator id="22">
+			<class-name>javaobject.cli.Position</class-name>
 		</instantiator>
 	</serialization-registration>
 </cache>

--- a/clicache/integration-test2/server.xml
+++ b/clicache/integration-test2/server.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<cache 
+	xmlns="http://geode.apache.org/schema/cache" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd" version="1.0">
+	<serialization-registration>
+		<instantiator id="2">
+			<class-name>javaobject.Position</class-name>
+		</instantiator>
+	</serialization-registration>
+</cache>

--- a/clicache/integration-test2/xunit.runner.json
+++ b/clicache/integration-test2/xunit.runner.json
@@ -1,4 +1,5 @@
 ﻿{
   "methodDisplay": "classAndMethod",
-  "parallelizeTestCollections": "false"
+  "parallelizeAssembly":  false ,
+  "parallelizeTestCollections": false
 }

--- a/tests/javaobject/CMakeLists.txt
+++ b/tests/javaobject/CMakeLists.txt
@@ -22,6 +22,7 @@ include(UseJava)
 
 file(GLOB_RECURSE SOURCES "*.java")
 
+
 add_jar(javaobject ${SOURCES}
   INCLUDE_JARS ${Geode_CLASSPATH}
 )

--- a/tests/javaobject/Position.java
+++ b/tests/javaobject/Position.java
@@ -113,38 +113,38 @@ public class Position implements Declarable, Serializable, DataSerializable {
   
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.avg20DaysVol = in.readLong();
-    this.bondRating = (String)DataSerializer.readObject(in);
+    this.bondRating = in.readUTF();
     this.convRatio = in.readDouble();
-    this.country = (String)DataSerializer.readObject(in);
+    this.country = in.readUTF();
     this.delta = in.readDouble();
     this.industry = in.readLong();
     this.issuer = in.readLong();
     this.mktValue = in.readDouble();
     this.qty = in.readDouble();
-    this.secId = (String)DataSerializer.readObject(in);
-    this.secLinks = (String)DataSerializer.readObject(in);
+    this.secId = in.readUTF();
+    this.secLinks = in.readUTF();
     this.secType = in.readUTF();
     this.sharesOutstanding = in.readInt();
-    this.underlyer = (String)DataSerializer.readObject(in);
+    this.underlyer = in.readUTF();
     this.volatility = in.readLong();
     this.pid = in.readInt();
   }
   
   public void toData(DataOutput out) throws IOException {
     out.writeLong(this.avg20DaysVol);
-    DataSerializer.writeObject(this.bondRating, out);
+    out.writeUTF(this.bondRating);
     out.writeDouble(this.convRatio);
-    DataSerializer.writeObject(this.country, out);
+    out.writeUTF(this.country);
     out.writeDouble(this.delta);
     out.writeLong(this.industry);
     out.writeLong(this.issuer);
     out.writeDouble(this.mktValue);
     out.writeDouble(this.qty);
-    DataSerializer.writeObject(this.secId, out);
-    DataSerializer.writeObject(this.secLinks, out);
+    out.writeUTF(this.secId);
+    out.writeUTF(this.secLinks);
     out.writeUTF(this.secType);
     out.writeInt(this.sharesOutstanding);
-    DataSerializer.writeObject(this.underlyer, out);
+    out.writeUTF(this.underlyer);
     out.writeLong(this.volatility);
     out.writeInt(this.pid);
   } 

--- a/tests/javaobject/cli/Position.java
+++ b/tests/javaobject/cli/Position.java
@@ -14,8 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//package org.apache.geode.cache.query.data;
-package javaobject;
+package javaobject.cli;
 
 import java.util.*;
 import java.io.*;
@@ -43,7 +42,7 @@ public class Position implements Declarable, Serializable, DataSerializable {
   public static int cnt = 0;
 
   static {
-     Instantiator.register(new Instantiator(Position.class, (byte) 2) {
+     Instantiator.register(new Instantiator(javaobject.cli.Position.class, (byte) 22) {
      public DataSerializable newInstance() {
         return new Position();
      }
@@ -113,38 +112,38 @@ public class Position implements Declarable, Serializable, DataSerializable {
   
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.avg20DaysVol = in.readLong();
-    this.bondRating = (String)DataSerializer.readObject(in);
+    this.bondRating = in.readUTF();
     this.convRatio = in.readDouble();
-    this.country = (String)DataSerializer.readObject(in);
+    this.country = in.readUTF();
     this.delta = in.readDouble();
     this.industry = in.readLong();
     this.issuer = in.readLong();
     this.mktValue = in.readDouble();
     this.qty = in.readDouble();
-    this.secId = (String)DataSerializer.readObject(in);
-    this.secLinks = (String)DataSerializer.readObject(in);
+    this.secId = in.readUTF();
+    this.secLinks = in.readUTF();
     this.secType = in.readUTF();
     this.sharesOutstanding = in.readInt();
-    this.underlyer = (String)DataSerializer.readObject(in);
+    this.underlyer = in.readUTF();
     this.volatility = in.readLong();
     this.pid = in.readInt();
   }
   
   public void toData(DataOutput out) throws IOException {
     out.writeLong(this.avg20DaysVol);
-    DataSerializer.writeObject(this.bondRating, out);
+    out.writeUTF(this.bondRating);
     out.writeDouble(this.convRatio);
-    DataSerializer.writeObject(this.country, out);
+    out.writeUTF(this.country);
     out.writeDouble(this.delta);
     out.writeLong(this.industry);
     out.writeLong(this.issuer);
     out.writeDouble(this.mktValue);
     out.writeDouble(this.qty);
-    DataSerializer.writeObject(this.secId, out);
-    DataSerializer.writeObject(this.secLinks, out);
+    out.writeUTF(this.secId);
+    out.writeUTF(this.secLinks);
     out.writeUTF(this.secType);
     out.writeInt(this.sharesOutstanding);
-    DataSerializer.writeObject(this.underlyer, out);
+    out.writeUTF(this.underlyer);
     out.writeLong(this.volatility);
     out.writeInt(this.pid);
   } 


### PR DESCRIPTION
- Preferred way to control parallel exection is to use xunit config ( "parallelizeAssembly":  false). Disable parallel until cpp style framework applied to cli.
- Also renamed a test