### PR TITLE
GEODE-5942: Remove named constants from PersistenceManager

### DIFF
--- a/cppcache/include/geode/PersistenceManager.hpp
+++ b/cppcache/include/geode/PersistenceManager.hpp
@@ -51,10 +51,6 @@ typedef std::shared_ptr<PersistenceManager> (*getPersistenceManagerInstance)(
  */
 class APACHE_GEODE_EXPORT PersistenceManager {
  public:
-  static constexpr char const* MAX_PAGE_COUNT = "MaxPageCount";
-  static constexpr char const* PAGE_SIZE = "PageSize";
-  static constexpr char const* PERSISTENCE_DIR = "PersistenceDirectory";
-
   /**
    * Returns the current persistence manager.
    * @return persistence manager

--- a/cppcache/integration-test/testOverflowPutGetSqLite.cpp
+++ b/cppcache/integration-test/testOverflowPutGetSqLite.cpp
@@ -50,6 +50,10 @@ using apache::geode::client::RegionShortcut;
 uint32_t numOfEnt;
 std::string sqlite_dir = "SqLiteRegionData";
 
+static constexpr char const *MAX_PAGE_COUNT = "MaxPageCount";
+static constexpr char const *PAGE_SIZE = "PageSize";
+static constexpr char const *PERSISTENCE_DIR = "PersistenceDirectory";
+
 // Return the number of keys and values in entries map.
 void getNumOfEntries(std::shared_ptr<Region> &regionPtr, uint32_t num) {
   auto v = regionPtr->keys();
@@ -338,9 +342,9 @@ void setSqLiteProperties(std::shared_ptr<Properties> &sqliteProperties,
                          int maxPageCount = 1073741823, int pageSize = 65536,
                          std::string pDir = sqlite_dir) {
   sqliteProperties = Properties::create();
-  sqliteProperties->insert(PersistenceManager::MAX_PAGE_COUNT, maxPageCount);
-  sqliteProperties->insert(PersistenceManager::PAGE_SIZE, pageSize);
-  sqliteProperties->insert(PersistenceManager::PERSISTENCE_DIR, pDir.c_str());
+  sqliteProperties->insert(MAX_PAGE_COUNT, maxPageCount);
+  sqliteProperties->insert(PAGE_SIZE, pageSize);
+  sqliteProperties->insert(PERSISTENCE_DIR, pDir.c_str());
   ASSERT(sqliteProperties != nullptr,
          "Expected sqlite properties to be NON-nullptr");
 }

--- a/cppcache/src/PersistenceManager.cpp
+++ b/cppcache/src/PersistenceManager.cpp
@@ -19,12 +19,6 @@
 
 namespace apache {
 namespace geode {
-namespace client {
-
-constexpr char const* PersistenceManager::MAX_PAGE_COUNT;
-constexpr char const* PersistenceManager::PAGE_SIZE;
-constexpr char const* PersistenceManager::PERSISTENCE_DIR;
-
-}  // namespace client
+namespace client {}  // namespace client
 }  // namespace geode
 }  // namespace apache

--- a/sqliteimpl/SqLiteImpl.cpp
+++ b/sqliteimpl/SqLiteImpl.cpp
@@ -33,6 +33,10 @@ namespace apache {
 namespace geode {
 namespace client {
 
+static constexpr char const* MAX_PAGE_COUNT = "MaxPageCount";
+static constexpr char const* PAGE_SIZE = "PageSize";
+static constexpr char const* PERSISTENCE_DIR = "PersistenceDirectory";
+
 void SqLiteImpl::init(const std::shared_ptr<Region> &region,
                       const std::shared_ptr<Properties> &diskProperties) {
   // Set the default values


### PR DESCRIPTION
- These should just be agreed-upon values between client code and plugin

Co-authored-by: Sai Boorlagaddda <sai.boorlagadda@gmail.com>