### PR TITLE
GEODE-5708: fix memory corruption.

### DIFF
--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(cpp-integration-test
   ExpirationTest.cpp
   FunctionExecutionTest.cpp
   PdxInstanceTest.cpp
+  RegionPutAllTest.cpp
   RegionPutGetAllTest.cpp
   RegisterKeysTest.cpp
   StructTest.cpp

--- a/cppcache/src/PutAllPartialResult.cpp
+++ b/cppcache/src/PutAllPartialResult.cpp
@@ -23,7 +23,8 @@ namespace client {
 PutAllPartialResult::PutAllPartialResult(int totalMapSize,
                                          std::recursive_mutex& responseLock) {
   m_succeededKeys = std::make_shared<VersionedCacheableObjectPartList>(
-      new std::vector<std::shared_ptr<CacheableKey>>(), responseLock);
+      std::make_shared<std::vector<std::shared_ptr<CacheableKey>>>(),
+      responseLock);
   m_totalMapSize = totalMapSize;
 }
 

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -104,8 +104,8 @@ class PutAllWork : public PooledWork<GfErrType>,
 
     // create new instanceof VCOPL
     std::recursive_mutex responseLock;
-    m_verObjPartListPtr = std::make_shared<VersionedCacheableObjectPartList>(
-        keys.get(), responseLock);
+    m_verObjPartListPtr =
+        std::make_shared<VersionedCacheableObjectPartList>(keys, responseLock);
 
     if (m_poolDM->isMultiUserMode()) {
       m_userAttribute = UserAttributes::threadLocalUserAttributes;
@@ -246,8 +246,8 @@ class RemoveAllWork : public PooledWork<GfErrType>,
     m_reply = new TcrMessageReply(true, m_poolDM);
     // create new instanceof VCOPL
     std::recursive_mutex responseLock;
-    m_verObjPartListPtr = std::make_shared<VersionedCacheableObjectPartList>(
-        keys.get(), responseLock);
+    m_verObjPartListPtr =
+        std::make_shared<VersionedCacheableObjectPartList>(keys, responseLock);
 
     if (m_poolDM->isMultiUserMode()) {
       m_userAttribute = UserAttributes::threadLocalUserAttributes;

--- a/cppcache/src/VersionedCacheableObjectPartList.hpp
+++ b/cppcache/src/VersionedCacheableObjectPartList.hpp
@@ -117,7 +117,7 @@ class VersionedCacheableObjectPartList : public CacheableObjectPartList {
   }
 
   VersionedCacheableObjectPartList(
-      std::vector<std::shared_ptr<CacheableKey>>* keys,
+      std::shared_ptr<std::vector<std::shared_ptr<CacheableKey>>> keys,
       std::recursive_mutex& responseLock)
       : m_tempKeys(keys), m_responseLock(responseLock) {
     m_regionIsVersioned = false;


### PR DESCRIPTION
Use shared pointer directly instead of create a shared pointer from a raw pointer.