### PR TITLE
GEODE-6491: Fix signed/unsigned problem reading size field in handshake message

### DIFF
--- a/cppcache/src/SerializationRegistry.cpp
+++ b/cppcache/src/SerializationRegistry.cpp
@@ -158,9 +158,9 @@ std::shared_ptr<Serializable> SerializationRegistry::deserialize(
     dsCode = static_cast<DSCode>(input.read());
   }
 
-  LOGDEBUG(
-      "SerializationRegistry::deserialize typeid = %d currentTypeId= %" PRId8,
-      typeId, dsCode);
+  LOGDEBUG("SerializationRegistry::deserialize typeId = %" PRId8
+           " dsCode = % " PRId8,
+           typeId, dsCode);
 
   switch (dsCode) {
     case DSCode::CacheableNullString: {

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -1132,8 +1132,7 @@ std::shared_ptr<CacheableBytes> TcrConnection::readHandshakeByteArray(
 int32_t TcrConnection::readHandshakeArraySize(
     std::chrono::microseconds connectTimeout) {
   auto arrayLenHeader = readHandshakeData(1, connectTimeout);
-  LOGDEBUG("Handshake: arrayLenHeader = %" PRIu8, arrayLenHeader[0]);
-
+  
   int32_t arrayLength = static_cast<uint8_t>(arrayLenHeader[0]);
   if (static_cast<int8_t>(arrayLenHeader[0]) == -2) {
     auto arrayLengthBytes = readHandshakeData(2, connectTimeout);
@@ -1148,8 +1147,7 @@ int32_t TcrConnection::readHandshakeArraySize(
         arrayLengthBytes.size());
     arrayLength = dataInput2.readInt32();
   }
-  LOGDEBUG("Handshake: recvMsgLen = %" PRIu32, arrayLength);
-
+  
   return arrayLength;
 }
 

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -301,10 +301,9 @@ bool TcrConnection::InitTcrConnection(
   size_t msgLength;
   auto data = reinterpret_cast<char*>(
       const_cast<uint8_t*>(handShakeMsg.getBuffer(&msgLength)));
-  LOGFINE(
-      "Attempting handshake with endpoint %s for %s%s connection", endpoint,
-      isClientNotification ? (isSecondary ? "secondary " : "primary ") : "",
-      isClientNotification ? "subscription" : "client");
+  LOGFINE("Attempting handshake with endpoint %s for %s%s connection", endpoint,
+          isClientNotification ? (isSecondary ? "secondary " : "primary ") : "",
+          isClientNotification ? "subscription" : "client");
   ConnErrType error = sendData(data, msgLength, connectTimeout, false);
 
   if (error == CONN_NOERR) {
@@ -1132,7 +1131,7 @@ std::shared_ptr<CacheableBytes> TcrConnection::readHandshakeByteArray(
 int32_t TcrConnection::readHandshakeArraySize(
     std::chrono::microseconds connectTimeout) {
   auto arrayLenHeader = readHandshakeData(1, connectTimeout);
-  
+
   int32_t arrayLength = static_cast<uint8_t>(arrayLenHeader[0]);
   if (static_cast<int8_t>(arrayLenHeader[0]) == -2) {
     auto arrayLengthBytes = readHandshakeData(2, connectTimeout);
@@ -1147,7 +1146,7 @@ int32_t TcrConnection::readHandshakeArraySize(
         arrayLengthBytes.size());
     arrayLength = dataInput2.readInt32();
   }
-  
+
   return arrayLength;
 }
 

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -338,7 +338,7 @@ class APACHE_GEODE_EXPORT TcrConnection {
   /*
    * To read the arraysize
    */
-  uint32_t readHandshakeArraySize(std::chrono::microseconds connectTimeout);
+  int32_t readHandshakeArraySize(std::chrono::microseconds connectTimeout);
 
   /*
    * This function reads "numberOfBytes" and ignores it.


### PR DESCRIPTION
If memberId length grew longer than 127 characters, which happens in some environments, geode-native would overflow a signed byte and start looking for a negative-length array.  Bad things happened after that.

Co-Authored-By: Mike Martell <mmartell@pivotal.io>
Co-Authored-By: Jacob Barrett <jbarrett@pivotal.io>
