### PR TITLE
GEODE-5968 Updated missing source headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -209,3 +209,29 @@ with separate copyright notices and license terms. Your use of those
 components are subject to the terms and conditions of the following
 licenses.
 
+---------------------------------------------------------------------------
+The MIT License (http://opensource.org/licenses/mit-license.html)
+---------------------------------------------------------------------------
+
+Apache Geode bundles the following files under the MIT license:
+
+  - cotire (https://github.com/sakra/cotire), Copyright (c) 2012-
+    2018 Sascha Kratky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/clicache/integration-test/DataOutputTests.cs
+++ b/clicache/integration-test/DataOutputTests.cs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 

--- a/clicache/integration-test/Settings.xml
+++ b/clicache/integration-test/Settings.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/clicache/integration-test/ThinClientAppDomainQueryTests.cs
+++ b/clicache/integration-test/ThinClientAppDomainQueryTests.cs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-﻿using System;
+using System;
 
 namespace Apache.Geode.Client.UnitTests
 {

--- a/clicache/integration-test/ThinClientSecurityAuthSetAuthInitializeTests.cs
+++ b/clicache/integration-test/ThinClientSecurityAuthSetAuthInitializeTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/clicache/integration-test/Timeouts.xml
+++ b/clicache/integration-test/Timeouts.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/clicache/integration-test/client_server_persistent_transactions.xml
+++ b/clicache/integration-test/client_server_persistent_transactions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/clicache/integration-test/client_server_transactions.xml
+++ b/clicache/integration-test/client_server_transactions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more

--- a/clicache/integration-test2/Cluster.cs
+++ b/clicache/integration-test2/Cluster.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/clicache/integration-test2/ClusterTest.cs
+++ b/clicache/integration-test2/ClusterTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/clicache/integration-test2/Command.cs
+++ b/clicache/integration-test2/Command.cs
@@ -1,4 +1,21 @@
-﻿using System;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Diagnostics;
 using System.Net;
 using System.IO;

--- a/clicache/integration-test2/Gfsh.cs
+++ b/clicache/integration-test2/Gfsh.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/clicache/integration-test2/GfshExecute.cs
+++ b/clicache/integration-test2/GfshExecute.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/clicache/integration-test2/GfshExecuteTest.cs
+++ b/clicache/integration-test2/GfshExecuteTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/clicache/integration-test2/GfshTest.cs
+++ b/clicache/integration-test2/GfshTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/clicache/integration-test2/TestBase.cs
+++ b/clicache/integration-test2/TestBase.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/clicache/integration-test2/cache.xml
+++ b/clicache/integration-test2/cache.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/clicache/integration-test2/packages.config
+++ b/clicache/integration-test2/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with

--- a/clicache/integration-test2/xunit.runner.json
+++ b/clicache/integration-test2/xunit.runner.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "methodDisplay": "classAndMethod",
   "parallelizeAssembly":  true,
   "parallelizeTestCollections": true 

--- a/clicache/plugins/SQLiteCLI/SqLiteImpl.cs
+++ b/clicache/plugins/SQLiteCLI/SqLiteImpl.cs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-﻿using System;
+using System;
 using System.Data;
 using System.Data.SQLite;
 using Apache.Geode.Client;

--- a/clicache/src/impl/AppDomainContext.cpp
+++ b/clicache/src/impl/AppDomainContext.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/clicache/test2/packages.config
+++ b/clicache/test2/packages.config
@@ -1,4 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <packages>
   <package id="Microsoft.VisualStudio.TestPlatform" version="14.0.0.1" targetFramework="net452" />
   <package id="xunit" version="2.4.0" targetFramework="net452" />

--- a/clicache/test2/xunit.runner.json
+++ b/clicache/test2/xunit.runner.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "methodDisplay": "classAndMethod",
   "parallelizeAssembly":  true,
   "parallelizeTestCollections": true 

--- a/examples/dotnet/AuthInitialize/ExampleAuthInitialize.cs
+++ b/examples/dotnet/AuthInitialize/ExampleAuthInitialize.cs
@@ -1,4 +1,21 @@
-﻿using System;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using Apache.Geode.Client;
 
 namespace Apache.Geode.Examples.AuthInitialize

--- a/examples/dotnet/AuthInitialize/Program.cs
+++ b/examples/dotnet/AuthInitialize/Program.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.

--- a/examples/dotnet/AuthInitialize/README.md
+++ b/examples/dotnet/AuthInitialize/README.md
@@ -1,4 +1,4 @@
-﻿# AuthInitialize Example
+# AuthInitialize Example
 This example shows how to create and register a custom `IAuthIntialize` authentication
 handler. 
 

--- a/examples/dotnet/AuthInitialize/startserver.ps1
+++ b/examples/dotnet/AuthInitialize/startserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/examples/dotnet/AuthInitialize/stopserver.ps1
+++ b/examples/dotnet/AuthInitialize/stopserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/examples/dotnet/ContinuousQueryCs/MyCqListener.cs
+++ b/examples/dotnet/ContinuousQueryCs/MyCqListener.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.

--- a/examples/dotnet/ContinuousQueryCs/Order.cs
+++ b/examples/dotnet/ContinuousQueryCs/Order.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.

--- a/examples/dotnet/ContinuousQueryCs/Program.cs
+++ b/examples/dotnet/ContinuousQueryCs/Program.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.

--- a/examples/dotnet/ContinuousQueryCs/README.md
+++ b/examples/dotnet/ContinuousQueryCs/README.md
@@ -1,4 +1,4 @@
-﻿# ContinuousQuery Example
+# ContinuousQuery Example
 This is a simple example showing how to execute a continuous query on a Goede region.
 
 ## Prerequisites

--- a/examples/dotnet/ContinuousQueryCs/startserver.ps1
+++ b/examples/dotnet/ContinuousQueryCs/startserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/examples/dotnet/ContinuousQueryCs/stopserver.ps1
+++ b/examples/dotnet/ContinuousQueryCs/stopserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/examples/dotnet/DataSerializableCs/Order.cs
+++ b/examples/dotnet/DataSerializableCs/Order.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.

--- a/examples/dotnet/DataSerializableCs/Program.cs
+++ b/examples/dotnet/DataSerializableCs/Program.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.

--- a/examples/dotnet/DataSerializableCs/startserver.ps1
+++ b/examples/dotnet/DataSerializableCs/startserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/examples/dotnet/DataSerializableCs/stopserver.ps1
+++ b/examples/dotnet/DataSerializableCs/stopserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/examples/dotnet/PdxAutoSerializer/Order.cs
+++ b/examples/dotnet/PdxAutoSerializer/Order.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.

--- a/examples/dotnet/PdxAutoSerializer/Program.cs
+++ b/examples/dotnet/PdxAutoSerializer/Program.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.

--- a/examples/dotnet/PdxAutoSerializer/README.md
+++ b/examples/dotnet/PdxAutoSerializer/README.md
@@ -1,4 +1,4 @@
-﻿# PdxAutoSerializer Example
+# PdxAutoSerializer Example
 This is a simple example showing how to register for auto-serialization of custom objects using the ReflectionBasedAutoSerializer class.
 
 ## Prerequisites

--- a/examples/dotnet/PdxAutoSerializer/startserver.ps1
+++ b/examples/dotnet/PdxAutoSerializer/startserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/examples/dotnet/PdxAutoSerializer/stopserver.ps1
+++ b/examples/dotnet/PdxAutoSerializer/stopserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/examples/dotnet/PdxSerializableCs/Order.cs
+++ b/examples/dotnet/PdxSerializableCs/Order.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.

--- a/examples/dotnet/PdxSerializableCs/Program.cs
+++ b/examples/dotnet/PdxSerializableCs/Program.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.

--- a/examples/dotnet/PdxSerializableCs/README.md
+++ b/examples/dotnet/PdxSerializableCs/README.md
@@ -1,4 +1,4 @@
-﻿# PdxSerializable Example
+# PdxSerializable Example
 This is a simple example showing how to register for serialization of custom objects using the IPDXSerializable class.
 
 ## Prerequisites

--- a/examples/dotnet/PdxSerializableCs/startserver.ps1
+++ b/examples/dotnet/PdxSerializableCs/startserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/examples/dotnet/PdxSerializableCs/stopserver.ps1
+++ b/examples/dotnet/PdxSerializableCs/stopserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/examples/dotnet/PutGetRemove/Program.cs
+++ b/examples/dotnet/PutGetRemove/Program.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.

--- a/examples/dotnet/PutGetRemove/README.md
+++ b/examples/dotnet/PutGetRemove/README.md
@@ -1,4 +1,4 @@
-﻿# PutGetRemove Example
+# PutGetRemove Example
 This is a very simple example showing how to create a `Cache` using the `CacheFactory`,
 configure a `Pool` with a `PoolFactory`, and configure a `Region` with a `RegionFactory`.
 We then put, get, and remove some primitive data in the region.

--- a/examples/dotnet/PutGetRemove/startserver.ps1
+++ b/examples/dotnet/PutGetRemove/startserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/examples/dotnet/PutGetRemove/stopserver.ps1
+++ b/examples/dotnet/PutGetRemove/stopserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/examples/dotnet/RemoteQueryCs/Order.cs
+++ b/examples/dotnet/RemoteQueryCs/Order.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.

--- a/examples/dotnet/RemoteQueryCs/Program.cs
+++ b/examples/dotnet/RemoteQueryCs/Program.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.

--- a/examples/dotnet/RemoteQueryCs/README.md
+++ b/examples/dotnet/RemoteQueryCs/README.md
@@ -1,4 +1,4 @@
-﻿# RemoteQuery Example
+# RemoteQuery Example
 This is a simple example showing how to execute a query on a remote region.
 
 ## Prerequisites

--- a/examples/dotnet/RemoteQueryCs/startserver.ps1
+++ b/examples/dotnet/RemoteQueryCs/startserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/examples/dotnet/RemoteQueryCs/stopserver.ps1
+++ b/examples/dotnet/RemoteQueryCs/stopserver.ps1
@@ -1,4 +1,4 @@
-﻿# Licensed to the Apache Software Foundation (ASF) under one or more
+# Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0

--- a/tests/cli/FwkClient/App.config
+++ b/tests/cli/FwkClient/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/xsds/cpp-cache-1.0.xsd
+++ b/xsds/cpp-cache-1.0.xsd
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
Remove BOM so that rat can check for correct headers. Add cotire
reference to LICENSE since it is included in the source and under
an MIT license.