### PR TITLE
Update lgtm to point to current Geode (1.10.0)

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -4,9 +4,9 @@ extraction:
       command:
         - mkdir _lgtm_build_dir
         - cd _lgtm_build_dir
-        - wget -O apache-geode.tgz http://mirror.transip.net/apache/geode/1.9.0/apache-geode-1.9.0.tgz
+        - wget -O apache-geode.tgz http://mirror.transip.net/apache/geode/1.10.0/apache-geode-1.10.0.tgz
         - tar xzf apache-geode.tgz
-        - cmake -DGEODE_ROOT="`pwd`/apache-geode-1.9.0" ..
+        - cmake -DGEODE_ROOT="`pwd`/apache-geode-1.10.0" ..
         - cd dependencies && cmake --build . -- -j2
     index:
       build_command:


### PR DESCRIPTION
- 1.9.0 no longer exists so lgtm doesn't actually build.  Updated it for 1.10.0

@vfordpivotal @steve-sienk @mreddington 