### PR TITLE
GEODE-4339: fix build

### DIFF
--- a/examples/cpp/sslputget/CMakeLists.txt.in
+++ b/examples/cpp/sslputget/CMakeLists.txt.in
@@ -20,7 +20,7 @@ project(cpp-sslputget LANGUAGES CXX)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 set(CMAKE_CXX_STANDARD 11)
 
-find_package(GeodeNative REQUIRED COMPONENTS cpp crypto)
+find_package(@PRODUCT_NAME_NOSPACE@ REQUIRED COMPONENTS cpp crypto)
 
 add_executable(${PROJECT_NAME} main.cpp)
 

--- a/examples/cpp/sslputget/CMakeLists.txt.in
+++ b/examples/cpp/sslputget/CMakeLists.txt.in
@@ -20,7 +20,7 @@ project(cpp-sslputget LANGUAGES CXX)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 set(CMAKE_CXX_STANDARD 11)
 
-find_package(@PRODUCT_NAME_NOSPACE@ REQUIRED COMPONENTS cpp crypto)
+find_package(GeodeNative REQUIRED COMPONENTS cpp crypto)
 
 add_executable(${PROJECT_NAME} main.cpp)
 

--- a/examples/dotnet/sslputget/CMakeLists.txt.in
+++ b/examples/dotnet/sslputget/CMakeLists.txt.in
@@ -19,7 +19,7 @@ project(dotnet-sslputget LANGUAGES CSharp)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 
-find_package(GeodeNative REQUIRED COMPONENTS dotnet crypto)
+find_package(@PRODUCT_NAME_NOSPACE@ REQUIRED COMPONENTS dotnet crypto)
 
 add_executable(${PROJECT_NAME} Program.cs)
 
@@ -33,7 +33,7 @@ file(GLOB SSL_CERTIFICATES
 file(INSTALL ${SSL_CERTIFICATES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 target_link_libraries(${PROJECT_NAME}
-    GeodeNative::dotnet
+    @PRODUCT_NAME_NOSPACE@::dotnet
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES


### PR DESCRIPTION
.net SSL example didn't parameterize things correctly in its CMakeLists.txt
