### PR TITLE
GEODE-5753: Fixes google-readability-casting clang-tidy warning.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
-Checks:          '-*,clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,google-*,-google-readability-todo,-google-runtime-references'
-WarningsAsErrors: 'google-build-using-namespace,google-readability-redundant-smartptr-get,google-explicit-constructor,google-global-names-in-headers,google-runtime-int'
+Checks:          '-*,clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,google-*,-google-readability-todo,-google-runtime-references,-google-default-arguments'
+WarningsAsErrors: 'google-build-using-namespace,google-readability-redundant-smartptr-get,google-explicit-constructor,google-global-names-in-headers,google-runtime-int,google-readability-casting'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 FormatStyle:     file

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -417,7 +417,8 @@ class APACHE_GEODE_EXPORT DataOutput {
   inline void reset() {
     if (m_haveBigBuffer) {
       // create smaller buffer
-      m_bytes.reset((uint8_t*)std::malloc(m_lowWaterMark * sizeof(uint8_t)));
+      m_bytes.reset(
+          static_cast<uint8_t*>(std::malloc(m_lowWaterMark * sizeof(uint8_t))));
       if (m_bytes == nullptr) {
         throw OutOfMemoryException("Out of Memory while resizing buffer");
       }
@@ -444,7 +445,8 @@ class APACHE_GEODE_EXPORT DataOutput {
       m_size = newSize;
 
       auto bytes = m_bytes.release();
-      auto tmp = (uint8_t*)std::realloc(bytes, m_size * sizeof(uint8_t));
+      auto tmp =
+          static_cast<uint8_t*>(std::realloc(bytes, m_size * sizeof(uint8_t)));
       if (tmp == nullptr) {
         throw OutOfMemoryException("Out of Memory while resizing buffer");
       }

--- a/cppcache/include/geode/Serializer.hpp
+++ b/cppcache/include/geode/Serializer.hpp
@@ -261,19 +261,19 @@ inline void readObject(apache::geode::client::DataInput& input, TObj*& array,
 template <typename TObj,
           typename std::enable_if<!std::is_base_of<Serializable, TObj>::value,
                                   Serializable>::type* = nullptr>
-inline uint32_t objectArraySize(const std::vector<TObj>& array) {
-  return (uint32_t)(sizeof(TObj) * array.size());
+inline size_t objectArraySize(const std::vector<TObj>& array) {
+  return sizeof(TObj) * array.size();
 }
 
 template <typename TObj,
           typename std::enable_if<std::is_base_of<Serializable, TObj>::value,
                                   Serializable>::type* = nullptr>
-inline uint32_t objectArraySize(const std::vector<TObj>& array) {
-  uint32_t size = 0;
+inline size_t objectArraySize(const std::vector<TObj>& array) {
+  size_t size = 0;
   for (auto obj : array) {
     size += obj.objectArraySize();
   }
-  size += (uint32_t)(sizeof(TObj) * array.size());
+  size += sizeof(TObj) * array.size();
   return size;
 }
 

--- a/cppcache/include/geode/internal/CacheableKeys.hpp
+++ b/cppcache/include/geode/internal/CacheableKeys.hpp
@@ -48,9 +48,7 @@ inline int32_t hashcode(const int16_t value) {
   return static_cast<int32_t>(value);
 }
 
-inline int32_t hashcode(const int32_t value) {
-  return static_cast<int32_t>(value);
-}
+inline int32_t hashcode(const int32_t value) { return value; }
 
 inline int32_t hashcode(const int64_t value) {
   int32_t hash = static_cast<int32_t>(value);

--- a/cppcache/integration-test/BuiltinCacheableWrappers.hpp
+++ b/cppcache/integration-test/BuiltinCacheableWrappers.hpp
@@ -129,7 +129,7 @@ inline double random(double maxValue) {
 
 template <typename TPRIM>
 inline TPRIM random(TPRIM maxValue) {
-  return (TPRIM)random((double)maxValue);
+  return static_cast<TPRIM>(random(static_cast<double>(maxValue)));
 }
 
 // This returns an array allocated on heap
@@ -338,7 +338,8 @@ class CacheableDateWrapper : public CacheableWrapper {
 
     const ACE_Time_Value currentTime = ACE_OS::gettimeofday();
     timeofday = currentTime.sec();
-    time_t epoctime = (time_t)(timeofday + (rnd * (rnd % 2 == 0 ? 1 : -1)));
+    time_t epoctime =
+        static_cast<time_t>(timeofday + (rnd * (rnd % 2 == 0 ? 1 : -1)));
 
     m_cacheableObject = CacheableDate::create(epoctime);
   }
@@ -1035,7 +1036,7 @@ class CacheableNullStringWrapper : public CacheableWrapper {
   // CacheableWrapper members
 
   void initRandomValue(int32_t) override {
-    m_cacheableObject = CacheableString::create((char*)nullptr);
+    m_cacheableObject = CacheableString::create(static_cast<char*>(nullptr));
   }
 
   uint32_t getCheckSum(const std::shared_ptr<Cacheable> object) const override {

--- a/cppcache/integration-test/ThinClientSecurityHelper.hpp
+++ b/cppcache/integration-test/ThinClientSecurityHelper.hpp
@@ -1,8 +1,3 @@
-#pragma once
-
-#ifndef GEODE_INTEGRATION_TEST_THINCLIENTSECURITYHELPER_H_
-#define GEODE_INTEGRATION_TEST_THINCLIENTSECURITYHELPER_H_
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,9 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#pragma once
+
+#ifndef GEODE_INTEGRATION_TEST_THINCLIENTSECURITYHELPER_H_
+#define GEODE_INTEGRATION_TEST_THINCLIENTSECURITYHELPER_H_
+
+#include <ace/Process.h>
+
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
-#include "ace/Process.h"
+#include "hacks/AceThreadId.h"
 
 namespace {
 
@@ -214,7 +217,6 @@ class putThread : public ACE_Task_Base {
   int svc(void) {
     int ops = 0;
     auto pid = ACE_OS::getpid();
-    auto thr_id = ACE_OS::thr_self();
     std::shared_ptr<CacheableKey> key;
     std::shared_ptr<CacheableString> value;
     std::vector<std::shared_ptr<CacheableKey>> keys0;
@@ -262,8 +264,8 @@ class putThread : public ACE_Task_Base {
             m_reg->destroy(key);
           }
         } catch (Exception& ex) {
-          printf("%d: %" PRIuPTR " exception got and exception message = %s\n",
-                 pid, (uintptr_t)thr_id, ex.what());
+          printf("%d: %" PRIu64 " exception got and exception message = %s\n",
+                 pid, hacks::aceThreadId(ACE_OS::thr_self()), ex.what());
         }
       }
     }

--- a/cppcache/integration-test/fw_dunit.cpp
+++ b/cppcache/integration-test/fw_dunit.cpp
@@ -176,10 +176,7 @@ class NamingContextImpl : virtual public NamingContext {
    * otherwise returns 0.
    */
   virtual int rebind(const char* key, int value) {
-    char buf[VALUE_MAX] = {0};
-    ACE_OS::sprintf(buf, "%d", value);
-    int res = rebind(key, (const char*)buf);
-    return res;
+    return rebind(key, std::to_string(value).c_str());
   }
 
   /**

--- a/cppcache/integration-test/testDataOutput.cpp
+++ b/cppcache/integration-test/testDataOutput.cpp
@@ -103,7 +103,7 @@ BEGIN_TEST(int_t)
   {
     DataOutputInternal dataOutput;
 
-    dataOutput.writeInt((int32_t)0x11223344);
+    dataOutput.writeInt(static_cast<int32_t>(0x11223344));
     const uint8_t* buffer = dataOutput.getBuffer();
     dumpnbytes(buffer, 4);
     ASSERT(buffer[0] == (uint8_t)0x11, "expected 0x11.");

--- a/cppcache/integration-test/testSerialization.cpp
+++ b/cppcache/integration-test/testSerialization.cpp
@@ -101,7 +101,7 @@ class OtherType : public DataSerializable {
 
   static std::shared_ptr<Cacheable> uniqueCT(int32_t i) {
     auto ot = std::make_shared<OtherType>();
-    ot->m_struct.a = (int)i;
+    ot->m_struct.a = static_cast<int>(i);
     ot->m_struct.b = (i % 2 == 0) ? true : false;
     ot->m_struct.c = static_cast<char>(65) + i;
     ot->m_struct.d = ((2.0) * static_cast<double>(i));

--- a/cppcache/integration-test/testThinClientCacheables.cpp
+++ b/cppcache/integration-test/testThinClientCacheables.cpp
@@ -261,7 +261,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, GetsTask)
     // have deserialized on server so checks serialization/deserialization
     // compatibility with java server.
     std::string queryStr = "SELECT DISTINCT iter.key, iter.value FROM /";
-    queryStr += ((std::string)regionNames[0] + ".entrySet AS iter");
+    queryStr += (std::string(regionNames[0]) + ".entrySet AS iter");
     dataReg->query(queryStr.c_str());
     dataReg->localInvalidateRegion();
     verifyReg->localInvalidateRegion();

--- a/cppcache/integration-test/testThinClientCacheablesLimits.cpp
+++ b/cppcache/integration-test/testThinClientCacheablesLimits.cpp
@@ -79,7 +79,7 @@ uint8_t* createRandByteArray(int size) {
 }
 char* createRandCharArray(int size) {
   char* ch;
-  ch = (char *) std::malloc((size + 1) * sizeof(char));
+  ch = static_cast<char*>(std::malloc((size + 1) * sizeof(char)));
   if (ch == nullptr) {
     throw OutOfMemoryException(
         "Out of Memory while resizing buffer");

--- a/cppcache/integration-test/testThinClientClearRegion.cpp
+++ b/cppcache/integration-test/testThinClientClearRegion.cpp
@@ -91,7 +91,7 @@ DUNIT_TASK(CLIENT2, SetupClient2)
                                     "__TEST_POOL1__", true, true);
     auto regPtr = getHelper()->getRegion(regionNames[0]);
     regPtr->registerAllKeys();
-    auto keyPtr = CacheableKey::create((const char*)"key01");
+    auto keyPtr = CacheableKey::create("key01");
     auto valPtr =
       CacheableBytes::create(std::vector<int8_t>{'v','a','l','u','e','0','1'});
     regPtr->put(keyPtr, valPtr);

--- a/cppcache/integration-test/testThinClientContainsKeyOnServer.cpp
+++ b/cppcache/integration-test/testThinClientContainsKeyOnServer.cpp
@@ -44,7 +44,7 @@ DUNIT_TASK(CLIENT1, SetupClient1)
     getHelper()->createPooledRegion(regionNames[0], false, locatorsG,
                                     "__TEST_POOL1__", true, true);
     auto regPtr = getHelper()->getRegion(regionNames[0]);
-    auto key = CacheableKey::create((const char*)"key01");
+    auto key = CacheableKey::create("key01");
     ASSERT(!regPtr->containsKeyOnServer(key), "key should not be there");
   }
 END_TASK(SetupClient1)

--- a/cppcache/integration-test/testThinClientPdxInstance.cpp
+++ b/cppcache/integration-test/testThinClientPdxInstance.cpp
@@ -1673,7 +1673,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
     auto setVec = CacheableVector::create();
     setVec->push_back(CacheableInt32::create(3));
     setVec->push_back(CacheableInt32::create(4));
-    wpiPtr->setField("m_vector", (std::shared_ptr<Cacheable>)setVec);
+    wpiPtr->setField("m_vector", setVec);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(newPiPtr->hasField("m_vector") == true, "m_vector = true expected");
@@ -1702,7 +1702,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
     setarr->push_back(CacheableInt32::create(3));
     setarr->push_back(CacheableInt32::create(4));
     setarr->push_back(CacheableInt32::create(5));
-    wpiPtr->setField("m_arraylist", (std::shared_ptr<Cacheable>)setarr);
+    wpiPtr->setField("m_arraylist", setarr);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(newPiPtr->hasField("m_arraylist") == true,
@@ -1733,7 +1733,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
     hashset->insert(CacheableInt32::create(3));
     hashset->insert(CacheableInt32::create(4));
     hashset->insert(CacheableInt32::create(5));
-    wpiPtr->setField("m_chs", (std::shared_ptr<Cacheable>)hashset);
+    wpiPtr->setField("m_chs", hashset);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(newPiPtr->hasField("m_chs") == true, "m_chs = true expected");
@@ -1759,7 +1759,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
     hashmap->emplace(CacheableInt32::create(3), CacheableInt32::create(3));
     hashmap->emplace(CacheableInt32::create(4), CacheableInt32::create(4));
     hashmap->emplace(CacheableInt32::create(5), CacheableInt32::create(5));
-    wpiPtr->setField("m_map", (std::shared_ptr<Cacheable>)hashmap);
+    wpiPtr->setField("m_map", hashmap);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(newPiPtr->hasField("m_map") == true, "m_map = true expected");
@@ -1785,7 +1785,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
     linkedhashset->insert(CacheableInt32::create(3));
     linkedhashset->insert(CacheableInt32::create(4));
     linkedhashset->insert(CacheableInt32::create(5));
-    wpiPtr->setField("m_clhs", (std::shared_ptr<Cacheable>)linkedhashset);
+    wpiPtr->setField("m_clhs", linkedhashset);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     ASSERT(newPiPtr->hasField("m_clhs") == true, "m_clhs = true expected");
@@ -1851,8 +1851,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
 
     wpiPtr = pIPtr->createWriter();
     try {
-      wpiPtr->setField("m_byteByteArray",
-                       (std::shared_ptr<Cacheable>)linkedhashset);
+      wpiPtr->setField("m_byteByteArray", linkedhashset);
       FAIL(
           "setField on m_byteByteArray with linkedhashset value should throw "
           "expected IllegalStateException");
@@ -1888,7 +1887,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
     wpiPtr = pIPtr->createWriter();
     auto childpdxobjPtr = std::make_shared<ChildPdx>(2);
     LOGINFO("created new childPdx");
-    wpiPtr->setField("m_childPdx", (std::shared_ptr<Cacheable>)childpdxobjPtr);
+    wpiPtr->setField("m_childPdx", childpdxobjPtr);
     LOGINFO("childPdx seField done");
     rptr->put(keyport1, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport1));

--- a/cppcache/integration-test/testThinClientRegionQueryDifferentServerConfigs.cpp
+++ b/cppcache/integration-test/testThinClientRegionQueryDifferentServerConfigs.cpp
@@ -102,8 +102,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, InitClientCreateRegionAndRunQueries)
     qh.populatePortfolioData(reg, qh.getPortfolioSetSize(),
                              qh.getPortfolioNumSets());
 
-    std::string qry1Str = (std::string) "select * from /" + qRegionNames[0];
-    std::string qry2Str = (std::string) "select * from /" + qRegionNames[1];
+    std::string qry1Str = std::string("select * from /") + qRegionNames[0];
+    std::string qry2Str = std::string("select * from /") + qRegionNames[1];
 
     std::shared_ptr<QueryService> qs = nullptr;
     qs = pool1->getQueryService();
@@ -164,8 +164,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, CreateRegionAndRunQueries)
     qh.populatePositionData(reg, qh.getPositionSetSize(),
                             qh.getPositionNumSets());
 
-    std::string qry1Str = (std::string) "select * from /" + qRegionNames[0];
-    std::string qry2Str = (std::string) "select * from /" + qRegionNames[1];
+    std::string qry1Str = std::string("select * from /") + qRegionNames[0];
+    std::string qry2Str = std::string("select * from /") + qRegionNames[1];
 
     std::shared_ptr<QueryService> qs = nullptr;
     qs = pool2->getQueryService();

--- a/cppcache/integration-test/testXmlCacheCreationWithPools.cpp
+++ b/cppcache/integration-test/testXmlCacheCreationWithPools.cpp
@@ -41,7 +41,7 @@ using apache::geode::client::Pool;
 static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 1;
-const char* endPoints = (const char*)nullptr;
+const char* endPoints = nullptr;
 const char* locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 

--- a/cppcache/integration-test/testXmlCacheInitialization.cpp
+++ b/cppcache/integration-test/testXmlCacheInitialization.cpp
@@ -37,7 +37,7 @@ using apache::geode::client::Exception;
 static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 1;
-const char* endPoints = (const char*)nullptr;
+const char* endPoints = nullptr;
 const char* locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 

--- a/cppcache/internal/hacks/AceThreadId.h
+++ b/cppcache/internal/hacks/AceThreadId.h
@@ -15,27 +15,30 @@
  * limitations under the License.
  */
 
-#include <geode/PdxSerializable.hpp>
-#include <geode/CacheableString.hpp>
-#include <geode/internal/CacheableKeys.hpp>
+#pragma once
 
-#include "PdxHelper.hpp"
+#ifndef INTERNAL_HACKS_ACETHREADID_H_
+#define INTERNAL_HACKS_ACETHREADID_H_
 
-namespace apache {
-namespace geode {
-namespace client {
+#include <cstdint>
+#include <type_traits>
 
-std::string PdxSerializable::toString() const { return getClassName(); }
+namespace hacks {
 
-bool PdxSerializable::operator==(const CacheableKey& other) const {
-  return (this == &other);
+template <class _T>
+uint64_t aceThreadId(
+    _T&& thread,
+    typename std::enable_if<std::is_pointer<_T>::value>::type* = nullptr) {
+  return reinterpret_cast<uintptr_t>(thread);
 }
 
-int32_t PdxSerializable::hashcode() const {
-  return internal::hashcode(
-      static_cast<int64_t>(reinterpret_cast<uintptr_t>(this)));
+template <class _T>
+uint64_t aceThreadId(
+    _T&& thread,
+    typename std::enable_if<std::is_integral<_T>::value>::type* = nullptr) {
+  return thread;
 }
 
-}  // namespace client
-}  // namespace geode
-}  // namespace apache
+}  // namespace hacks
+
+#endif  // INTERNAL_HACKS_ACETHREADID_H_

--- a/cppcache/src/ClientProxyMembershipID.cpp
+++ b/cppcache/src/ClientProxyMembershipID.cpp
@@ -127,7 +127,7 @@ void ClientProxyMembershipID::initObjectVars(
   memcpy(&temp, hostAddr, 4);
   m_memID.writeInt(static_cast<int32_t>(temp));
   // m_memID.writeInt((int32_t)hostPort);
-  m_memID.writeInt((int32_t)synch_counter);
+  m_memID.writeInt(static_cast<int32_t>(synch_counter));
   m_memID.writeString(hostname);
   m_memID.write(splitBrainFlag);  // splitbrain flags
 

--- a/cppcache/src/DataOutput.cpp
+++ b/cppcache/src/DataOutput.cpp
@@ -80,7 +80,7 @@ class TSSDataOutput {
     } else {
       uint8_t* buf;
       *size = 8192;
-      buf = (uint8_t*)std::malloc(8192 * sizeof(uint8_t));
+      buf = static_cast<uint8_t*>(std::malloc(8192 * sizeof(uint8_t)));
       if (buf == nullptr) {
         throw OutOfMemoryException("Out of Memory while resizing buffer");
       }

--- a/cppcache/src/FairQueue.hpp
+++ b/cppcache/src/FairQueue.hpp
@@ -58,7 +58,7 @@ class FairQueue {
     T* mp = getNoGetLock(isClosed);
 
     if (mp == nullptr && !isClosed) {
-      mp = getUntilWithToken(sec, isClosed, (void*)nullptr);
+      mp = getUntilWithToken(sec, isClosed, static_cast<void*>(nullptr));
     }
     return mp;
   }

--- a/cppcache/src/Log.cpp
+++ b/cppcache/src/Log.cpp
@@ -42,6 +42,7 @@
 #include "util/Log.hpp"
 #include "geodeBanner.hpp"
 #include "Assert.hpp"
+#include "../internal/hacks/AceThreadId.h"
 
 #if defined(_WIN32)
 #include <io.h>
@@ -561,12 +562,12 @@ char* Log::formatLogLine(char* buf, LogLevel level) {
   char* pbuf = buf;
   pbuf += ACE_OS::snprintf(pbuf, 15, "[%s ", Log::levelToChars(level));
   pbuf += ACE_OS::strftime(pbuf, MINBUFSIZE, "%Y/%m/%d %H:%M:%S", tm_val);
-  pbuf += ACE_OS::snprintf(pbuf, 15, ".%06" PRIu64 " ",
+  pbuf += ACE_OS::snprintf(pbuf, 15, ".%06" PRId64 " ",
                            static_cast<int64_t>(clock.usec()));
   pbuf += ACE_OS::strftime(pbuf, MINBUFSIZE, "%Z ", tm_val);
 
   ACE_OS::snprintf(pbuf, 300, "%s:%d %" PRIu64 "] ", g_uname.nodename, g_pid,
-                   (uint64_t)ACE_OS::thr_self());
+                   hacks::aceThreadId(ACE_OS::thr_self()));
 
   return buf;
 }

--- a/cppcache/src/PdxHelper.cpp
+++ b/cppcache/src/PdxHelper.cpp
@@ -272,7 +272,7 @@ std::shared_ptr<PdxSerializable> PdxHelper::deserializePdx(
 
     cachePerfStats.incPdxDeSerialization(len + 9);  // pdxLen + 1 + 2*4
 
-    return PdxHelper::deserializePdx(dataInput, (int32_t)typeId, (int32_t)len);
+    return PdxHelper::deserializePdx(dataInput, typeId, len);
 
   } else {
     // Read Length

--- a/cppcache/src/QueueConnectionRequest.cpp
+++ b/cppcache/src/QueueConnectionRequest.cpp
@@ -29,7 +29,7 @@ void QueueConnectionRequest::toData(DataOutput& output) const {
   output.write(static_cast<int8_t>(DSCode::ClientProxyMembershipId));
   uint32_t buffLen = 0;
   output.writeBytes(reinterpret_cast<uint8_t*>(const_cast<char*>(m_membershipID.getDSMemberId(buffLen))), buffLen);
-  output.writeInt((int32_t)1);
+  output.writeInt(static_cast<int32_t>(1));
   output.writeInt(static_cast<int32_t>(m_redundantCopies));
   writeSetOfServerLocation(output);
   output.writeBoolean(m_findDurable);

--- a/cppcache/src/TcpConn.cpp
+++ b/cppcache/src/TcpConn.cpp
@@ -86,7 +86,7 @@ int32_t TcpConn::maxSize(ACE_HANDLE sock, int32_t flag, int32_t size) {
 
 void TcpConn::createSocket(ACE_HANDLE sock) {
   LOGDEBUG("Creating plain socket stream");
-  m_io = new ACE_SOCK_Stream((ACE_HANDLE)sock);
+  m_io = new ACE_SOCK_Stream(sock);
   // m_io->enable(ACE_NONBLOCK);
 }
 
@@ -356,7 +356,7 @@ uint16_t TcpConn::getPort() {
   GF_DEV_ASSERT(m_io != nullptr);
 
   ACE_INET_Addr localAddr;
-  m_io->get_local_addr(*(ACE_Addr *)&localAddr);
+  m_io->get_local_addr(localAddr);
   return localAddr.get_port_number();
 }
 

--- a/cppcache/src/TcpConn.hpp
+++ b/cppcache/src/TcpConn.hpp
@@ -129,11 +129,11 @@ class APACHE_GEODE_EXPORT TcpConn : public Connector {
   }
 
   void setIntOption(int32_t level, int32_t option, int32_t val) {
-    setOption(level, option, (void*)&val, sizeof(int32_t));
+    setOption(level, option, &val, sizeof(int32_t));
   }
 
   void setBoolOption(int32_t level, int32_t option, bool val) {
-    setOption(level, option, (void*)&val, sizeof(bool));
+    setOption(level, option, &val, sizeof(bool));
   }
 
   virtual uint16_t getPort() override;

--- a/cppcache/src/TcpSslConn.cpp
+++ b/cppcache/src/TcpSslConn.cpp
@@ -119,7 +119,7 @@ void TcpSslConn::close() {
     m_ssl->close();
     gf_destroy_SslImpl func = reinterpret_cast<gf_destroy_SslImpl>(
         m_dll.symbol("gf_destroy_SslImpl"));
-    func((void*)m_ssl);
+    func(m_ssl);
     m_ssl = nullptr;
   }
 }
@@ -202,7 +202,7 @@ uint16_t TcpSslConn::getPort() {
   GF_DEV_ASSERT(m_ssl != nullptr);
 
   ACE_INET_Addr localAddr;
-  m_ssl->getLocalAddr(*(ACE_Addr*)&localAddr);
+  m_ssl->getLocalAddr(localAddr);
   return localAddr.get_port_number();
 }
 

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -139,7 +139,7 @@ bool TcrConnection::InitTcrConnection(
     // permissible value for bug #232 for now.
     //  minus 10 sec because the GFE 5.7 gridDev branch adds a
     // 5 sec buffer which was causing an int overflow.
-    handShakeMsg.writeInt((int32_t)0x7fffffff - 10000);
+    handShakeMsg.writeInt(static_cast<int32_t>(0x7fffffff) - 10000);
   }
 
   // Write header for byte FixedID since GFE 5.7
@@ -174,7 +174,7 @@ bool TcrConnection::InitTcrConnection(
     auto memIdBuffer = memId->getDSMemberId(memIdBufferLength);
     handShakeMsg.writeBytes(reinterpret_cast<int8_t*>(const_cast<char*>(memIdBuffer)), memIdBufferLength);
   }
-  handShakeMsg.writeInt((int32_t)1);
+  handShakeMsg.writeInt(static_cast<int32_t>(1));
 
   bool isDhOn = false;
   bool requireServerAuth = false;
@@ -475,17 +475,20 @@ bool TcrConnection::InitTcrConnection(
         if (isClientNotification) readHandshakeInstantiatorMsg(connectTimeout);
         break;
       case REPLY_AUTHENTICATION_FAILED: {
-        AuthenticationFailedException ex((char*)recvMessage.data());
+        AuthenticationFailedException ex(
+            reinterpret_cast<char*>(recvMessage.data()));
         GF_SAFE_DELETE_CON(m_conn);
         throwException(ex);
       }
       case REPLY_AUTHENTICATION_REQUIRED: {
-        AuthenticationRequiredException ex((char*)recvMessage.data());
+        AuthenticationRequiredException ex(
+            reinterpret_cast<char*>(recvMessage.data()));
         GF_SAFE_DELETE_CON(m_conn);
         throwException(ex);
       }
       case REPLY_DUPLICATE_DURABLE_CLIENT: {
-        DuplicateDurableClientException ex((char*)recvMessage.data());
+        DuplicateDurableClientException ex(
+            reinterpret_cast<char*>(recvMessage.data()));
         GF_SAFE_DELETE_CON(m_conn);
         throwException(ex);
       }
@@ -493,10 +496,11 @@ bool TcrConnection::InitTcrConnection(
       case REPLY_INVALID:
       case UNSUCCESSFUL_SERVER_TO_CLIENT: {
         LOGERROR("Handshake rejected by server[%s]: %s",
-                 m_endpointObj->name().c_str(), (char*)recvMessage.data());
-        auto message =
-            std::string("TcrConnection::TcrConnection: ") +
-            "Handshake rejected by server: " + (char*)recvMessage.data();
+                 m_endpointObj->name().c_str(),
+                 reinterpret_cast<char*>(recvMessage.data()));
+        auto message = std::string("TcrConnection::TcrConnection: ") +
+                       "Handshake rejected by server: " +
+                       reinterpret_cast<char*>(recvMessage.data());
         CacheServerException ex(message);
         GF_SAFE_DELETE_CON(m_conn);
         throw ex;
@@ -509,7 +513,8 @@ bool TcrConnection::InitTcrConnection(
             recvMessage.data());
         auto message =
             std::string("TcrConnection::TcrConnection: Unknown error") +
-            " received from server in handshake: " + (char*)recvMessage.data();
+            " received from server in handshake: " +
+            reinterpret_cast<char*>(recvMessage.data());
         MessageException ex(message);
         GF_SAFE_DELETE_CON(m_conn);
         throw ex;

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -84,7 +84,7 @@ void TcrMessage::setKeepAlive(bool keepalive) {
 }
 
 void TcrMessage::writeInterestResultPolicyPart(InterestResultPolicy policy) {
-  m_request->writeInt((int32_t)3);           // size
+  m_request->writeInt(static_cast<int32_t>(3));  // size
   m_request->write(static_cast<int8_t>(1));  // isObject
   m_request->write(static_cast<int8_t>(DSCode::FixedIDByte));
   m_request->write(static_cast<int8_t>(DSCode::InterestResultPolicy));
@@ -92,20 +92,20 @@ void TcrMessage::writeInterestResultPolicyPart(InterestResultPolicy policy) {
 }
 
 void TcrMessage::writeIntPart(int32_t intValue) {
-  m_request->writeInt((int32_t)4);
+  m_request->writeInt(static_cast<int32_t>(4));
   m_request->write(static_cast<int8_t>(0));
   m_request->writeInt(intValue);
 }
 
 void TcrMessage::writeBytePart(uint8_t byteValue) {
-  m_request->writeInt((int32_t)1);
+  m_request->writeInt(static_cast<int32_t>(1));
   m_request->write(static_cast<int8_t>(0));
   m_request->write(byteValue);
 }
 
 void TcrMessage::writeByteAndTimeOutPart(uint8_t byteValue,
                                          std::chrono::milliseconds timeout) {
-  m_request->writeInt((int32_t)5);  // 1 (byte) + 4 (timeout)
+  m_request->writeInt(static_cast<int32_t>(5));  // 1 (byte) + 4 (timeout)
   m_request->write(static_cast<int8_t>(0));
   m_request->write(byteValue);
   m_request->writeInt(static_cast<int32_t>(timeout.count()));
@@ -592,9 +592,10 @@ void TcrMessage::writeHeader(uint32_t msgType, uint32_t numOfParts) {
   LOGDEBUG("TcrMessage::writeHeader earlyAck = %d", earlyAck);
 
   m_request->writeInt(static_cast<int32_t>(msgType));
-  m_request->writeInt((int32_t)0);  // write a dummy message len('0' here). At
-                                    // the end write the length at the (buffer +
-                                    // 4) offset.
+  m_request->writeInt(
+      static_cast<int32_t>(0));  // write a dummy message len('0' here). At
+                                 // the end write the length at the (buffer +
+                                 // 4) offset.
   m_request->writeInt(static_cast<int32_t>(numOfParts));
   TXState* txState = TSSTXStateWrapper::s_geodeTSSTXState->getTXState();
   if (txState == nullptr) {
@@ -1803,14 +1804,14 @@ TcrMessagePing::TcrMessagePing(DataOutput* dataOutput, bool decodeAll) {
   m_decodeAll = decodeAll;
   m_request.reset(dataOutput);
   m_request->writeInt(m_msgType);
-  m_request->writeInt(
-      (int32_t)0);  // 17 is fixed message len ...  PING only has a header.
-  m_request->writeInt((int32_t)0);  // Number of parts.
+  m_request->writeInt(static_cast<int32_t>(
+      0));  // 17 is fixed message len ...  PING only has a header.
+  m_request->writeInt(static_cast<int32_t>(0));  // Number of parts.
   // int32_t txId = TcrMessage::m_transactionId++;
   // Setting the txId to 0 for all ping message as it is not being used on the
   // SERVER side or the
   // client side.
-  m_request->writeInt((int32_t)0);
+  m_request->writeInt(static_cast<int32_t>(0));
   m_request->write(static_cast<int8_t>(0));  // Early ack is '0'.
   m_msgLength = g_headerLen;
   m_txId = 0;
@@ -1822,13 +1823,13 @@ TcrMessageCloseConnection::TcrMessageCloseConnection(DataOutput* dataOutput,
   m_decodeAll = decodeAll;
   m_request.reset(dataOutput);
   m_request->writeInt(m_msgType);
-  m_request->writeInt((int32_t)6);
-  m_request->writeInt((int32_t)1);  // Number of parts.
+  m_request->writeInt(static_cast<int32_t>(6));
+  m_request->writeInt(static_cast<int32_t>(1));  // Number of parts.
   // int32_t txId = TcrMessage::m_transactionId++;
-  m_request->writeInt((int32_t)0);
+  m_request->writeInt(static_cast<int32_t>(0));
   m_request->write(static_cast<int8_t>(0));  // Early ack is '0'.
   // last two parts are not used ... setting zero in both the parts.
-  m_request->writeInt((int32_t)1);           // len is 1
+  m_request->writeInt(static_cast<int32_t>(1));  // len is 1
   m_request->write(static_cast<int8_t>(0));  // is obj is '0'.
   // cast away constness here since we want to modify this
   TcrMessage::m_keepalive = const_cast<uint8_t*>(m_request->getCursor());
@@ -2887,7 +2888,7 @@ std::shared_ptr<DSMemberForVersionStamp> TcrMessage::readDSMember(
     auto memId =
         std::shared_ptr<ClientProxyMembershipID>(new ClientProxyMembershipID());
     memId->fromData(input);
-    return (std::shared_ptr<DSMemberForVersionStamp>)memId;
+    return std::shared_ptr<DSMemberForVersionStamp>(memId);
   } else if (typeidLen == 2) {
     auto typeidofMember = input.readInt16();
     if (typeidofMember != static_cast<int16_t>(DSFid::DiskStoreId)) {

--- a/cppcache/src/ThinClientLocatorHelper.cpp
+++ b/cppcache/src/ThinClientLocatorHelper.cpp
@@ -108,7 +108,7 @@ GfErrType ThinClientLocatorHelper::getAllServers(
           std::make_shared<GetAllServersRequest>(serverGrp);
       auto data =
           m_poolDM->getConnectionManager().getCacheImpl()->createDataOutput();
-      data.writeInt((int32_t)1001);  // GOSSIPVERSION
+      data.writeInt(static_cast<int32_t>(1001));  // GOSSIPVERSION
       data.writeObject(request);
       auto sentLength = conn->send(
           reinterpret_cast<char*>(const_cast<uint8_t*>(data.getBuffer())), data.getBufferLength(),
@@ -195,7 +195,7 @@ GfErrType ThinClientLocatorHelper::getEndpointForNewCallBackConn(
               memId, exclEndPts, redundancy, false, serverGrp);
       auto data =
           m_poolDM->getConnectionManager().getCacheImpl()->createDataOutput();
-      data.writeInt((int32_t)1001);  // GOSSIPVERSION
+      data.writeInt(static_cast<int32_t>(1001));  // GOSSIPVERSION
       data.writeObject(request);
       auto sentLength = conn->send(
           reinterpret_cast<char*>(const_cast<uint8_t*>(data.getBuffer())), data.getBufferLength(),
@@ -373,7 +373,7 @@ GfErrType ThinClientLocatorHelper::updateLocators(
           std::make_shared<LocatorListRequest>(serverGrp);
       auto data =
           m_poolDM->getConnectionManager().getCacheImpl()->createDataOutput();
-      data.writeInt((int32_t)1001);  // GOSSIPVERSION
+      data.writeInt(static_cast<int32_t>(1001));  // GOSSIPVERSION
       data.writeObject(request);
       auto sentLength = conn->send(
           reinterpret_cast<char*>(const_cast<uint8_t*>(data.getBuffer())), data.getBufferLength(),

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -559,15 +559,14 @@ std::string ThinClientPoolDM::selectEndpoint(
     // Update Locator Request Stats
     getStats().incLoctorRequests();
 
-    if (GF_NOERR != ((ThinClientLocatorHelper*)m_locHelper)
+    if (GF_NOERR != (m_locHelper)
                         ->getEndpointForNewFwdConn(
                             outEndpoint, additionalLoc, excludeServers,
                             m_attrs->m_serverGrp, currentServer)) {
       throw IllegalStateException("Locator query failed");
     }
     // Update Locator stats
-    getStats().setLocators(
-        ((ThinClientLocatorHelper*)m_locHelper)->getCurLocatorsNum());
+    getStats().setLocators((m_locHelper)->getCurLocatorsNum());
     getStats().incLoctorResposes();
 
     char epNameStr[128] = {0};
@@ -2110,8 +2109,7 @@ int ThinClientPoolDM::updateLocatorList(volatile bool& isRunning) {
   while (isRunning) {
     m_updateLocatorListSema.acquire();
     if (isRunning && !m_connManager.isNetDown()) {
-      ((ThinClientLocatorHelper*)m_locHelper)
-          ->updateLocators(this->getServerGroup());
+      (m_locHelper)->updateLocators(this->getServerGroup());
     }
   }
   LOGFINE("Ending updateLocatorList thread for pool %s", m_poolName.c_str());

--- a/cppcache/src/Utils.cpp
+++ b/cppcache/src/Utils.cpp
@@ -173,7 +173,7 @@ std::string Utils::convertBytesToString(const uint8_t* bytes, size_t length,
     std::stringstream ss;
     ss << std::setfill('0') << std::hex;
     for (size_t i = 0; i < length; ++i) {
-      ss << std::setw(2) << (int)bytes[i];
+      ss << std::setw(2) << static_cast<int>(bytes[i]);
     }
     return ss.str();
   }

--- a/cppcache/src/VersionTag.cpp
+++ b/cppcache/src/VersionTag.cpp
@@ -81,7 +81,7 @@ void VersionTag::readMembers(uint16_t flags, DataInput& input) {
     auto internalMemId = std::make_shared<ClientProxyMembershipID>();
     internalMemId->readEssentialData(input);
     m_internalMemId = m_memberListForVersionStamp.add(
-        (std::shared_ptr<DSMemberForVersionStamp>)internalMemId);
+        std::dynamic_pointer_cast<DSMemberForVersionStamp>(internalMemId));
   }
   if ((flags & HAS_PREVIOUS_MEMBER_ID) != 0) {
     if ((flags & DUPLICATE_MEMBER_IDS) != 0) {

--- a/cppcache/src/statistics/StatArchiveWriter.cpp
+++ b/cppcache/src/statistics/StatArchiveWriter.cpp
@@ -105,7 +105,7 @@ void StatDataOutput::resetBuffer() {
 }
 
 void StatDataOutput::writeByte(int8_t v) {
-  dataBuffer->write((int8_t)v);
+  dataBuffer->write(v);
   bytesWritten += 1;
 }
 
@@ -227,7 +227,7 @@ void ResourceInst::writeSample() {
 }
 
 void ResourceInst::writeStatValue(StatisticDescriptor *sd, int64_t v) {
-  StatisticDescriptorImpl *sdImpl = (StatisticDescriptorImpl *)sd;
+  auto sdImpl = static_cast<StatisticDescriptorImpl *>(sd);
   if (sdImpl == nullptr) {
     throw NullPointerException("could not downcast to StatisticDescriptorImpl");
   }
@@ -581,7 +581,7 @@ const ResourceType *StatArchiveWriter::getResourceType(const Statistics *s) {
     for (int32_t i = 0; i < descCnt; i++) {
       std::string statsName = stats[i]->getName();
       this->dataBuffer->writeUTF(statsName);
-      StatisticDescriptorImpl *sdImpl = (StatisticDescriptorImpl *)stats[i];
+      auto sdImpl = static_cast<StatisticDescriptorImpl *>(stats[i]);
       if (sdImpl == nullptr) {
         throw NullPointerException(
             "could not down cast to StatisticDescriptorImpl");

--- a/cppcache/src/util/string.hpp
+++ b/cppcache/src/util/string.hpp
@@ -35,7 +35,7 @@ namespace client {
  */
 constexpr std::codecvt_mode codecvt_mode_native_endian =
     endian::native == endian::little ? std::little_endian
-                                     : (std::codecvt_mode)0;
+                                     : static_cast<std::codecvt_mode>(0);
 
 inline std::u16string to_utf16(const std::string& utf8) {
 #if defined(_MSC_VER) && _MSC_VER >= 1900

--- a/cppcache/test/CacheableStringTests.cpp
+++ b/cppcache/test/CacheableStringTests.cpp
@@ -79,7 +79,7 @@ inline std::string to_hex(const uint8_t* bytes, size_t len) {
   std::stringstream ss;
   ss << std::setfill('0') << std::hex;
   for (size_t i(0); i < len; ++i) {
-    ss << std::setw(2) << (int)bytes[i];
+    ss << std::setw(2) << static_cast<int>(bytes[i]);
   }
   return ss.str();
 }

--- a/cppcache/test/DataOutputTest.cpp
+++ b/cppcache/test/DataOutputTest.cpp
@@ -114,9 +114,9 @@ TEST_F(DataOutputTest, TestWriteInt8) {
 
 TEST_F(DataOutputTest, TestWriteSequenceNumber) {
   TestDataOutput dataOutput(nullptr);
-  dataOutput.writeInt((int32_t)55);
-  dataOutput.writeInt((int32_t)17);
-  dataOutput.writeInt((int32_t)0);
+  dataOutput.writeInt(static_cast<int32_t>(55));
+  dataOutput.writeInt(static_cast<int32_t>(17));
+  dataOutput.writeInt(static_cast<int32_t>(0));
   dataOutput.writeInt(getRandomSequenceNumber());
   dataOutput.write(static_cast<uint8_t>(0U));
   EXPECT_BYTEARRAY_EQ("000000370000001100000000\\h{8}00",

--- a/dhimpl/DHImpl.cpp
+++ b/dhimpl/DHImpl.cpp
@@ -81,9 +81,10 @@ ASN1_SEQUENCE(
 
   m_dh = DH_new();
 
-  BIGNUM* pbn = nullptr;
-  BIGNUM* gbn = nullptr;
-  DH_get0_pqg(m_dh, const_cast<const BIGNUM**>(&pbn), nullptr, const_cast<const BIGNUM**>(&gbn));
+  BIGNUM *pbn = nullptr;
+  BIGNUM *gbn = nullptr;
+  DH_get0_pqg(m_dh, const_cast<const BIGNUM **>(&pbn), nullptr,
+              const_cast<const BIGNUM **>(&gbn));
   BN_dec2bn(&pbn, dhP);
 
   LOGDH(" DHInit: P ptr is %p", pbn);
@@ -324,25 +325,22 @@ unsigned char *gf_encryptDH(const unsigned char *cleartext, int len,
   unsigned char *ciphertext =
       new unsigned char[len + 50];  // give enough room for padding
   int outlen, tmplen;
-  EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+  auto ctx = EVP_CIPHER_CTX_new();
 
-  const EVP_CIPHER *cipherFunc = getCipherFunc();
+  auto cipherFunc = getCipherFunc();
 
   // init openssl cipher context
   if (m_skAlgo == "AES") {
     int keySize = m_keySize > 128 ? m_keySize / 8 : 16;
-    EVP_EncryptInit_ex(ctx, cipherFunc, nullptr, (unsigned char *)m_key,
-                       (unsigned char *)m_key + keySize);
+    EVP_EncryptInit_ex(ctx, cipherFunc, nullptr, m_key, m_key + keySize);
   } else if (m_skAlgo == "Blowfish") {
     int keySize = m_keySize > 128 ? m_keySize / 8 : 16;
-    EVP_EncryptInit_ex(ctx, cipherFunc, nullptr, nullptr,
-                       (unsigned char *)m_key + keySize);
+    EVP_EncryptInit_ex(ctx, cipherFunc, nullptr, nullptr, m_key + keySize);
     EVP_CIPHER_CTX_set_key_length(ctx, keySize);
     LOGDH("DHencrypt: BF keysize is %d", keySize);
-    EVP_EncryptInit_ex(ctx, nullptr, nullptr, (unsigned char *)m_key, nullptr);
+    EVP_EncryptInit_ex(ctx, nullptr, nullptr, m_key, nullptr);
   } else if (m_skAlgo == "DESede") {
-    EVP_EncryptInit_ex(ctx, cipherFunc, nullptr, (unsigned char *)m_key,
-                       (unsigned char *)m_key + 24);
+    EVP_EncryptInit_ex(ctx, cipherFunc, nullptr, m_key, m_key + 24);
   }
 
   if (!EVP_EncryptUpdate(ctx, ciphertext, &outlen, cleartext, len)) {
@@ -393,12 +391,12 @@ bool gf_verifyDH(const char *subject, const unsigned char *challenge,
   }
 
   for (int item = 0; item < count; item++) {
-    certsubject =
-        X509_NAME_oneline(X509_get_subject_name(m_serverCerts[item]), nullptr, 0);
+    certsubject = X509_NAME_oneline(X509_get_subject_name(m_serverCerts[item]),
+                                    nullptr, 0);
 
     // Ignore first letter for comparision, openssl adds / before subject name
     // e.g. /CN=geode1
-    if (strcmp((const char *)certsubject + 1, subject) == 0) {
+    if (strcmp(certsubject + 1, subject) == 0) {
       evpkey = X509_get_pubkey(m_serverCerts[item]);
       cert = m_serverCerts[item];
       LOGDH("Found subject [%s] in stored certificates", certsubject);
@@ -510,7 +508,8 @@ int DH_PUBKEY_set(DH_PUBKEY **x, EVP_PKEY *pkey) {
 
   asn1int = BN_to_ASN1_INTEGER(pub_key, nullptr);
   if ((i = i2d_ASN1_INTEGER(asn1int, nullptr)) <= 0) goto err;
-  if ((s = reinterpret_cast<unsigned char *>(OPENSSL_malloc(i + 1))) == nullptr) {
+  if ((s = reinterpret_cast<unsigned char *>(OPENSSL_malloc(i + 1))) ==
+      nullptr) {
     X509err(X509_F_X509_PUBKEY_SET, ERR_R_MALLOC_FAILURE);
     goto err;
   }

--- a/tests/cpp/fwklib/CMakeLists.txt
+++ b/tests/cpp/fwklib/CMakeLists.txt
@@ -4,9 +4,9 @@
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -57,10 +57,11 @@ target_include_directories(framework
 )
 
 target_link_libraries(framework
-  PUBLIC 
+  PUBLIC
     apache-geode
   PRIVATE
     ACE
+		internal
 	  _WarningsAsError
 )
 

--- a/tests/cpp/fwklib/FwkLog.cpp
+++ b/tests/cpp/fwklib/FwkLog.cpp
@@ -17,8 +17,11 @@
 
 #include <cinttypes>
 
-#include "fwklib/FwkLog.hpp"
 #include <geode/Exception.hpp>
+
+#include "fwklib/FwkLog.hpp"
+#include "fwklib/PerfFwk.hpp"
+#include "hacks/AceThreadId.h"
 
 namespace apache {
 namespace geode {
@@ -74,9 +77,9 @@ void plog(const char* l, const char* s, const char* filename, int32_t lineno) {
 
   const char* fil = dirAndFile(filename);
 
-  fprintf(stdout, "[%s %s %s:P%d:T%" PRIXPTR "]::%s::%d  %s  %s\n", buf,
+  fprintf(stdout, "[%s %s %s:P%d:T%" PRIu64 "]::%s::%d  %s  %s\n", buf,
           u.sysname, u.nodename, ACE_OS::getpid(),
-          (uintptr_t)(ACE_Thread::self()), fil, lineno, l, s);
+          hacks::aceThreadId(ACE_OS::thr_self()), fil, lineno, l, s);
   fflush(stdout);
 }
 

--- a/tests/cpp/fwklib/TcpIpc.cpp
+++ b/tests/cpp/fwklib/TcpIpc.cpp
@@ -39,7 +39,7 @@ namespace testframework {
 
 void TcpIpc::clearNagle(ACE_HANDLE sock) {
   int32_t val = 1;
-  char *param = (char *)&val;
+  char *param = reinterpret_cast<char *>(&val);
   int32_t plen = sizeof(val);
 
   if (0 != ACE_OS::setsockopt(sock, IPPROTO_TCP, 1, param, plen)) {

--- a/tests/cpp/fwklib/UDPIpc.cpp
+++ b/tests/cpp/fwklib/UDPIpc.cpp
@@ -76,7 +76,7 @@ bool UDPMessage::receiveFrom(ACE_SOCK_Dgram& io,
     FWKEXCEPTION("UDPMessage::receiveFrom: Failed, header length: " << len);
   }
   clear();
-  memcpy((void*)&m_hdr, buffs.iov_base, UDP_HEADER_SIZE);
+  memcpy(&m_hdr, buffs.iov_base, UDP_HEADER_SIZE);
   if (m_hdr.tag != UDP_MSG_TAG) {
     FWKEXCEPTION("UDPMessage::receiveFrom: Failed, invalid tag: " << m_hdr.tag);
   }

--- a/tests/cpp/testobject/PdxClassV2.cpp
+++ b/tests/cpp/testobject/PdxClassV2.cpp
@@ -548,8 +548,8 @@ bool PdxTypesIgnoreUnreadFieldsV2::equals(
 }
 
 void PdxTypesIgnoreUnreadFieldsV2::updateMembers() {
-  m_i5 = (int32_t)m_diffInExtraFields;
-  m_i6 = (int32_t)m_diffInExtraFields;
+  m_i5 = static_cast<int32_t>(m_diffInExtraFields);
+  m_i6 = static_cast<int32_t>(m_diffInExtraFields);
 }
 
 void PdxTypesIgnoreUnreadFieldsV2::toData(PdxWriter& pw) const {
@@ -563,8 +563,8 @@ void PdxTypesIgnoreUnreadFieldsV2::toData(PdxWriter& pw) const {
   pw.writeInt("i5", m_diffInExtraFields);
   pw.writeInt("i6", m_diffInExtraFields);
 
-  m_i5 = (int32_t)m_diffInExtraFields;
-  m_i6 = (int32_t)m_diffInExtraFields;
+  m_i5 = static_cast<int32_t>(m_diffInExtraFields);
+  m_i6 = static_cast<int32_t>(m_diffInExtraFields);
 
   m_diffInSameFields++;
   m_diffInExtraFields++;


### PR DESCRIPTION
* Uses static_cast<> over C-style cast.
* Fixes ACE thread id to string.