### PR TITLE
GEODE-3415: Add apache-geode dependency to integration-test2

### DIFF
--- a/clicache/integration-test2/CMakeLists.txt
+++ b/clicache/integration-test2/CMakeLists.txt
@@ -104,4 +104,8 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     $<SHELL_PATH:$<TARGET_FILE:cryptoImpl>>
     $<$<CONFIG:Debug>:$<SHELL_PATH:$<TARGET_PDB_FILE:cryptoImpl>>>
     $<SHELL_PATH:$<TARGET_FILE_DIR:${PROJECT_NAME}>>
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    $<SHELL_PATH:$<TARGET_FILE:apache-geode>>
+    $<$<CONFIG:Debug>:$<SHELL_PATH:$<TARGET_PDB_FILE:apache-geode>>>
+    $<SHELL_PATH:$<TARGET_FILE_DIR:${PROJECT_NAME}>>
 )


### PR DESCRIPTION
With the new SslException class, cryptoimpl now depends on apache-geode.dll. This commit adds the copy to the post build step of cli's integration-test2.