### PR TITLE
GEODE-4337: Correct Path Searching in FindGeode module

### DIFF
--- a/cmake/FindGeode.cmake
+++ b/cmake/FindGeode.cmake
@@ -35,20 +35,20 @@ endif()
 set(_GEODE_HINTS)
 if(_GEODE_ROOT)
   set(_GEODE_HINTS ${_GEODE_ROOT}/bin)
+else()
+  set(_GEODE_PATHS
+    /geode/bin
+    /apache-geode/bin
+    /usr/geode/bin
+    /usr/apache-geode/bin
+    /usr/local/geode/bin
+    /usr/local/apache-geode/bin
+    /opt/geode/bin
+    /opt/apache-geode/bin
+    /opt/local/geode/bin
+    /opt/local/apache-geode/bin
+  )
 endif()
-
-set(_GEODE_PATHS
-  /geode/bin
-  /apache-geode/bin
-  /usr/geode/bin
-  /usr/apache-geode/bin
-  /usr/local/geode/bin
-  /usr/local/apache-geode/bin
-  /opt/geode/bin
-  /opt/apache-geode/bin
-  /opt/local/geode/bin
-  /opt/local/apache-geode/bin
-)
 
 if(WIN32)
   set(_GEODE_NAMES gfsh.bat)


### PR DESCRIPTION
- Function execution example includes a jar, so we need Geode to build the java code
- Geode find module problem was breaking build of examples.  It was setting the 'hints' variable to the value of GEODE_ROOT, which only works if the 'paths' parameter to find_package_handle_standard_args is empty, but it was always setting paths.  Switched it to set one or the other like the FindGeodeNative find module does, and all is better.

Co-authored-by: Matthew Reddington <mreddington@pivotal.io>