### PR TITLE
GEODE-5942: prefix variables in PersistenceManager

### DIFF
--- a/cppcache/include/geode/PersistenceManager.hpp
+++ b/cppcache/include/geode/PersistenceManager.hpp
@@ -51,9 +51,9 @@ typedef std::shared_ptr<PersistenceManager> (*getPersistenceManagerInstance)(
  */
 class APACHE_GEODE_EXPORT PersistenceManager {
  public:
-  static constexpr char const* MAX_PAGE_COUNT = "MaxPageCount";
-  static constexpr char const* PAGE_SIZE = "PageSize";
-  static constexpr char const* PERSISTENCE_DIR = "PersistenceDirectory";
+  static constexpr char const* PM_MAX_PAGE_COUNT = "MaxPageCount";
+  static constexpr char const* PM_PAGE_SIZE = "PageSize";
+  static constexpr char const* PM_PERSISTENCE_DIR = "PersistenceDirectory";
 
   /**
    * Returns the current persistence manager.

--- a/cppcache/integration-test/testOverflowPutGetSqLite.cpp
+++ b/cppcache/integration-test/testOverflowPutGetSqLite.cpp
@@ -337,9 +337,9 @@ void setSqLiteProperties(std::shared_ptr<Properties> &sqliteProperties,
                          int maxPageCount = 1073741823, int pageSize = 65536,
                          std::string pDir = sqlite_dir) {
   sqliteProperties = Properties::create();
-  sqliteProperties->insert(PersistenceManager::MAX_PAGE_COUNT, maxPageCount);
-  sqliteProperties->insert(PersistenceManager::PAGE_SIZE, pageSize);
-  sqliteProperties->insert(PersistenceManager::PERSISTENCE_DIR, pDir.c_str());
+  sqliteProperties->insert(PersistenceManager::PM_MAX_PAGE_COUNT, maxPageCount);
+  sqliteProperties->insert(PersistenceManager::PM_PAGE_SIZE, pageSize);
+  sqliteProperties->insert(PersistenceManager::PM_PERSISTENCE_DIR, pDir.c_str());
   ASSERT(sqliteProperties != nullptr,
          "Expected sqlite properties to be NON-nullptr");
 }

--- a/cppcache/integration-test/testOverflowPutGetSqLite.cpp
+++ b/cppcache/integration-test/testOverflowPutGetSqLite.cpp
@@ -339,7 +339,8 @@ void setSqLiteProperties(std::shared_ptr<Properties> &sqliteProperties,
   sqliteProperties = Properties::create();
   sqliteProperties->insert(PersistenceManager::PM_MAX_PAGE_COUNT, maxPageCount);
   sqliteProperties->insert(PersistenceManager::PM_PAGE_SIZE, pageSize);
-  sqliteProperties->insert(PersistenceManager::PM_PERSISTENCE_DIR, pDir.c_str());
+  sqliteProperties->insert(PersistenceManager::PM_PERSISTENCE_DIR,
+                           pDir.c_str());
   ASSERT(sqliteProperties != nullptr,
          "Expected sqlite properties to be NON-nullptr");
 }

--- a/cppcache/src/PersistenceManager.cpp
+++ b/cppcache/src/PersistenceManager.cpp
@@ -21,9 +21,9 @@ namespace apache {
 namespace geode {
 namespace client {
 
-constexpr char const* PersistenceManager::MAX_PAGE_COUNT;
-constexpr char const* PersistenceManager::PAGE_SIZE;
-constexpr char const* PersistenceManager::PERSISTENCE_DIR;
+constexpr char const* PersistenceManager::PM_MAX_PAGE_COUNT;
+constexpr char const* PersistenceManager::PM_PAGE_SIZE;
+constexpr char const* PersistenceManager::PM_PERSISTENCE_DIR;
 
 }  // namespace client
 }  // namespace geode

--- a/sqliteimpl/SqLiteImpl.cpp
+++ b/sqliteimpl/SqLiteImpl.cpp
@@ -43,9 +43,9 @@ void SqLiteImpl::init(const std::shared_ptr<Region> &region,
   m_persistanceDir = g_default_persistence_directory;
   std::string regionName = region->getName();
   if (diskProperties != nullptr) {
-    auto maxPageCountPtr = diskProperties->find(MAX_PAGE_COUNT);
-    auto pageSizePtr = diskProperties->find(PAGE_SIZE);
-    auto persDir = diskProperties->find(PERSISTENCE_DIR);
+    auto maxPageCountPtr = diskProperties->find(PM_MAX_PAGE_COUNT);
+    auto pageSizePtr = diskProperties->find(PM_PAGE_SIZE);
+    auto persDir = diskProperties->find(PM_PERSISTENCE_DIR);
 
     if (maxPageCountPtr != nullptr) {
       maxPageCount = atoi(maxPageCountPtr->value().c_str());


### PR DESCRIPTION
  PAGE_SIZE causes conflicts with system library header files.
  So adding a PM prefix to all variables in PersistenceManager.

Signed-off-by: Matthew Reddington <mreddington@gmail.com>