### PR TITLE
GEODE-6012: Corrected package name in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,14 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu
+#FROM ubuntu
+FROM ubuntu:16.04
 LABEL maintainer Apache Geode <dev@geode.apache.org>
 
 ENV CLANG_VERSION 6.0
 RUN apt-get update && \
         apt-get install -y \
             libc++-dev \
-            libc++api-dev \
+            libc++abi-dev \
             clang-${CLANG_VERSION} \
             clang-tidy-${CLANG_VERSION} \
             clang-format-${CLANG_VERSION} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#FROM ubuntu
-FROM ubuntu:16.04
+FROM ubuntu
 LABEL maintainer Apache Geode <dev@geode.apache.org>
 
 ENV CLANG_VERSION 6.0


### PR DESCRIPTION
- libc++api-dev (non-existent) changed to libc++abi-dev

Docker image successfully builds and geode-native is able to be built on resulting image.