### PR TITLE
GEODE-6300: Fix AddDomain gripe in CLI tests

### DIFF
--- a/cppcache/src/ThreadPool.cpp
+++ b/cppcache/src/ThreadPool.cpp
@@ -25,8 +25,8 @@ namespace client {
 
 const char* ThreadPool::NC_Pool_Thread = "NC Pool Thread";
 
-ThreadPool::ThreadPool(size_t threadPoolSize) : shutdown_(false),
-appDomainContext_(createAppDomainContext()) {
+ThreadPool::ThreadPool(size_t threadPoolSize)
+    : shutdown_(false), appDomainContext_(createAppDomainContext()) {
   workers_.reserve(threadPoolSize);
 
   std::function<void()> executeWork = [this] {
@@ -34,7 +34,7 @@ appDomainContext_(createAppDomainContext()) {
     while (true) {
       std::unique_lock<decltype(queueMutex_)> lock(queueMutex_);
       queueCondition_.wait(lock,
-        [this] { return shutdown_ || !queue_.empty(); });
+                           [this] { return shutdown_ || !queue_.empty(); });
 
       if (shutdown_) {
         break;
@@ -47,17 +47,14 @@ appDomainContext_(createAppDomainContext()) {
 
       try {
         work->call();
-      }
-      catch (...) {
+      } catch (...) {
         // ignore
       }
     }
   };
 
   if (appDomainContext_) {
-    executeWork = [executeWork, this] {
-      appDomainContext_->run(executeWork);
-    };
+    executeWork = [executeWork, this] { appDomainContext_->run(executeWork); };
   }
 
   for (size_t i = 0; i < threadPoolSize; i++) {

--- a/cppcache/src/ThreadPool.hpp
+++ b/cppcache/src/ThreadPool.hpp
@@ -92,7 +92,7 @@ class ThreadPool {
   std::mutex queueMutex_;
   std::condition_variable queueCondition_;
   static const char* NC_Pool_Thread;
-  AppDomainContext *appDomainContext_;
+  AppDomainContext* appDomainContext_;
 };
 
 }  // namespace client

--- a/cppcache/src/ThreadPool.hpp
+++ b/cppcache/src/ThreadPool.hpp
@@ -27,6 +27,8 @@
 #include <thread>
 #include <vector>
 
+#include "AppDomainContext.hpp"
+
 namespace apache {
 namespace geode {
 namespace client {
@@ -90,6 +92,7 @@ class ThreadPool {
   std::mutex queueMutex_;
   std::condition_variable queueCondition_;
   static const char* NC_Pool_Thread;
+  AppDomainContext *appDomainContext_;
 };
 
 }  // namespace client


### PR DESCRIPTION
Need to make sure *everything* run in thread pool gets the rightAppDomain context

Co-authored-by: Matthew Reddington <mreddington@pivotal.io>