### PR TITLE
GEODE-6826: Refactor chunk processing

### DIFF
--- a/cppcache/src/TcrChunkedContext.hpp
+++ b/cppcache/src/TcrChunkedContext.hpp
@@ -121,37 +121,37 @@ class TcrChunkedResult {
  */
 class TcrChunkedContext {
  private:
-  const uint8_t* m_bytes;
+  const std::vector<uint8_t> m_chunk;
   const int32_t m_len;
   const uint8_t m_isLastChunkWithSecurity;
   const CacheImpl* m_cache;
   TcrChunkedResult* m_result;
 
  public:
-  inline TcrChunkedContext(const uint8_t* bytes, int32_t len,
+  inline TcrChunkedContext(const std::vector<uint8_t> chunk, int32_t len,
                            TcrChunkedResult* result,
                            uint8_t isLastChunkWithSecurity,
                            const CacheImpl* cacheImpl)
-      : m_bytes(bytes),
+      : m_chunk(chunk),
         m_len(len),
         m_isLastChunkWithSecurity(isLastChunkWithSecurity),
         m_cache(cacheImpl),
         m_result(result) {}
 
-  inline ~TcrChunkedContext() { _GEODE_SAFE_DELETE_ARRAY(m_bytes); }
+  inline ~TcrChunkedContext() = default;
 
-  inline const uint8_t* getBytes() const { return m_bytes; }
+  inline const uint8_t* getBytes() const { return m_chunk.data(); }
 
-  inline int32_t getLen() const { return m_len; }
+  inline int32_t getLen() const { return m_chunk.size(); }
 
   void handleChunk(bool inSameThread) {
-    if (m_bytes == nullptr) {
+    if (m_chunk.empty()) {
       // this is the last chunk for some set of chunks
       m_result->finalize(inSameThread);
     } else if (!m_result->exceptionOccurred()) {
       try {
-        m_result->fireHandleChunk(m_bytes, m_len, m_isLastChunkWithSecurity,
-                                  m_cache);
+        m_result->fireHandleChunk(m_chunk.data(), m_len,
+                                  m_isLastChunkWithSecurity, m_cache);
       } catch (Exception& ex) {
         LOGERROR("HandleChunk error message %s, name = %s", ex.what(),
                  ex.getName().c_str());

--- a/cppcache/src/TcrChunkedContext.hpp
+++ b/cppcache/src/TcrChunkedContext.hpp
@@ -142,7 +142,7 @@ class TcrChunkedContext {
 
   inline const uint8_t* getBytes() const { return m_chunk.data(); }
 
-  inline int32_t getLen() const { return m_chunk.size(); }
+  inline int32_t getLen() const { return static_cast<int32_t>(m_chunk.size()); }
 
   void handleChunk(bool inSameThread) {
     if (m_chunk.empty()) {

--- a/cppcache/src/TcrChunkedContext.hpp
+++ b/cppcache/src/TcrChunkedContext.hpp
@@ -142,7 +142,7 @@ class TcrChunkedContext {
 
   inline const uint8_t* getBytes() const { return m_chunk.data(); }
 
-  inline int32_t getLen() const { return static_cast<int32_t>(m_chunk.size()); }
+  inline size_t getLen() const { return m_chunk.size(); }
 
   void handleChunk(bool inSameThread) {
     if (m_chunk.empty()) {

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -44,8 +44,7 @@ namespace geode {
 namespace client {
 
 const int HEADER_LENGTH = 17;
-const int HDR_LEN = 5;
-const int HDR_LEN_12 = 12;
+const int CHUNK_HEADER_LENGTH= 5;
 const int64_t INITIAL_CONNECTION_ID = 26739;
 
 #define throwException(ex)                            \
@@ -1017,8 +1016,8 @@ void TcrConnection::readResponseHeader(std::chrono::microseconds timeout,
 void TcrConnection::readChunkHeader(std::chrono::microseconds timeout,
                                     int32_t& chunkLength,
                                     int8_t& lastChunkAndSecurityFlags) {
-  uint8_t chunkHeader[HDR_LEN];
-  auto error = receiveData(reinterpret_cast<char*>(chunkHeader), HDR_LEN,
+  uint8_t chunkHeader[CHUNK_HEADER_LENGTH];
+  auto error = receiveData(reinterpret_cast<char*>(chunkHeader), CHUNK_HEADER_LENGTH,
                            timeout, true, false);
   if (error != CONN_NOERR) {
     if (error & CONN_TIMEOUT) {
@@ -1035,10 +1034,10 @@ void TcrConnection::readChunkHeader(std::chrono::microseconds timeout,
   LOGDEBUG(
       "TcrConnection::readChunkHeader: received header from "
       "endpoint %s; bytes: %s",
-      m_endpoint, Utils::convertBytesToString(chunkHeader, HDR_LEN).c_str());
+      m_endpoint, Utils::convertBytesToString(chunkHeader, CHUNK_HEADER_LENGTH).c_str());
 
   auto input = m_connectionManager->getCacheImpl()->createDataInput(chunkHeader,
-                                                                    HDR_LEN);
+                                                                    CHUNK_HEADER_LENGTH);
   chunkLength = input.readInt32();
   lastChunkAndSecurityFlags = input.read();
   LOGDEBUG(

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -44,7 +44,8 @@ namespace geode {
 namespace client {
 
 const int HEADER_LENGTH = 17;
-const int CHUNK_HEADER_LENGTH= 5;
+const int CHUNK_HEADER_LENGTH = 5;
+const int8_t LAST_CHUNK_MASK = 0x1;
 const int64_t INITIAL_CONNECTION_ID = 26739;
 
 #define throwException(ex)                            \
@@ -1017,8 +1018,8 @@ void TcrConnection::readChunkHeader(std::chrono::microseconds timeout,
                                     int32_t& chunkLength,
                                     int8_t& lastChunkAndSecurityFlags) {
   uint8_t chunkHeader[CHUNK_HEADER_LENGTH];
-  auto error = receiveData(reinterpret_cast<char*>(chunkHeader), CHUNK_HEADER_LENGTH,
-                           timeout, true, false);
+  auto error = receiveData(reinterpret_cast<char*>(chunkHeader),
+                           CHUNK_HEADER_LENGTH, timeout, true, false);
   if (error != CONN_NOERR) {
     if (error & CONN_TIMEOUT) {
       throwException(TimeoutException(
@@ -1034,10 +1035,11 @@ void TcrConnection::readChunkHeader(std::chrono::microseconds timeout,
   LOGDEBUG(
       "TcrConnection::readChunkHeader: received header from "
       "endpoint %s; bytes: %s",
-      m_endpoint, Utils::convertBytesToString(chunkHeader, CHUNK_HEADER_LENGTH).c_str());
+      m_endpoint,
+      Utils::convertBytesToString(chunkHeader, CHUNK_HEADER_LENGTH).c_str());
 
-  auto input = m_connectionManager->getCacheImpl()->createDataInput(chunkHeader,
-                                                                    CHUNK_HEADER_LENGTH);
+  auto input = m_connectionManager->getCacheImpl()->createDataInput(
+      chunkHeader, CHUNK_HEADER_LENGTH);
   chunkLength = input.readInt32();
   lastChunkAndSecurityFlags = input.read();
   LOGDEBUG(
@@ -1084,7 +1086,7 @@ bool TcrConnection::processChunk(TcrMessageReply& reply,
   reply.processChunk(chunkBody, chunkLength,
                      m_endpointObj->getDistributedMemberID(),
                      lastChunkAndSecurityFlags);
-  return (lastChunkAndSecurityFlags & 0x01) ? false : true;
+  return (lastChunkAndSecurityFlags & LAST_CHUNK_MASK) ? false : true;
 }
 
 void TcrConnection::close() {

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -17,8 +17,6 @@
 
 #include "TcrConnection.hpp"
 
-#include <memory.h>
-
 #include <cinttypes>
 
 #include <ace/INET_Addr.h>

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -967,8 +967,8 @@ void TcrConnection::readMessageChunked(
                                        m_endpointObj->getDistributedMemberID());
 
   try {
-    auto isLastChunk = false;
     int8_t flags = 0x0;
+    auto hasMoreChunks = true;
     int chunkNum = 0;
 
     do {
@@ -1004,7 +1004,7 @@ void TcrConnection::readMessageChunked(
       chunkLen = input.readInt32();
       flags = input.read();
       //  check that chunk length is valid.
-      isLastChunk = (flags & 0x01) ? true : false;
+      hasMoreChunks = (flags & 0x01) ? false : true;
 
       uint8_t* chunk_body;
       _GEODE_NEW(chunk_body, uint8_t[chunkLen]);
@@ -1033,7 +1033,7 @@ void TcrConnection::readMessageChunked(
 
       reply.processChunk(chunk_body, chunkLen,
                          m_endpointObj->getDistributedMemberID(), flags);
-    } while (!isLastChunk);
+    } while (hasMoreChunks);
   } catch (const Exception&) {
     auto ex = reply.getChunkedResultHandler()->getException();
     LOGDEBUG("Found existing exception ", ex->what());

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -942,17 +942,10 @@ void TcrConnection::readResponseHeader(std::chrono::microseconds timeout,
 
   auto input = m_connectionManager->getCacheImpl()->createDataInput(msg_header,
                                                                     HDR_LEN_12);
-  readResponseHeaderVariables(&input, messageType, numberOfParts,
-                              transactionId);
+  messageType = input.readInt32();
+  numberOfParts = input.readInt32();
+  transactionId = input.readInt32();
 }  // namespace client
-
-void TcrConnection::readResponseHeaderVariables(DataInput* di, int32_t& msgType,
-                                                int32_t& numberOfParts,
-                                                int32_t& transactionId) {
-  msgType = di->readInt32();
-  numberOfParts = di->readInt32();
-  transactionId = di->readInt32();
-}
 
 void TcrConnection::readMessageChunked(
     TcrMessageReply& reply, std::chrono::microseconds receiveTimeoutSec,

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -326,10 +326,6 @@ class APACHE_GEODE_EXPORT TcrConnection {
                           uint8_t* msg_header, int32_t& messageType,
                           int32_t& numberOfParts, int32_t& transactionId);
 
-  void readResponseHeaderVariables(DataInput* di, int32_t& msgType,
-                                   int32_t& numberOfParts,
-                                   int32_t& transactionId);
-
   //  void readResponseHeader(std::chrono::microseconds timeout,
   //                          uint32_t& messageType, uint32_t& numberOfParts,
   //                          uint32_t& transactionId);

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -66,6 +66,18 @@ namespace apache {
 namespace geode {
 namespace client {
 
+struct chunkHeader {
+  int32_t chunkLength;
+  int8_t flags;
+};
+
+struct chunkedResponseHeader {
+  int32_t messageType;
+  int32_t numberOfParts;
+  int32_t transactionId;
+  chunkHeader header;
+};
+
 enum ConnErrType {
   CONN_NOERR = 0x0,
   CONN_NODATA = 0x1,
@@ -322,13 +334,9 @@ class APACHE_GEODE_EXPORT TcrConnection {
   std::chrono::microseconds calculateHeaderTimeout(
       std::chrono::microseconds receiveTimeout, bool retry);
 
-  void readResponseHeader(std::chrono::microseconds timeout,
-                          int32_t& messageType, int32_t& numberOfParts,
-                          int32_t& transactionId, int32_t& chunkLength,
-                          int8_t& flags);
+  chunkedResponseHeader readResponseHeader(std::chrono::microseconds timeout);
 
-  void readChunkHeader(std::chrono::microseconds timeout, int32_t& chunkLength,
-                       int8_t& lastChunkAndSecurityFlags);
+  chunkHeader readChunkHeader(std::chrono::microseconds timeout);
 
   void readChunkBody(std::chrono::microseconds timeout, int32_t chunkLength,
                      uint8_t** chunkBody);

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -324,13 +324,14 @@ class APACHE_GEODE_EXPORT TcrConnection {
 
   void readResponseHeader(std::chrono::microseconds timeout,
                           uint8_t* msg_header, int32_t& messageType,
-                          int32_t& numberOfParts, int32_t& transactionId);
+                          int32_t& numberOfParts, int32_t& transactionId,
+                          int32_t& chunkLength, int8_t& flags);
 
   //  void readResponseHeader(std::chrono::microseconds timeout,
   //                          uint32_t& messageType, uint32_t& numberOfParts,
   //                          uint32_t& transactionId);
   void readChunkHeader(std::chrono::microseconds timeout, int32_t& chunkLength,
-                       uint8_t& lastChunkAndSecurityFlags);
+                       int8_t& lastChunkAndSecurityFlags);
 
   /**
    * To read Intantiator message(which meant for java client), here we are

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -318,6 +318,10 @@ class APACHE_GEODE_EXPORT TcrConnection {
   int64_t connectionId;
   const TcrConnectionManager* m_connectionManager;
   DiffieHellman* m_dh;
+
+  std::chrono::microseconds calculateHeaderTimeout(
+      std::chrono::microseconds receiveTimeout, bool retry);
+
   /**
    * To read Intantiator message(which meant for java client), here we are
    * ignoring it

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -338,8 +338,8 @@ class APACHE_GEODE_EXPORT TcrConnection {
 
   chunkHeader readChunkHeader(std::chrono::microseconds timeout);
 
-  void readChunkBody(std::chrono::microseconds timeout, int32_t chunkLength,
-                     uint8_t** chunkBody);
+  std::vector<uint8_t> readChunkBody(std::chrono::microseconds timeout,
+                                     int32_t chunkLength);
 
   bool processChunk(TcrMessageReply& reply, std::chrono::microseconds timeout,
                     int32_t chunkLength, int8_t lastChunkAndSecurityFlags);

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -259,13 +259,13 @@ class APACHE_GEODE_EXPORT TcrConnection {
    * connection and sets the reply message
    * parameter.
    * @param      reply response message
-   * @param      receiveTimeoutSec read timeout in sec
+   * @param      receiveTimeout read timeout
    * @param      doHeaderTimeoutRetries retry when header receive times out
    * @exception  GeodeIOException  if an I/O error occurs (socket failure).
    * @exception  TimeoutException  if timeout happens during read
    */
   void readMessageChunked(TcrMessageReply& reply,
-                          std::chrono::microseconds receiveTimeoutSec,
+                          std::chrono::microseconds receiveTimeout,
                           bool doHeaderTimeoutRetries);
 
   /**

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -323,9 +323,9 @@ class APACHE_GEODE_EXPORT TcrConnection {
       std::chrono::microseconds receiveTimeout, bool retry);
 
   void readResponseHeader(std::chrono::microseconds timeout,
-                          uint8_t* msg_header, int32_t& messageType,
-                          int32_t& numberOfParts, int32_t& transactionId,
-                          int32_t& chunkLength, int8_t& flags);
+                          int32_t& messageType, int32_t& numberOfParts,
+                          int32_t& transactionId, int32_t& chunkLength,
+                          int8_t& flags);
 
   //  void readResponseHeader(std::chrono::microseconds timeout,
   //                          uint32_t& messageType, uint32_t& numberOfParts,

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -322,6 +322,15 @@ class APACHE_GEODE_EXPORT TcrConnection {
   std::chrono::microseconds calculateHeaderTimeout(
       std::chrono::microseconds receiveTimeout, bool retry);
 
+  void readResponseHeader(std::chrono::microseconds timeout,
+                          uint8_t* msg_header);
+
+  //  void readResponseHeader(std::chrono::microseconds timeout,
+  //                          uint32_t& messageType, uint32_t& numberOfParts,
+  //                          uint32_t& transactionId);
+  void readChunkHeader(std::chrono::microseconds timeout, int32_t& chunkLength,
+                       uint8_t& lastChunkAndSecurityFlags);
+
   /**
    * To read Intantiator message(which meant for java client), here we are
    * ignoring it

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -333,6 +333,9 @@ class APACHE_GEODE_EXPORT TcrConnection {
   void readChunkHeader(std::chrono::microseconds timeout, int32_t& chunkLength,
                        int8_t& lastChunkAndSecurityFlags);
 
+  void readChunkBody(std::chrono::microseconds timeout, int32_t chunkLength,
+                     uint8_t** chunkBody);
+
   /**
    * To read Intantiator message(which meant for java client), here we are
    * ignoring it

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -327,16 +327,13 @@ class APACHE_GEODE_EXPORT TcrConnection {
                           int32_t& transactionId, int32_t& chunkLength,
                           int8_t& flags);
 
-  //  void readResponseHeader(std::chrono::microseconds timeout,
-  //                          uint32_t& messageType, uint32_t& numberOfParts,
-  //                          uint32_t& transactionId);
-  void readChunkHeader(std::chrono::microseconds timeout, int32_t chunkNumber,
-                       int32_t& chunkLength, int8_t& lastChunkAndSecurityFlags);
+  void readChunkHeader(std::chrono::microseconds timeout, int32_t& chunkLength,
+                       int8_t& lastChunkAndSecurityFlags);
 
   void readChunkBody(std::chrono::microseconds timeout, int32_t chunkLength,
                      uint8_t** chunkBody);
 
-  void processChunk(TcrMessageReply& reply, std::chrono::microseconds timeout,
+  bool processChunk(TcrMessageReply& reply, std::chrono::microseconds timeout,
                     int32_t chunkLength, int8_t lastChunkAndSecurityFlags);
 
   /**

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -330,8 +330,8 @@ class APACHE_GEODE_EXPORT TcrConnection {
   //  void readResponseHeader(std::chrono::microseconds timeout,
   //                          uint32_t& messageType, uint32_t& numberOfParts,
   //                          uint32_t& transactionId);
-  void readChunkHeader(std::chrono::microseconds timeout, int32_t& chunkLength,
-                       int8_t& lastChunkAndSecurityFlags);
+  void readChunkHeader(std::chrono::microseconds timeout, int32_t chunkNumber,
+                       int32_t& chunkLength, int8_t& lastChunkAndSecurityFlags);
 
   void readChunkBody(std::chrono::microseconds timeout, int32_t chunkLength,
                      uint8_t** chunkBody);

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -336,6 +336,9 @@ class APACHE_GEODE_EXPORT TcrConnection {
   void readChunkBody(std::chrono::microseconds timeout, int32_t chunkLength,
                      uint8_t** chunkBody);
 
+  void processChunk(TcrMessageReply& reply, std::chrono::microseconds timeout,
+                    int32_t chunkLength, int8_t lastChunkAndSecurityFlags);
+
   /**
    * To read Intantiator message(which meant for java client), here we are
    * ignoring it

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -325,6 +325,10 @@ class APACHE_GEODE_EXPORT TcrConnection {
   void readResponseHeader(std::chrono::microseconds timeout,
                           uint8_t* msg_header);
 
+  void readResponseHeaderVariables(DataInput* di, int32_t& msgType,
+                                   int32_t& numberOfParts,
+                                   int32_t& transactionId);
+
   //  void readResponseHeader(std::chrono::microseconds timeout,
   //                          uint32_t& messageType, uint32_t& numberOfParts,
   //                          uint32_t& transactionId);

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -323,7 +323,8 @@ class APACHE_GEODE_EXPORT TcrConnection {
       std::chrono::microseconds receiveTimeout, bool retry);
 
   void readResponseHeader(std::chrono::microseconds timeout,
-                          uint8_t* msg_header);
+                          uint8_t* msg_header, int32_t& messageType,
+                          int32_t& numberOfParts, int32_t& transactionId);
 
   void readResponseHeaderVariables(DataInput* di, int32_t& msgType,
                                    int32_t& numberOfParts,

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -759,7 +759,7 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
             m_tcdm->getConnectionManager().getCacheImpl());
         m_chunkedResult->setEndpointMemId(endpointmemId);
         m_tcdm->queueChunk(chunkedContext);
-        if (bytes == nullptr) {
+        if (chunk.empty()) {
           // last chunk -- wait for processing of all the chunks to complete
           m_chunkedResult->waitFinalize();
           auto ex = m_chunkedResult->getException();
@@ -783,7 +783,7 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
             m_tcdm->getConnectionManager().getCacheImpl());
         m_chunkedResult->setEndpointMemId(endpointmemId);
         m_tcdm->queueChunk(chunkedContext);
-        if (bytes == nullptr) {
+        if (chunk.empty()) {
           // last chunk -- wait for processing of all the chunks to complete
           m_chunkedResult->waitFinalize();
           //  Throw any exception during processing here.
@@ -801,7 +801,7 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
       } else if (TcrMessage::CQ_EXCEPTION_TYPE == m_msgType ||
                  TcrMessage::CQDATAERROR_MSG_TYPE == m_msgType ||
                  TcrMessage::GET_ALL_DATA_ERROR == m_msgType) {
-        if (bytes != nullptr) {
+        if (chunk.size()) {
           chunkSecurityHeader(1, bytes, len, isLastChunkAndisSecurityHeader);
           _GEODE_SAFE_DELETE_ARRAY(bytes);
         }
@@ -812,7 +812,7 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
                                                     // error
     case EXECUTE_FUNCTION_ERROR:
     case EXECUTE_REGION_FUNCTION_ERROR: {
-      if (bytes != nullptr) {
+      if (chunk.size()) {
         // DeleteArray<const uint8_t> delChunk(bytes);
         //  DataInput input(bytes, len);
         // TODO: this not send two part...
@@ -826,7 +826,7 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
       break;
     }
     case TcrMessage::EXCEPTION: {
-      if (bytes != nullptr) {
+      if (chunk.size()) {
         DeleteArray<uint8_t> delChunk(bytes);
         auto input =
             m_tcdm->getConnectionManager().getCacheImpl()->createDataInput(
@@ -840,7 +840,7 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
     case TcrMessage::RESPONSE_FROM_SECONDARY: {
       // TODO: how many parts
       chunkSecurityHeader(1, bytes, len, isLastChunkAndisSecurityHeader);
-      if (bytes != nullptr) {
+      if (chunk.size()) {
         DeleteArray<uint8_t> delChunk(bytes);
         LOGFINEST("processChunk - got response from secondary, ignoring.");
       }
@@ -848,7 +848,7 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
     }
     case TcrMessage::PUT_DATA_ERROR: {
       chunkSecurityHeader(1, bytes, len, isLastChunkAndisSecurityHeader);
-      if (nullptr != bytes) {
+      if (chunk.size()) {
         auto input =
             m_tcdm->getConnectionManager().getCacheImpl()->createDataInput(
                 bytes, len);
@@ -864,7 +864,7 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
     }
     case TcrMessage::GET_ALL_DATA_ERROR: {
       chunkSecurityHeader(1, bytes, len, isLastChunkAndisSecurityHeader);
-      if (bytes != nullptr) {
+      if (chunk.size()) {
         _GEODE_SAFE_DELETE_ARRAY(bytes);
       }
 
@@ -872,7 +872,7 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
     }
     default: {
       // TODO: how many parts what should we do here
-      if (bytes != nullptr) {
+      if (chunk.size()) {
         _GEODE_SAFE_DELETE_ARRAY(bytes);
       } else {
         LOGWARN(

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -795,7 +795,7 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
       } else if (TcrMessage::CQ_EXCEPTION_TYPE == m_msgType ||
                  TcrMessage::CQDATAERROR_MSG_TYPE == m_msgType ||
                  TcrMessage::GET_ALL_DATA_ERROR == m_msgType) {
-        if (chunk.size()) {
+        if (!chunk.empty()) {
           chunkSecurityHeader(1, chunk, len, isLastChunkAndisSecurityHeader);
         }
       }
@@ -805,7 +805,7 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
                                                     // error
     case EXECUTE_FUNCTION_ERROR:
     case EXECUTE_REGION_FUNCTION_ERROR: {
-      if (chunk.size()) {
+      if (!chunk.empty()) {
         // DeleteArray<const uint8_t> delChunk(bytes);
         //  DataInput input(bytes, len);
         // TODO: this not send two part...
@@ -818,7 +818,7 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
       break;
     }
     case TcrMessage::EXCEPTION: {
-      if (chunk.size()) {
+      if (!chunk.empty()) {
         auto input =
             m_tcdm->getConnectionManager().getCacheImpl()->createDataInput(
                 chunk.data(), len);
@@ -838,7 +838,7 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
     }
     case TcrMessage::PUT_DATA_ERROR: {
       chunkSecurityHeader(1, chunk, len, isLastChunkAndisSecurityHeader);
-      if (chunk.size()) {
+      if (!chunk.empty()) {
         auto input =
             m_tcdm->getConnectionManager().getCacheImpl()->createDataInput(
                 chunk.data(), len);

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -221,7 +221,7 @@ class APACHE_GEODE_EXPORT TcrMessage {
 
   void startProcessChunk(ACE_Semaphore& finalizeSema);
   // nullptr chunk means that this is the last chunk
-  void processChunk(const uint8_t* chunk, int32_t chunkLen,
+  void processChunk(const std::vector<uint8_t>& chunk, int32_t chunkLen,
                     uint16_t endpointmemId,
                     const uint8_t isLastChunkAndisSecurityHeader = 0x00);
   /* For creating a region on the java server */

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -569,8 +569,8 @@ class APACHE_GEODE_EXPORT TcrMessage {
   void writeMillisecondsPart(std::chrono::milliseconds millis);
   void writeByteAndTimeOutPart(uint8_t byteValue,
                                std::chrono::milliseconds timeout);
-  void chunkSecurityHeader(int skipParts, const uint8_t* bytes, int32_t len,
-                           uint8_t isLastChunkAndSecurityHeader);
+  void chunkSecurityHeader(int skipParts, const std::vector<uint8_t> bytes,
+                           int32_t len, uint8_t isLastChunkAndSecurityHeader);
 
   void readEventIdPart(DataInput& input, bool skip = false,
                        int32_t parts = 1);  // skip num parts then read eventid

--- a/dependencies/rat/CMakeLists.txt
+++ b/dependencies/rat/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project( rat VERSION 0.12 LANGUAGES NONE )
+project( rat VERSION 0.13 LANGUAGES NONE )
 # used to check licenses in source
 
 set( ARTIFACT_NAME apache-rat-${PROJECT_VERSION} )
@@ -26,4 +26,4 @@ execute_process(
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-set( Rat_JAR ${CMAKE_CURRENT_BINARY_DIR}/${ARTIFACT_NAME}/${ARTIFACT_NAME}.jar CACHE STRING "Full path to Apaceh Rat jar." )
+set( Rat_JAR ${CMAKE_CURRENT_BINARY_DIR}/${ARTIFACT_NAME}/${ARTIFACT_NAME}.jar CACHE STRING "Full path to Apache Rat jar." FORCE)


### PR DESCRIPTION
The purpose and functionality of TcrConnection::readMessageChunked should now be more apparent.  Refactored it into several helper methods, cleaned up named constants and variable names, de-obfuscated confusing loop logic. 