### PR TITLE
GEODE-6718: Refactor TcrConnection::sendRequestForChunkedResponse, derived class, and remove pass-through calls in TrcConnection and derived

### DIFF
--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -714,12 +714,12 @@ void TcrConnection::sendRequestForChunkedResponse(
 bool TcrConnection::replyHasValidTimeout(const TcrMessage& request) const {
   auto messageType = request.getMessageType();
   return ((messageType == TcrMessage::QUERY) ||
-      (messageType == TcrMessage::QUERY_WITH_PARAMETERS) ||
-      (messageType == TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE) ||
-      (messageType == TcrMessage::GETDURABLECQS_MSG_TYPE) ||
-      (messageType == TcrMessage::EXECUTE_FUNCTION) ||
-      (messageType == TcrMessage::EXECUTE_REGION_FUNCTION) ||
-      (messageType == TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP));
+          (messageType == TcrMessage::QUERY_WITH_PARAMETERS) ||
+          (messageType == TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE) ||
+          (messageType == TcrMessage::GETDURABLECQS_MSG_TYPE) ||
+          (messageType == TcrMessage::EXECUTE_FUNCTION) ||
+          (messageType == TcrMessage::EXECUTE_REGION_FUNCTION) ||
+          (messageType == TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP));
 }
 
 std::chrono::microseconds TcrConnection::sendWithTimeouts(
@@ -748,8 +748,8 @@ bool TcrConnection::replyHasResult(const TcrMessage& request,
             reply.getChunkedResultHandler());
     if (resultCollector->getResult() == false) {
       LOGDEBUG(
-            "TcrConnection::sendRequestForChunkedResponse: function execution, "
-            "no response desired");
+          "TcrConnection::sendRequestForChunkedResponse: function execution, "
+          "no response desired");
       hasResult = false;
     }
   }

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -692,11 +692,8 @@ char* TcrConnection::sendRequest(const char* buffer, size_t len,
 }
 
 std::chrono::microseconds TcrConnection::sendWithTimeouts(
-    const char* data,
-    size_t len,
-    std::chrono::microseconds sendTimeout,
-    std::chrono::microseconds receiveTimeout
-    ) {
+    const char* data, size_t len, std::chrono::microseconds sendTimeout,
+    std::chrono::microseconds receiveTimeout) {
   std::chrono::microseconds timeSpent{0};
   send(timeSpent, data, len, sendTimeout, true);
 
@@ -708,21 +705,20 @@ std::chrono::microseconds TcrConnection::sendWithTimeouts(
   return timeSpent;
 }
 
-bool TcrConnection::replyHasResult(
-    const TcrMessage& request,
-    TcrMessageReply& reply
-    ) {
+bool TcrConnection::replyHasResult(const TcrMessage& request,
+                                   TcrMessageReply& reply) {
   auto hasResult = true;
 
   // no need of it now, this will not come here
-  if (request.getMessageType() == TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP) {
+  if (request.getMessageType() ==
+      TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP) {
     ChunkedFunctionExecutionResponse* resultCollector =
         static_cast<ChunkedFunctionExecutionResponse*>(
             reply.getChunkedResultHandler());
     if (resultCollector->getResult() == false) {
       LOGDEBUG(
-            "TcrConnection::sendRequestForChunkedResponse: function execution, "
-            "no response desired");
+          "TcrConnection::sendRequestForChunkedResponse: function execution, "
+          "no response desired");
       hasResult = false;
     }
   }
@@ -734,13 +730,13 @@ void TcrConnection::sendRequestForChunkedResponse(
     const TcrMessage& request, size_t len, TcrMessageReply& reply,
     std::chrono::microseconds sendTimeoutSec,
     std::chrono::microseconds receiveTimeoutSec) {
-
   if (replyHasValidTimeout(request)) {
     receiveTimeoutSec = reply.getTimeout();
     sendTimeoutSec = reply.getTimeout();
   }
 
-  receiveTimeoutSec -= sendWithTimeouts(request.getMsgData(), len, sendTimeoutSec, receiveTimeoutSec);
+  receiveTimeoutSec -= sendWithTimeouts(request.getMsgData(), len,
+                                        sendTimeoutSec, receiveTimeoutSec);
 
   // to help in decoding the reply based on what was the request type
   reply.setMessageTypeRequest(request.getMessageType());
@@ -753,12 +749,12 @@ void TcrConnection::sendRequestForChunkedResponse(
 bool TcrConnection::replyHasValidTimeout(const TcrMessage& request) const {
   auto messageType = request.getMessageType();
   return ((messageType == TcrMessage::QUERY) ||
-    (messageType == TcrMessage::QUERY_WITH_PARAMETERS) ||
-    (messageType == TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE) ||
-    (messageType == TcrMessage::GETDURABLECQS_MSG_TYPE) ||
-    (messageType == TcrMessage::EXECUTE_FUNCTION) ||
-    (messageType == TcrMessage::EXECUTE_REGION_FUNCTION) ||
-    (messageType == TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP));
+          (messageType == TcrMessage::QUERY_WITH_PARAMETERS) ||
+          (messageType == TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE) ||
+          (messageType == TcrMessage::GETDURABLECQS_MSG_TYPE) ||
+          (messageType == TcrMessage::EXECUTE_FUNCTION) ||
+          (messageType == TcrMessage::EXECUTE_REGION_FUNCTION) ||
+          (messageType == TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP));
 }
 
 void TcrConnection::send(const char* buffer, size_t len,

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -695,7 +695,7 @@ void TcrConnection::sendRequestForChunkedResponse(
     const TcrMessage& request, size_t len, TcrMessageReply& reply,
     std::chrono::microseconds sendTimeoutSec,
     std::chrono::microseconds receiveTimeoutSec) {
-  if (replyHasValidTimeout(request)) {
+  if (useReplyTimeout(request)) {
     receiveTimeoutSec = reply.getTimeout();
     sendTimeoutSec = reply.getTimeout();
   }
@@ -711,7 +711,7 @@ void TcrConnection::sendRequestForChunkedResponse(
   }
 }
 
-bool TcrConnection::replyHasValidTimeout(const TcrMessage& request) const {
+bool TcrConnection::useReplyTimeout(const TcrMessage& request) const {
   auto messageType = request.getMessageType();
   return ((messageType == TcrMessage::QUERY) ||
           (messageType == TcrMessage::QUERY_WITH_PARAMETERS) ||

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -419,14 +419,9 @@ class APACHE_GEODE_EXPORT TcrConnection {
   ThinClientPoolDM* m_poolDM;
   bool replyHasValidTimeout(const TcrMessage& request) const;
   std::chrono::microseconds sendWithTimeouts(
-      const char* data,
-      size_t len,
-      std::chrono::microseconds sendTimeout,
+      const char* data, size_t len, std::chrono::microseconds sendTimeout,
       std::chrono::microseconds receiveTimeout);
-  bool replyHasResult(
-      const TcrMessage& request,
-      TcrMessageReply& reply
-  );
+  bool replyHasResult(const TcrMessage& request, TcrMessageReply& reply);
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -417,6 +417,7 @@ class APACHE_GEODE_EXPORT TcrConnection {
   volatile bool m_isBeingUsed;
   std::atomic<uint32_t> m_isUsed;
   ThinClientPoolDM* m_poolDM;
+  bool replyHasValidTimeout(const TcrMessage& request) const;
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -418,6 +418,15 @@ class APACHE_GEODE_EXPORT TcrConnection {
   std::atomic<uint32_t> m_isUsed;
   ThinClientPoolDM* m_poolDM;
   bool replyHasValidTimeout(const TcrMessage& request) const;
+  std::chrono::microseconds sendWithTimeouts(
+      const char* data,
+      size_t len,
+      std::chrono::microseconds sendTimeout,
+      std::chrono::microseconds receiveTimeout);
+  bool replyHasResult(
+      const TcrMessage& request,
+      TcrMessageReply& reply
+  );
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -417,7 +417,7 @@ class APACHE_GEODE_EXPORT TcrConnection {
   volatile bool m_isBeingUsed;
   std::atomic<uint32_t> m_isUsed;
   ThinClientPoolDM* m_poolDM;
-  bool replyHasValidTimeout(const TcrMessage& request) const;
+  bool useReplyTimeout(const TcrMessage& request) const;
   std::chrono::microseconds sendWithTimeouts(
       const char* data, size_t len, std::chrono::microseconds sendTimeout,
       std::chrono::microseconds receiveTimeout);

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -794,7 +794,8 @@ GfErrType TcrEndpoint::sendRequestConn(const TcrMessage& request,
         type == TcrMessage::EXECUTE_REGION_FUNCTION) &&
        (request.hasResult() & 2))) {
     conn->sendRequestForChunkedResponse(request, request.getMsgLength(), reply,
-                                        request.getTimeout(), reply.getTimeout());
+                                        request.getTimeout(),
+                                        reply.getTimeout());
   } else if (type == TcrMessage::REGISTER_INTEREST_LIST ||
              type == TcrMessage::REGISTER_INTEREST ||
              type == TcrMessage::QUERY ||
@@ -826,7 +827,8 @@ GfErrType TcrEndpoint::sendRequestConn(const TcrMessage& request,
              type == TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE ||
              type == TcrMessage::GETDURABLECQS_MSG_TYPE) {
     conn->sendRequestForChunkedResponse(request, request.getMsgLength(), reply,
-                                        request.getTimeout(), reply.getTimeout());
+                                        request.getTimeout(),
+                                        reply.getTimeout());
     LOGDEBUG("sendRequestConn: calling sendRequestForChunkedResponse DONE");
   } else {
     // Chk request type to request if so request.getCallBackArg flag & setCall

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -793,7 +793,8 @@ GfErrType TcrEndpoint::sendRequestConn(const TcrMessage& request,
   if (((type == TcrMessage::EXECUTE_FUNCTION ||
         type == TcrMessage::EXECUTE_REGION_FUNCTION) &&
        (request.hasResult() & 2))) {
-    sendRequestForChunkedResponse(request, reply, conn);
+    conn->sendRequestForChunkedResponse(request, request.getMsgLength(), reply,
+                                        request.getTimeout(), reply.getTimeout());
   } else if (type == TcrMessage::REGISTER_INTEREST_LIST ||
              type == TcrMessage::REGISTER_INTEREST ||
              type == TcrMessage::QUERY ||
@@ -824,7 +825,8 @@ GfErrType TcrEndpoint::sendRequestConn(const TcrMessage& request,
              type == TcrMessage::MONITORCQ_MSG_TYPE ||
              type == TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE ||
              type == TcrMessage::GETDURABLECQS_MSG_TYPE) {
-    sendRequestForChunkedResponse(request, reply, conn);
+    conn->sendRequestForChunkedResponse(request, request.getMsgLength(), reply,
+                                        request.getTimeout(), reply.getTimeout());
     LOGDEBUG("sendRequestConn: calling sendRequestForChunkedResponse DONE");
   } else {
     // Chk request type to request if so request.getCallBackArg flag & setCall
@@ -1311,12 +1313,6 @@ void TcrEndpoint::processMarker() {
 
 std::shared_ptr<QueryService> TcrEndpoint::getQueryService() {
   return m_cacheImpl->getQueryService(true);
-}
-
-void TcrEndpoint::sendRequestForChunkedResponse(const TcrMessage& request,
-                                                TcrMessageReply& reply,
-                                                TcrConnection* conn) {
-  conn->sendRequestForChunkedResponse(request, request.getMsgLength(), reply);
 }
 
 void TcrEndpoint::closeFailedConnection(TcrConnection*& conn) {

--- a/cppcache/src/TcrEndpoint.hpp
+++ b/cppcache/src/TcrEndpoint.hpp
@@ -210,9 +210,6 @@ class TcrEndpoint {
   virtual void processMarker();
   virtual void triggerRedundancyThread();
   virtual std::shared_ptr<QueryService> getQueryService();
-  virtual void sendRequestForChunkedResponse(const TcrMessage& request,
-                                             TcrMessageReply& reply,
-                                             TcrConnection* conn);
   virtual void closeFailedConnection(TcrConnection*& conn);
   void closeConnection(TcrConnection*& conn);
   virtual void handleNotificationStats(int64_t byteLength);

--- a/cppcache/src/TcrPoolEndPoint.cpp
+++ b/cppcache/src/TcrPoolEndPoint.cpp
@@ -40,12 +40,6 @@ void TcrPoolEndPoint::processMarker() { m_dm->processMarker(); }
 std::shared_ptr<QueryService> TcrPoolEndPoint::getQueryService() {
   return m_dm->getQueryServiceWithoutCheck();
 }
-void TcrPoolEndPoint::sendRequestForChunkedResponse(const TcrMessage& request,
-                                                    TcrMessageReply& reply,
-                                                    TcrConnection* conn) {
-  conn->sendRequestForChunkedResponse(request, request.getMsgLength(), reply,
-                                      request.getTimeout(), reply.getTimeout());
-}
 ThinClientPoolDM* TcrPoolEndPoint::getPoolHADM() { return m_dm; }
 void TcrPoolEndPoint::triggerRedundancyThread() {
   m_dm->triggerRedundancyThread();

--- a/cppcache/src/TcrPoolEndPoint.hpp
+++ b/cppcache/src/TcrPoolEndPoint.hpp
@@ -39,9 +39,6 @@ class TcrPoolEndPoint : public TcrEndpoint {
   bool checkDupAndAdd(std::shared_ptr<EventId> eventid) override;
   void processMarker() override;
   std::shared_ptr<QueryService> getQueryService() override;
-  void sendRequestForChunkedResponse(const TcrMessage& request,
-                                     TcrMessageReply& reply,
-                                     TcrConnection* conn) override;
   void closeFailedConnection(TcrConnection*& conn) override;
   GfErrType registerDM(bool clientNotification, bool isSecondary = false,
                        bool isActiveEndpoint = false,


### PR DESCRIPTION
The method in TcrConnection greatly needed clarification/simplification, and the corresponding methods in Tcr*Endpoint literally do nothing.  This is a nice small thing that can be done to make things more readable and maintainable.