### PR TITLE
Geode-5962: Fix putAll crash with null values

### DIFF
--- a/cppcache/integration/test/RegionPutGetAllTest.cpp
+++ b/cppcache/integration/test/RegionPutGetAllTest.cpp
@@ -221,16 +221,9 @@ TEST(RegionPutGetAllTest, nullValue) {
 
   auto keys = to_keys(map);
 
-  try {
-    region->putAll(map);
-  } catch (CacheServerException) {
-    localDestroy(*region, keys);
-    return;
-  }
+  EXPECT_THROW(region->putAll(map), CacheServerException);
 
-  // TODO - Understand: Clear local cache to force fetch from server?
   localDestroy(*region, keys);
-  FAIL();
 }
 
 }  // namespace

--- a/cppcache/integration/test/RegionPutGetAllTest.cpp
+++ b/cppcache/integration/test/RegionPutGetAllTest.cpp
@@ -198,4 +198,33 @@ TEST(RegionPutGetAllTest, variousPdxTypes) {
   assert_eq(putAllMap, getAllMap);
 }
 
+// Matt and I wrote this test for GEODE-5962, but it isn't finished yet so disable.
+TEST(RegionPutGetAllTest, DISABLED_nullValue) {
+  Cluster cluster{LocatorCount{1}, ServerCount{2}};
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("REPLICATE")
+      .execute();
+
+  auto cache = cluster.createCache();
+  auto region = setupRegion(cache);
+
+  setupPdxTypes(cache);
+
+  HashMapOfCacheable map;
+
+  // Add a null value
+  map.emplace(CacheableInt32::create(PdxTypesHelper1::index),
+              std::shared_ptr<PdxTypesHelper1::type>());
+
+  auto keys = to_keys(map);
+
+  region->putAll(map);
+
+  // TODO - Understand: Clear local cache to force fetch from server?
+  localDestroy(*region, keys);
+}
+
 }  // namespace

--- a/cppcache/integration/test/RegionPutGetAllTest.cpp
+++ b/cppcache/integration/test/RegionPutGetAllTest.cpp
@@ -221,9 +221,7 @@ TEST(RegionPutGetAllTest, nullValue) {
 
   auto keys = to_keys(map);
 
-  EXPECT_THROW(region->putAll(map), CacheServerException);
-
-  localDestroy(*region, keys);
+  ASSERT_THROW(region->putAll(map), CacheServerException);
 }
 
 }  // namespace

--- a/cppcache/integration/test/RegionPutGetAllTest.cpp
+++ b/cppcache/integration/test/RegionPutGetAllTest.cpp
@@ -199,8 +199,6 @@ TEST(RegionPutGetAllTest, variousPdxTypes) {
   assert_eq(putAllMap, getAllMap);
 }
 
-// Matt and I wrote this test for GEODE-5962, but it isn't finished yet so
-// disable.
 TEST(RegionPutGetAllTest, nullValue) {
   Cluster cluster{LocatorCount{1}, ServerCount{2}};
   cluster.getGfsh()

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -862,7 +862,7 @@ void TcrMessage::processChunk(const uint8_t* bytes, int32_t len,
       if (bytes != nullptr) {
         _GEODE_SAFE_DELETE_ARRAY(bytes);
       }
-      // nothing else to done since this will be taken care of at higher level
+
       break;
     }
     default: {

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -841,7 +841,7 @@ void TcrMessage::processChunk(const uint8_t* bytes, int32_t len,
       }
       break;
     }
-    case PUT_DATA_ERROR: {
+    case TcrMessage::PUT_DATA_ERROR: {
       chunkSecurityHeader(1, bytes, len, isLastChunkAndisSecurityHeader);
       if (nullptr != bytes) {
         auto input =


### PR DESCRIPTION
This adds an error handler to TcrMessage to catch PUT_DATA_ERROR messages from the server. Also adds a test to ensure a proper exception is bubbled up to the user.