### PR TITLE
GEODE 6835 - fix auth retry logic

### DIFF
--- a/cppcache/integration/framework/Cluster.cpp
+++ b/cppcache/integration/framework/Cluster.cpp
@@ -33,7 +33,7 @@ void Locator::start() {
     cluster_.getGfsh().stop().locator().withDir(name_).execute();
   }
 
-  auto locator = cluster_.getGfsh()
+  cluster_.getGfsh()
       .start()
       .locator()
       .withDir(name_)
@@ -42,23 +42,10 @@ void Locator::start() {
       .withPort(locatorAddress_.port)
       .withMaxHeap("256m")
       .withJmxManagerPort(jmxManagerPort_)
-      .withHttpServicePort(0);
-
-  if (!cluster_.getClasspath().empty()) {
-    locator.withClasspath(cluster_.getClasspath());
-  }
-
-  if (!cluster_.getSecurityManager().empty()) {
-    locator.withSecurityManager(cluster_.getSecurityManager());
-  }
-
-  if ((!cluster_.getUser().empty()) && (!cluster_.getPassword().empty())) {
-    locator.execute(cluster_.getUser(), cluster_.getPassword());
-  } else {
-    locator.execute();
-  }
-
-//  std::cout << "locator: " << locatorAddress_.port << ": started" << std::endl << std::flush;
+      .withHttpServicePort(0)
+      .withClasspath(cluster_.getClasspath())
+      .withSecurityManager(cluster_.getSecurityManager())
+      .execute(cluster_.getUser(), cluster_.getPassword());
 
   started_ = true;
 }
@@ -74,7 +61,7 @@ void Server::start() {
   auto safeName = name_;
   std::replace(safeName.begin(), safeName.end(), '/', '_');
 
-  auto server = cluster_.getGfsh()
+  cluster_.getGfsh()
       .start()
       .server()
       .withDir(name_)
@@ -83,25 +70,12 @@ void Server::start() {
       .withPort(serverAddress_.port)
       .withMaxHeap("1g")
       .withLocators(locators_.front().getAddress().address + "[" +
-                    std::to_string(locators_.front().getAddress().port) + "]");
-
-  if (!cluster_.getClasspath().empty()) {
-    server.withClasspath(cluster_.getClasspath());
-  }
-
-  if (!cluster_.getSecurityManager().empty()) {
-    server.withSecurityManager(cluster_.getSecurityManager());
-  }
-
-  if (!cluster_.getUser().empty()) {
-    server.withUser(cluster_.getUser());
-  }
-
-  if (!cluster_.getPassword().empty()) {
-    server.withPassword(cluster_.getPassword());
-  }
-
-  server.execute();
+                    std::to_string(locators_.front().getAddress().port) + "]")
+      .withClasspath(cluster_.getClasspath())
+      .withSecurityManager(cluster_.getSecurityManager())
+      .withUser(cluster_.getUser())
+      .withPassword(cluster_.getPassword())
+      .execute();
 
 //  std::cout << "server: " << serverAddress_.port << ": started" << std::endl << std::flush;
 

--- a/cppcache/integration/framework/Cluster.cpp
+++ b/cppcache/integration/framework/Cluster.cpp
@@ -33,7 +33,7 @@ void Locator::start() {
     cluster_.getGfsh().stop().locator().withDir(name_).execute();
   }
 
-  cluster_.getGfsh()
+  auto locator = cluster_.getGfsh()
       .start()
       .locator()
       .withDir(name_)
@@ -42,8 +42,17 @@ void Locator::start() {
       .withPort(locatorAddress_.port)
       .withMaxHeap("256m")
       .withJmxManagerPort(jmxManagerPort_)
-      .withHttpServicePort(0)
-      .execute();
+      .withHttpServicePort(0);
+
+  if (!cluster_.getClasspath().empty()) {
+    locator.withClasspath(cluster_.getClasspath());
+  }
+
+  if (!cluster_.getSecurityManager().empty()) {
+    locator.withSecurityManager(cluster_.getSecurityManager());
+  }
+
+  locator.execute();
 
   //    std::cout << "locator: " << locatorAddress_.port << ": started"
   //              << std::endl;
@@ -62,7 +71,7 @@ void Server::start() {
   auto safeName = name_;
   std::replace(safeName.begin(), safeName.end(), '/', '_');
 
-  cluster_.getGfsh()
+  auto server = cluster_.getGfsh()
       .start()
       .server()
       .withDir(name_)
@@ -71,8 +80,25 @@ void Server::start() {
       .withPort(serverAddress_.port)
       .withMaxHeap("1g")
       .withLocators(locators_.front().getAddress().address + "[" +
-                    std::to_string(locators_.front().getAddress().port) + "]")
-      .execute();
+                    std::to_string(locators_.front().getAddress().port) + "]");
+
+  if (!cluster_.getClasspath().empty()) {
+    server.withClasspath(cluster_.getClasspath());
+  }
+
+  if (!cluster_.getSecurityManager().empty()) {
+    server.withSecurityManager(cluster_.getSecurityManager());
+  }
+
+  if (!cluster_.getUser().empty()) {
+    server.withUser(cluster_.getUser());
+  }
+
+  if (!cluster_.getPassword().empty()) {
+    server.withPassword(cluster_.getPassword());
+  }
+
+  server.execute();
 
   //    std::cout << "server: " << serverAddress_.port << ": started" <<
   //    std::endl;

--- a/cppcache/integration/framework/Cluster.cpp
+++ b/cppcache/integration/framework/Cluster.cpp
@@ -52,18 +52,21 @@ void Locator::start() {
     locator.withSecurityManager(cluster_.getSecurityManager());
   }
 
-  locator.execute();
+  if ((!cluster_.getUser().empty()) && (!cluster_.getPassword().empty())) {
+    locator.execute(cluster_.getUser(), cluster_.getPassword());
+  } else {
+    locator.execute();
+  }
 
-  //    std::cout << "locator: " << locatorAddress_.port << ": started"
-  //              << std::endl;
+//  std::cout << "locator: " << locatorAddress_.port << ": started" << std::endl << std::flush;
+
   started_ = true;
 }
 
 void Locator::stop() {
   cluster_.getGfsh().stop().locator().withDir(name_).execute();
 
-  //    std::cout << "locator: " << locatorAddress_.port << ": stopped"
-  //              << std::endl;
+//  std::cout << "locator: " << locatorAddress_.port << ": stopped" << std::endl << std::flush;
   started_ = false;
 }
 
@@ -100,16 +103,15 @@ void Server::start() {
 
   server.execute();
 
-  //    std::cout << "server: " << serverAddress_.port << ": started" <<
-  //    std::endl;
+//  std::cout << "server: " << serverAddress_.port << ": started" << std::endl << std::flush;
+
   started_ = true;
 }
 
 void Server::stop() {
   cluster_.getGfsh().stop().server().withDir(name_).execute();
 
-  //    std::cout << "server: " << serverAddress_.port << ": stopped" <<
-  //    std::endl;
+//  std::cout << "server: " << serverAddress_.port << ": stopped" << std::endl << std::flush;
   started_ = false;
 }
 

--- a/cppcache/integration/framework/Gfsh.h
+++ b/cppcache/integration/framework/Gfsh.h
@@ -124,12 +124,16 @@ class Gfsh {
       };
 
       Locator &withClasspath(const std::string classpath) {
-        command_ += " --classpath=" + classpath;
+        if (!classpath.empty()) {
+          command_ += " --classpath=" + classpath;
+        }
         return *this;
       };
 
       Locator &withSecurityManager(const std::string securityManager) {
-        command_ += " --J=-Dgemfire.security-manager=" + securityManager;
+        if (!securityManager.empty()) {
+          command_ += " --J=-Dgemfire.security-manager=" + securityManager;
+        }
         return *this;
       };
 
@@ -179,22 +183,31 @@ class Gfsh {
       };
 
       Server &withClasspath(const std::string classpath) {
-        command_ += " --classpath=" + classpath;
+        if (!classpath.empty()) {
+          command_ += " --classpath=" + classpath;
+        }
         return *this;
       };
 
       Server &withSecurityManager(const std::string securityManager) {
-        command_ += " --J=-Dgemfire.security-manager=" + securityManager;
+        if (!securityManager.empty()) {
+          command_ += " --J=-Dgemfire.security-manager=" + securityManager;
+        }
         return *this;
       };
 
       Server &withUser(const std::string user) {
-        command_ += " --user=" + user;
+        if (!user.empty()) {
+          command_ += " --user=" + user;
+        }
+
         return *this;
       };
 
       Server &withPassword(const std::string password) {
-        command_ += " --password=" + password;
+        if (!password.empty()) {
+          command_ += " --password=" + password;
+        }
         return *this;
       };
     };

--- a/cppcache/integration/framework/Gfsh.h
+++ b/cppcache/integration/framework/Gfsh.h
@@ -58,7 +58,8 @@ class Gfsh {
   template <class Result>
   class Command {
    public:
-    virtual Result execute() { Result{gfsh_}.parse(gfsh_.execute(command_)); }
+    virtual Result execute(const std::string &user, const std::string &password) { Result{gfsh_}.parse(gfsh_.execute(command_, user, password)); }
+    virtual Result execute() { Result{gfsh_}.parse(gfsh_.execute(command_, "", "")); }
 
    protected:
     Command(Gfsh &gfsh, std::string command)
@@ -312,12 +313,18 @@ class Gfsh {
   };
 
  protected:
-  virtual void execute(const std::string &command) = 0;
+  virtual void execute(const std::string &command, const std::string &user, const std::string &password) = 0;
 };
 
 template <>
-inline void Gfsh::Command<void>::execute() {
-  gfsh_.execute(command_);
+inline void Gfsh::Command<void>::execute(const std::string &user, const std::string &password) {
+  gfsh_.execute(command_, user, password);
 }
+
+template <>
+inline void Gfsh::Command<void>::execute() {
+  gfsh_.execute(command_, "", "");
+}
+
 
 #endif  // INTEGRATION_TEST_FRAMEWORK_GFSH_H

--- a/cppcache/integration/framework/Gfsh.h
+++ b/cppcache/integration/framework/Gfsh.h
@@ -121,6 +121,21 @@ class Gfsh {
         command_ += " --max-heap=" + maxHeap;
         return *this;
       };
+
+      Locator &withClasspath(const std::string classpath) {
+        command_ += " --classpath=" + classpath;
+        return *this;
+      };
+
+      Locator &withSecurityManager(const std::string securityManager) {
+        command_ += " --J=-Dgemfire.security-manager=" + securityManager;
+        return *this;
+      };
+
+      Locator &withConnect(const std::string connect) {
+        command_ += " --connect=" + connect;
+        return *this;
+      };
     };
 
     class Server : public Command<void> {
@@ -159,6 +174,26 @@ class Gfsh {
 
       Server &withMaxHeap(const std::string maxHeap) {
         command_ += " --max-heap=" + maxHeap;
+        return *this;
+      };
+
+      Server &withClasspath(const std::string classpath) {
+        command_ += " --classpath=" + classpath;
+        return *this;
+      };
+
+      Server &withSecurityManager(const std::string securityManager) {
+        command_ += " --J=-Dgemfire.security-manager=" + securityManager;
+        return *this;
+      };
+
+      Server &withUser(const std::string user) {
+        command_ += " --user=" + user;
+        return *this;
+      };
+
+      Server &withPassword(const std::string password) {
+        command_ += " --password=" + password;
         return *this;
       };
     };
@@ -240,6 +275,16 @@ class Gfsh {
 
     Connect &withJmxManager(const std::string &jmxManager) {
       command_ += " --jmx-manager=" + jmxManager;
+      return *this;
+    };
+
+    Connect &withUser(const std::string &user) {
+      command_ += " --user=" + user;
+      return *this;
+    };
+
+    Connect &withPassword(const std::string &password) {
+      command_ += " --password=" + password;
       return *this;
     };
   };

--- a/cppcache/integration/framework/GfshExecute.h
+++ b/cppcache/integration/framework/GfshExecute.h
@@ -70,47 +70,14 @@ class GfshExecute : public Gfsh {
   };
 
  protected:
-  void execute(const std::string &command) override;
+  void execute(const std::string &command, const std::string &user, const std::string &password) override;
 
   boost::process::child executeChild(std::vector<std::string> &commands,
                                      boost::process::environment &env,
                                      boost::process::ipstream &outStream,
                                      boost::process::ipstream &errStream);
 
-  void extractConnectionCommand(const std::string &command) {
-        if (starts_with(command, std::string("connect"))) {
-          connection_ = command;
-    } else if (starts_with(command, std::string("start locator"))) {
-      auto jmxManagerHost = std::string("localhost");
-      auto jmxManagerPort = std::string("1099");
-//      auto securityManagerUser = std::string("user");
-//      auto securityManagerPassword = std::string("password");
-
-      std::regex jmxManagerHostRegex("bind-address=([^\\s]+)");
-      std::smatch jmxManagerHostMatch;
-      if (std::regex_search(command, jmxManagerHostMatch,
-                            jmxManagerHostRegex)) {
-        jmxManagerHost = jmxManagerHostMatch[1];
-      }
-
-      std::regex jmxManagerPortRegex("jmx-manager-port=(\\d+)");
-      std::smatch jmxManagerPortMatch;
-      if (std::regex_search(command, jmxManagerPortMatch,
-                            jmxManagerPortRegex)) {
-        jmxManagerPort = jmxManagerPortMatch[1];
-      }
-
-//      std::regex securityManagerUserRegex("--user=(^\\s+)");
-//      std::smatch securityManagerUserMatch;
-//      if (std::regex_search(command, jmxManagerHostMatch,
-//          jmxManagerHostRegex)) {
-//            jmxManagerHost = jmxManagerHostMatch[1];
-//          }
-
-      connection_ = "connect --jmx-manager=" + jmxManagerHost + "[" +
-                    jmxManagerPort + "] --user=root --password=root-password";
-    }
-  }
+  void extractConnectionCommand(const std::string &command, const std::string &user = "", const std::string &password = "");
 
  private:
   std::string connection_;

--- a/cppcache/integration/framework/GfshExecute.h
+++ b/cppcache/integration/framework/GfshExecute.h
@@ -78,11 +78,13 @@ class GfshExecute : public Gfsh {
                                      boost::process::ipstream &errStream);
 
   void extractConnectionCommand(const std::string &command) {
-    if (starts_with(command, std::string("connect"))) {
-      connection_ = command;
+        if (starts_with(command, std::string("connect"))) {
+          connection_ = command;
     } else if (starts_with(command, std::string("start locator"))) {
       auto jmxManagerHost = std::string("localhost");
       auto jmxManagerPort = std::string("1099");
+//      auto securityManagerUser = std::string("user");
+//      auto securityManagerPassword = std::string("password");
 
       std::regex jmxManagerHostRegex("bind-address=([^\\s]+)");
       std::smatch jmxManagerHostMatch;
@@ -98,8 +100,15 @@ class GfshExecute : public Gfsh {
         jmxManagerPort = jmxManagerPortMatch[1];
       }
 
+//      std::regex securityManagerUserRegex("--user=(^\\s+)");
+//      std::smatch securityManagerUserMatch;
+//      if (std::regex_search(command, jmxManagerHostMatch,
+//          jmxManagerHostRegex)) {
+//            jmxManagerHost = jmxManagerHostMatch[1];
+//          }
+
       connection_ = "connect --jmx-manager=" + jmxManagerHost + "[" +
-                    jmxManagerPort + "]";
+                    jmxManagerPort + "] --user=root --password=root-password";
     }
   }
 

--- a/cppcache/integration/test/AuthInitializeTest.cpp
+++ b/cppcache/integration/test/AuthInitializeTest.cpp
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <random>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <geode/AuthInitialize.hpp>
+#include <geode/Cache.hpp>
+#include <geode/CqAttributes.hpp>
+#include <geode/CqAttributesFactory.hpp>
+#include <geode/CqEvent.hpp>
+#include <geode/CqListener.hpp>
+#include <geode/PoolManager.hpp>
+#include <geode/QueryService.hpp>
+#include <geode/RegionFactory.hpp>
+#include <geode/RegionShortcut.hpp>
+
+#include "CacheRegionHelper.hpp"
+#include "SimpleCqListener.hpp"
+#include "framework/Cluster.h"
+#include "framework/Framework.h"
+#include "framework/Gfsh.h"
+
+namespace {
+
+using apache::geode::client::AuthInitialize;
+using apache::geode::client::Cache;
+using apache::geode::client::Cacheable;
+using apache::geode::client::CacheableKey;
+using apache::geode::client::CacheableString;
+using apache::geode::client::CacheFactory;
+using apache::geode::client::CqAttributes;
+using apache::geode::client::CqAttributesFactory;
+using apache::geode::client::CqEvent;
+using apache::geode::client::CqListener;
+using apache::geode::client::CqOperation;
+using apache::geode::client::Exception;
+using apache::geode::client::HashMapOfCacheable;
+using apache::geode::client::Pool;
+using apache::geode::client::Properties;
+using apache::geode::client::QueryService;
+using apache::geode::client::Region;
+using apache::geode::client::RegionShortcut;
+
+using std::chrono::minutes;
+
+const int32_t CQ_PLUS_AUTH_TEST_REGION_ENTRY_COUNT = 100000;
+
+class SimpleAuthInitialize : public apache::geode::client::AuthInitialize {
+ public:
+  std::shared_ptr<Properties> getCredentials(
+      const std::shared_ptr<Properties>& securityprops,
+      const std::string& /*server*/) override {
+    std::cout << "SimpleAuthInitialize::GetCredentials called\n";
+    //    Exception ex("Debugging SimpleAuthInitialize::getCredentials");
+    //    std::cout << ex.getStackTrace() << std::endl;
+
+    securityprops->insert("security-username", username_);
+    securityprops->insert("security-password", password_);
+
+    countOfGetCredentialsCalls_++;
+    return securityprops;
+  }
+
+  void close() override { std::cout << "SimpleAuthInitialize::close called\n"; }
+
+  SimpleAuthInitialize()
+      : AuthInitialize(),
+        username_("root"),
+        password_("root-password"),
+        countOfGetCredentialsCalls_(0) {
+    std::cout << "SimpleAuthInitialize::SimpleAuthInitialize called\n";
+  }
+  SimpleAuthInitialize(std::string username, std::string password)
+      : username_(std::move(username)),
+        password_(std::move(password)),
+        countOfGetCredentialsCalls_(0) {}
+
+  ~SimpleAuthInitialize() override = default;
+
+  int32_t getGetCredentialsCallCount() { return countOfGetCredentialsCalls_; }
+
+ private:
+  std::string username_;
+  std::string password_;
+  int32_t countOfGetCredentialsCalls_;
+};
+
+Cache createCache(std::shared_ptr<SimpleAuthInitialize> auth) {
+  auto cache = CacheFactory()
+                   .set("log-level", "debug")
+                   .set("log-file", "geode_native.log")
+                   .set("statistic-sampling-enabled", "false")
+                   .setAuthInitialize(auth)
+                   .create();
+
+  return cache;
+}
+
+Cache createCacheWithBadPassword(std::shared_ptr<SimpleAuthInitialize> auth) {
+  auto cache = CacheFactory()
+                   .set("log-level", "debug")
+                   .set("log-file", "geode_native.log")
+                   .set("statistic-sampling-enabled", "false")
+                   .setAuthInitialize(auth)
+                   .create();
+
+  return cache;
+}
+
+Cache createCacheWithBadUsername() {
+  auto cache = CacheFactory()
+                   .set("log-level", "debug")
+                   .set("log-file", "geode_native.log")
+                   .set("statistic-sampling-enabled", "false")
+                   .setAuthInitialize(std::make_shared<SimpleAuthInitialize>(
+                       "unauthorized-user", "root-password"))
+                   .create();
+
+  return cache;
+}
+
+std::shared_ptr<Pool> createPool(Cluster& cluster, Cache& cache,
+                                 bool subscriptionEnabled) {
+  auto poolFactory = cache.getPoolManager().createFactory();
+
+  cluster.applyLocators(poolFactory);
+  poolFactory.setPRSingleHopEnabled(true).setSubscriptionEnabled(
+      subscriptionEnabled);
+
+  return poolFactory.create("default");
+}
+
+std::shared_ptr<Region> setupRegion(Cache& cache,
+                                    const std::shared_ptr<Pool>& pool) {
+  auto region = cache.createRegionFactory(RegionShortcut::PROXY)
+                    .setPoolName(pool->getName())
+                    .create("region");
+
+  return region;
+}
+
+TEST(AuthInitializeTest, putGetWithBasicAuth) {
+  Cluster cluster(
+      Name(std::string(::testing::UnitTest::GetInstance()
+                           ->current_test_info()
+                           ->test_case_name()) +
+           "/" +
+           ::testing::UnitTest::GetInstance()->current_test_info()->name()),
+      Classpath{getFrameworkString(FrameworkVariable::JavaObjectJarPath)},
+      SecurityManager{"javaobject.SimpleSecurityManager"}, User{"root"},
+      Password{"root-password"}, LocatorCount{1}, ServerCount{1});
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("PARTITION")
+      .execute();
+
+  auto authInitialize = std::make_shared<SimpleAuthInitialize>();
+  auto cache = createCache(authInitialize);
+  auto pool = createPool(cluster, cache, false);
+  auto region = setupRegion(cache, pool);
+
+  region->put("foo", "bar");
+  auto value = region->get("foo");
+  auto stringValue = std::dynamic_pointer_cast<CacheableString>(value)->value();
+  ASSERT_EQ(stringValue, std::string("bar"));
+  ASSERT_GT(authInitialize->getGetCredentialsCallCount(), 0);
+}
+
+TEST(AuthInitializeTest, putWithBadUsername) {
+  Cluster cluster(
+      Name(std::string(::testing::UnitTest::GetInstance()
+                           ->current_test_info()
+                           ->test_case_name()) +
+           "/" +
+           ::testing::UnitTest::GetInstance()->current_test_info()->name()),
+      Classpath{getFrameworkString(FrameworkVariable::JavaObjectJarPath)},
+      SecurityManager{"javaobject.SimpleSecurityManager"}, User{"root"},
+      Password{"root-password"}, LocatorCount{1}, ServerCount{1});
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("PARTITION")
+      .execute();
+  auto authInitialize = std::make_shared<SimpleAuthInitialize>(
+      "unauthorized-user", "root-password");
+  auto cache = createCache(authInitialize);
+  auto pool = createPool(cluster, cache, false);
+  auto region = setupRegion(cache, pool);
+
+  try {
+    region->put("foo", "bar");
+  } catch (const apache::geode::client::NotConnectedException&) {
+  } catch (const apache::geode::client::Exception& ex) {
+    std::cerr << "Caught unexpected exception: " << ex.what() << std::endl;
+    FAIL();
+  }
+
+  ASSERT_GT(authInitialize->getGetCredentialsCallCount(), 0);
+}
+
+TEST(AuthInitializeTest, putWithBadPassword) {
+  Cluster cluster(
+      Name(std::string(::testing::UnitTest::GetInstance()
+                           ->current_test_info()
+                           ->test_case_name()) +
+           "/" +
+           ::testing::UnitTest::GetInstance()->current_test_info()->name()),
+      Classpath{getFrameworkString(FrameworkVariable::JavaObjectJarPath)},
+      SecurityManager{"javaobject.SimpleSecurityManager"}, User{"root"},
+      Password{"root-password"}, LocatorCount{1}, ServerCount{1});
+
+  auto authInitialize =
+      std::make_shared<SimpleAuthInitialize>("root", "bad-password");
+  auto cache = createCache(authInitialize);
+  auto pool = createPool(cluster, cache, false);
+  auto region = setupRegion(cache, pool);
+
+  try {
+    region->put("foo", "bar");
+  } catch (const apache::geode::client::NotConnectedException&) {
+  } catch (const apache::geode::client::Exception& ex) {
+    std::cerr << "Caught unexpected exception: " << ex.what() << std::endl;
+    FAIL();
+  }
+
+  ASSERT_GT(authInitialize->getGetCredentialsCallCount(), 0);
+}
+
+TEST(AuthInitializeTest, badCredentialsWithSubscriptionEnabled) {
+  Cluster cluster(
+      Name(std::string(::testing::UnitTest::GetInstance()
+                           ->current_test_info()
+                           ->test_case_name()) +
+           "/" +
+           ::testing::UnitTest::GetInstance()->current_test_info()->name()),
+      Classpath{getFrameworkString(FrameworkVariable::JavaObjectJarPath)},
+      SecurityManager{"javaobject.SimpleSecurityManager"}, User{"root"},
+      Password{"root-password"}, LocatorCount{1}, ServerCount{1});
+
+  auto authInitialize =
+      std::make_shared<SimpleAuthInitialize>("root", "bad-password");
+  auto cache = createCache(authInitialize);
+
+  try {
+    createPool(cluster, cache, true);
+  } catch (const apache::geode::client::AuthenticationFailedException&) {
+  } catch (const apache::geode::client::Exception& ex) {
+    std::cerr << "Caught unexpected exception: " << ex.what() << std::endl;
+    FAIL();
+  }
+
+  ASSERT_GT(authInitialize->getGetCredentialsCallCount(), 0);
+}
+
+}  // namespace

--- a/cppcache/integration/test/AuthInitializeTest.cpp
+++ b/cppcache/integration/test/AuthInitializeTest.cpp
@@ -41,13 +41,13 @@
 #include "framework/Framework.h"
 #include "framework/Gfsh.h"
 
-using apache::geode::client::AuthInitialize;
 using apache::geode::client::AuthenticationFailedException;
+using apache::geode::client::AuthInitialize;
 using apache::geode::client::Cache;
-using apache::geode::client::CacheFactory;
 using apache::geode::client::Cacheable;
 using apache::geode::client::CacheableKey;
 using apache::geode::client::CacheableString;
+using apache::geode::client::CacheFactory;
 using apache::geode::client::CqAttributes;
 using apache::geode::client::CqAttributesFactory;
 using apache::geode::client::CqEvent;
@@ -212,4 +212,3 @@ TEST(AuthInitializeTest, badCredentialsWithSubscriptionEnabled) {
 
   ASSERT_GT(authInitialize->getGetCredentialsCallCount(), 0);
 }
-

--- a/cppcache/integration/test/AuthInitializeTest.cpp
+++ b/cppcache/integration/test/AuthInitializeTest.cpp
@@ -77,29 +77,6 @@ Cache createCache(std::shared_ptr<SimpleAuthInitialize> auth) {
   return cache;
 }
 
-Cache createCacheWithBadPassword(std::shared_ptr<SimpleAuthInitialize> auth) {
-  auto cache = CacheFactory()
-                   .set("log-level", "debug")
-                   .set("log-file", "geode_native.log")
-                   .set("statistic-sampling-enabled", "false")
-                   .setAuthInitialize(auth)
-                   .create();
-
-  return cache;
-}
-
-Cache createCacheWithBadUsername() {
-  auto cache = CacheFactory()
-                   .set("log-level", "debug")
-                   .set("log-file", "geode_native.log")
-                   .set("statistic-sampling-enabled", "false")
-                   .setAuthInitialize(std::make_shared<SimpleAuthInitialize>(
-                       "unauthorized-user", "root-password"))
-                   .create();
-
-  return cache;
-}
-
 std::shared_ptr<Pool> createPool(Cluster& cluster, Cache& cache,
                                  bool subscriptionEnabled) {
   auto poolFactory = cache.getPoolManager().createFactory();

--- a/cppcache/integration/test/AuthInitializeTest.cpp
+++ b/cppcache/integration/test/AuthInitializeTest.cpp
@@ -41,14 +41,13 @@
 #include "framework/Framework.h"
 #include "framework/Gfsh.h"
 
-namespace {
-
 using apache::geode::client::AuthInitialize;
+using apache::geode::client::AuthenticationFailedException;
 using apache::geode::client::Cache;
+using apache::geode::client::CacheFactory;
 using apache::geode::client::Cacheable;
 using apache::geode::client::CacheableKey;
 using apache::geode::client::CacheableString;
-using apache::geode::client::CacheFactory;
 using apache::geode::client::CqAttributes;
 using apache::geode::client::CqAttributesFactory;
 using apache::geode::client::CqEvent;
@@ -56,6 +55,7 @@ using apache::geode::client::CqListener;
 using apache::geode::client::CqOperation;
 using apache::geode::client::Exception;
 using apache::geode::client::HashMapOfCacheable;
+using apache::geode::client::NotConnectedException;
 using apache::geode::client::Pool;
 using apache::geode::client::Properties;
 using apache::geode::client::QueryService;
@@ -150,8 +150,8 @@ TEST(AuthInitializeTest, putWithBadUsername) {
 
   try {
     region->put("foo", "bar");
-  } catch (const apache::geode::client::NotConnectedException&) {
-  } catch (const apache::geode::client::Exception& ex) {
+  } catch (const NotConnectedException&) {
+  } catch (const Exception& ex) {
     std::cerr << "Caught unexpected exception: " << ex.what() << std::endl;
     FAIL();
   }
@@ -178,8 +178,8 @@ TEST(AuthInitializeTest, putWithBadPassword) {
 
   try {
     region->put("foo", "bar");
-  } catch (const apache::geode::client::NotConnectedException&) {
-  } catch (const apache::geode::client::Exception& ex) {
+  } catch (const NotConnectedException&) {
+  } catch (const Exception& ex) {
     std::cerr << "Caught unexpected exception: " << ex.what() << std::endl;
     FAIL();
   }
@@ -204,8 +204,8 @@ TEST(AuthInitializeTest, badCredentialsWithSubscriptionEnabled) {
 
   try {
     createPool(cluster, cache, true);
-  } catch (const apache::geode::client::AuthenticationFailedException&) {
-  } catch (const apache::geode::client::Exception& ex) {
+  } catch (const AuthenticationFailedException&) {
+  } catch (const Exception& ex) {
     std::cerr << "Caught unexpected exception: " << ex.what() << std::endl;
     FAIL();
   }
@@ -213,4 +213,3 @@ TEST(AuthInitializeTest, badCredentialsWithSubscriptionEnabled) {
   ASSERT_GT(authInitialize->getGetCredentialsCallCount(), 0);
 }
 
-}  // namespace

--- a/cppcache/integration/test/AuthInitializeTest.cpp
+++ b/cppcache/integration/test/AuthInitializeTest.cpp
@@ -35,6 +35,7 @@
 #include <geode/RegionShortcut.hpp>
 
 #include "CacheRegionHelper.hpp"
+#include "SimpleAuthInitialize.hpp"
 #include "SimpleCqListener.hpp"
 #include "framework/Cluster.h"
 #include "framework/Framework.h"
@@ -64,46 +65,6 @@ using apache::geode::client::RegionShortcut;
 using std::chrono::minutes;
 
 const int32_t CQ_PLUS_AUTH_TEST_REGION_ENTRY_COUNT = 100000;
-
-class SimpleAuthInitialize : public apache::geode::client::AuthInitialize {
- public:
-  std::shared_ptr<Properties> getCredentials(
-      const std::shared_ptr<Properties>& securityprops,
-      const std::string& /*server*/) override {
-    std::cout << "SimpleAuthInitialize::GetCredentials called\n";
-    //    Exception ex("Debugging SimpleAuthInitialize::getCredentials");
-    //    std::cout << ex.getStackTrace() << std::endl;
-
-    securityprops->insert("security-username", username_);
-    securityprops->insert("security-password", password_);
-
-    countOfGetCredentialsCalls_++;
-    return securityprops;
-  }
-
-  void close() override { std::cout << "SimpleAuthInitialize::close called\n"; }
-
-  SimpleAuthInitialize()
-      : AuthInitialize(),
-        username_("root"),
-        password_("root-password"),
-        countOfGetCredentialsCalls_(0) {
-    std::cout << "SimpleAuthInitialize::SimpleAuthInitialize called\n";
-  }
-  SimpleAuthInitialize(std::string username, std::string password)
-      : username_(std::move(username)),
-        password_(std::move(password)),
-        countOfGetCredentialsCalls_(0) {}
-
-  ~SimpleAuthInitialize() override = default;
-
-  int32_t getGetCredentialsCallCount() { return countOfGetCredentialsCalls_; }
-
- private:
-  std::string username_;
-  std::string password_;
-  int32_t countOfGetCredentialsCalls_;
-};
 
 Cache createCache(std::shared_ptr<SimpleAuthInitialize> auth) {
   auto cache = CacheFactory()

--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -28,6 +28,8 @@ add_executable(cpp-integration-test
   RegionPutAllTest.cpp
   RegionPutGetAllTest.cpp
   RegisterKeysTest.cpp
+  SimpleAuthInitialize.cpp
+  SimpleAuthInitialize.hpp
   SimpleCqListener.cpp
   SimpleCqListener.hpp
   StructTest.cpp

--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -13,9 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-file(GLOB_RECURSE SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
-
-add_executable(cpp-integration-test ${SOURCES})
+add_executable(cpp-integration-test
+  AuthInitializeTest.cpp
+  CommitConflictExceptionTest.cpp
+  CqPlusAuthInitializeTest.cpp
+  CqTest.cpp
+  DataSerializableTest.cpp
+  EnableChunkHandlerThreadTest.cpp
+  ExampleTest.cpp
+  ExpirationTest.cpp
+  FunctionExecutionTest.cpp
+  PdxInstanceTest.cpp
+  RegionGetAllTest.cpp
+  RegionPutAllTest.cpp
+  RegionPutGetAllTest.cpp
+  RegisterKeysTest.cpp
+  SimpleCqListener.cpp
+  SimpleCqListener.hpp
+  StructTest.cpp
+  TransactionCleaningTest.cpp
+)
 
 target_compile_definitions(cpp-integration-test
   PUBLIC

--- a/cppcache/integration/test/CqPlusAuthInitializeTest.cpp
+++ b/cppcache/integration/test/CqPlusAuthInitializeTest.cpp
@@ -212,9 +212,9 @@ TEST(CqPlusAuthInitializeTest, putInALoopWhileSubscribedAndAuthenticated) {
     FAIL();
   }
 
-  for (i = 0; i < 100; i++) {
+  for (i = 0; i < 1000; i++) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    if (testListener->getCreationCount() ==
+    if (testListener->getDestructionCount() ==
         CQ_PLUS_AUTH_TEST_REGION_ENTRY_COUNT) {
       break;
     }

--- a/cppcache/integration/test/CqPlusAuthInitializeTest.cpp
+++ b/cppcache/integration/test/CqPlusAuthInitializeTest.cpp
@@ -64,7 +64,7 @@ using apache::geode::client::RegionShortcut;
 
 using std::chrono::minutes;
 
-const int32_t CQ_PLUS_AUTH_TEST_REGION_ENTRY_COUNT = 100000;
+const int32_t CQ_PLUS_AUTH_TEST_REGION_ENTRY_COUNT = 50000;
 
 Cache createCache(std::shared_ptr<SimpleAuthInitialize> auth) {
   auto cache = CacheFactory()

--- a/cppcache/integration/test/CqPlusAuthInitializeTest.cpp
+++ b/cppcache/integration/test/CqPlusAuthInitializeTest.cpp
@@ -77,36 +77,10 @@ Cache createCache(std::shared_ptr<SimpleAuthInitialize> auth) {
   return cache;
 }
 
-Cache createCacheWithBadPassword() {
-  auto cache = CacheFactory()
-                   .set("log-level", "debug")
-                   .set("log-file", "geode_native.log")
-                   .set("statistic-sampling-enabled", "false")
-                   .setAuthInitialize(std::make_shared<SimpleAuthInitialize>(
-                       "root", "bad-password"))
-                   .create();
-
-  return cache;
-}
-
-Cache createCacheWithBadUsername() {
-  auto cache = CacheFactory()
-                   .set("log-level", "debug")
-                   .set("log-file", "geode_native.log")
-                   .set("statistic-sampling-enabled", "false")
-                   .setAuthInitialize(std::make_shared<SimpleAuthInitialize>(
-                       "unauthorized-user", "root-password"))
-                   .create();
-
-  return cache;
-}
-
 std::shared_ptr<Pool> createPool(Cluster& cluster, Cache& cache,
                                  bool subscriptionEnabled) {
   auto poolFactory = cache.getPoolManager().createFactory().setIdleTimeout(
       std::chrono::milliseconds(0));
-  //                         .setMinConnections(1)
-  //                         .setMaxConnections(1);
 
   cluster.applyLocators(poolFactory);
   poolFactory.setPRSingleHopEnabled(true).setSubscriptionEnabled(

--- a/cppcache/integration/test/CqTest.cpp
+++ b/cppcache/integration/test/CqTest.cpp
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <random>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <geode/CqAttributesFactory.hpp>
+#include <geode/QueryService.hpp>
+#include <geode/RegionFactory.hpp>
+#include <geode/RegionShortcut.hpp>
+
+#include "CacheRegionHelper.hpp"
+#include "SimpleCqListener.hpp"
+#include "framework/Cluster.h"
+#include "framework/Framework.h"
+#include "framework/Gfsh.h"
+
+namespace {
+
+using apache::geode::client::Cache;
+using apache::geode::client::Cacheable;
+using apache::geode::client::CacheableKey;
+using apache::geode::client::CqAttributesFactory;
+using apache::geode::client::HashMapOfCacheable;
+using apache::geode::client::Pool;
+using apache::geode::client::Region;
+using apache::geode::client::RegionShortcut;
+
+using std::chrono::minutes;
+
+//
+// TODO: Use a random number of entries.  Need to investigate how to log this
+// from/import it to a test first.
+//
+const int32_t CQ_TEST_REGION_ENTRY_COUNT = 100;
+
+Cache createCache() {
+  using apache::geode::client::CacheFactory;
+
+  auto cache = CacheFactory()
+                   .set("log-level", "none")
+                   .set("statistic-sampling-enabled", "false")
+                   .create();
+
+  return cache;
+}
+
+std::shared_ptr<Pool> createPool(Cluster& cluster, Cache& cache) {
+  auto poolFactory = cache.getPoolManager().createFactory();
+  cluster.applyLocators(poolFactory);
+  poolFactory.setPRSingleHopEnabled(true);
+  poolFactory.setSubscriptionEnabled(true);
+  return poolFactory.create("default");
+}
+
+std::shared_ptr<Region> setupRegion(Cache& cache,
+                                    const std::shared_ptr<Pool>& pool) {
+  auto region = cache.createRegionFactory(RegionShortcut::PROXY)
+                    .setPoolName(pool->getName())
+                    .create("region");
+
+  return region;
+}
+
+TEST(CqTest, testCqCreateUpdateDestroy) {
+  Cluster cluster{LocatorCount{1}, ServerCount{2}};
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("PARTITION")
+      .execute();
+
+  auto cache = createCache();
+  auto pool = createPool(cluster, cache);
+  auto region = setupRegion(cache, pool);
+  auto queryService = cache.getQueryService();
+
+  CqAttributesFactory attributesFactory;
+  auto testListener = std::make_shared<SimpleCqListener>();
+  attributesFactory.addCqListener(testListener);
+  auto cqAttributes = attributesFactory.create();
+
+  auto query =
+      queryService->newCq("SimpleCQ", "SELECT * FROM /region", cqAttributes);
+
+  query->execute();
+
+  for (int i = 0; i < CQ_TEST_REGION_ENTRY_COUNT; i++) {
+    region->put("key" + std::to_string(i), "value" + std::to_string(i));
+  }
+
+  for (int i = 0; i < CQ_TEST_REGION_ENTRY_COUNT; i++) {
+    region->put("key" + std::to_string(i), "value" + std::to_string(i + 1));
+  }
+
+  for (int i = 0; i < CQ_TEST_REGION_ENTRY_COUNT; i++) {
+    region->destroy("key" + std::to_string(i));
+  }
+
+  for (int i = 0; i < 100; i++) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    if (testListener->getCreationCount() == CQ_TEST_REGION_ENTRY_COUNT) {
+      break;
+    }
+  }
+
+  ASSERT_EQ(testListener->getCreationCount(), CQ_TEST_REGION_ENTRY_COUNT);
+  ASSERT_EQ(testListener->getUpdateCount(), CQ_TEST_REGION_ENTRY_COUNT);
+  ASSERT_EQ(testListener->getDestructionCount(), CQ_TEST_REGION_ENTRY_COUNT);
+}
+
+}  // namespace

--- a/cppcache/integration/test/RegionPlusAuthInitializeTest.cpp
+++ b/cppcache/integration/test/RegionPlusAuthInitializeTest.cpp
@@ -23,8 +23,14 @@
 
 #include <gtest/gtest.h>
 
+#include <geode/AuthInitialize.hpp>
 #include <geode/Cache.hpp>
+#include <geode/CqAttributes.hpp>
+#include <geode/CqAttributesFactory.hpp>
+#include <geode/CqEvent.hpp>
+#include <geode/CqListener.hpp>
 #include <geode/PoolManager.hpp>
+#include <geode/QueryService.hpp>
 #include <geode/RegionFactory.hpp>
 #include <geode/RegionShortcut.hpp>
 
@@ -35,32 +41,99 @@
 
 namespace {
 
+using apache::geode::client::AuthInitialize;
 using apache::geode::client::Cache;
 using apache::geode::client::Cacheable;
 using apache::geode::client::CacheableKey;
 using apache::geode::client::CacheableString;
+using apache::geode::client::CacheFactory;
+using apache::geode::client::CqAttributes;
+using apache::geode::client::CqAttributesFactory;
+using apache::geode::client::CqEvent;
+using apache::geode::client::CqListener;
+using apache::geode::client::CqOperation;
 using apache::geode::client::HashMapOfCacheable;
 using apache::geode::client::Pool;
+using apache::geode::client::Properties;
+using apache::geode::client::QueryService;
 using apache::geode::client::Region;
 using apache::geode::client::RegionShortcut;
 
 using std::chrono::minutes;
 
-Cache createCache() {
-  using apache::geode::client::CacheFactory;
+class SimpleAuthInitialize : public apache::geode::client::AuthInitialize {
+  std::shared_ptr<Properties> getCredentials(
+      const std::shared_ptr<Properties>& securityprops,
+      const std::string& /*server*/) override {
+    std::cout << "SimpleAuthInitialize::GetCredentials called\n";
 
+    securityprops->insert("security-username", "root");
+    securityprops->insert("security-password", "root-password");
+
+    return securityprops;
+  }
+
+  void close() override { std::cout << "SimpleAuthInitialize::close called\n"; }
+
+ public:
+  SimpleAuthInitialize() : AuthInitialize() {
+    std::cout << "SimpleAuthInitialize::SimpleAuthInitialize called\n";
+  }
+  ~SimpleAuthInitialize() override = default;
+};
+
+Cache createCache() {
   auto cache = CacheFactory()
-                   .set("log-level", "debug")
+                   .set("log-level", "none")
                    .set("statistic-sampling-enabled", "false")
+                   .setAuthInitialize(std::make_shared<SimpleAuthInitialize>())
                    .create();
 
   return cache;
 }
 
+class SimpleCqListener : public CqListener {
+ public:
+  void onEvent(const CqEvent& cqEvent) override {
+    auto opStr = "Default";
+
+    auto key(dynamic_cast<CacheableString*>(cqEvent.getKey().get()));
+    auto value(dynamic_cast<CacheableString*>(cqEvent.getNewValue().get()));
+
+    switch (cqEvent.getQueryOperation()) {
+      case CqOperation::OP_TYPE_CREATE:
+        opStr = "CREATE";
+        std::cout << "CqListener CREATE event received" << std::endl;
+        break;
+      case CqOperation::OP_TYPE_UPDATE:
+        opStr = "UPDATE";
+        std::cout << "CqListener UPDATE event received" << std::endl;
+        break;
+      case CqOperation::OP_TYPE_DESTROY:
+        opStr = "DESTROY";
+        std::cout << "CqListener DESTROY event received" << std::endl;
+        break;
+      default:
+        break;
+    }
+  }
+
+  void onError(const CqEvent& cqEvent) override {
+    std::cout << __FUNCTION__ << " called"
+              << dynamic_cast<CacheableString*>(cqEvent.getKey().get())->value()
+              << std::endl;
+  }
+
+  void close() override { std::cout << __FUNCTION__ << " called" << std::endl; }
+};
+
 std::shared_ptr<Pool> createPool(Cluster& cluster, Cache& cache) {
-  auto poolFactory = cache.getPoolManager().createFactory();
+  auto poolFactory =
+      cache.getPoolManager().createFactory().setSubscriptionEnabled(true);
+
   cluster.applyLocators(poolFactory);
   poolFactory.setPRSingleHopEnabled(true);
+
   return poolFactory.create("default");
 }
 
@@ -74,28 +147,70 @@ std::shared_ptr<Region> setupRegion(Cache& cache,
 }
 
 TEST(RegionPlusAuthInitializeTest, putInALoopWhileSubscribedAndAuthenticated) {
-  Cluster cluster{LocatorCount{1}, ServerCount{2}};
-  cluster.getGfsh()
-      .create()
-      .region()
-      .withName("region")
-      .withType("PARTITION")
+  auto locatorPort = Framework::getAvailablePort();
+  auto jmxManagerPort = Framework::getAvailablePort();
+  auto serverPort = Framework::getAvailablePort();
+
+  auto gfe = GfshExecute();
+  gfe.start()
+      .locator()
+      .withDir("putInALoopWhileSubscribedAndAuthenticated")
+      //      .withName("locator")
+      .withBindAddress("localhost")
+      .withPort(locatorPort)
+      .withClasspath("../../../../tests/javaobject/javaobject.jar")
+      .withSecurityManager("javaobject.SimpleSecurityManager")
+      .withJmxManagerPort(jmxManagerPort)
+      .withHttpServicePort(0)
+      //            .withStartJmxManager("true")
+      //      .withConnect("false")
       .execute();
 
+  gfe.start()
+      .server()
+      .withDir("putInALoopWhileSubscribedAndAuthenticated")
+      //      .withName("server")
+      .withBindAddress("localhost")
+      .withPort(serverPort)
+      .withMaxHeap("1g")
+      .withClasspath("../../../../tests/javaobject/javaobject.jar")
+      .withSecurityManager("javaobject.SimpleSecurityManager")
+      .withUser("root")
+      .withPassword("root-password")
+
+      .execute();
+
+  gfe.create().region().withName("region").withType("PARTITION").execute();
+
   auto cache = createCache();
-  auto pool = createPool(cluster, cache);
-  auto region = setupRegion(cache, pool);
 
-  HashMapOfCacheable all;
-  for (int i = 0; i < 100; i++) {
-    region->put(CacheableKey::create(i), Cacheable::create(std::to_string(i)));
-    all.emplace(CacheableKey::create(i), Cacheable::create(std::to_string(i)));
-  }
+  auto pool = cache.getPoolManager()
+                  .createFactory()
+                  .setSubscriptionEnabled(true)
+                  .addServer("localhost", serverPort)
+                  .create("default");
+
+  auto region = cache.createRegionFactory(RegionShortcut::PROXY)
+                    .setPoolName(pool->getName())
+                    .create("region");
+  std::cerr << "Created region" << std::endl;
+
+  auto queryService = cache.getQueryService();
+  std::cerr << "Got query service" << std::endl;
+  CqAttributesFactory attributesFactory;
+  attributesFactory.addCqListener(std::make_shared<SimpleCqListener>());
+  std::cerr << "Added CqListener" << std::endl;
+
+  auto attributes = attributesFactory.create();
+
+  auto query = queryService->newCq("select * from /region", attributes);
+  std::cerr << "Created query" << std::endl;
 
   for (int i = 0; i < 100; i++) {
-    // TODO some way force synchronous client metadata update first.
-    region->putAll(all);
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    auto key = "key" + std::to_string(i);
+    auto value = "value" + std::to_string(i);
+    region->put(key, value);
+    std::cerr << "Put (" << key << ", " << value << ")" << std::endl;
   }
 }
 

--- a/cppcache/integration/test/RegionPlusAuthInitializeTest.cpp
+++ b/cppcache/integration/test/RegionPlusAuthInitializeTest.cpp
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <random>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <geode/Cache.hpp>
+#include <geode/PoolManager.hpp>
+#include <geode/RegionFactory.hpp>
+#include <geode/RegionShortcut.hpp>
+
+#include "CacheRegionHelper.hpp"
+#include "framework/Cluster.h"
+#include "framework/Framework.h"
+#include "framework/Gfsh.h"
+
+namespace {
+
+using apache::geode::client::Cache;
+using apache::geode::client::Cacheable;
+using apache::geode::client::CacheableKey;
+using apache::geode::client::CacheableString;
+using apache::geode::client::HashMapOfCacheable;
+using apache::geode::client::Pool;
+using apache::geode::client::Region;
+using apache::geode::client::RegionShortcut;
+
+using std::chrono::minutes;
+
+Cache createCache() {
+  using apache::geode::client::CacheFactory;
+
+  auto cache = CacheFactory()
+                   .set("log-level", "debug")
+                   .set("statistic-sampling-enabled", "false")
+                   .create();
+
+  return cache;
+}
+
+std::shared_ptr<Pool> createPool(Cluster& cluster, Cache& cache) {
+  auto poolFactory = cache.getPoolManager().createFactory();
+  cluster.applyLocators(poolFactory);
+  poolFactory.setPRSingleHopEnabled(true);
+  return poolFactory.create("default");
+}
+
+std::shared_ptr<Region> setupRegion(Cache& cache,
+                                    const std::shared_ptr<Pool>& pool) {
+  auto region = cache.createRegionFactory(RegionShortcut::PROXY)
+                    .setPoolName(pool->getName())
+                    .create("region");
+
+  return region;
+}
+
+TEST(RegionPlusAuthInitializeTest, putInALoopWhileSubscribedAndAuthenticated) {
+  Cluster cluster{LocatorCount{1}, ServerCount{2}};
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("PARTITION")
+      .execute();
+
+  auto cache = createCache();
+  auto pool = createPool(cluster, cache);
+  auto region = setupRegion(cache, pool);
+
+  HashMapOfCacheable all;
+  for (int i = 0; i < 100; i++) {
+    region->put(CacheableKey::create(i), Cacheable::create(std::to_string(i)));
+    all.emplace(CacheableKey::create(i), Cacheable::create(std::to_string(i)));
+  }
+
+  for (int i = 0; i < 100; i++) {
+    // TODO some way force synchronous client metadata update first.
+    region->putAll(all);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+}
+
+}  // namespace

--- a/cppcache/integration/test/SimpleAuthInitialize.cpp
+++ b/cppcache/integration/test/SimpleAuthInitialize.cpp
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SimpleAuthInitialize.hpp"
+
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <random>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+using apache::geode::client::AuthInitialize;
+using apache::geode::client::Properties;
+
+std::shared_ptr<Properties> SimpleAuthInitialize::getCredentials(
+    const std::shared_ptr<Properties>& securityprops,
+    const std::string& /*server*/) {
+  std::cout << "SimpleAuthInitialize::GetCredentials called\n";
+
+  securityprops->insert("security-username", username_);
+  securityprops->insert("security-password", password_);
+
+  countOfGetCredentialsCalls_++;
+  return securityprops;
+}
+
+void SimpleAuthInitialize::close() {
+  std::cout << "SimpleAuthInitialize::close called\n";
+}
+
+SimpleAuthInitialize::SimpleAuthInitialize()
+    : AuthInitialize(),
+      username_("root"),
+      password_("root-password"),
+      countOfGetCredentialsCalls_(0) {
+  std::cout << "SimpleAuthInitialize::SimpleAuthInitialize called\n";
+}
+
+SimpleAuthInitialize::SimpleAuthInitialize(std::string username,
+                                           std::string password)
+    : username_(std::move(username)),
+      password_(std::move(password)),
+      countOfGetCredentialsCalls_(0) {}
+
+int32_t SimpleAuthInitialize::getGetCredentialsCallCount() {
+  return countOfGetCredentialsCalls_;
+}

--- a/cppcache/integration/test/SimpleAuthInitialize.hpp
+++ b/cppcache/integration/test/SimpleAuthInitialize.hpp
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef SIMPLEAUTHINITIALIZE_H_
+#define SIMPLEAUTHINITIALIZE_H_
+
+#include <string>
+
+#include <geode/AuthInitialize.hpp>
+#include <geode/Properties.hpp>
+
+class SimpleAuthInitialize : public apache::geode::client::AuthInitialize {
+ public:
+  std::shared_ptr<apache::geode::client::Properties> getCredentials(
+      const std::shared_ptr<apache::geode::client::Properties>& securityprops,
+      const std::string& /*server*/) override;
+
+  void close() override;
+
+  SimpleAuthInitialize();
+
+  SimpleAuthInitialize(std::string username, std::string password);
+
+  ~SimpleAuthInitialize() override = default;
+
+  int32_t getGetCredentialsCallCount();
+
+ private:
+  std::string username_;
+  std::string password_;
+  int32_t countOfGetCredentialsCalls_;
+};
+
+#endif  // SIMPLEAUTHINITIALIZE_H_

--- a/cppcache/integration/test/SimpleCqListener.cpp
+++ b/cppcache/integration/test/SimpleCqListener.cpp
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SimpleCqListener.hpp"
+
+#include <iostream>
+
+#include <geode/CqListener.hpp>
+#include <geode/CqOperation.hpp>
+
+SimpleCqListener::SimpleCqListener()
+    : creationCount_(0), updateCount_(0), destructionCount_(0) {}
+
+void SimpleCqListener::onEvent(const apache::geode::client::CqEvent& cqEvent) {
+  switch (cqEvent.getQueryOperation()) {
+    case apache::geode::client::CqOperation::OP_TYPE_CREATE:
+      creationCount_++;
+      break;
+    case apache::geode::client::CqOperation::OP_TYPE_UPDATE:
+      updateCount_++;
+      break;
+    case apache::geode::client::CqOperation::OP_TYPE_DESTROY:
+      destructionCount_++;
+      break;
+    default:
+      break;
+  }
+}
+
+void SimpleCqListener::onError(const apache::geode::client::CqEvent& cqEvent) {
+  std::cout << __FUNCTION__ << " called"
+            << dynamic_cast<apache::geode::client::CacheableString*>(
+                   cqEvent.getKey().get())
+                   ->value()
+            << std::endl;
+}
+
+void SimpleCqListener::close() {
+  std::cout << __FUNCTION__ << " called" << std::endl;
+}
+
+int32_t SimpleCqListener::getCreationCount() { return creationCount_; }
+
+int32_t SimpleCqListener::getUpdateCount() { return updateCount_; }
+
+int32_t SimpleCqListener::getDestructionCount() { return destructionCount_; }

--- a/cppcache/integration/test/SimpleCqListener.hpp
+++ b/cppcache/integration/test/SimpleCqListener.hpp
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef SIMPLE_CQ_LISTENER_H
+#define SIMPLE_CQ_LISTENER_H
+
+#include <geode/CacheableString.hpp>
+#include <geode/CqListener.hpp>
+#include <geode/CqOperation.hpp>
+
+class SimpleCqListener : public apache::geode::client::CqListener {
+ public:
+  SimpleCqListener();
+  void onEvent(const apache::geode::client::CqEvent& cqEvent) override;
+  void onError(const apache::geode::client::CqEvent& cqEvent) override;
+  void close() override;
+
+  int32_t getCreationCount();
+  int32_t getUpdateCount();
+  int32_t getDestructionCount();
+
+ private:
+  int32_t creationCount_;
+  int32_t updateCount_;
+  int32_t destructionCount_;
+};
+
+#endif // SIMPLE_CQ_LISTENER_H
+

--- a/cppcache/integration/test/SimpleCqListener.hpp
+++ b/cppcache/integration/test/SimpleCqListener.hpp
@@ -41,5 +41,4 @@ class SimpleCqListener : public apache::geode::client::CqListener {
   int32_t destructionCount_;
 };
 
-#endif // SIMPLE_CQ_LISTENER_H
-
+#endif  // SIMPLE_CQ_LISTENER_H

--- a/cppcache/src/AdminRegion.cpp
+++ b/cppcache/src/AdminRegion.cpp
@@ -70,7 +70,7 @@ TcrConnectionManager* AdminRegion::getConnectionManager() {
 void AdminRegion::put(const std::shared_ptr<CacheableKey>& keyPtr,
                       const std::shared_ptr<Cacheable>& valuePtr) {
   GfErrType err = putNoThrow(keyPtr, valuePtr);
-  GfErrTypeToException("AdminRegion::put", err);
+  throwExceptionIfError("AdminRegion::put", err);
 }
 
 GfErrType AdminRegion::putNoThrow(const std::shared_ptr<CacheableKey>& keyPtr,

--- a/cppcache/src/CacheTransactionManagerImpl.cpp
+++ b/cppcache/src/CacheTransactionManagerImpl.cpp
@@ -125,7 +125,7 @@ void CacheTransactionManagerImpl::rollback() {
   try {
     GfErrType err = rollback(txState, true);
     if (err != GF_NOERR) {
-      GfErrTypeToException("Error while committing", err);
+      throwExceptionIfError("Error while committing", err);
     }
   } catch (const Exception& ex) {
     // TODO: put a log message

--- a/cppcache/src/CqQueryImpl.cpp
+++ b/cppcache/src/CqQueryImpl.cpp
@@ -273,7 +273,6 @@ GfErrType CqQueryImpl::execute(TcrEndpoint* endpoint) {
   err = m_tccdm->sendRequestToEP(request, reply, endpoint);
 
   if (err != GF_NOERR) {
-    // throwExceptionIfError("CqQuery::execute(endpoint)", err);
     return err;
   }
 

--- a/cppcache/src/CqQueryImpl.cpp
+++ b/cppcache/src/CqQueryImpl.cpp
@@ -273,7 +273,7 @@ GfErrType CqQueryImpl::execute(TcrEndpoint* endpoint) {
   err = m_tccdm->sendRequestToEP(request, reply, endpoint);
 
   if (err != GF_NOERR) {
-    // GfErrTypeToException("CqQuery::execute(endpoint)", err);
+    // throwExceptionIfError("CqQuery::execute(endpoint)", err);
     return err;
   }
 
@@ -330,7 +330,7 @@ bool CqQueryImpl::executeCq(TcrMessage::MsgType) {
   GfErrType err = GF_NOERR;
   err = m_tccdm->sendSyncRequest(msg, reply);
   if (err != GF_NOERR) {
-    GfErrTypeToException("CqQuery::executeCq:", err);
+    throwExceptionIfError("CqQuery::executeCq:", err);
   }
   if (reply.getMessageType() == TcrMessage::EXCEPTION ||
       reply.getMessageType() == TcrMessage::CQDATAERROR_MSG_TYPE ||
@@ -342,7 +342,7 @@ bool CqQueryImpl::executeCq(TcrMessage::MsgType) {
           std::string("CqQuery::executeCq: exception at the server side: ") +
           reply.getException());
     } else {
-      GfErrTypeToException("CqQuery::executeCq", err);
+      throwExceptionIfError("CqQuery::executeCq", err);
     }
   }
   std::lock_guard<decltype(m_mutex)> _guard(m_mutex);
@@ -387,7 +387,7 @@ std::shared_ptr<CqResults> CqQueryImpl::executeWithInitialResults(
   err = m_tccdm->sendSyncRequest(msg, reply);
   if (err != GF_NOERR) {
     LOGDEBUG("CqQueryImpl::executeCqWithInitialResults errorred!!!!");
-    GfErrTypeToException("CqQuery::executeCqWithInitialResults:", err);
+    throwExceptionIfError("CqQuery::executeCqWithInitialResults:", err);
   }
   if (reply.getMessageType() == TcrMessage::EXCEPTION ||
       reply.getMessageType() == TcrMessage::CQDATAERROR_MSG_TYPE ||
@@ -399,7 +399,7 @@ std::shared_ptr<CqResults> CqQueryImpl::executeWithInitialResults(
           std::string("CqQuery::executeWithInitialResults: exception ") +
           "at the server side: " + reply.getException());
     } else {
-      GfErrTypeToException("CqQuery::executeWithInitialResults", err);
+      throwExceptionIfError("CqQuery::executeWithInitialResults", err);
     }
   }
   m_cqState = CqState::RUNNING;
@@ -478,7 +478,7 @@ void CqQueryImpl::sendStopOrClose(TcrMessage::MsgType requestType) {
   }
 
   if (err != GF_NOERR) {
-    GfErrTypeToException("CqQuery::stop/close:", err);
+    throwExceptionIfError("CqQuery::stop/close:", err);
   }
   if (reply.getMessageType() == TcrMessage::EXCEPTION ||
       reply.getMessageType() == TcrMessage::CQDATAERROR_MSG_TYPE ||
@@ -490,7 +490,7 @@ void CqQueryImpl::sendStopOrClose(TcrMessage::MsgType requestType) {
           std::string("CqQuery::stop/close: exception at the server side: ") +
           reply.getException());
     } else {
-      GfErrTypeToException("CqQuery::stop/close", err);
+      throwExceptionIfError("CqQuery::stop/close", err);
     }
   }
 }

--- a/cppcache/src/CqService.cpp
+++ b/cppcache/src/CqService.cpp
@@ -559,7 +559,7 @@ std::shared_ptr<CacheableArrayList> CqService::getAllDurableCqsFromServer() {
   err = m_tccdm->sendSyncRequest(msg, reply);
   if (err != GF_NOERR) {
     LOGDEBUG("CqService::getAllDurableCqsFromServer!!!!");
-    GfErrTypeToException("CqService::getAllDurableCqsFromServer:", err);
+    throwExceptionIfError("CqService::getAllDurableCqsFromServer:", err);
   }
   if (reply.getMessageType() == TcrMessage::EXCEPTION ||
       reply.getMessageType() == TcrMessage::GET_DURABLE_CQS_DATA_ERROR) {
@@ -571,7 +571,7 @@ std::shared_ptr<CacheableArrayList> CqService::getAllDurableCqsFromServer() {
               << "at the server side: " << reply.getException();
       throw CqQueryException(message.str());
     } else {
-      GfErrTypeToException("CqService::getAllDurableCqsFromServer", err);
+      throwExceptionIfError("CqService::getAllDurableCqsFromServer", err);
     }
   }
 

--- a/cppcache/src/ErrType.hpp
+++ b/cppcache/src/ErrType.hpp
@@ -40,7 +40,7 @@ typedef enum {
   GF_NOTSUP = 12,         /**< operation not supported          */
   GF_SCPGBL = 13,         /**< attempt to exit global scope     */
   GF_SCPEXC = 14,         /**< maximum scopes exceeded          */
-  GF_TIMEOUT = 15,         /**< operation timed out              */
+  GF_TIMEOUT = 15,        /**< operation timed out              */
   GF_OVRFLW = 16,         /**< arithmetic overflow              */
   GF_IOERR = 17,          /**< paging file I/O error            */
   GF_EINTR = 18,          /**< interrupted Geode call         */

--- a/cppcache/src/ErrType.hpp
+++ b/cppcache/src/ErrType.hpp
@@ -40,7 +40,7 @@ typedef enum {
   GF_NOTSUP = 12,         /**< operation not supported          */
   GF_SCPGBL = 13,         /**< attempt to exit global scope     */
   GF_SCPEXC = 14,         /**< maximum scopes exceeded          */
-  GF_TIMOUT = 15,         /**< operation timed out              */
+  GF_TIMEOUT = 15,         /**< operation timed out              */
   GF_OVRFLW = 16,         /**< arithmetic overflow              */
   GF_IOERR = 17,          /**< paging file I/O error            */
   GF_EINTR = 18,          /**< interrupted Geode call         */

--- a/cppcache/src/ExceptionTypes.cpp
+++ b/cppcache/src/ExceptionTypes.cpp
@@ -165,7 +165,7 @@ const std::string& getThreadLocalExceptionMessage();
       setThreadLocalExceptionMessage(nullptr);
       throw ex;
     }
-    case GF_TIMOUT: {
+    case GF_TIMEOUT: {
       message.append(!exMsg.empty() ? exMsg : ": timed out");
       TimeoutException ex(message);
       setThreadLocalExceptionMessage(nullptr);

--- a/cppcache/src/ExecutionImpl.cpp
+++ b/cppcache/src/ExecutionImpl.cpp
@@ -119,7 +119,7 @@ std::shared_ptr<ResultCollector> ExecutionImpl::execute(
           err = getFuncAttributes(func, &attr);
         }
         if (err != GF_NOERR) {
-          GfErrTypeToException("Execute::GET_FUNCTION_ATTRIBUTES", err);
+          throwExceptionIfError("Execute::GET_FUNCTION_ATTRIBUTES", err);
         }
         if (!attr->empty() && err == GF_NOERR) {
           m_func_attrs[func] = attr;
@@ -437,14 +437,14 @@ void ExecutionImpl::executeOnAllServers(const std::string& func,
       throw FunctionExecutionException(
           "Execute: failed to execute function with server.");
     } else {
-      GfErrTypeToException("Execute", err);
+      throwExceptionIfError("Execute", err);
     }
   }
 
   if (err == GF_AUTHENTICATION_FAILED_EXCEPTION ||
       err == GF_NOT_AUTHORIZED_EXCEPTION ||
       err == GF_AUTHENTICATION_REQUIRED_EXCEPTION) {
-    GfErrTypeToException("Execute", err);
+    throwExceptionIfError("Execute", err);
   }
 
   if (err != GF_NOERR) {
@@ -515,7 +515,7 @@ std::shared_ptr<CacheableVector> ExecutionImpl::executeOnPool(
                                                     reply.getException());
     }
     if (ThinClientBaseDM::isFatalClientError(err)) {
-      GfErrTypeToException("ExecuteOnPool:", err);
+      throwExceptionIfError("ExecuteOnPool:", err);
     } else if (err != GF_NOERR) {
       if (getResult & 1) {
         resultCollector->reset();
@@ -527,7 +527,7 @@ std::shared_ptr<CacheableVector> ExecutionImpl::executeOnPool(
         }
         continue;
       } else {
-        GfErrTypeToException("ExecuteOnPool:", err);
+        throwExceptionIfError("ExecuteOnPool:", err);
       }
     }
     // auto values =

--- a/cppcache/src/LocalRegion.cpp
+++ b/cppcache/src/LocalRegion.cpp
@@ -142,28 +142,28 @@ void LocalRegion::invalidateRegion(
     const std::shared_ptr<Serializable>& aCallbackArgument) {
   GfErrType err =
       invalidateRegionNoThrow(aCallbackArgument, CacheEventFlags::NORMAL);
-  GfErrTypeToException("Region::invalidateRegion", err);
+  throwExceptionIfError("Region::invalidateRegion", err);
 }
 
 void LocalRegion::localInvalidateRegion(
     const std::shared_ptr<Serializable>& aCallbackArgument) {
   GfErrType err =
       invalidateRegionNoThrow(aCallbackArgument, CacheEventFlags::LOCAL);
-  GfErrTypeToException("Region::localInvalidateRegion", err);
+  throwExceptionIfError("Region::localInvalidateRegion", err);
 }
 
 void LocalRegion::destroyRegion(
     const std::shared_ptr<Serializable>& aCallbackArgument) {
   GfErrType err =
       destroyRegionNoThrow(aCallbackArgument, true, CacheEventFlags::NORMAL);
-  GfErrTypeToException("Region::destroyRegion", err);
+  throwExceptionIfError("Region::destroyRegion", err);
 }
 
 void LocalRegion::localDestroyRegion(
     const std::shared_ptr<Serializable>& aCallbackArgument) {
   GfErrType err =
       destroyRegionNoThrow(aCallbackArgument, true, CacheEventFlags::LOCAL);
-  GfErrTypeToException("Region::localDestroyRegion", err);
+  throwExceptionIfError("Region::localDestroyRegion", err);
 }
 
 void LocalRegion::tombstoneOperationNoThrow(
@@ -334,7 +334,7 @@ std::shared_ptr<Cacheable> LocalRegion::get(
 
   // rptr = handleReplay(err, rptr);
 
-  GfErrTypeToException("Region::get", err);
+  throwExceptionIfError("Region::get", err);
 
   return rptr;
 }
@@ -350,7 +350,7 @@ void LocalRegion::put(const std::shared_ptr<CacheableKey>& key,
   updateStatOpTime(m_regionStats->getStat(), m_regionStats->getPutTimeId(),
                    sampleStartNanos);
   //  handleReplay(err, nullptr);
-  GfErrTypeToException("Region::put", err);
+  throwExceptionIfError("Region::put", err);
 }
 
 void LocalRegion::localPut(
@@ -361,7 +361,7 @@ void LocalRegion::localPut(
   std::shared_ptr<VersionTag> versionTag;
   GfErrType err = putNoThrow(key, value, aCallbackArgument, oldValue, -1,
                              CacheEventFlags::LOCAL, versionTag);
-  GfErrTypeToException("Region::localPut", err);
+  throwExceptionIfError("Region::localPut", err);
 }
 
 void LocalRegion::putAll(
@@ -374,7 +374,7 @@ void LocalRegion::putAll(
   updateStatOpTime(m_regionStats->getStat(), m_regionStats->getPutAllTimeId(),
                    sampleStartNanos);
   // handleReplay(err, nullptr);
-  GfErrTypeToException("Region::putAll", err);
+  throwExceptionIfError("Region::putAll", err);
 }
 
 void LocalRegion::removeAll(
@@ -387,7 +387,7 @@ void LocalRegion::removeAll(
   GfErrType err = removeAllNoThrow(keys, aCallbackArgument);
   updateStatOpTime(m_regionStats->getStat(),
                    m_regionStats->getRemoveAllTimeId(), sampleStartNanos);
-  GfErrTypeToException("Region::removeAll", err);
+  throwExceptionIfError("Region::removeAll", err);
 }
 
 void LocalRegion::create(
@@ -398,7 +398,7 @@ void LocalRegion::create(
   GfErrType err = createNoThrow(key, value, aCallbackArgument, -1,
                                 CacheEventFlags::NORMAL, versionTag);
   // handleReplay(err, nullptr);
-  GfErrTypeToException("Region::create", err);
+  throwExceptionIfError("Region::create", err);
 }
 
 void LocalRegion::localCreate(
@@ -408,7 +408,7 @@ void LocalRegion::localCreate(
   std::shared_ptr<VersionTag> versionTag;
   GfErrType err = createNoThrow(key, value, aCallbackArgument, -1,
                                 CacheEventFlags::LOCAL, versionTag);
-  GfErrTypeToException("Region::localCreate", err);
+  throwExceptionIfError("Region::localCreate", err);
 }
 
 void LocalRegion::invalidate(
@@ -418,7 +418,7 @@ void LocalRegion::invalidate(
   GfErrType err = invalidateNoThrow(key, aCallbackArgument, -1,
                                     CacheEventFlags::NORMAL, versionTag);
   //  handleReplay(err, nullptr);
-  GfErrTypeToException("Region::invalidate", err);
+  throwExceptionIfError("Region::invalidate", err);
 }
 
 void LocalRegion::localInvalidate(
@@ -427,7 +427,7 @@ void LocalRegion::localInvalidate(
   std::shared_ptr<VersionTag> versionTag;
   GfErrType err = invalidateNoThrow(keyPtr, aCallbackArgument, -1,
                                     CacheEventFlags::LOCAL, versionTag);
-  GfErrTypeToException("Region::localInvalidate", err);
+  throwExceptionIfError("Region::localInvalidate", err);
 }
 
 void LocalRegion::destroy(
@@ -438,7 +438,7 @@ void LocalRegion::destroy(
   GfErrType err = destroyNoThrow(key, aCallbackArgument, -1,
                                  CacheEventFlags::NORMAL, versionTag);
   // handleReplay(err, nullptr);
-  GfErrTypeToException("Region::destroy", err);
+  throwExceptionIfError("Region::destroy", err);
 }
 
 void LocalRegion::localDestroy(
@@ -447,7 +447,7 @@ void LocalRegion::localDestroy(
   std::shared_ptr<VersionTag> versionTag;
   GfErrType err = destroyNoThrow(key, aCallbackArgument, -1,
                                  CacheEventFlags::LOCAL, versionTag);
-  GfErrTypeToException("Region::localDestroy", err);
+  throwExceptionIfError("Region::localDestroy", err);
 }
 
 bool LocalRegion::remove(
@@ -463,7 +463,7 @@ bool LocalRegion::remove(
   if (err == GF_NOERR) {
     result = true;
   } else if (err != GF_ENOENT && err != GF_CACHE_ENTRY_NOT_FOUND) {
-    GfErrTypeToException("Region::remove", err);
+    throwExceptionIfError("Region::remove", err);
   }
 
   return result;
@@ -480,7 +480,7 @@ bool LocalRegion::removeEx(
   if (err == GF_NOERR) {
     result = true;
   } else if (err != GF_ENOENT && err != GF_CACHE_ENTRY_NOT_FOUND) {
-    GfErrTypeToException("Region::removeEx", err);
+    throwExceptionIfError("Region::removeEx", err);
   }
 
   return result;
@@ -499,7 +499,7 @@ bool LocalRegion::localRemove(
   if (err == GF_NOERR) {
     result = true;
   } else if (err != GF_ENOENT && err != GF_CACHE_ENTRY_NOT_FOUND) {
-    GfErrTypeToException("Region::localRemove", err);
+    throwExceptionIfError("Region::localRemove", err);
   }
 
   return result;
@@ -517,7 +517,7 @@ bool LocalRegion::localRemoveEx(
   if (err == GF_NOERR) {
     result = true;
   } else if (err != GF_ENOENT && err != GF_CACHE_ENTRY_NOT_FOUND) {
-    GfErrTypeToException("Region::localRemoveEx", err);
+    throwExceptionIfError("Region::localRemoveEx", err);
   }
 
   return result;
@@ -582,7 +582,7 @@ HashMapOfCacheable LocalRegion::getAll_internal(
   updateStatOpTime(m_regionStats->getStat(), m_regionStats->getGetAllTimeId(),
                    sampleStartNanos);
 
-  GfErrTypeToException("Region::getAll", err);
+  throwExceptionIfError("Region::getAll", err);
 
   return *values;
 }
@@ -2169,7 +2169,7 @@ void LocalRegion::clear(
 void LocalRegion::localClear(
     const std::shared_ptr<Serializable>& aCallbackArgument) {
   GfErrType err = localClearNoThrow(aCallbackArgument, CacheEventFlags::LOCAL);
-  if (err != GF_NOERR) GfErrTypeToException("LocalRegion::localClear", err);
+  if (err != GF_NOERR) throwExceptionIfError("LocalRegion::localClear", err);
 }
 GfErrType LocalRegion::localClearNoThrow(
     const std::shared_ptr<Serializable>& aCallbackArgument,

--- a/cppcache/src/RemoteQuery.cpp
+++ b/cppcache/src/RemoteQuery.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<SelectResults> RemoteQuery::execute(
   reply.setChunkedResultHandler(
       static_cast<TcrChunkedResult*>(resultCollector));
   GfErrType err = executeNoThrow(timeout, reply, func, tcdm, paramList);
-  GfErrTypeToException(func, err);
+  throwExceptionIfError(func, err);
 
   std::shared_ptr<SelectResults> sr;
 

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -66,11 +66,11 @@ struct FinalizeProcessChunk {
   }
 };
 
-  bool TcrConnection::initTcrConnection(
-      TcrEndpoint* endpointObj, const char* endpoint,
-      synchronized_set<std::unordered_set<uint16_t>>& ports,
-      bool isClientNotification, bool isSecondary,
-      std::chrono::microseconds connectTimeout) {
+bool TcrConnection::initTcrConnection(
+    TcrEndpoint* endpointObj, const char* endpoint,
+    synchronized_set<std::unordered_set<uint16_t>>& ports,
+    bool isClientNotification, bool isSecondary,
+    std::chrono::microseconds connectTimeout) {
   m_conn = nullptr;
   m_endpointObj = endpointObj;
   m_poolDM = dynamic_cast<ThinClientPoolDM*>(m_endpointObj->getPoolHADM());

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -943,10 +943,8 @@ void TcrConnection::readMessageChunked(TcrMessageReply& reply,
       header = readChunkHeader(headerTimeout);
     }
   } catch (const Exception&) {
-    auto handler = reply.getChunkedResultHandler();
-    if (handler) {
-      auto ex = handler->getException();
-      if (ex) {
+    if (auto handler = reply.getChunkedResultHandler()) {
+      if (auto ex = handler->getException()) {
         LOGDEBUG("Found existing exception ", ex->what());
         handler->clearException();
       }

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -943,9 +943,14 @@ void TcrConnection::readMessageChunked(TcrMessageReply& reply,
       header = readChunkHeader(headerTimeout);
     }
   } catch (const Exception&) {
-    auto ex = reply.getChunkedResultHandler()->getException();
-    LOGDEBUG("Found existing exception ", ex->what());
-    reply.getChunkedResultHandler()->clearException();
+    auto handler = reply.getChunkedResultHandler();
+    if (handler) {
+      auto ex = handler->getException();
+      if (ex) {
+        LOGDEBUG("Found existing exception ", ex->what());
+        handler->clearException();
+      }
+    }
     throw;
   }
 

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -66,11 +66,11 @@ struct FinalizeProcessChunk {
   }
 };
 
-bool TcrConnection::InitTcrConnection(
-    TcrEndpoint* endpointObj, const char* endpoint,
-    synchronized_set<std::unordered_set<uint16_t>>& ports,
-    bool isClientNotification, bool isSecondary,
-    std::chrono::microseconds connectTimeout) {
+  bool TcrConnection::initTcrConnection(
+      TcrEndpoint* endpointObj, const char* endpoint,
+      synchronized_set<std::unordered_set<uint16_t>>& ports,
+      bool isClientNotification, bool isSecondary,
+      std::chrono::microseconds connectTimeout) {
   m_conn = nullptr;
   m_endpointObj = endpointObj;
   m_poolDM = dynamic_cast<ThinClientPoolDM*>(m_endpointObj->getPoolHADM());

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -125,7 +125,7 @@ class APACHE_GEODE_EXPORT TcrConnection {
    * @param     ports     List of local ports for connections to endpoint
    * @param     numPorts  Size of ports list
    */
-  bool InitTcrConnection(
+  bool initTcrConnection(
       TcrEndpoint* endpointObj, const char* endpoint,
       synchronized_set<std::unordered_set<uint16_t>>& ports,
       bool isClientNotification = false, bool isSecondary = false,

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -183,7 +183,7 @@ GfErrType TcrEndpoint::createNewConnectionWL(
 GfErrType TcrEndpoint::createNewConnection(
     TcrConnection*& newConn, bool isClientNotification, bool isSecondary,
     std::chrono::microseconds connectTimeout, int32_t timeoutRetries,
-    bool sendUpdateNotification, bool appThreadRequest) {
+    bool appThreadRequest) {
   LOGFINE(
       "TcrEndpoint::createNewConnection: connectTimeout =%d "
       "m_needToConnectInLock=%d appThreadRequest =%d",
@@ -212,25 +212,25 @@ GfErrType TcrEndpoint::createNewConnection(
         }
         // m_connected = true;
       }
-      if (!isClientNotification && sendUpdateNotification) {
-        bool notificationStarted;
-        {
-          std::lock_guard<decltype(m_notifyReceiverLock)> guard(
-              m_notifyReceiverLock);
-          notificationStarted = (m_numRegionListener > 0) || m_isQueueHosted;
-        }
-        if (notificationStarted) {
-          LOGFINE("Sending update notification message to endpoint %s",
-                  m_name.c_str());
-          TcrMessageUpdateClientNotification updateNotificationMsg(
-              new DataOutput(newConn->getConnectionManager()
-                                 .getCacheImpl()
-                                 ->createDataOutput()),
-              static_cast<int32_t>(newConn->getPort()));
-          newConn->send(updateNotificationMsg.getMsgData(),
-                        updateNotificationMsg.getMsgLength());
-        }
-      }
+//      if (!isClientNotification && sendUpdateNotification) {
+//        bool notificationStarted;
+//        {
+//          std::lock_guard<decltype(m_notifyReceiverLock)> guard(
+//              m_notifyReceiverLock);
+//          notificationStarted = (m_numRegionListener > 0) || m_isQueueHosted;
+//        }
+//        if (notificationStarted) {
+//          LOGFINE("Sending update notification message to endpoint %s",
+//                  m_name.c_str());
+//          TcrMessageUpdateClientNotification updateNotificationMsg(
+//              new DataOutput(newConn->getConnectionManager()
+//                                 .getCacheImpl()
+//                                 ->createDataOutput()),
+//              static_cast<int32_t>(newConn->getPort()));
+//          newConn->send(updateNotificationMsg.getMsgData(),
+//                        updateNotificationMsg.getMsgLength());
+//        }
+//      }
       err = GF_NOERR;
       break;
     } catch (const TimeoutException&) {

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -212,25 +212,6 @@ GfErrType TcrEndpoint::createNewConnection(
         }
         // m_connected = true;
       }
-//      if (!isClientNotification && sendUpdateNotification) {
-//        bool notificationStarted;
-//        {
-//          std::lock_guard<decltype(m_notifyReceiverLock)> guard(
-//              m_notifyReceiverLock);
-//          notificationStarted = (m_numRegionListener > 0) || m_isQueueHosted;
-//        }
-//        if (notificationStarted) {
-//          LOGFINE("Sending update notification message to endpoint %s",
-//                  m_name.c_str());
-//          TcrMessageUpdateClientNotification updateNotificationMsg(
-//              new DataOutput(newConn->getConnectionManager()
-//                                 .getCacheImpl()
-//                                 ->createDataOutput()),
-//              static_cast<int32_t>(newConn->getPort()));
-//          newConn->send(updateNotificationMsg.getMsgData(),
-//                        updateNotificationMsg.getMsgLength());
-//        }
-//      }
       err = GF_NOERR;
       break;
     } catch (const TimeoutException&) {

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -308,7 +308,10 @@ void TcrEndpoint::authenticateEndpoint(TcrConnection*& conn) {
     err = sendRequestConnWithRetry(request, reply, conn);
     LOGDEBUG("TcrEndpoint::authenticateEndpoint - ERROR: %d", err);
     if (err == GF_NOERR) {
-      LOGDEBUG("TcrEndpoint::authenticateEndpoint - successfully authenticated on conn %p", conn);
+      LOGDEBUG(
+          "TcrEndpoint::authenticateEndpoint - successfully authenticated on "
+          "conn %p",
+          conn);
       // put the object into local region
       switch (reply.getMessageType()) {
         case TcrMessage::RESPONSE: {

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -332,7 +332,7 @@ void TcrEndpoint::authenticateEndpoint(TcrConnection*& conn) {
       }
     }
     // throw exception if it is not authenticated
-    GfErrTypeToException("TcrEndpoint::authenticateEndpoint", err);
+    throwExceptionIfError("TcrEndpoint::authenticateEndpoint", err);
 
     m_isAuthenticated = true;
   }

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -148,7 +148,7 @@ GfErrType TcrEndpoint::createNewConnectionWL(
         LOGFINE("TcrEndpoint::createNewConnectionWL got lock");
         newConn =
             new TcrConnection(m_cacheImpl->tcrConnectionManager(), m_connected);
-        newConn->InitTcrConnection(this, m_name.c_str(), m_ports,
+        newConn->initTcrConnection(this, m_name.c_str(), m_ports,
                                    isClientNotification, isSecondary,
                                    connectTimeout);
 
@@ -196,7 +196,7 @@ GfErrType TcrEndpoint::createNewConnection(
         if (!needtoTakeConnectLock() || !appThreadRequest) {
           newConn = new TcrConnection(m_cacheImpl->tcrConnectionManager(),
                                       m_connected);
-          bool authenticate = newConn->InitTcrConnection(
+          bool authenticate = newConn->initTcrConnection(
               this, m_name.c_str(), m_ports, isClientNotification, isSecondary,
               connectTimeout);
           if (authenticate) {

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -235,7 +235,7 @@ GfErrType TcrEndpoint::createNewConnection(
       break;
     } catch (const TimeoutException&) {
       LOGINFO("Timeout in handshake with endpoint[%s]", m_name.c_str());
-      err = GF_TIMOUT;
+      err = GF_TIMEOUT;
       m_needToConnectInLock = true;  // while creating the connection
       std::this_thread::sleep_for(std::chrono::milliseconds(50));
     } catch (const GeodeIOException& ex) {
@@ -535,7 +535,7 @@ void TcrEndpoint::pingServer(ThinClientPoolDM* poolDM) {
     if (error == GF_NOERR) {
       m_pingSent = true;
     }
-    if (error == GF_TIMOUT && m_pingTimeouts < 2) {
+    if (error == GF_TIMEOUT && m_pingTimeouts < 2) {
       ++m_pingTimeouts;
     } else {
       m_pingTimeouts = 0;
@@ -972,7 +972,7 @@ GfErrType TcrEndpoint::sendRequestWithRetry(
           return GF_NOERR;
         }
       } catch (const TimeoutException&) {
-        error = GF_TIMOUT;
+        error = GF_TIMEOUT;
         LOGFINE(
             "Send timed out for endpoint %s. "
             "Message txid = %d",
@@ -1059,7 +1059,7 @@ GfErrType TcrEndpoint::sendRequestWithRetry(
         epFailure = true;
         failReason = "server connection could not be obtained";
         if (timeout <= std::chrono::microseconds::zero()) {
-          error = GF_TIMOUT;
+          error = GF_TIMEOUT;
           LOGWARN(
               "No connection available for %ld seconds "
               "for endpoint %s.",

--- a/cppcache/src/TcrEndpoint.hpp
+++ b/cppcache/src/TcrEndpoint.hpp
@@ -157,8 +157,7 @@ class TcrEndpoint {
       TcrConnection*& newConn, bool isClientNotification = false,
       bool isSecondary = false,
       std::chrono::microseconds connectTimeout = DEFAULT_CONNECT_TIMEOUT,
-      int32_t timeoutRetries = 1, bool sendUpdateNotification = true,
-      bool appThreadRequest = false);
+      int32_t timeoutRetries = 1, bool appThreadRequest = false);
 
   bool needtoTakeConnectLock();
 

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -2469,15 +2469,15 @@ TcrMessageRemoveAll::TcrMessageRemoveAll(
   writeMessageLength();
 }
 
-TcrMessageUpdateClientNotification::TcrMessageUpdateClientNotification(
-    DataOutput* dataOutput, int32_t port) {
-  m_msgType = TcrMessage::UPDATE_CLIENT_NOTIFICATION;
-  m_request.reset(dataOutput);
-
-  writeHeader(m_msgType, 1);
-  writeIntPart(port);
-  writeMessageLength();
-}
+//TcrMessageUpdateClientNotification::TcrMessageUpdateClientNotification(
+//    DataOutput* dataOutput, int32_t port) {
+//  m_msgType = TcrMessage::UPDATE_CLIENT_NOTIFICATION;
+//  m_request.reset(dataOutput);
+//
+//  writeHeader(m_msgType, 1);
+//  writeIntPart(port);
+//  writeMessageLength();
+//}
 
 TcrMessageGetAll::TcrMessageGetAll(
     DataOutput* dataOutput, const Region* region,
@@ -2805,7 +2805,7 @@ void TcrMessage::createUserCredentialMessage(TcrConnection* conn) {
   writeObjectPart(encryptBytes);
 
   writeMessageLength();
-  LOGDEBUG("TcrMessage CUCM() = %s ",
+  LOGDEBUG("TcrMessage::createUserCredentialMessage  msg = %s ",
            Utils::convertBytesToString(m_request->getBuffer(),
                                        m_request->getBufferLength())
                .c_str());
@@ -2835,13 +2835,20 @@ void TcrMessage::addSecurityPart(int64_t connectionId, int64_t unique_id,
 
   auto encryptBytes = conn->encryptBytes(bytes);
 
+  LOGDEBUG("TcrMessage::addSecurityPart [%p] length = %" PRId32
+           ", encrypted ID = %s ",
+           this, encryptBytes->length(),
+           Utils::convertBytesToString(encryptBytes->value().data(),
+                                       encryptBytes->length())
+               .c_str());
+
   writeObjectPart(encryptBytes);
   writeMessageLength();
   m_securityHeaderLength = 4 + 1 + encryptBytes->length();
-  LOGDEBUG("TcrMessage addsp = %s ",
-           Utils::convertBytesToString(m_request->getBuffer(),
-                                       m_request->getBufferLength())
-               .c_str());
+  //  LOGDEBUG("TcrMessage addsp = %s ",
+  //           Utils::convertBytesToString(m_request->getBuffer(),
+  //                                       m_request->getBufferLength())
+  //               .c_str());
 }
 
 void TcrMessage::addSecurityPart(int64_t connectionId, TcrConnection* conn) {

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -2835,10 +2835,6 @@ void TcrMessage::addSecurityPart(int64_t connectionId, int64_t unique_id,
   writeObjectPart(encryptBytes);
   writeMessageLength();
   m_securityHeaderLength = 4 + 1 + encryptBytes->length();
-  //  LOGDEBUG("TcrMessage addsp = %s ",
-  //           Utils::convertBytesToString(m_request->getBuffer(),
-  //                                       m_request->getBufferLength())
-  //               .c_str());
 }
 
 void TcrMessage::addSecurityPart(int64_t connectionId, TcrConnection* conn) {

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -2827,7 +2827,7 @@ void TcrMessage::addSecurityPart(int64_t connectionId, int64_t unique_id,
 
   LOGDEBUG("TcrMessage::addSecurityPart [%p] length = %" PRId32
            ", encrypted ID = %s ",
-           this, encryptBytes->length(),
+           conn, encryptBytes->length(),
            Utils::convertBytesToString(encryptBytes->value().data(),
                                        encryptBytes->length())
                .c_str());

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -81,11 +81,11 @@ inline void writeInt(uint8_t* buffer, uint32_t value) {
 extern void setThreadLocalExceptionMessage(const char*);
 
 // AtomicInc TcrMessage::m_transactionId = 0;
-uint8_t* TcrMessage::m_keepalive = nullptr;
+uint8_t* TcrMessage::m_keepAlive = nullptr;
 const int TcrMessage::m_flag_empty = 0x01;
 const int TcrMessage::m_flag_concurrency_checks = 0x02;
 
-bool TcrMessage::isKeepAlive() { return *m_keepalive > 0; }
+bool TcrMessage::isKeepAlive() { return (m_keepAlive && (*m_keepAlive > 0)); }
 
 bool TcrMessage::isUserInitiativeOps(const TcrMessage& msg) {
   int32_t msgType = msg.getMessageType();
@@ -358,8 +358,8 @@ TcrMessage* TcrMessage::getCloseConnMessage(CacheImpl* cacheImpl) {
 
 void TcrMessage::setKeepAlive(bool keepalive) {
   // TODO global
-  if (TcrMessage::m_keepalive != nullptr) {
-    *TcrMessage::m_keepalive = keepalive ? 1 : 0;
+  if (TcrMessage::m_keepAlive != nullptr) {
+    *TcrMessage::m_keepAlive = keepalive ? 1 : 0;
   }
 }
 
@@ -2084,7 +2084,7 @@ TcrMessageCloseConnection::TcrMessageCloseConnection(DataOutput* dataOutput,
   m_request->writeInt(static_cast<int32_t>(1));  // len is 1
   m_request->write(static_cast<int8_t>(0));      // is obj is '0'.
   // cast away constness here since we want to modify this
-  TcrMessage::m_keepalive = const_cast<uint8_t*>(m_request->getCursor());
+  TcrMessage::m_keepAlive = const_cast<uint8_t*>(m_request->getCursor());
   m_request->write(static_cast<int8_t>(0));  // keepalive is '0'.
 }
 

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -2469,16 +2469,6 @@ TcrMessageRemoveAll::TcrMessageRemoveAll(
   writeMessageLength();
 }
 
-//TcrMessageUpdateClientNotification::TcrMessageUpdateClientNotification(
-//    DataOutput* dataOutput, int32_t port) {
-//  m_msgType = TcrMessage::UPDATE_CLIENT_NOTIFICATION;
-//  m_request.reset(dataOutput);
-//
-//  writeHeader(m_msgType, 1);
-//  writeIntPart(port);
-//  writeMessageLength();
-//}
-
 TcrMessageGetAll::TcrMessageGetAll(
     DataOutput* dataOutput, const Region* region,
     const std::vector<std::shared_ptr<CacheableKey>>* keys,

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -471,7 +471,7 @@ class TcrMessage {
   uint8_t m_hasResult;
 
   static std::atomic<int32_t> m_transactionId;
-  static uint8_t* m_keepalive;
+  static uint8_t* m_keepAlive;
   const static int m_flag_empty;
   const static int m_flag_concurrency_checks;
 

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -888,12 +888,12 @@ class TcrMessagePeriodicAck : public TcrMessage {
   ~TcrMessagePeriodicAck() override = default;
 };
 
-class TcrMessageUpdateClientNotification : public TcrMessage {
- public:
-  TcrMessageUpdateClientNotification(DataOutput* dataOutput, int32_t port);
-
-  ~TcrMessageUpdateClientNotification() override = default;
-};
+//class TcrMessageUpdateClientNotification : public TcrMessage {
+// public:
+//  TcrMessageUpdateClientNotification(DataOutput* dataOutput, int32_t port);
+//
+//  ~TcrMessageUpdateClientNotification() override = default;
+//};
 
 class TcrMessageGetAll : public TcrMessage {
  public:

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -888,13 +888,6 @@ class TcrMessagePeriodicAck : public TcrMessage {
   ~TcrMessagePeriodicAck() override = default;
 };
 
-//class TcrMessageUpdateClientNotification : public TcrMessage {
-// public:
-//  TcrMessageUpdateClientNotification(DataOutput* dataOutput, int32_t port);
-//
-//  ~TcrMessageUpdateClientNotification() override = default;
-//};
-
 class TcrMessageGetAll : public TcrMessage {
  public:
   TcrMessageGetAll(

--- a/cppcache/src/ThinClientDistributionManager.cpp
+++ b/cppcache/src/ThinClientDistributionManager.cpp
@@ -157,7 +157,7 @@ GfErrType ThinClientDistributionManager::sendSyncRequest(TcrMessage& request,
        type == TcrMessage::EXECUTE_REGION_FUNCTION ||
        type == TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP ||
        type == TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE) &&
-      error == GF_TIMOUT) {
+      error == GF_TIMEOUT) {
     forceSelect = true;
   }
 
@@ -178,7 +178,7 @@ GfErrType ThinClientDistributionManager::sendSyncRequest(TcrMessage& request,
            type == TcrMessage::EXECUTE_REGION_FUNCTION ||
            type == TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP ||
            type == TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE) &&
-          error == GF_TIMOUT) {
+          error == GF_TIMEOUT) {
         return error;
       }
       currentEndpoint = m_activeEndpoint;

--- a/cppcache/src/ThinClientDistributionManager.cpp
+++ b/cppcache/src/ThinClientDistributionManager.cpp
@@ -58,7 +58,7 @@ void ThinClientDistributionManager::init() {
               m_endpoints[m_activeEndpoint]->name().c_str());
     } else if (isFatalError(err)) {
       m_connManager.disconnect(this, m_endpoints);
-      GfErrTypeToException("ThinClientDistributionManager::init", err);
+      throwExceptionIfError("ThinClientDistributionManager::init", err);
     }
   }
   ThinClientBaseDM::init();
@@ -370,7 +370,7 @@ GfErrType ThinClientDistributionManager::sendUserCredentials(
       }
     }
     // throw exception if it is not authenticated
-    // GfErrTypeToException("ThinClientDistributionManager::sendUserCredentials",
+    // throwExceptionIfError("ThinClientDistributionManager::sendUserCredentials",
     // err);
   }
 

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -938,7 +938,7 @@ int32_t ThinClientPoolDM::GetPDXIdForType(
   err = sendSyncRequest(request, reply);
 
   if (err != GF_NOERR) {
-    GfErrTypeToException("Operation Failed", err);
+    throwExceptionIfError("Operation Failed", err);
   } else if (reply.getMessageType() == TcrMessage::EXCEPTION) {
     LOGDEBUG("ThinClientPoolDM::GetPDXTypeById: Exception = %s ",
              reply.getException());
@@ -978,7 +978,7 @@ void ThinClientPoolDM::AddPdxType(std::shared_ptr<Serializable> pdxType,
   err = sendSyncRequest(request, reply);
 
   if (err != GF_NOERR) {
-    GfErrTypeToException("Operation Failed", err);
+    throwExceptionIfError("Operation Failed", err);
   } else if (reply.getMessageType() == TcrMessage::EXCEPTION) {
     LOGDEBUG("ThinClientPoolDM::GetPDXTypeById: Exception = %s ",
              reply.getException());
@@ -999,7 +999,7 @@ std::shared_ptr<Serializable> ThinClientPoolDM::GetPDXTypeById(int32_t typeId) {
   err = sendSyncRequest(request, reply);
 
   if (err != GF_NOERR) {
-    GfErrTypeToException("Operation Failed", err);
+    throwExceptionIfError("Operation Failed", err);
   } else if (reply.getMessageType() == TcrMessage::EXCEPTION) {
     LOGDEBUG("ThinClientPoolDM::GetPDXTypeById: Exception = %s ",
              reply.getException());
@@ -1023,7 +1023,7 @@ int32_t ThinClientPoolDM::GetEnumValue(std::shared_ptr<Serializable> enumInfo) {
   err = sendSyncRequest(request, reply);
 
   if (err != GF_NOERR) {
-    GfErrTypeToException("Operation Failed", err);
+    throwExceptionIfError("Operation Failed", err);
   } else if (reply.getMessageType() == TcrMessage::EXCEPTION) {
     LOGDEBUG("ThinClientPoolDM::GetEnumValue: Exception = %s ",
              reply.getException());
@@ -1062,7 +1062,7 @@ std::shared_ptr<Serializable> ThinClientPoolDM::GetEnum(int32_t val) {
   err = sendSyncRequest(request, reply);
 
   if (err != GF_NOERR) {
-    GfErrTypeToException("Operation Failed", err);
+    throwExceptionIfError("Operation Failed", err);
   } else if (reply.getMessageType() == TcrMessage::EXCEPTION) {
     LOGDEBUG("ThinClientPoolDM::GetEnum: Exception = %s ",
              reply.getException());
@@ -1087,7 +1087,7 @@ void ThinClientPoolDM::AddEnum(std::shared_ptr<Serializable> enumInfo,
   err = sendSyncRequest(request, reply);
 
   if (err != GF_NOERR) {
-    GfErrTypeToException("Operation Failed", err);
+    throwExceptionIfError("Operation Failed", err);
   } else if (reply.getMessageType() == TcrMessage::EXCEPTION) {
     LOGDEBUG("ThinClientPoolDM::AddEnum: Exception = %s ",
              reply.getException());

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -1434,7 +1434,7 @@ GfErrType ThinClientPoolDM::sendSyncRequest(
         "ThinClientPoolDM::sendSyncRequest: isUserNeedToReAuthenticate = %d ",
         isUserNeedToReAuthenticate);
     LOGDEBUG(
-        "ThinClientPoolDM::sendSyncRequest: m_isMultiUserMode = %d  conn = %d  "
+        "ThinClientPoolDM::sendSyncRequest: m_isMultiUserMode = %d  conn = %p  "
         "type = %d",
         m_isMultiUserMode, conn, type);
 

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -673,7 +673,7 @@ GfErrType ThinClientPoolDM::sendRequestToAllServers(
     err = funcExe->getResult();
     if (err != GF_NOERR) {
       if (funcExe->getException() == nullptr) {
-        if (err == GF_TIMOUT) {
+        if (err == GF_TIMEOUT) {
           getStats().incTimeoutClientOps();
         } else {
           getStats().incFailedClientOps();
@@ -1370,7 +1370,7 @@ GfErrType ThinClientPoolDM::sendSyncRequest(
          type == TcrMessage::EXECUTE_REGION_FUNCTION ||
          type == TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP ||
          type == TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE) &&
-        error == GF_TIMOUT) {
+        error == GF_TIMEOUT) {
       return error;
     }
 
@@ -1492,7 +1492,7 @@ GfErrType ThinClientPoolDM::sendSyncRequest(
                                                  // for Sticky conn.
           LOGDEBUG("putting connection back in queue DONE");
         } else {
-          if (error != GF_TIMOUT) removeEPConnections(ep);
+          if (error != GF_TIMEOUT) removeEPConnections(ep);
           // Update stats for the connection that failed.
           removeEPConnections(1, false);
           setStickyNull(isBGThread ||
@@ -1572,7 +1572,7 @@ GfErrType ThinClientPoolDM::sendSyncRequest(
       getStats().setCurClientOps(--m_clientOps);
       if (error == GF_NOERR) {
         getStats().incSucceedClientOps(); /*inc Id for clientOs stat*/
-      } else if (error == GF_TIMOUT) {
+      } else if (error == GF_TIMEOUT) {
         getStats().incTimeoutClientOps();
       } else {
         getStats().incFailedClientOps();
@@ -1592,7 +1592,7 @@ GfErrType ThinClientPoolDM::sendSyncRequest(
 
   if (error == GF_NOERR) {
     getStats().incSucceedClientOps();
-  } else if (error == GF_TIMOUT) {
+  } else if (error == GF_TIMEOUT) {
     getStats().incTimeoutClientOps();
   } else {
     getStats().incFailedClientOps();

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -228,8 +228,7 @@ void ThinClientPoolDM::init() {
   // to set security flag at pool level
   m_isSecurityOn = cacheImpl->getAuthInitialize() != nullptr;
 
-  LOGDEBUG("ThinClientPoolDM::init: security in on/off = %d ",
-           m_isSecurityOn);
+  LOGDEBUG("ThinClientPoolDM::init: security in on/off = %d ", m_isSecurityOn);
 
   m_connManager.init(true);
 
@@ -1381,8 +1380,7 @@ GfErrType ThinClientPoolDM::sendSyncRequest(
     bool isUserNeedToReAuthenticate = false;
     bool singleHopConnFound = false;
     bool connFound = false;
-    if (!m_isMultiUserMode ||
-        (!TcrMessage::isUserInitiativeOps(request))) {
+    if (!m_isMultiUserMode || (!TcrMessage::isUserInitiativeOps(request))) {
       conn = getConnectionFromQueueW(&queueErr, excludeServers, isBGThread,
                                      request, version, singleHopConnFound,
                                      connFound, serverLocation);
@@ -1463,11 +1461,11 @@ GfErrType ThinClientPoolDM::sendSyncRequest(
           (m_isSecurityOn || m_isMultiUserMode)) {
         if (!m_isMultiUserMode && !ep->isAuthenticated()) {
           // first authenticate him on this endpoint
-          userCredMsgErr = sendUserCredentials(
-              getCredentials(ep), conn, isBGThread, isServerException);
+          userCredMsgErr = sendUserCredentials(getCredentials(ep), conn,
+                                               isBGThread, isServerException);
         } else if (isUserNeedToReAuthenticate) {
-          userCredMsgErr = sendUserCredentials(
-              userAttr->getCredentials(), conn, isBGThread, isServerException);
+          userCredMsgErr = sendUserCredentials(userAttr->getCredentials(), conn,
+                                               isBGThread, isServerException);
         }
       }
 
@@ -1963,8 +1961,8 @@ GfErrType ThinClientPoolDM::sendRequestToEP(const TcrMessage& request,
         (m_isSecurityOn || m_isMultiUserMode)) {
       if (!m_isMultiUserMode && !currentEndpoint->isAuthenticated()) {
         // first authenticate him on this endpoint
-        error = sendUserCredentials(getCredentials(currentEndpoint),
-                                          conn, false, isServerException);
+        error = sendUserCredentials(getCredentials(currentEndpoint), conn,
+                                    false, isServerException);
       } else if (m_isMultiUserMode) {
         ua = UserAttributes::threadLocalUserAttributes;
         if (ua) {
@@ -1973,7 +1971,7 @@ GfErrType ThinClientPoolDM::sendRequestToEP(const TcrMessage& request,
 
           if (uca == nullptr) {
             error = sendUserCredentials(ua->getCredentials(), conn, false,
-                                              isServerException);
+                                        isServerException);
           }
         } else {
           LOGWARN("Attempted operation type %d without credentials",

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -1734,7 +1734,7 @@ GfErrType ThinClientPoolDM::createPoolConnectionToAEndPoint(
                                          ->getDistributedSystem()
                                          .getSystemProperties()
                                          .connectTimeout(),
-                                     false, true, appThreadrequest);
+                                     false, appThreadrequest);
   if (conn == nullptr || error != GF_NOERR) {
     LOGFINE("2Failed to connect to %s", theEP->name().c_str());
     if (conn != nullptr) _GEODE_SAFE_DELETE(conn);

--- a/cppcache/src/ThinClientPoolHADM.cpp
+++ b/cppcache/src/ThinClientPoolHADM.cpp
@@ -76,7 +76,7 @@ void ThinClientPoolHADM::startBackgroundThreads() {
           "No locators were available during pool initialization with "
           "subscription redundancy.");
     } else {
-      GfErrTypeToException("ThinClientPoolHADM::init", err);
+      throwExceptionIfError("ThinClientPoolHADM::init", err);
     }
   }
 

--- a/cppcache/src/ThinClientRedundancyManager.cpp
+++ b/cppcache/src/ThinClientRedundancyManager.cpp
@@ -865,7 +865,7 @@ GfErrType ThinClientRedundancyManager::sendSyncRequestCq(
         gua.setAuthenticatedView(authenticatedView);
       }
       err = theHADM->sendRequestToEP(request, reply, primaryEndpoint);
-      if (err == GF_NOERR || err == GF_TIMOUT ||
+      if (err == GF_NOERR || err == GF_TIMEOUT ||
           ThinClientBaseDM::isFatalClientError(err)) {
         break;
       }

--- a/cppcache/src/ThinClientRedundancyManager.cpp
+++ b/cppcache/src/ThinClientRedundancyManager.cpp
@@ -44,6 +44,8 @@ namespace apache {
 namespace geode {
 namespace client {
 
+const int MIN_RETRY_ATTEMPTS = 5;
+
 const char* ThinClientRedundancyManager::NC_PerodicACK = "NC PerodicACK";
 
 ThinClientRedundancyManager::ThinClientRedundancyManager(
@@ -831,9 +833,8 @@ GfErrType ThinClientRedundancyManager::sendSyncRequestCq(
 
   int32_t attempts = static_cast<int32_t>(m_redundantEndpoints.size()) +
                      static_cast<int32_t>(m_nonredundantEndpoints.size());
-  // TODO: FIXME: avoid magic number 5 for retry attempts
-  attempts = attempts < 5
-                 ? 5
+  attempts = attempts < MIN_RETRY_ATTEMPTS
+                 ? MIN_RETRY_ATTEMPTS
                  : attempts;  // at least 5 attempts if ep lists are small.
 
   AuthenticatedView* authenticatedView = nullptr;

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -416,10 +416,10 @@ void ThinClientRegion::registerKeys(
                                       interestPolicy, receiveValues);
 
   if (m_tcrdm->isFatalError(err)) {
-    GfErrTypeToException("Region::registerKeys", err);
+    throwExceptionIfError("Region::registerKeys", err);
   }
 
-  GfErrTypeToException("Region::registerKeys", err);
+  throwExceptionIfError("Region::registerKeys", err);
 }
 
 void ThinClientRegion::unregisterKeys(
@@ -452,7 +452,7 @@ void ThinClientRegion::unregisterKeys(
         "keys vector is empty");
   }
   GfErrType err = unregisterKeysNoThrow(keys);
-  GfErrTypeToException("Region::unregisterKeys", err);
+  throwExceptionIfError("Region::unregisterKeys", err);
 }
 
 void ThinClientRegion::registerAllKeys(bool isDurable, bool getInitialValues,
@@ -504,11 +504,11 @@ void ThinClientRegion::registerAllKeys(bool isDurable, bool getInitialValues,
                            interestPolicy, receiveValues);
 
   if (m_tcrdm->isFatalError(err)) {
-    GfErrTypeToException("Region::registerAllKeys", err);
+    throwExceptionIfError("Region::registerAllKeys", err);
   }
 
   // Get the entries from the server using a special GET_ALL message
-  GfErrTypeToException("Region::registerAllKeys", err);
+  throwExceptionIfError("Region::registerAllKeys", err);
 }
 
 void ThinClientRegion::registerRegex(const std::string& regex, bool isDurable,
@@ -558,10 +558,10 @@ void ThinClientRegion::registerRegex(const std::string& regex, bool isDurable,
                            interestPolicy, receiveValues);
 
   if (m_tcrdm->isFatalError(err)) {
-    GfErrTypeToException("Region::registerRegex", err);
+    throwExceptionIfError("Region::registerRegex", err);
   }
 
-  GfErrTypeToException("Region::registerRegex", err);
+  throwExceptionIfError("Region::registerRegex", err);
 }
 
 void ThinClientRegion::unregisterRegex(const std::string& regex) {
@@ -584,7 +584,7 @@ void ThinClientRegion::unregisterRegex(const std::string& regex) {
   }
 
   GfErrType err = unregisterRegexNoThrow(regex);
-  GfErrTypeToException("Region::unregisterRegex", err);
+  throwExceptionIfError("Region::unregisterRegex", err);
 }
 
 void ThinClientRegion::unregisterAllKeys() {
@@ -601,7 +601,7 @@ void ThinClientRegion::unregisterAllKeys() {
     }
   }
   GfErrType err = unregisterRegexNoThrow(".*");
-  GfErrTypeToException("Region::unregisterAllKeys", err);
+  throwExceptionIfError("Region::unregisterAllKeys", err);
 }
 
 std::shared_ptr<SelectResults> ThinClientRegion::query(
@@ -731,7 +731,7 @@ std::vector<std::shared_ptr<CacheableKey>> ThinClientRegion::serverKeys() {
 
   err = m_tcrdm->sendSyncRequest(request, reply);
 
-  GfErrTypeToException("Region::serverKeys", err);
+  throwExceptionIfError("Region::serverKeys", err);
 
   switch (reply.getMessageType()) {
     case TcrMessage::RESPONSE: {
@@ -754,7 +754,7 @@ std::vector<std::shared_ptr<CacheableKey>> ThinClientRegion::serverKeys() {
       break;
     }
   }
-  GfErrTypeToException("Region::serverKeys", err);
+  throwExceptionIfError("Region::serverKeys", err);
 
   return serverKeys;
 }
@@ -800,7 +800,7 @@ bool ThinClientRegion::containsKeyOnServer(
   auto rptr = CacheableBoolean::create(ret);
 
   rptr = std::dynamic_pointer_cast<CacheableBoolean>(handleReplay(err, rptr));
-  GfErrTypeToException("Region::containsKeyOnServer ", err);
+  throwExceptionIfError("Region::containsKeyOnServer ", err);
   return rptr->value();
 }
 
@@ -848,7 +848,7 @@ bool ThinClientRegion::containsValueForKey_remote(
 
   rptr = std::dynamic_pointer_cast<CacheableBoolean>(handleReplay(err, rptr));
 
-  GfErrTypeToException("Region::containsValueForKey ", err);
+  throwExceptionIfError("Region::containsValueForKey ", err);
   return rptr->value();
 }
 
@@ -856,7 +856,7 @@ void ThinClientRegion::clear(
     const std::shared_ptr<Serializable>& aCallbackArgument) {
   GfErrType err = GF_NOERR;
   err = localClearNoThrow(aCallbackArgument, CacheEventFlags::NORMAL);
-  if (err != GF_NOERR) GfErrTypeToException("Region::clear", err);
+  if (err != GF_NOERR) throwExceptionIfError("Region::clear", err);
 
   /** @brief Create message and send to bridge server */
 
@@ -865,7 +865,7 @@ void ThinClientRegion::clear(
                                 std::chrono::milliseconds(-1), m_tcrdm.get());
   TcrMessageReply reply(true, m_tcrdm.get());
   err = m_tcrdm->sendSyncRequest(request, reply);
-  if (err != GF_NOERR) GfErrTypeToException("Region::clear", err);
+  if (err != GF_NOERR) throwExceptionIfError("Region::clear", err);
 
   switch (reply.getMessageType()) {
     case TcrMessage::REPLY:
@@ -892,7 +892,7 @@ void ThinClientRegion::clear(
     err = invokeCacheListenerForRegionEvent(
         aCallbackArgument, CacheEventFlags::NORMAL, AFTER_REGION_CLEAR);
   }
-  GfErrTypeToException("Region::clear", err);
+  throwExceptionIfError("Region::clear", err);
 }
 
 GfErrType ThinClientRegion::getNoThrow_remote(
@@ -1983,7 +1983,7 @@ uint32_t ThinClientRegion::size_remote() {
   err = m_tcrdm->sendSyncRequest(request, reply);
 
   if (err != GF_NOERR) {
-    GfErrTypeToException("Region::size", err);
+    throwExceptionIfError("Region::size", err);
   }
 
   switch (reply.getMessageType()) {
@@ -2004,7 +2004,7 @@ uint32_t ThinClientRegion::size_remote() {
       err = GF_NOTOBJ;
   }
 
-  GfErrTypeToException("Region::size", err);
+  throwExceptionIfError("Region::size", err);
   return 0;
 }
 
@@ -2881,7 +2881,7 @@ void ThinClientRegion::registerInterestGetValues(
   auto exceptions = std::make_shared<HashMapOfException>();
   auto err = getAllNoThrow_remote(keys, nullptr, exceptions, resultKeys, true,
                                   nullptr);
-  GfErrTypeToException(method, err);
+  throwExceptionIfError(method, err);
   // log any exceptions here
   for (const auto& iter : *exceptions) {
     LOGWARN("%s Exception for key %s:: %s: %s", method,
@@ -2988,7 +2988,7 @@ void ThinClientRegion::executeFunction(
     }
 
     if (ThinClientBaseDM::isFatalClientError(err)) {
-      GfErrTypeToException("ExecuteOnRegion:", err);
+      throwExceptionIfError("ExecuteOnRegion:", err);
     } else if (err != GF_NOERR) {
       if (err == GF_FUNCTION_EXCEPTION) {
         reExecute = true;
@@ -3009,7 +3009,7 @@ void ThinClientRegion::executeFunction(
             "%d ",
             attempt);
         if (attempt > retryAttempts) {
-          GfErrTypeToException("ExecuteOnRegion:", err);
+          throwExceptionIfError("ExecuteOnRegion:", err);
         }
         reExecuteForServ = true;
         rc->clearResults();
@@ -3019,7 +3019,7 @@ void ThinClientRegion::executeFunction(
             "function timeout. Name: %s, timeout: %d, params: %d, "
             "retryAttempts: %d ",
             func.c_str(), timeout.count(), getResult, retryAttempts);
-        GfErrTypeToException("ExecuteOnRegion", GF_TIMEOUT);
+        throwExceptionIfError("ExecuteOnRegion", GF_TIMEOUT);
       } else if (err == GF_CLIENT_WAIT_TIMEOUT ||
                  err == GF_CLIENT_WAIT_TIMEOUT_REFRESH_PRMETADATA) {
         LOGINFO(
@@ -3027,10 +3027,10 @@ void ThinClientRegion::executeFunction(
             "blacklisted. Name: %s, timeout: %d, params: %d, retryAttempts: "
             "%d ",
             func.c_str(), timeout.count(), getResult, retryAttempts);
-        GfErrTypeToException("ExecuteOnRegion", GF_CLIENT_WAIT_TIMEOUT);
+        throwExceptionIfError("ExecuteOnRegion", GF_CLIENT_WAIT_TIMEOUT);
       } else {
         LOGDEBUG("executeFunction err = %d ", err);
-        GfErrTypeToException("ExecuteOnRegion:", err);
+        throwExceptionIfError("ExecuteOnRegion:", err);
       }
     } else {
       reExecute = false;
@@ -3081,7 +3081,7 @@ std::shared_ptr<CacheableVector> ThinClientRegion::reExecuteFunction(
     }
 
     if (ThinClientBaseDM::isFatalClientError(err)) {
-      GfErrTypeToException("ExecuteOnRegion:", err);
+      throwExceptionIfError("ExecuteOnRegion:", err);
     } else if (err != GF_NOERR) {
       if (err == GF_FUNCTION_EXCEPTION) {
         reExecute = true;
@@ -3104,17 +3104,17 @@ std::shared_ptr<CacheableVector> ThinClientRegion::reExecuteFunction(
             "= %d ",
             attempt);
         if (attempt > retryAttempts) {
-          GfErrTypeToException("ExecuteOnRegion:", err);
+          throwExceptionIfError("ExecuteOnRegion:", err);
         }
         reExecute = true;
         rc->clearResults();
         failedNodes->clear();
       } else if (err == GF_TIMEOUT) {
         LOGINFO("function timeout");
-        GfErrTypeToException("ExecuteOnRegion", GF_CACHE_TIMEOUT_EXCEPTION);
+        throwExceptionIfError("ExecuteOnRegion", GF_CACHE_TIMEOUT_EXCEPTION);
       } else {
         LOGDEBUG("reExecuteFunction err = %d ", err);
-        GfErrTypeToException("ExecuteOnRegion:", err);
+        throwExceptionIfError("ExecuteOnRegion:", err);
       }
     }
   } while (reExecute);
@@ -3218,7 +3218,7 @@ bool ThinClientRegion::executeFunctionSH(
   }
 
   if (abortError != GF_NOERR) {
-    GfErrTypeToException("ExecuteOnRegion:", abortError);
+    throwExceptionIfError("ExecuteOnRegion:", abortError);
   }
   return reExecute;
 }
@@ -3282,7 +3282,7 @@ void ThinClientRegion::txDestroy(
     std::shared_ptr<VersionTag> versionTag) {
   GfErrType err = destroyNoThrowTX(key, aCallbackArgument, -1,
                                    CacheEventFlags::NORMAL, versionTag);
-  GfErrTypeToException("Region::destroyTX", err);
+  throwExceptionIfError("Region::destroyTX", err);
 }
 
 void ThinClientRegion::txInvalidate(
@@ -3291,7 +3291,7 @@ void ThinClientRegion::txInvalidate(
     std::shared_ptr<VersionTag> versionTag) {
   GfErrType err = invalidateNoThrowTX(key, aCallbackArgument, -1,
                                       CacheEventFlags::NORMAL, versionTag);
-  GfErrTypeToException("Region::invalidateTX", err);
+  throwExceptionIfError("Region::invalidateTX", err);
 }
 
 void ThinClientRegion::txPut(
@@ -3306,7 +3306,7 @@ void ThinClientRegion::txPut(
 
   updateStatOpTime(m_regionStats->getStat(), m_regionStats->getPutTimeId(),
                    sampleStartNanos);
-  GfErrTypeToException("Region::putTX", err);
+  throwExceptionIfError("Region::putTX", err);
 }
 
 void ThinClientRegion::setProcessedMarker(bool) {}

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -3014,12 +3014,12 @@ void ThinClientRegion::executeFunction(
         reExecuteForServ = true;
         rc->clearResults();
         failedNodes->clear();
-      } else if (err == GF_TIMOUT) {
+      } else if (err == GF_TIMEOUT) {
         LOGINFO(
             "function timeout. Name: %s, timeout: %d, params: %d, "
             "retryAttempts: %d ",
             func.c_str(), timeout.count(), getResult, retryAttempts);
-        GfErrTypeToException("ExecuteOnRegion", GF_TIMOUT);
+        GfErrTypeToException("ExecuteOnRegion", GF_TIMEOUT);
       } else if (err == GF_CLIENT_WAIT_TIMEOUT ||
                  err == GF_CLIENT_WAIT_TIMEOUT_REFRESH_PRMETADATA) {
         LOGINFO(
@@ -3109,7 +3109,7 @@ std::shared_ptr<CacheableVector> ThinClientRegion::reExecuteFunction(
         reExecute = true;
         rc->clearResults();
         failedNodes->clear();
-      } else if (err == GF_TIMOUT) {
+      } else if (err == GF_TIMEOUT) {
         LOGINFO("function timeout");
         GfErrTypeToException("ExecuteOnRegion", GF_CACHE_TIMEOUT_EXCEPTION);
       } else {

--- a/cppcache/src/Utils.cpp
+++ b/cppcache/src/Utils.cpp
@@ -164,6 +164,11 @@ std::string Utils::convertBytesToString(const uint8_t* bytes, size_t length,
   return "";
 }
 
+std::string Utils::convertBytesToString(const int8_t* bytes, size_t length,
+                                        size_t maxLength) {
+  return Utils::convertBytesToString(reinterpret_cast<const uint8_t*>(bytes), length, maxLength);
+}
+
 int64_t Utils::startStatOpTime() {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
              std::chrono::steady_clock::now().time_since_epoch())

--- a/cppcache/src/Utils.cpp
+++ b/cppcache/src/Utils.cpp
@@ -166,7 +166,8 @@ std::string Utils::convertBytesToString(const uint8_t* bytes, size_t length,
 
 std::string Utils::convertBytesToString(const int8_t* bytes, size_t length,
                                         size_t maxLength) {
-  return Utils::convertBytesToString(reinterpret_cast<const uint8_t*>(bytes), length, maxLength);
+  return Utils::convertBytesToString(reinterpret_cast<const uint8_t*>(bytes),
+                                     length, maxLength);
 }
 
 int64_t Utils::startStatOpTime() {

--- a/cppcache/src/Utils.hpp
+++ b/cppcache/src/Utils.hpp
@@ -168,6 +168,13 @@ class APACHE_GEODE_EXPORT Utils {
    * Convert the byte array to a string as "%d %d ...".
    * <code>maxLength</code> as zero implies no limit.
    */
+  static std::string convertBytesToString(const int8_t* bytes, size_t length,
+                                          size_t maxLength = _GF_MSG_LIMIT);
+
+  /**
+   * Convert the byte array to a string as "%d %d ...".
+   * <code>maxLength</code> as zero implies no limit.
+   */
   inline static std::string convertBytesToString(
       const char* bytes, size_t length, size_t maxLength = _GF_MSG_LIMIT) {
     return convertBytesToString(reinterpret_cast<const uint8_t*>(bytes), length,

--- a/cppcache/src/util/exception.hpp
+++ b/cppcache/src/util/exception.hpp
@@ -33,7 +33,7 @@ namespace client {
 extern void APACHE_GEODE_EXPORT GfErrTypeThrowException(const char* str,
                                                         GfErrType err);
 
-#define throwExceptionIfError(str, err)   \
+#define throwExceptionIfError(str, err)  \
   {                                      \
     if (err != GF_NOERR) {               \
       GfErrTypeThrowException(str, err); \

--- a/cppcache/src/util/exception.hpp
+++ b/cppcache/src/util/exception.hpp
@@ -33,7 +33,7 @@ namespace client {
 extern void APACHE_GEODE_EXPORT GfErrTypeThrowException(const char* str,
                                                         GfErrType err);
 
-#define GfErrTypeToException(str, err)   \
+#define throwExceptionIfError(str, err)   \
   {                                      \
     if (err != GF_NOERR) {               \
       GfErrTypeThrowException(str, err); \


### PR DESCRIPTION
This turned out to be caused by (as far as we can tell) a _completely different_ issue than retry logic for authentication.  The actual issue is/was that the native client was sending an UPDATE_CLIENT_NOTIFICATION request to the server, and this request hasn't been supported on the server for a very long time, like several years.  When the server gets this request in a scenario without a security manager, it is simply ignored, so the behavior was never discovered.  With a security manager, however, the server first attempts to retrieve the unique ID part of the request from the end, which should be there for an authenticated connection, and when it doesn't find the secured ID it throws a ClientAuthenticationRequired exception and closes the connection.  Fix is to stop sending this request altogether, since at the very best it was accomplishing nothing.  This PR also includes a number of simple refactors (variable renaming, etc) found in the course of debugging, as well as a new test case for this scenario and required enhancements to the integration test framework. 

@mreddington @steve-sienk