### PR TITLE
GEODE-7203: Fix build break in examples

### DIFF
--- a/examples/cpp/pdxserializable/Order.cpp
+++ b/examples/cpp/pdxserializable/Order.cpp
@@ -40,8 +40,8 @@ void Order::toData(PdxWriter& pdxWriter) const {
 }
 
 std::string Order::toString() const {
-  return "OrderID: " + std::to_string(order_id_) + std::endl + " Product Name: " +
-          name_ + std::endl + " Quantity: " + std::to_string(quantity_);
+  return "OrderID: " + std::to_string(order_id_) + "\n Product Name: " +
+          name_ + "\n Quantity: " + std::to_string(quantity_);
 }
 
 const std::string& Order::getClassName() const {


### PR DESCRIPTION
- std::endl doesn't work in string concatenation expression

@mreddington @steve-sienk @vfordpivotal @charliemblack @dihardman 