### PR TITLE
GEODE-5025: Uses templates to define Cacheable types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,11 +259,10 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 
   target_compile_options(_WarningsAsError INTERFACE
     /WX
+	/wd4996
 	/wd4068 # TODO fix
 	)
 
-  # TODO error on warnings
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4996")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ignore:4099")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /ignore:4099")
 

--- a/clicache/src/CacheableBuiltins.hpp
+++ b/clicache/src/CacheableBuiltins.hpp
@@ -570,49 +570,49 @@ namespace Apache
       /// An immutable wrapper for byte arrays that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using CacheableBytes = CacheableArray<native::CacheableArray<int8_t, native::internal::DSCode::CacheableBytes>, Byte, static_cast<int8_t>(DSCode::CacheableBytes)>;
+      using CacheableBytes = CacheableArray<native::internal::CacheableArrayPrimitive<int8_t, native::internal::DSCode::CacheableBytes>, Byte, static_cast<int8_t>(DSCode::CacheableBytes)>;
 
       /// <summary>
       /// An immutable wrapper for array of doubles that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using CacheableDoubleArray = CacheableArray<native::CacheableArray<double, native::internal::DSCode::CacheableDoubleArray>, Double, static_cast<int8_t>(DSCode::CacheableDoubleArray)>;
+      using CacheableDoubleArray = CacheableArray<native::internal::CacheableArrayPrimitive<double, native::internal::DSCode::CacheableDoubleArray>, Double, static_cast<int8_t>(DSCode::CacheableDoubleArray)>;
 
       /// <summary>
       /// An immutable wrapper for array of floats that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using CacheableFloatArray = CacheableArray<native::CacheableArray<float, native::internal::DSCode::CacheableFloatArray>, Single, static_cast<int8_t>(DSCode::CacheableFloatArray)>;
+      using CacheableFloatArray = CacheableArray<native::internal::CacheableArrayPrimitive<float, native::internal::DSCode::CacheableFloatArray>, Single, static_cast<int8_t>(DSCode::CacheableFloatArray)>;
 
       /// <summary>
       /// An immutable wrapper for array of 16-bit integers that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using CacheableInt16Array = CacheableArray<native::CacheableArray<int16_t, native::internal::DSCode::CacheableInt16Array>, System::Int16, static_cast<int8_t>(DSCode::CacheableInt16Array)>;
+      using CacheableInt16Array = CacheableArray<native::internal::CacheableArrayPrimitive<int16_t, native::internal::DSCode::CacheableInt16Array>, System::Int16, static_cast<int8_t>(DSCode::CacheableInt16Array)>;
 
       /// <summary>
       /// An immutable wrapper for array of 32-bit integers that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using CacheableInt32Array = CacheableArray<native::CacheableArray<int32_t, native::internal::DSCode::CacheableInt32Array>, System::Int32, static_cast<int8_t>(DSCode::CacheableInt32Array)>;
+      using CacheableInt32Array = CacheableArray<native::internal::CacheableArrayPrimitive<int32_t, native::internal::DSCode::CacheableInt32Array>, System::Int32, static_cast<int8_t>(DSCode::CacheableInt32Array)>;
 
       /// <summary>
       /// An immutable wrapper for array of 64-bit integers that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using CacheableInt64Array = CacheableArray<native::CacheableArray<int64_t, native::internal::DSCode::CacheableInt64Array>, System::Int64, static_cast<int8_t>(DSCode::CacheableInt64Array)>;
+      using CacheableInt64Array = CacheableArray<native::internal::CacheableArrayPrimitive<int64_t, native::internal::DSCode::CacheableInt64Array>, System::Int64, static_cast<int8_t>(DSCode::CacheableInt64Array)>;
 
       /// <summary>
       /// An immutable wrapper for array of booleans that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using BooleanArray = CacheableArray<native::CacheableArray<bool, native::internal::DSCode::BooleanArray>, bool, static_cast<int8_t>(DSCode::BooleanArray)>;
+      using BooleanArray = CacheableArray<native::internal::CacheableArrayPrimitive<bool, native::internal::DSCode::BooleanArray>, bool, static_cast<int8_t>(DSCode::BooleanArray)>;
 
       /// <summary>
       /// An immutable wrapper for array of 16-bit characters that can serve
       /// as a distributable object for caching.
       /// </summary>
-      using CharArray = CacheableArray<native::CacheableArray<char16_t, native::internal::DSCode::CharArray>, Char, static_cast<int8_t>(DSCode::CharArray)>;
+      using CharArray = CacheableArray<native::internal::CacheableArrayPrimitive<char16_t, native::internal::DSCode::CharArray>, Char, static_cast<int8_t>(DSCode::CharArray)>;
     }  // namespace Client
   }  // namespace Geode
 }  // namespace Apache

--- a/cppcache/include/geode/CacheableBuiltins.hpp
+++ b/cppcache/include/geode/CacheableBuiltins.hpp
@@ -242,58 +242,115 @@ using CacheableStringArray =
     CacheableArrayPrimitive<std::shared_ptr<CacheableString>,
                             DSCode::CacheableStringArray>;
 
+// The following are defined as classes to avoid the issues with MSVC++
+// warning/erroring on C4503
+
 /**
  * A mutable <code>Cacheable</code> vector wrapper that can serve as
  * a distributable object for caching.
  */
-using CacheableVector =
-    CacheableContainerPrimitive<std::vector<std::shared_ptr<Cacheable>>,
-                                DSCode::CacheableVector>;
+class APACHE_GEODE_EXPORT CacheableVector
+    : public CacheableContainerPrimitive<
+          std::vector<std::shared_ptr<Cacheable>>, DSCode::CacheableVector,
+          CacheableVector> {
+ public:
+  using CacheableContainerPrimitive::CacheableContainerPrimitive;
+};
+
+template class CacheableContainerPrimitive<
+    std::vector<std::shared_ptr<Cacheable>>, DSCode::CacheableVector,
+    CacheableVector>;
 
 /**
  * A mutable <code>CacheableKey</code> to <code>Serializable</code>
  * hash map that can serve as a distributable object for caching.
  */
-using CacheableHashMap =
-    CacheableContainerPrimitive<HashMapOfCacheable, DSCode::CacheableHashMap>;
+class APACHE_GEODE_EXPORT CacheableHashMap
+    : public CacheableContainerPrimitive<
+          HashMapOfCacheable, DSCode::CacheableHashMap, CacheableHashMap> {
+ public:
+  using CacheableContainerPrimitive::CacheableContainerPrimitive;
+};
+
+template class CacheableContainerPrimitive<
+    HashMapOfCacheable, DSCode::CacheableHashMap, CacheableHashMap>;
 
 /**
  * A mutable <code>CacheableKey</code> hash set wrapper that can serve as
  * a distributable object for caching.
  */
-using CacheableHashSet = CacheableContainerPrimitive<HashSetOfCacheableKey,
-                                                     DSCode::CacheableHashSet>;
+// using CacheableHashSet = CacheableContainerPrimitive<HashSetOfCacheableKey,
+//                                                     DSCode::CacheableHashSet>;
+class APACHE_GEODE_EXPORT CacheableHashSet
+    : public CacheableContainerPrimitive<
+          HashSetOfCacheableKey, DSCode::CacheableHashSet, CacheableHashSet> {
+ public:
+  using CacheableContainerPrimitive::CacheableContainerPrimitive;
+};
+
+template class CacheableContainerPrimitive<
+    HashSetOfCacheableKey, DSCode::CacheableHashSet, CacheableHashSet>;
 
 /**
  * A mutable <code>Cacheable</code> array list wrapper that can serve as
  * a distributable object for caching.
  */
-using CacheableArrayList =
-    CacheableContainerPrimitive<std::vector<std::shared_ptr<Cacheable>>,
-                                DSCode::CacheableArrayList>;
+class APACHE_GEODE_EXPORT CacheableArrayList
+    : public CacheableContainerPrimitive<
+          std::vector<std::shared_ptr<Cacheable>>, DSCode::CacheableArrayList,
+          CacheableArrayList> {
+ public:
+  using CacheableContainerPrimitive::CacheableContainerPrimitive;
+};
+
+template class CacheableContainerPrimitive<
+    std::vector<std::shared_ptr<Cacheable>>, DSCode::CacheableArrayList,
+    CacheableArrayList>;
 
 /**
  * A mutable <code>Cacheable</code> array list wrapper that can serve as
  * a distributable object for caching.
  */
-using CacheableLinkedList =
-    CacheableContainerPrimitive<std::vector<std::shared_ptr<Cacheable>>,
-                                DSCode::CacheableLinkedList>;
+class APACHE_GEODE_EXPORT CacheableLinkedList
+    : public CacheableContainerPrimitive<
+          std::vector<std::shared_ptr<Cacheable>>, DSCode::CacheableLinkedList,
+          CacheableLinkedList> {
+ public:
+  using CacheableContainerPrimitive::CacheableContainerPrimitive;
+};
+
+template class CacheableContainerPrimitive<
+    std::vector<std::shared_ptr<Cacheable>>, DSCode::CacheableLinkedList,
+    CacheableLinkedList>;
 
 /**
  * A mutable <code>Cacheable</code> stack wrapper that can serve as
  * a distributable object for caching.
  */
-using CacheableStack =
-    CacheableContainerPrimitive<std::vector<std::shared_ptr<Cacheable>>,
-                                DSCode::CacheableStack>;
+class APACHE_GEODE_EXPORT CacheableStack
+    : public CacheableContainerPrimitive<
+          std::vector<std::shared_ptr<Cacheable>>, DSCode::CacheableStack,
+          CacheableStack> {
+ public:
+  using CacheableContainerPrimitive::CacheableContainerPrimitive;
+};
+
+template class CacheableContainerPrimitive<
+    HashMapOfCacheable, DSCode::CacheableStack, CacheableStack>;
 
 /**
  * A mutable <code>CacheableKey</code> to <code>Serializable</code>
  * hash map that can serve as a distributable object for caching.
  */
-using CacheableHashTable =
-    CacheableContainerPrimitive<HashMapOfCacheable, DSCode::CacheableHashTable>;
+class APACHE_GEODE_EXPORT CacheableHashTable
+    : public CacheableContainerPrimitive<
+          HashMapOfCacheable, DSCode::CacheableHashTable, CacheableHashTable> {
+ public:
+  using CacheableContainerPrimitive::CacheableContainerPrimitive;
+};
+
+template class CacheableContainerPrimitive<
+    HashMapOfCacheable, DSCode::CacheableHashTable, CacheableHashTable>;
 
 /**
  * A mutable <code>CacheableKey</code> to <code>Serializable</code>
@@ -302,9 +359,17 @@ using CacheableHashTable =
  * to <code>CacheableHashMap</code> i.e. does not provide the semantics of
  * java <code>IdentityHashMap</code>.
  */
-using CacheableIdentityHashMap =
-    CacheableContainerPrimitive<HashMapOfCacheable,
-                                DSCode::CacheableIdentityHashMap>;
+class APACHE_GEODE_EXPORT CacheableIdentityHashMap
+    : public CacheableContainerPrimitive<HashMapOfCacheable,
+                                         DSCode::CacheableIdentityHashMap,
+                                         CacheableIdentityHashMap> {
+ public:
+  using CacheableContainerPrimitive::CacheableContainerPrimitive;
+};
+
+template class CacheableContainerPrimitive<HashMapOfCacheable,
+                                           DSCode::CacheableIdentityHashMap,
+                                           CacheableIdentityHashMap>;
 
 /**
  * A mutable <code>CacheableKey</code> hash set wrapper that can serve as
@@ -313,9 +378,17 @@ using CacheableIdentityHashMap =
  * <code>CacheableHashSet</code> i.e. does not provide the predictable
  * iteration semantics of java <code>LinkedHashSet</code>.
  */
-using CacheableLinkedHashSet =
-    CacheableContainerPrimitive<HashSetOfCacheableKey,
-                                DSCode::CacheableLinkedHashSet>;
+class APACHE_GEODE_EXPORT CacheableLinkedHashSet
+    : public CacheableContainerPrimitive<HashSetOfCacheableKey,
+                                         DSCode::CacheableLinkedHashSet,
+                                         CacheableLinkedHashSet> {
+ public:
+  using CacheableContainerPrimitive::CacheableContainerPrimitive;
+};
+
+template class CacheableContainerPrimitive<HashSetOfCacheableKey,
+                                           DSCode::CacheableLinkedHashSet,
+                                           CacheableLinkedHashSet>;
 
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/CacheableBuiltins.hpp
+++ b/cppcache/include/geode/CacheableBuiltins.hpp
@@ -137,7 +137,7 @@ inline std::shared_ptr<Cacheable> Serializable::create(int16_t value) {
 }
 
 /**
- * An immutable wrapper for 132-bit integers that can serve as
+ * An immutable wrapper for 32-bit integers that can serve as
  * a distributable key object for caching.
  */
 using CacheableInt32 =
@@ -167,7 +167,7 @@ inline std::shared_ptr<Cacheable> Serializable::create(int64_t value) {
 }
 
 /**
- * An immutable wrapper for 64-bit integers that can serve as
+ * An immutable wrapper for 16-bit characters that can serve as
  * a distributable key object for caching.
  */
 using CacheableCharacter =

--- a/cppcache/include/geode/CacheableBuiltins.hpp
+++ b/cppcache/include/geode/CacheableBuiltins.hpp
@@ -39,14 +39,17 @@ namespace client {
 
 using internal::DataSerializablePrimitive;
 
-template<typename TObj, DSCode TYPEID>
-class APACHE_GEODE_EXPORT CacheableKeyPrimitive : public DataSerializablePrimitive,
-                                                  public CacheableKey {
+/**
+ * Template class for primitive key types.
+ */
+template <typename TObj, DSCode TYPEID>
+class APACHE_GEODE_EXPORT CacheableKeyPrimitive
+    : public DataSerializablePrimitive,
+      public CacheableKey {
  private:
   TObj value_;
 
  public:
-
   inline CacheableKeyPrimitive() = default;
 
   inline explicit CacheableKeyPrimitive(const TObj value) : value_(value) {}
@@ -66,19 +69,15 @@ class APACHE_GEODE_EXPORT CacheableKeyPrimitive : public DataSerializablePrimiti
 
   DSCode getDsCode() const override { return TYPEID; }
 
-  std::string toString() const override {
-    return std::to_string(value_);
-  }
+  std::string toString() const override { return std::to_string(value_); }
 
-  int32_t hashcode() const override {
-    return internal::hashcode(value_);
-  }
+  int32_t hashcode() const override { return internal::hashcode(value_); }
 
   bool operator==(const CacheableKey& other) const override {
     // TODO change to using dynamic_cast of this template specialization
 
     if (const auto otherPrimitive =
-        dynamic_cast<const DataSerializablePrimitive*>(&other)) {
+            dynamic_cast<const DataSerializablePrimitive*>(&other)) {
       if (otherPrimitive->getDsCode() != TYPEID) {
         return false;
       }
@@ -107,15 +106,14 @@ class APACHE_GEODE_EXPORT CacheableKeyPrimitive : public DataSerializablePrimiti
   }
 
   /** Factory function to create an instance with the given value. */
-  inline static std::shared_ptr<CacheableKeyPrimitive> create(const TObj value) {
+  inline static std::shared_ptr<CacheableKeyPrimitive> create(
+      const TObj value) {
     return std::make_shared<CacheableKeyPrimitive>(value);
   }
-
 };
 
-
 /** Function to copy an array from source to destination. */
-template<typename TObj>
+template <typename TObj>
 inline void copyArray(TObj* dest, const TObj* src, size_t length) {
   std::memcpy(dest, src, length * sizeof(TObj));
 }
@@ -124,7 +122,7 @@ inline void copyArray(TObj* dest, const TObj* src, size_t length) {
  * Function to copy an array of <code>std::shared_ptr</code>s from
  * source to destination.
  */
-template<typename TObj>
+template <typename TObj>
 inline void copyArray(std::shared_ptr<TObj>* dest,
                       const std::shared_ptr<TObj>* src, size_t length) {
   for (size_t index = 0; index < length; index++) {
@@ -132,70 +130,17 @@ inline void copyArray(std::shared_ptr<TObj>* dest,
   }
 }
 
-/** Template class for container Cacheable types. */
-template<typename TBase, DSCode TYPEID>
-class APACHE_GEODE_EXPORT CacheableContainerType
-    : public DataSerializablePrimitive,
-      public TBase {
- protected:
-  inline CacheableContainerType() : TBase() {}
-  inline explicit CacheableContainerType(const int32_t n) : TBase(n) {}
-
- public:
-  // Cacheable methods
-
-  void toData(DataOutput& output) const override {
-    apache::geode::client::serializer::writeObject(output, *this);
-  }
-
-  void fromData(DataInput& input) override {
-    apache::geode::client::serializer::readObject(input, *this);
-  }
-
-  DSCode getDsCode() const override { return TYPEID; }
-
-  size_t objectSize() const override {
-    return sizeof(CacheableContainerType) + serializer::objectSize(*this);
-  }
-};
-
-
-#define _GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(p, c)     \
-  template class CacheableContainerType<p, DSCode::c>; \
-  typedef CacheableContainerType<p, DSCode::c> _##c;
-
-// use a class instead of typedef for bug #283
-#define _GEODE_CACHEABLE_CONTAINER_TYPE_(p, c)                         \
-  class APACHE_GEODE_EXPORT c : public _##c {                          \
-   public:                                                             \
-    inline c() : _##c() {}                                             \
-    inline explicit c(const int32_t n) : _##c(n) {}                    \
-                                                                       \
-    /** Factory function registered with serialization registry. */    \
-    static std::shared_ptr<Serializable> createDeserializable() {      \
-      return std::make_shared<c>();                                    \
-    }                                                                  \
-    /** Factory function to create a default instance. */              \
-    inline static std::shared_ptr<c> create() {                        \
-      return std::make_shared<c>();                                    \
-    }                                                                  \
-    /** Factory function to create an instance with the given size. */ \
-    inline static std::shared_ptr<c> create(const int32_t n) {         \
-      return std::make_shared<c>(n);                                   \
-    }                                                                  \
-  };
-
-
 /**
  * An immutable wrapper for bool that can serve as
  * a distributable key object for caching.
  */
-using CacheableBoolean = CacheableKeyPrimitive<bool, internal::DSCode::CacheableBoolean>;
-template<>
+using CacheableBoolean =
+    CacheableKeyPrimitive<bool, internal::DSCode::CacheableBoolean>;
+template <>
 inline std::shared_ptr<CacheableKey> CacheableKey::create(bool value) {
   return CacheableBoolean::create(value);
 }
-template<>
+template <>
 inline std::shared_ptr<Cacheable> Serializable::create(bool value) {
   return CacheableBoolean::create(value);
 }
@@ -204,12 +149,13 @@ inline std::shared_ptr<Cacheable> Serializable::create(bool value) {
  * An immutable wrapper for byte that can serve as
  * a distributable key object for caching.
  */
-using CacheableByte = CacheableKeyPrimitive<int8_t, internal::DSCode::CacheableByte>;
-template<>
+using CacheableByte =
+    CacheableKeyPrimitive<int8_t, internal::DSCode::CacheableByte>;
+template <>
 inline std::shared_ptr<CacheableKey> CacheableKey::create(int8_t value) {
   return CacheableByte::create(value);
 }
-template<>
+template <>
 inline std::shared_ptr<Cacheable> Serializable::create(int8_t value) {
   return CacheableByte::create(value);
 }
@@ -218,12 +164,13 @@ inline std::shared_ptr<Cacheable> Serializable::create(int8_t value) {
  * An immutable wrapper for doubles that can serve as
  * a distributable key object for caching.
  */
-using CacheableDouble = CacheableKeyPrimitive<double, internal::DSCode::CacheableDouble>;
-template<>
+using CacheableDouble =
+    CacheableKeyPrimitive<double, internal::DSCode::CacheableDouble>;
+template <>
 inline std::shared_ptr<CacheableKey> CacheableKey::create(double value) {
   return CacheableDouble::create(value);
 }
-template<>
+template <>
 inline std::shared_ptr<Cacheable> Serializable::create(double value) {
   return CacheableDouble::create(value);
 }
@@ -232,12 +179,13 @@ inline std::shared_ptr<Cacheable> Serializable::create(double value) {
  * An immutable wrapper for floats that can serve as
  * a distributable key object for caching.
  */
-using CacheableFloat = CacheableKeyPrimitive<float, internal::DSCode::CacheableFloat>;
-template<>
+using CacheableFloat =
+    CacheableKeyPrimitive<float, internal::DSCode::CacheableFloat>;
+template <>
 inline std::shared_ptr<CacheableKey> CacheableKey::create(float value) {
   return CacheableFloat::create(value);
 }
-template<>
+template <>
 inline std::shared_ptr<Cacheable> Serializable::create(float value) {
   return CacheableFloat::create(value);
 }
@@ -246,12 +194,13 @@ inline std::shared_ptr<Cacheable> Serializable::create(float value) {
  * An immutable wrapper for 16-bit integers that can serve as
  * a distributable key object for caching.
  */
-using CacheableInt16 = CacheableKeyPrimitive<int16_t, internal::DSCode::CacheableInt16>;
-template<>
+using CacheableInt16 =
+    CacheableKeyPrimitive<int16_t, internal::DSCode::CacheableInt16>;
+template <>
 inline std::shared_ptr<CacheableKey> CacheableKey::create(int16_t value) {
   return CacheableInt16::create(value);
 }
-template<>
+template <>
 inline std::shared_ptr<Cacheable> Serializable::create(int16_t value) {
   return CacheableInt16::create(value);
 }
@@ -260,12 +209,13 @@ inline std::shared_ptr<Cacheable> Serializable::create(int16_t value) {
  * An immutable wrapper for 132-bit integers that can serve as
  * a distributable key object for caching.
  */
-using CacheableInt32 = CacheableKeyPrimitive<int32_t, internal::DSCode::CacheableInt32>;
-template<>
+using CacheableInt32 =
+    CacheableKeyPrimitive<int32_t, internal::DSCode::CacheableInt32>;
+template <>
 inline std::shared_ptr<CacheableKey> CacheableKey::create(int32_t value) {
   return CacheableInt32::create(value);
 }
-template<>
+template <>
 inline std::shared_ptr<Cacheable> Serializable::create(int32_t value) {
   return CacheableInt32::create(value);
 }
@@ -274,12 +224,13 @@ inline std::shared_ptr<Cacheable> Serializable::create(int32_t value) {
  * An immutable wrapper for 64-bit integers that can serve as
  * a distributable key object for caching.
  */
-using CacheableInt64 = CacheableKeyPrimitive<int64_t, internal::DSCode::CacheableInt64>;
-template<>
+using CacheableInt64 =
+    CacheableKeyPrimitive<int64_t, internal::DSCode::CacheableInt64>;
+template <>
 inline std::shared_ptr<CacheableKey> CacheableKey::create(int64_t value) {
   return CacheableInt64::create(value);
 }
-template<>
+template <>
 inline std::shared_ptr<Cacheable> Serializable::create(int64_t value) {
   return CacheableInt64::create(value);
 }
@@ -288,23 +239,22 @@ inline std::shared_ptr<Cacheable> Serializable::create(int64_t value) {
  * An immutable wrapper for 64-bit integers that can serve as
  * a distributable key object for caching.
  */
-using CacheableCharacter = CacheableKeyPrimitive<char16_t, internal::DSCode::CacheableCharacter>;
-template<>
+using CacheableCharacter =
+    CacheableKeyPrimitive<char16_t, internal::DSCode::CacheableCharacter>;
+template <>
 inline std::shared_ptr<CacheableKey> CacheableKey::create(char16_t value) {
   return CacheableCharacter::create(value);
 }
-template<>
+template <>
 inline std::shared_ptr<Cacheable> Serializable::create(char16_t value) {
   return CacheableCharacter::create(value);
 }
 
-
-
-
 // Instantiations for array built-in Cacheables
 
-template<typename T, DSCode GeodeTypeId>
-class APACHE_GEODE_EXPORT CacheableArray : public DataSerializablePrimitive {
+template <typename T, DSCode GeodeTypeId>
+class APACHE_GEODE_EXPORT CacheableArrayPrimitive
+    : public DataSerializablePrimitive {
  protected:
   DSCode getDsCode() const override { return GeodeTypeId; }
 
@@ -317,47 +267,46 @@ class APACHE_GEODE_EXPORT CacheableArray : public DataSerializablePrimitive {
   std::vector<T> m_value;
 
  public:
-  inline CacheableArray() = default;
+  inline CacheableArrayPrimitive() = default;
 
-  template<typename TT>
-  CacheableArray(TT&& value) : m_value(std::forward<TT>(value)) {}
+  template <typename TT>
+  CacheableArrayPrimitive(TT&& value) : m_value(std::forward<TT>(value)) {}
 
-  ~CacheableArray() noexcept override = default;
+  ~CacheableArrayPrimitive() noexcept override = default;
 
-  CacheableArray(const CacheableArray& other) = delete;
+  CacheableArrayPrimitive(const CacheableArrayPrimitive& other) = delete;
 
-  CacheableArray& operator=(const CacheableArray& other) = delete;
+  CacheableArrayPrimitive& operator=(const CacheableArrayPrimitive& other) =
+      delete;
 
   inline const std::vector<T>& value() const { return m_value; }
 
   inline int32_t length() const { return static_cast<int32_t>(m_value.size()); }
 
   static std::shared_ptr<Serializable> createDeserializable() {
-    return std::make_shared<CacheableArray < T, GeodeTypeId>>
-    ();
+    return std::make_shared<CacheableArrayPrimitive<T, GeodeTypeId>>();
   }
 
-  inline static std::shared_ptr<CacheableArray<T, GeodeTypeId>> create() {
-    return std::make_shared<CacheableArray < T, GeodeTypeId>>
-    ();
+  inline static std::shared_ptr<CacheableArrayPrimitive<T, GeodeTypeId>>
+  create() {
+    return std::make_shared<CacheableArrayPrimitive<T, GeodeTypeId>>();
   }
 
-  inline static std::shared_ptr<CacheableArray<T, GeodeTypeId>> create(
+  inline static std::shared_ptr<CacheableArrayPrimitive<T, GeodeTypeId>> create(
       const std::vector<T>& value) {
-    return std::make_shared<CacheableArray < T, GeodeTypeId>>
-    (value);
+    return std::make_shared<CacheableArrayPrimitive<T, GeodeTypeId>>(value);
   }
 
-  inline static std::shared_ptr<CacheableArray<T, GeodeTypeId>> create(
+  inline static std::shared_ptr<CacheableArrayPrimitive<T, GeodeTypeId>> create(
       std::vector<T>&& value) {
-    return std::make_shared<CacheableArray < T, GeodeTypeId>>
-    (std::move(value));
+    return std::make_shared<CacheableArrayPrimitive<T, GeodeTypeId>>(
+        std::move(value));
   }
 
   inline T operator[](int32_t index) const {
     if (index >= static_cast<int32_t>(m_value.size())) {
       throw OutOfRangeException(
-          "CacheableArray::operator[]: Index out of range.");
+          "CacheableArrayPrimitive::operator[]: Index out of range.");
     }
     return m_value[index];
   }
@@ -375,123 +324,155 @@ class APACHE_GEODE_EXPORT CacheableArray : public DataSerializablePrimitive {
  * An immutable wrapper for byte arrays that can serve as
  * a distributable object for caching.
  */
-using CacheableBytes = CacheableArray<int8_t, DSCode::CacheableBytes>;
+using CacheableBytes = CacheableArrayPrimitive<int8_t, DSCode::CacheableBytes>;
 
 /**
  * An immutable wrapper for array of booleans that can serve as
  * a distributable object for caching.
  */
-using BooleanArray = CacheableArray<bool, DSCode::BooleanArray>;
+using BooleanArray = CacheableArrayPrimitive<bool, DSCode::BooleanArray>;
 
 /**
  * An immutable wrapper for array of wide-characters that can serve as
  * a distributable object for caching.
  */
-using CharArray = CacheableArray<char16_t, DSCode::CharArray>;
+using CharArray = CacheableArrayPrimitive<char16_t, DSCode::CharArray>;
 
 /**
  * An immutable wrapper for array of doubles that can serve as
  * a distributable object for caching.
  */
 using CacheableDoubleArray =
-CacheableArray<double, DSCode::CacheableDoubleArray>;
+    CacheableArrayPrimitive<double, DSCode::CacheableDoubleArray>;
 
 /**
  * An immutable wrapper for array of floats that can serve as
  * a distributable object for caching.
  */
-using CacheableFloatArray = CacheableArray<float, DSCode::CacheableFloatArray>;
+using CacheableFloatArray =
+    CacheableArrayPrimitive<float, DSCode::CacheableFloatArray>;
 
 /**
  * An immutable wrapper for array of 16-bit integers that can serve as
  * a distributable object for caching.
  */
 using CacheableInt16Array =
-CacheableArray<int16_t, DSCode::CacheableInt16Array>;
+    CacheableArrayPrimitive<int16_t, DSCode::CacheableInt16Array>;
 
 /**
  * An immutable wrapper for array of 32-bit integers that can serve as
  * a distributable object for caching.
  */
 using CacheableInt32Array =
-CacheableArray<int32_t, DSCode::CacheableInt32Array>;
+    CacheableArrayPrimitive<int32_t, DSCode::CacheableInt32Array>;
 
 /**
  * An immutable wrapper for array of 64-bit integers that can serve as
  * a distributable object for caching.
  */
 using CacheableInt64Array =
-CacheableArray<int64_t, DSCode::CacheableInt64Array>;
+    CacheableArrayPrimitive<int64_t, DSCode::CacheableInt64Array>;
 
 /**
  * An immutable wrapper for array of strings that can serve as
  * a distributable object for caching.
  */
-using CacheableStringArray = CacheableArray<std::shared_ptr<CacheableString>,
-                                            DSCode::CacheableStringArray>;
+using CacheableStringArray =
+    CacheableArrayPrimitive<std::shared_ptr<CacheableString>,
+                            DSCode::CacheableStringArray>;
 
-// Instantiations for container types (Vector/HashMap/HashSet) Cacheables
+/** Template class for container Cacheable types. */
+template <typename TBase, DSCode TYPEID>
+class APACHE_GEODE_EXPORT CacheableContainerPrimitive
+    : public DataSerializablePrimitive,
+      public TBase {
+ public:
+  inline CacheableContainerPrimitive() : TBase() {}
 
-_GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(std::vector<std::shared_ptr<Cacheable>>,
-                                     CacheableVector)
+  inline explicit CacheableContainerPrimitive(const int32_t n) : TBase(n) {}
+
+  void toData(DataOutput& output) const override {
+    apache::geode::client::serializer::writeObject(output, *this);
+  }
+
+  void fromData(DataInput& input) override {
+    apache::geode::client::serializer::readObject(input, *this);
+  }
+
+  DSCode getDsCode() const override { return TYPEID; }
+
+  size_t objectSize() const override {
+    return sizeof(CacheableContainerPrimitive) + serializer::objectSize(*this);
+  }
+
+  /** Factory function registered with serialization registry. */
+  static std::shared_ptr<Serializable> createDeserializable() {
+    return std::make_shared<CacheableContainerPrimitive>();
+  }
+  /** Factory function to create a default instance. */
+  inline static std::shared_ptr<CacheableContainerPrimitive> create() {
+    return std::make_shared<CacheableContainerPrimitive>();
+  }
+  /** Factory function to create an instance with the given size. */
+  inline static std::shared_ptr<CacheableContainerPrimitive> create(
+      const int32_t n) {
+    return std::make_shared<CacheableContainerPrimitive>(n);
+  }
+};
+
 /**
  * A mutable <code>Cacheable</code> vector wrapper that can serve as
  * a distributable object for caching.
  */
-_GEODE_CACHEABLE_CONTAINER_TYPE_(std::vector<std::shared_ptr<Cacheable>>,
-                                 CacheableVector)
+using CacheableVector =
+    CacheableContainerPrimitive<std::vector<std::shared_ptr<Cacheable>>,
+                                DSCode::CacheableVector>;
 
-_GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(HashMapOfCacheable, CacheableHashMap)
 /**
  * A mutable <code>CacheableKey</code> to <code>Serializable</code>
  * hash map that can serve as a distributable object for caching.
  */
-_GEODE_CACHEABLE_CONTAINER_TYPE_(HashMapOfCacheable, CacheableHashMap)
+using CacheableHashMap =
+    CacheableContainerPrimitive<HashMapOfCacheable, DSCode::CacheableHashMap>;
 
-_GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(HashSetOfCacheableKey, CacheableHashSet)
 /**
  * A mutable <code>CacheableKey</code> hash set wrapper that can serve as
  * a distributable object for caching.
  */
-_GEODE_CACHEABLE_CONTAINER_TYPE_(HashSetOfCacheableKey, CacheableHashSet)
+using CacheableHashSet = CacheableContainerPrimitive<HashSetOfCacheableKey,
+                                                     DSCode::CacheableHashSet>;
 
-_GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(std::vector<std::shared_ptr<Cacheable>>,
-                                     CacheableArrayList)
 /**
  * A mutable <code>Cacheable</code> array list wrapper that can serve as
  * a distributable object for caching.
  */
-_GEODE_CACHEABLE_CONTAINER_TYPE_(std::vector<std::shared_ptr<Cacheable>>,
-                                 CacheableArrayList)
+using CacheableArrayList =
+    CacheableContainerPrimitive<std::vector<std::shared_ptr<Cacheable>>,
+                                DSCode::CacheableArrayList>;
 
-// linketlist for JSON formattor issue
-_GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(std::vector<std::shared_ptr<Cacheable>>,
-                                     CacheableLinkedList)
 /**
  * A mutable <code>Cacheable</code> array list wrapper that can serve as
  * a distributable object for caching.
  */
-_GEODE_CACHEABLE_CONTAINER_TYPE_(std::vector<std::shared_ptr<Cacheable>>,
-                                 CacheableLinkedList)
+using CacheableLinkedList =
+    CacheableContainerPrimitive<std::vector<std::shared_ptr<Cacheable>>,
+                                DSCode::CacheableLinkedList>;
 
-_GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(std::vector<std::shared_ptr<Cacheable>>,
-                                     CacheableStack)
 /**
  * A mutable <code>Cacheable</code> stack wrapper that can serve as
  * a distributable object for caching.
  */
-_GEODE_CACHEABLE_CONTAINER_TYPE_(std::vector<std::shared_ptr<Cacheable>>,
-                                 CacheableStack)
+using CacheableStack =
+    CacheableContainerPrimitive<std::vector<std::shared_ptr<Cacheable>>,
+                                DSCode::CacheableStack>;
 
-_GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(HashMapOfCacheable, CacheableHashTable)
 /**
  * A mutable <code>CacheableKey</code> to <code>Serializable</code>
  * hash map that can serve as a distributable object for caching.
  */
-_GEODE_CACHEABLE_CONTAINER_TYPE_(HashMapOfCacheable, CacheableHashTable)
+using CacheableHashTable =
+    CacheableContainerPrimitive<HashMapOfCacheable, DSCode::CacheableHashTable>;
 
-_GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(HashMapOfCacheable,
-                                     CacheableIdentityHashMap)
 /**
  * A mutable <code>CacheableKey</code> to <code>Serializable</code>
  * hash map that can serve as a distributable object for caching. This is
@@ -499,10 +480,10 @@ _GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(HashMapOfCacheable,
  * to <code>CacheableHashMap</code> i.e. does not provide the semantics of
  * java <code>IdentityHashMap</code>.
  */
-_GEODE_CACHEABLE_CONTAINER_TYPE_(HashMapOfCacheable, CacheableIdentityHashMap)
+using CacheableIdentityHashMap =
+    CacheableContainerPrimitive<HashMapOfCacheable,
+                                DSCode::CacheableIdentityHashMap>;
 
-_GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(HashSetOfCacheableKey,
-                                     CacheableLinkedHashSet)
 /**
  * A mutable <code>CacheableKey</code> hash set wrapper that can serve as
  * a distributable object for caching. This is provided for compability
@@ -510,7 +491,9 @@ _GEODE_CACHEABLE_CONTAINER_TYPE_DEF_(HashSetOfCacheableKey,
  * <code>CacheableHashSet</code> i.e. does not provide the predictable
  * iteration semantics of java <code>LinkedHashSet</code>.
  */
-_GEODE_CACHEABLE_CONTAINER_TYPE_(HashSetOfCacheableKey, CacheableLinkedHashSet)
+using CacheableLinkedHashSet =
+    CacheableContainerPrimitive<HashSetOfCacheableKey,
+                                DSCode::CacheableLinkedHashSet>;
 
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/CacheableBuiltins.hpp
+++ b/cppcache/include/geode/CacheableBuiltins.hpp
@@ -257,7 +257,7 @@ class APACHE_GEODE_EXPORT CacheableVector
   using CacheableContainerPrimitive::CacheableContainerPrimitive;
 };
 
-template class CacheableContainerPrimitive<
+template class internal::CacheableContainerPrimitive<
     std::vector<std::shared_ptr<Cacheable>>, DSCode::CacheableVector,
     CacheableVector>;
 
@@ -272,7 +272,7 @@ class APACHE_GEODE_EXPORT CacheableHashMap
   using CacheableContainerPrimitive::CacheableContainerPrimitive;
 };
 
-template class CacheableContainerPrimitive<
+template class internal::CacheableContainerPrimitive<
     HashMapOfCacheable, DSCode::CacheableHashMap, CacheableHashMap>;
 
 /**
@@ -288,7 +288,7 @@ class APACHE_GEODE_EXPORT CacheableHashSet
   using CacheableContainerPrimitive::CacheableContainerPrimitive;
 };
 
-template class CacheableContainerPrimitive<
+template class internal::CacheableContainerPrimitive<
     HashSetOfCacheableKey, DSCode::CacheableHashSet, CacheableHashSet>;
 
 /**
@@ -303,7 +303,7 @@ class APACHE_GEODE_EXPORT CacheableArrayList
   using CacheableContainerPrimitive::CacheableContainerPrimitive;
 };
 
-template class CacheableContainerPrimitive<
+template class internal::CacheableContainerPrimitive<
     std::vector<std::shared_ptr<Cacheable>>, DSCode::CacheableArrayList,
     CacheableArrayList>;
 
@@ -319,7 +319,7 @@ class APACHE_GEODE_EXPORT CacheableLinkedList
   using CacheableContainerPrimitive::CacheableContainerPrimitive;
 };
 
-template class CacheableContainerPrimitive<
+template class internal::CacheableContainerPrimitive<
     std::vector<std::shared_ptr<Cacheable>>, DSCode::CacheableLinkedList,
     CacheableLinkedList>;
 
@@ -335,7 +335,7 @@ class APACHE_GEODE_EXPORT CacheableStack
   using CacheableContainerPrimitive::CacheableContainerPrimitive;
 };
 
-template class CacheableContainerPrimitive<
+template class internal::CacheableContainerPrimitive<
     HashMapOfCacheable, DSCode::CacheableStack, CacheableStack>;
 
 /**
@@ -349,7 +349,7 @@ class APACHE_GEODE_EXPORT CacheableHashTable
   using CacheableContainerPrimitive::CacheableContainerPrimitive;
 };
 
-template class CacheableContainerPrimitive<
+template class internal::CacheableContainerPrimitive<
     HashMapOfCacheable, DSCode::CacheableHashTable, CacheableHashTable>;
 
 /**
@@ -367,9 +367,9 @@ class APACHE_GEODE_EXPORT CacheableIdentityHashMap
   using CacheableContainerPrimitive::CacheableContainerPrimitive;
 };
 
-template class CacheableContainerPrimitive<HashMapOfCacheable,
-                                           DSCode::CacheableIdentityHashMap,
-                                           CacheableIdentityHashMap>;
+template class internal::CacheableContainerPrimitive<
+    HashMapOfCacheable, DSCode::CacheableIdentityHashMap,
+    CacheableIdentityHashMap>;
 
 /**
  * A mutable <code>CacheableKey</code> hash set wrapper that can serve as
@@ -386,9 +386,9 @@ class APACHE_GEODE_EXPORT CacheableLinkedHashSet
   using CacheableContainerPrimitive::CacheableContainerPrimitive;
 };
 
-template class CacheableContainerPrimitive<HashSetOfCacheableKey,
-                                           DSCode::CacheableLinkedHashSet,
-                                           CacheableLinkedHashSet>;
+template class internal::CacheableContainerPrimitive<
+    HashSetOfCacheableKey, DSCode::CacheableLinkedHashSet,
+    CacheableLinkedHashSet>;
 
 }  // namespace client
 }  // namespace geode

--- a/cppcache/include/geode/internal/CacheableBuiltinTemplates.hpp
+++ b/cppcache/include/geode/internal/CacheableBuiltinTemplates.hpp
@@ -171,7 +171,7 @@ class APACHE_GEODE_EXPORT CacheableArrayPrimitive
 };
 
 /** Template class for container Cacheable types. */
-template <typename TBase, DSCode TYPEID>
+template <typename TBase, DSCode TYPEID, class _Derived>
 class APACHE_GEODE_EXPORT CacheableContainerPrimitive
     : public DataSerializablePrimitive,
       public TBase {
@@ -191,21 +191,22 @@ class APACHE_GEODE_EXPORT CacheableContainerPrimitive
   DSCode getDsCode() const override { return TYPEID; }
 
   size_t objectSize() const override {
-    return sizeof(CacheableContainerPrimitive) + serializer::objectSize(*this);
+    return sizeof(_Derived) + serializer::objectSize(*this);
   }
 
   /** Factory function registered with serialization registry. */
-  static std::shared_ptr<Serializable> createDeserializable() {
-    return std::make_shared<CacheableContainerPrimitive>();
+  inline static std::shared_ptr<Serializable> createDeserializable() {
+    return std::make_shared<_Derived>();
   }
+
   /** Factory function to create a default instance. */
-  inline static std::shared_ptr<CacheableContainerPrimitive> create() {
-    return std::make_shared<CacheableContainerPrimitive>();
+  inline static std::shared_ptr<_Derived> create() {
+    return std::make_shared<_Derived>();
   }
+
   /** Factory function to create an instance with the given size. */
-  inline static std::shared_ptr<CacheableContainerPrimitive> create(
-      const int32_t n) {
-    return std::make_shared<CacheableContainerPrimitive>(n);
+  inline static std::shared_ptr<_Derived> create(const int32_t n) {
+    return std::make_shared<_Derived>(n);
   }
 };
 

--- a/cppcache/include/geode/internal/CacheableBuiltinTemplates.hpp
+++ b/cppcache/include/geode/internal/CacheableBuiltinTemplates.hpp
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_CACHEABLEBUILTINTEMPLATES_H_
+#define GEODE_CACHEABLEBUILTINTEMPLATES_H_
+
+#include <cstring>
+
+#include "../Serializable.hpp"
+#include "../CacheableKey.hpp"
+#include "../Serializer.hpp"
+#include "CacheableKeys.hpp"
+#include "../CacheableString.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+namespace internal {
+
+/**
+ * Template class for primitive key types.
+ */
+template <typename TObj, DSCode TYPEID>
+class APACHE_GEODE_EXPORT CacheableKeyPrimitive
+    : public DataSerializablePrimitive,
+      public CacheableKey {
+ private:
+  TObj value_;
+
+ public:
+  inline CacheableKeyPrimitive() = default;
+
+  inline explicit CacheableKeyPrimitive(const TObj value) : value_(value) {}
+
+  ~CacheableKeyPrimitive() noexcept override = default;
+
+  /** Gets the contained value. */
+  inline TObj value() const { return value_; }
+
+  void toData(DataOutput& output) const override {
+    apache::geode::client::serializer::writeObject(output, value_);
+  }
+
+  void fromData(DataInput& input) override {
+    apache::geode::client::serializer::readObject(input, value_);
+  }
+
+  DSCode getDsCode() const override { return TYPEID; }
+
+  std::string toString() const override { return std::to_string(value_); }
+
+  int32_t hashcode() const override { return internal::hashcode(value_); }
+
+  bool operator==(const CacheableKey& other) const override {
+    // TODO change to using dynamic_cast of this template specialization
+
+    if (const auto otherPrimitive =
+            dynamic_cast<const DataSerializablePrimitive*>(&other)) {
+      if (otherPrimitive->getDsCode() != TYPEID) {
+        return false;
+      }
+    }
+    auto& otherValue = static_cast<const CacheableKeyPrimitive&>(other);
+    return internal::equals(value_, otherValue.value_);
+  }
+
+  /** Return true if this key matches other key value. */
+  inline bool operator==(const TObj other) const {
+    return internal::equals(value_, other);
+  }
+
+  virtual size_t objectSize() const override {
+    return sizeof(CacheableKeyPrimitive);
+  }
+
+  /** Factory function registered with serialization registry. */
+  static std::shared_ptr<Serializable> createDeserializable() {
+    return std::make_shared<CacheableKeyPrimitive>();
+  }
+
+  /** Factory function to create a new default instance. */
+  inline static std::shared_ptr<CacheableKeyPrimitive> create() {
+    return std::make_shared<CacheableKeyPrimitive>();
+  }
+
+  /** Factory function to create an instance with the given value. */
+  inline static std::shared_ptr<CacheableKeyPrimitive> create(
+      const TObj value) {
+    return std::make_shared<CacheableKeyPrimitive>(value);
+  }
+};
+
+template <typename T, DSCode GeodeTypeId>
+class APACHE_GEODE_EXPORT CacheableArrayPrimitive
+    : public DataSerializablePrimitive {
+ protected:
+  DSCode getDsCode() const override { return GeodeTypeId; }
+
+  size_t objectSize() const override {
+    return static_cast<uint32_t>(
+        apache::geode::client::serializer::objectArraySize(m_value));
+  }
+
+ private:
+  std::vector<T> m_value;
+
+ public:
+  inline CacheableArrayPrimitive() = default;
+
+  template <typename TT>
+  CacheableArrayPrimitive(TT&& value) : m_value(std::forward<TT>(value)) {}
+
+  ~CacheableArrayPrimitive() noexcept override = default;
+
+  CacheableArrayPrimitive(const CacheableArrayPrimitive& other) = delete;
+
+  CacheableArrayPrimitive& operator=(const CacheableArrayPrimitive& other) =
+      delete;
+
+  inline const std::vector<T>& value() const { return m_value; }
+
+  inline int32_t length() const { return static_cast<int32_t>(m_value.size()); }
+
+  static std::shared_ptr<Serializable> createDeserializable() {
+    return std::make_shared<CacheableArrayPrimitive<T, GeodeTypeId>>();
+  }
+
+  inline static std::shared_ptr<CacheableArrayPrimitive<T, GeodeTypeId>>
+  create() {
+    return std::make_shared<CacheableArrayPrimitive<T, GeodeTypeId>>();
+  }
+
+  inline static std::shared_ptr<CacheableArrayPrimitive<T, GeodeTypeId>> create(
+      const std::vector<T>& value) {
+    return std::make_shared<CacheableArrayPrimitive<T, GeodeTypeId>>(value);
+  }
+
+  inline static std::shared_ptr<CacheableArrayPrimitive<T, GeodeTypeId>> create(
+      std::vector<T>&& value) {
+    return std::make_shared<CacheableArrayPrimitive<T, GeodeTypeId>>(
+        std::move(value));
+  }
+
+  inline T operator[](int32_t index) const {
+    if (index >= static_cast<int32_t>(m_value.size())) {
+      throw OutOfRangeException(
+          "CacheableArrayPrimitive::operator[]: Index out of range.");
+    }
+    return m_value[index];
+  }
+
+  virtual void toData(DataOutput& output) const override {
+    apache::geode::client::serializer::writeArrayObject(output, m_value);
+  }
+
+  virtual void fromData(DataInput& input) override {
+    m_value = apache::geode::client::serializer::readArrayObject<T>(input);
+  }
+};
+
+/** Template class for container Cacheable types. */
+template <typename TBase, DSCode TYPEID>
+class APACHE_GEODE_EXPORT CacheableContainerPrimitive
+    : public DataSerializablePrimitive,
+      public TBase {
+ public:
+  inline CacheableContainerPrimitive() : TBase() {}
+
+  inline explicit CacheableContainerPrimitive(const int32_t n) : TBase(n) {}
+
+  void toData(DataOutput& output) const override {
+    apache::geode::client::serializer::writeObject(output, *this);
+  }
+
+  void fromData(DataInput& input) override {
+    apache::geode::client::serializer::readObject(input, *this);
+  }
+
+  DSCode getDsCode() const override { return TYPEID; }
+
+  size_t objectSize() const override {
+    return sizeof(CacheableContainerPrimitive) + serializer::objectSize(*this);
+  }
+
+  /** Factory function registered with serialization registry. */
+  static std::shared_ptr<Serializable> createDeserializable() {
+    return std::make_shared<CacheableContainerPrimitive>();
+  }
+  /** Factory function to create a default instance. */
+  inline static std::shared_ptr<CacheableContainerPrimitive> create() {
+    return std::make_shared<CacheableContainerPrimitive>();
+  }
+  /** Factory function to create an instance with the given size. */
+  inline static std::shared_ptr<CacheableContainerPrimitive> create(
+      const int32_t n) {
+    return std::make_shared<CacheableContainerPrimitive>(n);
+  }
+};
+
+}  // namespace internal
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_CACHEABLEBUILTINTEMPLATES_H_

--- a/cppcache/include/geode/internal/CacheableBuiltinTemplates.hpp
+++ b/cppcache/include/geode/internal/CacheableBuiltinTemplates.hpp
@@ -68,16 +68,12 @@ class APACHE_GEODE_EXPORT CacheableKeyPrimitive
   int32_t hashcode() const override { return internal::hashcode(value_); }
 
   bool operator==(const CacheableKey& other) const override {
-    // TODO change to using dynamic_cast of this template specialization
-
-    if (const auto otherPrimitive =
-            dynamic_cast<const DataSerializablePrimitive*>(&other)) {
-      if (otherPrimitive->getDsCode() != TYPEID) {
-        return false;
-      }
+    if (auto&& otherPrimitive =
+            dynamic_cast<const CacheableKeyPrimitive*>(&other)) {
+      return internal::equals(value_, otherPrimitive->value_);
     }
-    auto& otherValue = static_cast<const CacheableKeyPrimitive&>(other);
-    return internal::equals(value_, otherValue.value_);
+
+    return false;
   }
 
   /** Return true if this key matches other key value. */

--- a/cppcache/integration-test/testThinClientSecurityAuthorizationMU.cpp
+++ b/cppcache/integration-test/testThinClientSecurityAuthorizationMU.cpp
@@ -30,7 +30,6 @@
 
 #include "ThinClientSecurity.hpp"
 
-using apache::geode::client::CacheableArray;
 using apache::geode::client::CacheableArrayList;
 using apache::geode::client::CacheableBoolean;
 using apache::geode::client::CacheableVector;

--- a/cppcache/src/PdxInstanceFactory.cpp
+++ b/cppcache/src/PdxInstanceFactory.cpp
@@ -197,8 +197,7 @@ PdxInstanceFactory& PdxInstanceFactory::writeByteArray(
   isFieldAdded(fieldName);
   m_pdxType->addVariableLengthTypeField(fieldName, "byte[]",
                                         PdxFieldTypes::BYTE_ARRAY);
-  auto cacheableObject =
-      CacheableArray<int8_t, DSCode::CacheableBytes>::create(value);
+  auto cacheableObject = CacheableBytes::create(value);
   m_FieldVsValues.emplace(fieldName, cacheableObject);
   return *this;
 }

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -157,7 +157,7 @@ void PdxInstanceImpl::writeField(PdxWriter& writer,
     }
     case PdxFieldTypes::BYTE_ARRAY: {
       if (auto&& val = std::dynamic_pointer_cast<
-              CacheableArray<int8_t, DSCode::CacheableBytes>>(value)) {
+              CacheableArrayPrimitive<int8_t, DSCode::CacheableBytes>>(value)) {
         writer.writeByteArray(fieldName, val->value());
       }
       break;
@@ -1818,8 +1818,7 @@ void PdxInstanceImpl::setField(const std::string& fieldName,
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  auto cacheableObject =
-      CacheableArray<int8_t, DSCode::CacheableBytes>::create(value);
+  auto cacheableObject = CacheableBytes::create(value);
   m_updatedFields[fieldName] = cacheableObject;
 }
 

--- a/cppcache/src/SerializationRegistry.hpp
+++ b/cppcache/src/SerializationRegistry.hpp
@@ -29,6 +29,7 @@
 
 #include <geode/internal/geode_globals.hpp>
 #include <geode/internal/DataSerializableInternal.hpp>
+#include <geode/internal/DataSerializablePrimitive.hpp>
 #include <geode/Serializable.hpp>
 #include <geode/PdxSerializer.hpp>
 #include <geode/DataOutput.hpp>
@@ -61,6 +62,7 @@ namespace geode {
 namespace client {
 
 using internal::DataSerializableInternal;
+using internal::DataSerializablePrimitive;
 
 typedef ACE_Hash_Map_Manager<int64_t, TypeFactoryMethod, ACE_Null_Mutex>
     IdToFactoryMap;


### PR DESCRIPTION
Replaces the old macros with templates to define `Cacheable` built in types. This allows you to debug into the types should there be issues. 