### PR TITLE
GEODE-5638: Move cppcache/integration-tests to legacy

### DIFF
--- a/cppcache/integration-test/CMakeLists.txt
+++ b/cppcache/integration-test/CMakeLists.txt
@@ -87,7 +87,7 @@ foreach(FILE ${SOURCES})
   set(TESTS ${TESTS} ${TEST})
   add_dependencies(integration-tests ${TEST})
   add_executable(${TEST} ${FILE})
-  set_target_properties(${TEST} PROPERTIES FOLDER cpp/test/integration)
+  set_target_properties(${TEST} PROPERTIES FOLDER cpp/test/integration/legacy)
 
   target_link_libraries(${TEST}
     PRIVATE


### PR DESCRIPTION
This change puts all of the old framework cpp integration tests into a legacy subdirectory to make it easier to find the other test related projects.