### PR TITLE
GEODE-6624: Fix nested exception in geode-native causing SIGABRT

### DIFF
--- a/cppcache/src/TcrChunkedContext.hpp
+++ b/cppcache/src/TcrChunkedContext.hpp
@@ -111,6 +111,8 @@ class TcrChunkedResult {
   inline void setException(std::shared_ptr<Exception> ex) { m_ex = ex; }
 
   inline std::shared_ptr<Exception>& getException() { return m_ex; }
+
+  inline void clearException() { m_ex = nullptr; }
 };
 
 /**


### PR DESCRIPTION
Co-authored-by: Matthew Reddington <mreddington@pivotal.io>

We were hitting a nested exception, which caused a SIGABRT in the client.  Now we catch the second exception, and clear the first out of the "pending" location, so it doesn't get thrown from within a catch block and blow us up.