### PR TITLE
GEODE-7299: Fix PdxInstanceImpl memory leak

### DIFF
--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -706,7 +706,7 @@ int32_t PdxInstanceImpl::hashcode() const {
 }
 
 void PdxInstanceImpl::updatePdxStream(uint8_t* newPdxStream, int len) {
-  m_buffer = std::vector<const uint8_t>(newPdxStream, newPdxStream + len);
+  m_buffer = std::vector<uint8_t>(newPdxStream, newPdxStream + len);
   m_bufferLength = len;
 }
 

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -61,7 +61,7 @@ bool sortFunc(std::shared_ptr<PdxFieldType> field1,
 
 PdxInstanceImpl::~PdxInstanceImpl() noexcept {}
 
-PdxInstanceImpl::PdxInstanceImpl(uint8_t* buffer, int length, int typeId,
+PdxInstanceImpl::PdxInstanceImpl(const uint8_t* buffer, int length, int typeId,
                                  CachePerfStats& cacheStats,
                                  PdxTypeRegistry& pdxTypeRegistry,
                                  const CacheImpl& cacheImpl,
@@ -1334,9 +1334,8 @@ void PdxInstanceImpl::toDataMutable(PdxWriter& writer) {
   int position = 0;  // ignore typeid and length
   int nextFieldPosition = 0;
   if (m_buffer != nullptr) {
-    uint8_t* copy = apache::geode::client::DataInput::getBufferCopy(
-        m_buffer.get(), m_bufferLength);
-    auto dataInput = m_cacheImpl.createDataInput(copy, m_bufferLength);
+    auto dataInput =
+        m_cacheImpl.createDataInput(m_buffer.get(), m_bufferLength);
     for (size_t i = 0; i < pdxFieldList->size(); i++) {
       auto currPf = pdxFieldList->at(i);
       LOGDEBUG("toData filedname = %s , isVarLengthType = %d ",
@@ -1365,7 +1364,6 @@ void PdxInstanceImpl::toDataMutable(PdxWriter& writer) {
         position = nextFieldPosition;  // mark next field;
       }
     }
-    _GEODE_SAFE_DELETE_ARRAY(copy);
   } else {
     for (size_t i = 0; i < pdxFieldList->size(); i++) {
       auto currPf = pdxFieldList->at(i);

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -706,7 +706,8 @@ int32_t PdxInstanceImpl::hashcode() const {
 }
 
 void PdxInstanceImpl::updatePdxStream(uint8_t* newPdxStream, int len) {
-  m_buffer = std::vector<uint8_t>(newPdxStream, newPdxStream + len);
+  m_buffer.resize(len);
+  memcpy(m_buffer.data(), newPdxStream, len);
   m_bufferLength = len;
 }
 

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -709,6 +709,9 @@ int32_t PdxInstanceImpl::hashcode() const {
 }
 
 void PdxInstanceImpl::updatePdxStream(uint8_t* newPdxStream, int len) {
+  _GEODE_SAFE_DELETE_ARRAY(m_buffer);
+  m_buffer = nullptr;
+  m_bufferLength = 0;
   m_buffer = DataInput::getBufferCopy(newPdxStream, len);
   m_bufferLength = len;
 }

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -61,8 +61,8 @@ bool sortFunc(std::shared_ptr<PdxFieldType> field1,
 
 PdxInstanceImpl::~PdxInstanceImpl() noexcept {}
 
-PdxInstanceImpl::PdxInstanceImpl(const uint8_t* buffer, int length, int typeId,
-                                 CachePerfStats& cacheStats,
+PdxInstanceImpl::PdxInstanceImpl(const uint8_t* buffer, size_t length,
+                                 int typeId, CachePerfStats& cacheStats,
                                  PdxTypeRegistry& pdxTypeRegistry,
                                  const CacheImpl& cacheImpl,
                                  bool enableTimeStatistics)
@@ -1062,7 +1062,8 @@ std::shared_ptr<PdxSerializable> PdxInstanceImpl::getObject() {
   int64_t sampleStartNanos =
       m_enableTimeStatistics ? Utils::startStatOpTime() : 0;
   //[ToDo] do we have to call incPdxDeSerialization here?
-  auto ret = PdxHelper::deserializePdx(dataInput, m_typeId, m_buffer.size());
+  auto ret = PdxHelper::deserializePdx(dataInput, m_typeId,
+                                       static_cast<int32_t>(m_buffer.size()));
 
   if (m_enableTimeStatistics) {
     Utils::updateStatOpTime(m_cacheStats.getStat(),

--- a/cppcache/src/PdxInstanceImpl.hpp
+++ b/cppcache/src/PdxInstanceImpl.hpp
@@ -217,7 +217,7 @@ class APACHE_GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
 
  private:
   std::shared_ptr<const uint8_t> m_buffer;
-  size_t m_bufferLength;
+  int32_t m_bufferLength;
   int m_typeId;
   std::shared_ptr<PdxType> m_pdxType;
   FieldVsValues m_updatedFields;

--- a/cppcache/src/PdxInstanceImpl.hpp
+++ b/cppcache/src/PdxInstanceImpl.hpp
@@ -199,7 +199,7 @@ class APACHE_GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
    * @brief constructors
    */
 
-  PdxInstanceImpl(uint8_t* buffer, int length, int typeId,
+  PdxInstanceImpl(const uint8_t* buffer, int length, int typeId,
                   CachePerfStats& cacheStats, PdxTypeRegistry& pdxTypeRegistry,
                   const CacheImpl& cacheImpl, bool enableTimeStatistics);
 
@@ -216,8 +216,8 @@ class APACHE_GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
   void updatePdxStream(uint8_t* newPdxStream, int len);
 
  private:
-  std::shared_ptr<uint8_t> m_buffer;
-  int m_bufferLength;
+  std::shared_ptr<const uint8_t> m_buffer;
+  size_t m_bufferLength;
   int m_typeId;
   std::shared_ptr<PdxType> m_pdxType;
   FieldVsValues m_updatedFields;

--- a/cppcache/src/PdxInstanceImpl.hpp
+++ b/cppcache/src/PdxInstanceImpl.hpp
@@ -199,7 +199,7 @@ class APACHE_GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
    * @brief constructors
    */
 
-  PdxInstanceImpl(const uint8_t* buffer, int length, int typeId,
+  PdxInstanceImpl(const uint8_t* buffer, size_t length, int typeId,
                   CachePerfStats& cacheStats, PdxTypeRegistry& pdxTypeRegistry,
                   const CacheImpl& cacheImpl, bool enableTimeStatistics);
 

--- a/cppcache/src/PdxInstanceImpl.hpp
+++ b/cppcache/src/PdxInstanceImpl.hpp
@@ -216,7 +216,8 @@ class APACHE_GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
   void updatePdxStream(uint8_t* newPdxStream, int len);
 
  private:
-  std::shared_ptr<const uint8_t> m_buffer;
+  std::vector<const uint8_t> m_buffer;
+  //  std::shared_ptr<const uint8_t> m_buffer;
   int32_t m_bufferLength;
   int m_typeId;
   std::shared_ptr<PdxType> m_pdxType;

--- a/cppcache/src/PdxInstanceImpl.hpp
+++ b/cppcache/src/PdxInstanceImpl.hpp
@@ -217,7 +217,6 @@ class APACHE_GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
 
  private:
   std::vector<uint8_t> m_buffer;
-  int32_t m_bufferLength;
   int m_typeId;
   std::shared_ptr<PdxType> m_pdxType;
   FieldVsValues m_updatedFields;

--- a/cppcache/src/PdxInstanceImpl.hpp
+++ b/cppcache/src/PdxInstanceImpl.hpp
@@ -216,8 +216,7 @@ class APACHE_GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
   void updatePdxStream(uint8_t* newPdxStream, int len);
 
  private:
-  std::vector<const uint8_t> m_buffer;
-  //  std::shared_ptr<const uint8_t> m_buffer;
+  std::vector<uint8_t> m_buffer;
   int32_t m_bufferLength;
   int m_typeId;
   std::shared_ptr<PdxType> m_pdxType;

--- a/cppcache/src/PdxInstanceImpl.hpp
+++ b/cppcache/src/PdxInstanceImpl.hpp
@@ -216,7 +216,7 @@ class APACHE_GEODE_EXPORT PdxInstanceImpl : public WritablePdxInstance {
   void updatePdxStream(uint8_t* newPdxStream, int len);
 
  private:
-  uint8_t* m_buffer;
+  std::shared_ptr<uint8_t> m_buffer;
   int m_bufferLength;
   int m_typeId;
   std::shared_ptr<PdxType> m_pdxType;

--- a/cppcache/test/PdxInstanceImplTest.cpp
+++ b/cppcache/test/PdxInstanceImplTest.cpp
@@ -55,13 +55,14 @@ TEST(PdxInstanceImplTest, updatePdxStream) {
   auto cache = cacheFactory.create();
   CacheImpl cacheImpl(&cache, properties, true, false, nullptr);
   auto buffer = std::vector<uint8_t>(__1M__, 0xcc);
+  auto len = static_cast<int32_t>(buffer.size());
   PdxInstanceImpl pdxInstanceImpl(
-      buffer.data(), buffer.size(), 0xdeadbeef, cacheImpl.getCachePerfStats(),
+      buffer.data(), len, 0xdeadbeef, cacheImpl.getCachePerfStats(),
       *(cacheImpl.getPdxTypeRegistry()), cacheImpl, false);
 
   for (auto i = 0; i < __100K__; i++) {
     try {
-      pdxInstanceImpl.updatePdxStream(buffer.data(), buffer.size());
+      pdxInstanceImpl.updatePdxStream(buffer.data(), len);
     } catch (const std::exception&) {
       GTEST_FAIL();
     }

--- a/cppcache/test/PdxInstanceImplTest.cpp
+++ b/cppcache/test/PdxInstanceImplTest.cpp
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <CachePerfStats.hpp>
+#include <PdxInstanceImpl.hpp>
+#include <statistics/StatisticsFactory.hpp>
+
+#include <gtest/gtest.h>
+
+#include <geode/AuthenticatedView.hpp>
+#include <geode/Cache.hpp>
+#include <geode/PoolManager.hpp>
+#include <geode/Properties.hpp>
+#include <geode/RegionFactory.hpp>
+#include <geode/RegionShortcut.hpp>
+
+using apache::geode::client::Cache;
+using apache::geode::client::CacheFactory;
+using apache::geode::client::CacheImpl;
+using apache::geode::client::CachePerfStats;
+using apache::geode::client::PdxInstanceImpl;
+using apache::geode::client::Properties;
+using apache::geode::statistics::StatisticsFactory;
+
+#define __1K__ 1024
+#define __100K__ (100 * __1K__)
+#define __1M__ (__1K__ * __1K__)
+
+//
+// Test to check for memory leak in PdxInstanceImpl::updatePdxStream.  This
+// method was leaking a buffer equivalent in size to the passed-in buffer on
+// each call.  Test will still pass without the fix in updatePdxStream, but it
+// will take *much* longer to complete (60sec+ vs ~4sec on a typical machine).
+// Still, to actually verify the fix, you will have to run this test under a
+// memory-checking framework of some kind, such as Valgrind or XCode's
+// Instruments.
+//
+TEST(PdxInstanceImplTest, updatePdxStream) {
+  auto properties = std::make_shared<Properties>();
+  CacheFactory cacheFactory;
+  auto cache = cacheFactory.create();
+  CacheImpl cacheImpl(&cache, properties, true, false, nullptr);
+  auto buffer = std::vector<uint8_t>(__1M__, 0xcc);
+  PdxInstanceImpl pdxInstanceImpl(
+      buffer.data(), buffer.size(), 0xdeadbeef, cacheImpl.getCachePerfStats(),
+      *(cacheImpl.getPdxTypeRegistry()), cacheImpl, false);
+
+  for (auto i = 0; i < __100K__; i++) {
+    try {
+      pdxInstanceImpl.updatePdxStream(buffer.data(), buffer.size());
+    } catch (const std::exception&) {
+      GTEST_FAIL();
+    }
+  }
+}


### PR DESCRIPTION
updatePdxStream was stepping on the m_buffer value with a newly-allocated copy, thus leaking the existing m_buffer value.  Made m_buffer a std::shared_ptr, and let the runtime handle the memory management properly for us.

@mreddington @steve-sienk @vfordpivotal @dihardman @charliemblack 