### PR TITLE
GEODE-6160: Properly escape backslashes in .cpackignore

### DIFF
--- a/.cpackignore
+++ b/.cpackignore
@@ -1,16 +1,17 @@
-/\.git/
-/\.DS_Store
+/\\.git/
+/\\.DS_Store
 
 /build-.*/
 
 /build/
-/\.settings/
-/\.cproject
-/\.project
-/\.idea/
-\.vs/
-\.vscode/
+/\\.settings/
+/\\.cproject
+/\\.project
+/\\.idea/
+\\.vs/
+\\.vscode/
 
 /examples/dotnet/.*/bin/
 /examples/dotnet/.*/obj/
-\.ruby-version
+\\.ruby-version
+


### PR DESCRIPTION
Co-authored-by: Matthew Reddington <mreddington@pivotal.io>