### PR TITLE
GEODE-7180: Disable IPv6 support by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ project(nativeclient LANGUAGES C CXX)
 option(USE_PCH "Use precompiled headers (PCH)." OFF)
 option(USE_CPP_COVERAGE "Enable profiling and coverage report analysis for apache-geode cpp library." OFF)
 option(USE_RAT "Enable Apache Rat checking." OFF)
-option(SUPPORT_IPV6 "Enable IPv6 support." OFF)
+option(WITH_IPV6 "Enable IPv6 support." OFF)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ project(nativeclient LANGUAGES C CXX)
 option(USE_PCH "Use precompiled headers (PCH)." OFF)
 option(USE_CPP_COVERAGE "Enable profiling and coverage report analysis for apache-geode cpp library." OFF)
 option(USE_RAT "Enable Apache Rat checking." OFF)
+option(SUPPORT_IPV6 "Enable IPv6 support." OFF)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 

--- a/cppcache/src/PoolFactory.cpp
+++ b/cppcache/src/PoolFactory.cpp
@@ -308,6 +308,7 @@ PoolFactory& PoolFactory::addCheck(const std::string& host, int port) {
   }
 
   ACE_INET_Addr addr(port, host.c_str());
+#ifdef SUPPORT_IPV6
   // check unknown host
   const int maxlength = 256;
   const int maxhostlength = 256;
@@ -319,6 +320,9 @@ PoolFactory& PoolFactory::addCheck(const std::string& host, int port) {
 
   if ((strcmp(char_localhost, host.c_str()) != 0) &&
       (strcmp(char_localhost, char_array) == 0)) {
+#else
+  if (!(addr.get_ip_address())) {
+#endif
     throw IllegalArgumentException("Unknown host " + host);
   }
   return *this;

--- a/cppcache/src/TcpConn.cpp
+++ b/cppcache/src/TcpConn.cpp
@@ -94,7 +94,11 @@ void TcpConn::createSocket(ACE_HANDLE sock) {
 }
 
 void TcpConn::init() {
+#ifdef SUPPORT_IPV6
   ACE_HANDLE sock = ACE_OS::socket(m_addr.get_type(), SOCK_STREAM, 0);
+#else
+  ACE_HANDLE sock = ACE_OS::socket(AF_INET, SOCK_STREAM, 0);
+#endif
   if (sock == ACE_INVALID_HANDLE) {
     int32_t lastError = ACE_OS::last_error();
     LOGERROR("Failed to create socket. Errno: %d: %s", lastError,

--- a/cppcache/src/config.h.in
+++ b/cppcache/src/config.h.in
@@ -55,4 +55,6 @@
 #define ACE_Thread_NULL 0
 #endif
 
+#cmakedefine WITH_IPV6
+
 #endif  // GEODE_CONFIG_H_

--- a/dependencies/ACE/config.h.in
+++ b/dependencies/ACE/config.h.in
@@ -27,7 +27,7 @@
 
 #endif // __cplusplus >= 201103L
 
-#ifdef SUPPORT_IPV6
+#ifdef WITH_IPV6
 #define ACE_HAS_IPV6 1
 #endif
 

--- a/dependencies/ACE/config.h.in
+++ b/dependencies/ACE/config.h.in
@@ -27,7 +27,9 @@
 
 #endif // __cplusplus >= 201103L
 
+#ifdef SUPPORT_IPV6
 #define ACE_HAS_IPV6 1
+#endif
 
 #include "ace/config-@ACE_CONFIG@.h"
 


### PR DESCRIPTION
This gets tests passing again until we can sort out the issues with the fix for GEODE-7086.