### PR TITLE
GEODE-6165: Fix rat errors

### DIFF
--- a/packer/windows/install-doxygen.ps1
+++ b/packer/windows/install-doxygen.ps1
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 $package = 'doxygen.install'
 $url  = 'http://doxygen.nl/files/doxygen-1.8.14-setup.exe'
 $sha256 = '7B1A361E0C94ADB35EB75EEE069223E7AE19A4444C5B87F65539F7951BF96025'

--- a/packer/windows/uninstall-doxygen.ps1
+++ b/packer/windows/uninstall-doxygen.ps1
@@ -1,6 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Enable the system password to be retrieved from the AWS Console after this AMI is built and used to launch code
+
 $package = 'doxygen.install'
 $uninstallRegKey = 'HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\doxygen_is1'
 
 Import-Module C:\ProgramData\chocolatey\helpers\chocolateyInstaller.psm1
 $uninstallPath = (Get-ItemProperty $uninstallRegKey UninstallString).UninstallString
 Uninstall-ChocolateyPackage $package 'exe' '/VERYSILENT' $uninstallPath
+


### PR DESCRIPTION
- Doxygen Powershell scripts were missing license headers