### PR TITLE
GEODE-7182: fix warning in TcpSslConn.cpp 

### DIFF
--- a/cppcache/src/TcpSslConn.cpp
+++ b/cppcache/src/TcpSslConn.cpp
@@ -57,7 +57,7 @@ void TcpSslConn::createSocket(ACE_HANDLE sock) {
   LOGDEBUG("Creating SSL socket stream");
   try {
     m_ssl = getSSLImpl(sock, m_pubkeyfile, m_privkeyfile);
-  } catch (std::exception e) {
+  } catch (std::exception& e) {
     throw SslException(e.what());
   }
 }


### PR DESCRIPTION
This enables successful compilation with gcc 8.3