### PR TITLE
GEODE-6961: Trim leading whitespace from server error message

### DIFF
--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -1098,6 +1098,13 @@ void TcrMessage::processChunk(const std::vector<uint8_t>& chunk, int32_t len,
         auto errorString = readStringPart(input);
 
         if (!errorString.empty()) {
+          errorString.erase(
+              errorString.begin(),
+              std::find_if(errorString.begin(), errorString.end(),
+                           std::not1(std::ptr_fun<int, int>(std::isspace))));
+          LOGDEBUG(
+              "TcrMessage::%s: setting thread-local ex msg to \"%s\", %s, %d",
+              __FUNCTION__, errorString.c_str(), __FILE__, __LINE__);
           setThreadLocalExceptionMessage(errorString.c_str());
         }
       }


### PR DESCRIPTION
This was causing a negative test for Region::PutAll to fail, on one (and only one) of our test machines, the error message coming back from the server contains leading whitespace.  Simply trimming the leading space fixes the test failure.