### PR TITLE
Create configuration for LGTM.com

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,16 @@
+extraction:
+  cpp:
+    configure:
+      command:
+        - mkdir _lgtm_build_dir
+        - cd _lgtm_build_dir
+        - wget -O apache-geode.zip http://mirror.transip.net/apache/geode/1.7.0/apache-geode-1.7.0.zip
+        - unzip apache-geode.zip
+        - cmake -DGEODE_ROOT="`pwd`/apache-geode-1.7.0" ..
+        - cd dependencies && cmake --build . -- -j2
+    index:
+      build_command:
+        - cd _lgtm_build_dir && cmake --build . --target apache-geode  -- -j 2
+  csharp:
+    index:
+      buildless: true


### PR DESCRIPTION
Following our conversation [here](https://discuss.lgtm.com/t/apache-geode-native-not-detected-as-c-project/1506/13) about getting the C++ code building on LGTM.com, here's the configuration file that was used.

By including it here, you'll be able to update it when a different version of geode is needed to successfully build the project, and add further configuration options etc.

cc @pivotal-jbarrett 