### PR TITLE
GEODE-6022: Make 3.12 the minimum cmake version

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,7 +1,7 @@
 # Building
 
 ## Prerequisites (All Platforms)
-* [CMake 3.10](https://cmake.org/) or newer
+* [CMake 3.12](https://cmake.org/) or newer
 * C++11 compiler *(see platform specific requirements)*
 * [Doxygen 8.11](http://www.stack.nl/~dimitri/doxygen/download.html) *(for building source documentation)*
 * [Apache Geode](http://geode.apache.org/releases/) binaries installed or available to link against

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(nativeclient LANGUAGES C CXX)
 
 option(USE_PCH "Use precompiled headers (PCH)." OFF)


### PR DESCRIPTION
This updates the cmake minimum version from 3.10 to 3.12.