### PR TITLE
GEODE-6800: CacheableFileName Linker Error

### DIFF
--- a/cppcache/include/geode/CacheableFileName.hpp
+++ b/cppcache/include/geode/CacheableFileName.hpp
@@ -44,10 +44,10 @@ class Serializable;
 
 class APACHE_GEODE_EXPORT CacheableFileName : public CacheableString {
  public:
-  inline CacheableFileName() = default;
-  inline explicit CacheableFileName(const std::string& value)
+  CacheableFileName() = default;
+  explicit CacheableFileName(const std::string& value)
       : CacheableString(value) {}
-  inline explicit CacheableFileName(std::string&& value)
+  explicit CacheableFileName(std::string&& value)
       : CacheableString(std::move(value)) {}
   ~CacheableFileName() noexcept override = default;
   void operator=(const CacheableFileName& other) = delete;


### PR DESCRIPTION
Having the ctors inline is throwing some versions of gcc and clang through a loop. Not having them in the vtable is tolerated by some, but causing linker errors on others.

Co-authored-by: Matthew Reddington <mreddington@pivotal.io>