### PR TITLE
GEODE-6114: Fix cpack break in examples

### DIFF
--- a/examples/dotnet/CMakeLists.txt
+++ b/examples/dotnet/CMakeLists.txt
@@ -21,7 +21,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt.in ${CMAKE_CURRENT_BIN
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/CMakeLists.txt
-  BUILD-DOTNET-EXAMPLES.md
   DESTINATION examples/dotnet)
 
 function(add_example)


### PR DESCRIPTION
- a .md file was deleted from the repo, but not removed from the install list