### PR TITLE
GEODe-6165: Bypass chocolately for install of Doxygen on Windows

### DIFF
--- a/packer/windows-2012-r2-base.json
+++ b/packer/windows-2012-r2-base.json
@@ -46,6 +46,12 @@
       ]
     },
     {
+      "type":"powershell",
+      "scripts":[
+        "windows/install-doxygen.ps1"
+      ]
+    },
+    {
       "type":"file",
       "source":"windows/init-ssh.ps1",
       "destination":"$Env:ProgramFiles/Amazon/Ec2ConfigService/Scripts/init-ssh.ps1"

--- a/packer/windows/install-dependencies.ps1
+++ b/packer/windows/install-dependencies.ps1
@@ -17,7 +17,8 @@ choco install jdk8 -confirm
 choco install cmake.portable -confirm
 choco install git.install -confirm
 choco install activeperl -confirm
-choco install doxygen.install --allowEmptyChecksums -confirm
+#Restore this line when Chocolatey Doxygen install gets fixed (2018-12-06)
+#choco install doxygen.install --allowEmptyChecksums -confirm
 choco install dogtail.dotnet3.5sp1 -confirm
 choco install nunit.install --version 2.6.4 -confirm
 choco install netfx-4.5.2-devpack --allowEmptyChecksums -confirm

--- a/packer/windows/install-doxygen.ps1
+++ b/packer/windows/install-doxygen.ps1
@@ -1,0 +1,11 @@
+$package = 'doxygen.install'
+$url  = 'http://doxygen.nl/files/doxygen-1.8.14-setup.exe'
+$sha256 = '7B1A361E0C94ADB35EB75EEE069223E7AE19A4444C5B87F65539F7951BF96025'
+
+Import-Module C:\ProgramData\chocolatey\helpers\chocolateyInstaller.psm1
+Install-ChocolateyPackage $package 'exe' '/VERYSILENT' $url -Checksum $sha256 -ChecksumType 'sha256'
+
+$oldpath = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).path
+$newpath = "$oldpath;C:\Program Files\doxygen\bin"
+Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+$ENV:PATH=$newpath

--- a/packer/windows/uninstall-doxygen.ps1
+++ b/packer/windows/uninstall-doxygen.ps1
@@ -1,0 +1,6 @@
+$package = 'doxygen.install'
+$uninstallRegKey = 'HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\doxygen_is1'
+
+Import-Module C:\ProgramData\chocolatey\helpers\chocolateyInstaller.psm1
+$uninstallPath = (Get-ItemProperty $uninstallRegKey UninstallString).UninstallString
+Uninstall-ChocolateyPackage $package 'exe' '/VERYSILENT' $uninstallPath


### PR DESCRIPTION
- Actually invokes Chocolatey-InstallPackage Powershell module directly with the correct URL, rather than use the Doxygen install package
- Easily removed once Doxygen package is fixed

Co-authored-by: Matthew Reddington <mreddington@pivotal.io>
Co-authored-by: Ernest Burghardt <eburghardt@pivotal.io>