### PR TITLE
GEODE-7147: Update Travis-CI resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ services:
 env:
   global:
     - DOCKER_ARGS="--rm --volume=${TRAVIS_BUILD_DIR}:/geode-native"
-    - DOCKER_IMAGE="apachegeode/geode-native-build:clang"
+    - DOCKER_IMAGE="apachegeode/geode-native-build:latest"
     - SOURCE_DIR="/geode-native"
 
   matrix:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,7 @@ ENV GEODE_VERSION 1.9.0
 RUN wget "https://www.apache.org/dyn/closer.cgi?action=download&filename=geode/${GEODE_VERSION}/apache-geode-${GEODE_VERSION}.tgz" --quiet -O - | \
         tar xzf -
 
-ENV RAT_VERSION 0.12
+ENV RAT_VERSION 0.13
 RUN wget "https://www.apache.org/dyn/closer.cgi?action=download&filename=creadur/apache-rat-${RAT_VERSION}/apache-rat-${RAT_VERSION}-bin.tar.gz" --quiet -O - | \
         tar xzf -
 


### PR DESCRIPTION
- Apache Creadur Rat version upgraded to 0.13
- Docker image tag changed to apachegeode/geode-native-build:latest