### PR TITLE
GEODE-7447: Fix logging format spec <--> variable size mismatches

### DIFF
--- a/cppcache/src/ClientMetadataService.cpp
+++ b/cppcache/src/ClientMetadataService.cpp
@@ -214,7 +214,6 @@ void ClientMetadataService::getBucketServerLocation(
     LOGDEBUG(
         "ClientMetadataService::getBucketServerLocation m_regionMetaDataMap "
         "size is %zu",
-
         m_regionMetaDataMap.size());
     std::string path(region->getFullPath());
     std::shared_ptr<ClientMetadata> cptr = nullptr;

--- a/cppcache/src/EntryExpiryHandler.cpp
+++ b/cppcache/src/EntryExpiryHandler.cpp
@@ -63,7 +63,7 @@ int EntryExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
         m_regionPtr->getFullPath().c_str(),
         std::to_string(curr_time.time_since_epoch().count()).c_str(),
         std::to_string(lastTimeForExp.time_since_epoch().count()).c_str(),
-        std::to_string(m_duration.count()).c_str()),
+        std::to_string(m_duration.count()).c_str(),
         std::to_string(elapsed.count()).c_str());
     if (elapsed >= m_duration) {
       DoTheExpirationAction(key);

--- a/cppcache/src/EntryExpiryHandler.cpp
+++ b/cppcache/src/EntryExpiryHandler.cpp
@@ -61,19 +61,19 @@ int EntryExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
         "%s,%s,%s,%s",
         Utils::nullSafeToString(key).c_str(),
         m_regionPtr->getFullPath().c_str(),
-        std::to_string(curr_time.time_since_epoch().count()).c_str(),
-        std::to_string(lastTimeForExp.time_since_epoch().count()).c_str(),
-        std::to_string(m_duration.count()).c_str(),
-        std::to_string(elapsed.count()).c_str());
+        to_string(curr_time.time_since_epoch()).c_str(),
+        to_string(lastTimeForExp.time_since_epoch()).c_str(),
+        to_string(m_duration).c_str(), to_string(elapsed).c_str());
     if (elapsed >= m_duration) {
       DoTheExpirationAction(key);
     } else {
       // reset the task after
       // (lastAccessTime + entryExpiryDuration - curr_time) in seconds
       auto remaining = m_duration - elapsed;
+      auto remainingStr = std::to_string(remaining.count());
       LOGDEBUG(
-          "Resetting expiry task %z secs later for key [%s] of region [%s]",
-          remaining.count(), Utils::nullSafeToString(key).c_str(),
+          "Resetting expiry task %s secs later for key [%s] of region [%s]",
+          remainingStr.c_str(), Utils::nullSafeToString(key).c_str(),
           m_regionPtr->getFullPath().c_str());
       m_regionPtr->getCacheImpl()->getExpiryTaskManager().resetTask(
           expProps.getExpiryTaskId(), remaining);

--- a/cppcache/src/EntryExpiryHandler.cpp
+++ b/cppcache/src/EntryExpiryHandler.cpp
@@ -58,12 +58,13 @@ int EntryExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
     auto elapsed = curr_time - lastTimeForExp;
     LOGDEBUG(
         "Entered entry expiry task handler for key [%s] of region [%s]: "
-        "%z,%z,%z,%z",
+        "%s,%s,%s,%s",
         Utils::nullSafeToString(key).c_str(),
         m_regionPtr->getFullPath().c_str(),
-        curr_time.time_since_epoch().count(),
-        lastTimeForExp.time_since_epoch().count(), m_duration.count(),
-        elapsed.count());
+        std::to_string(curr_time.time_since_epoch().count()).c_str(),
+        std::to_string(lastTimeForExp.time_since_epoch().count()).c_str(),
+        std::to_string(m_duration.count()).c_str()),
+        std::to_string(elapsed.count()).c_str());
     if (elapsed >= m_duration) {
       DoTheExpirationAction(key);
     } else {

--- a/cppcache/src/EntryExpiryHandler.cpp
+++ b/cppcache/src/EntryExpiryHandler.cpp
@@ -70,7 +70,7 @@ int EntryExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
       // reset the task after
       // (lastAccessTime + entryExpiryDuration - curr_time) in seconds
       auto remaining = m_duration - elapsed;
-      auto remainingStr = std::to_string(remaining.count());
+      auto remainingStr = to_string(remaining);
       LOGDEBUG(
           "Resetting expiry task %s secs later for key [%s] of region [%s]",
           remainingStr.c_str(), Utils::nullSafeToString(key).c_str(),

--- a/cppcache/src/LocalRegion.cpp
+++ b/cppcache/src/LocalRegion.cpp
@@ -694,11 +694,13 @@ void LocalRegion::setRegionExpiryTask() {
         rptr->getCacheImpl()->getExpiryTaskManager().scheduleExpiryTask(
             handler, duration, std::chrono::seconds::zero());
     handler->setExpiryTaskId(expiryTaskId);
+    auto durationStr = std::to_string(duration.count());
+    auto expiryTaskIdStr = std::to_string(expiryTaskId);
     LOGFINE(
-        "expiry for region [%s], expiry task id = %z, duration = %s, "
+        "expiry for region [%s], expiry task id = %s, duration = %s, "
         "action = %d",
-        m_fullPath.c_str(), expiryTaskId,
-        std::to_string(duration.count()).c_str(), getRegionExpiryAction());
+        m_fullPath.c_str(), expiryTaskIdStr.c_str(), durationStr.c_str(),
+        getRegionExpiryAction());
   }
 }
 

--- a/cppcache/src/LocalRegion.cpp
+++ b/cppcache/src/LocalRegion.cpp
@@ -695,10 +695,10 @@ void LocalRegion::setRegionExpiryTask() {
             handler, duration, std::chrono::seconds::zero());
     handler->setExpiryTaskId(expiryTaskId);
     LOGFINE(
-        "expiry for region [%s], expiry task id = %z, duration = %z, "
+        "expiry for region [%s], expiry task id = %z, duration = %s, "
         "action = %d",
-        m_fullPath.c_str(), expiryTaskId, duration.count(),
-        getRegionExpiryAction());
+        m_fullPath.c_str(), expiryTaskId,
+        std::to_string(duration.count()).c_str(), getRegionExpiryAction());
   }
 }
 
@@ -719,9 +719,9 @@ void LocalRegion::registerEntryExpiryTask(
     entry->getKeyI(key);
     LOGFINEST(
         "entry expiry in region [%s], key [%s], task id = %z, "
-        "duration = %z, action = %d",
+        "duration = %s, action = %d",
         m_fullPath.c_str(), Utils::nullSafeToString(key).c_str(), id,
-        duration.count(), getEntryExpirationAction());
+        std::to_string(duration.count()).c_str(), getEntryExpirationAction());
   }
   expProps.setExpiryTaskId(id);
 }
@@ -2796,14 +2796,14 @@ void LocalRegion::updateAccessAndModifiedTimeForEntry(
       ptr->getKeyI(key);
       keyStr = Utils::nullSafeToString(key);
     }
-    LOGDEBUG("Setting last accessed time for key [%s] in region %s to %z",
+    LOGDEBUG("Setting last accessed time for key [%s] in region %s to %s",
              keyStr.c_str(), getFullPath().c_str(),
-             currTime.time_since_epoch().count());
+             std::to_string(currTime.time_since_epoch().count()).c_str());
     expProps.updateLastAccessTime(currTime);
     if (modified) {
-      LOGDEBUG("Setting last modified time for key [%s] in region %s to %z",
+      LOGDEBUG("Setting last modified time for key [%s] in region %s to %s",
                keyStr.c_str(), getFullPath().c_str(),
-               currTime.time_since_epoch().count());
+               std::to_string(currTime.time_since_epoch().count()).c_str());
       expProps.updateLastModifiedTime(currTime);
     }
   }

--- a/cppcache/src/LocalRegion.cpp
+++ b/cppcache/src/LocalRegion.cpp
@@ -110,7 +110,7 @@ void LocalRegion::updateAccessAndModifiedTime(bool modified) {
   // locking not required since setters use atomic operations
   if (regionExpiryEnabled()) {
     auto now = std::chrono::system_clock::now();
-    auto timeStr = std::to_string(now.time_since_epoch().count());
+    auto timeStr = to_string(now.time_since_epoch());
     LOGDEBUG("Setting last accessed time for region %s to %s",
              getFullPath().c_str(), timeStr.c_str());
     m_cacheStatistics->setLastAccessedTime(now);

--- a/cppcache/src/LocalRegion.cpp
+++ b/cppcache/src/LocalRegion.cpp
@@ -110,12 +110,13 @@ void LocalRegion::updateAccessAndModifiedTime(bool modified) {
   // locking not required since setters use atomic operations
   if (regionExpiryEnabled()) {
     auto now = std::chrono::system_clock::now();
-    LOGDEBUG("Setting last accessed time for region %s to %z",
-             getFullPath().c_str(), now.time_since_epoch().count());
+    auto timeStr = std::to_string(now.time_since_epoch().count());
+    LOGDEBUG("Setting last accessed time for region %s to %s",
+             getFullPath().c_str(), timeStr.c_str());
     m_cacheStatistics->setLastAccessedTime(now);
     if (modified) {
-      LOGDEBUG("Setting last modified time for region %s to %z",
-               getFullPath().c_str(), now.time_since_epoch().count());
+      LOGDEBUG("Setting last modified time for region %s to %s",
+               getFullPath().c_str(), timeStr.c_str());
       m_cacheStatistics->setLastModifiedTime(now);
     }
     // TODO:  should we really touch the parent region??
@@ -694,7 +695,7 @@ void LocalRegion::setRegionExpiryTask() {
         rptr->getCacheImpl()->getExpiryTaskManager().scheduleExpiryTask(
             handler, duration, std::chrono::seconds::zero());
     handler->setExpiryTaskId(expiryTaskId);
-    auto durationStr = std::to_string(duration.count());
+    auto durationStr = to_string(duration);
     auto expiryTaskIdStr = std::to_string(expiryTaskId);
     LOGFINE(
         "expiry for region [%s], expiry task id = %s, duration = %s, "
@@ -720,10 +721,11 @@ void LocalRegion::registerEntryExpiryTask(
     std::shared_ptr<CacheableKey> key;
     entry->getKeyI(key);
     LOGFINEST(
-        "entry expiry in region [%s], key [%s], task id = %z, "
+        "entry expiry in region [%s], key [%s], task id = %d, "
         "duration = %s, action = %d",
-        m_fullPath.c_str(), Utils::nullSafeToString(key).c_str(), id,
-        std::to_string(duration.count()).c_str(), getEntryExpirationAction());
+        m_fullPath.c_str(), Utils::nullSafeToString(key).c_str(),
+        static_cast<int32_t>(id), to_string(duration).c_str(),
+        getEntryExpirationAction());
   }
   expProps.setExpiryTaskId(id);
 }
@@ -2800,12 +2802,12 @@ void LocalRegion::updateAccessAndModifiedTimeForEntry(
     }
     LOGDEBUG("Setting last accessed time for key [%s] in region %s to %s",
              keyStr.c_str(), getFullPath().c_str(),
-             std::to_string(currTime.time_since_epoch().count()).c_str());
+             to_string(currTime.time_since_epoch()).c_str());
     expProps.updateLastAccessTime(currTime);
     if (modified) {
       LOGDEBUG("Setting last modified time for key [%s] in region %s to %s",
                keyStr.c_str(), getFullPath().c_str(),
-               std::to_string(currTime.time_since_epoch().count()).c_str());
+               to_string(currTime.time_since_epoch()).c_str());
       expProps.updateLastModifiedTime(currTime);
     }
   }

--- a/cppcache/src/MapEntry.hpp
+++ b/cppcache/src/MapEntry.hpp
@@ -96,8 +96,9 @@ class APACHE_GEODE_EXPORT ExpEntryProperties {
 
   inline void cancelExpiryTaskId(
       const std::shared_ptr<CacheableKey>& key) const {
-    LOGDEBUG("Cancelling expiration task for key [%s] with id [%z]",
-             Utils::nullSafeToString(key).c_str(), m_expiryTaskId);
+    auto taskIdStr = std::to_string(m_expiryTaskId);
+    LOGDEBUG("Cancelling expiration task for key [%s] with id [%s]",
+             Utils::nullSafeToString(key).c_str(), taskIdStr.c_str());
     m_expiryTaskManager->cancelTask(m_expiryTaskId);
   }
 

--- a/cppcache/src/RegionExpiryHandler.cpp
+++ b/cppcache/src/RegionExpiryHandler.cpp
@@ -55,19 +55,21 @@ int RegionExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
     }
 
     auto elapsed = curr_time - lastTimeForExp;
-    LOGDEBUG("Entered region expiry task handler for region [%s]: %z,%z,%z,%z",
+    LOGDEBUG("Entered region expiry task handler for region [%s]: %s,%s,%s,%s",
              m_regionPtr->getFullPath().c_str(),
-             curr_time.time_since_epoch().count(),
-             lastTimeForExp.time_since_epoch().count(), m_duration.count(),
-             elapsed.count());
+             std::to_string(curr_time.time_since_epoch().count()).c_str(),
+             std::to_string(lastTimeForExp.time_since_epoch().count()).c_str(),
+             std::to_string(m_duration.count()).c_str(),
+             std::to_string(elapsed.count()).c_str());
     if (elapsed >= m_duration) {
       DoTheExpirationAction();
     } else {
       auto remaining = m_duration - elapsed;
       // reset the task after
       // (lastAccessTime + entryExpiryDuration - curr_time) in seconds
-      LOGDEBUG("Resetting expiry task for region [%s] after %z sec",
-               m_regionPtr->getFullPath().c_str(), remaining.count());
+      LOGDEBUG("Resetting expiry task for region [%s] after %s sec",
+               m_regionPtr->getFullPath().c_str(),
+               std::to_string(remaining.count()).c_str());
       m_regionPtr->getCacheImpl()->getExpiryTaskManager().resetTask(
           m_expiryTaskId, remaining);
       return 0;

--- a/cppcache/src/RegionExpiryHandler.cpp
+++ b/cppcache/src/RegionExpiryHandler.cpp
@@ -57,10 +57,9 @@ int RegionExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
     auto elapsed = curr_time - lastTimeForExp;
     LOGDEBUG("Entered region expiry task handler for region [%s]: %s,%s,%s,%s",
              m_regionPtr->getFullPath().c_str(),
-             std::to_string(curr_time.time_since_epoch().count()).c_str(),
-             std::to_string(lastTimeForExp.time_since_epoch().count()).c_str(),
-             std::to_string(m_duration.count()).c_str(),
-             std::to_string(elapsed.count()).c_str());
+             to_string(curr_time.time_since_epoch()).c_str(),
+             to_string(lastTimeForExp.time_since_epoch()).c_str(),
+             to_string(m_duration).c_str(), to_string(elapsed).c_str());
     if (elapsed >= m_duration) {
       DoTheExpirationAction();
     } else {
@@ -69,7 +68,7 @@ int RegionExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
       // (lastAccessTime + entryExpiryDuration - curr_time) in seconds
       LOGDEBUG("Resetting expiry task for region [%s] after %s sec",
                m_regionPtr->getFullPath().c_str(),
-               std::to_string(remaining.count()).c_str());
+               to_string(remaining).c_str());
       m_regionPtr->getCacheImpl()->getExpiryTaskManager().resetTask(
           m_expiryTaskId, remaining);
       return 0;

--- a/cppcache/src/TcpConn.cpp
+++ b/cppcache/src/TcpConn.cpp
@@ -209,9 +209,9 @@ void TcpConn::connect() {
 
   ACE_OS::signal(SIGPIPE, SIG_IGN);  // Ignore broken pipe
 
-  LOGFINER("Connecting plain socket stream to %s:%d waiting %z micro sec",
+  LOGFINER("Connecting plain socket stream to %s:%d waiting %s micro sec",
            ipaddr.get_host_name(), ipaddr.get_port_number(),
-           waitMicroSeconds.count());
+           std::to_string(waitMicroSeconds.count()).c_str());
 
   ACE_SOCK_Connector conn;
   int32_t retVal = 0;

--- a/cppcache/src/TcpConn.cpp
+++ b/cppcache/src/TcpConn.cpp
@@ -211,7 +211,7 @@ void TcpConn::connect() {
 
   LOGFINER("Connecting plain socket stream to %s:%d waiting %s micro sec",
            ipaddr.get_host_name(), ipaddr.get_port_number(),
-           std::to_string(waitMicroSeconds.count()).c_str());
+           to_string(waitMicroSeconds).c_str());
 
   ACE_SOCK_Connector conn;
   int32_t retVal = 0;

--- a/cppcache/src/TcpSslConn.cpp
+++ b/cppcache/src/TcpSslConn.cpp
@@ -91,9 +91,9 @@ void TcpSslConn::connect() {
 
   std::chrono::microseconds waitMicroSeconds = m_waitMilliSeconds;
 
-  LOGDEBUG("Connecting SSL socket stream to %s:%d waiting %z micro sec",
+  LOGDEBUG("Connecting SSL socket stream to %s:%d waiting %s micro sec",
            m_addr.get_host_name(), m_addr.get_port_number(),
-           waitMicroSeconds.count());
+           std::to_string(waitMicroSeconds.count()).c_str());
 
   int32_t retVal = m_ssl->connect(m_addr, waitMicroSeconds);
 

--- a/cppcache/src/TcpSslConn.cpp
+++ b/cppcache/src/TcpSslConn.cpp
@@ -93,7 +93,7 @@ void TcpSslConn::connect() {
 
   LOGDEBUG("Connecting SSL socket stream to %s:%d waiting %s micro sec",
            m_addr.get_host_name(), m_addr.get_port_number(),
-           std::to_string(waitMicroSeconds.count()).c_str());
+           to_string(waitMicroSeconds).c_str());
 
   int32_t retVal = m_ssl->connect(m_addr, waitMicroSeconds);
 

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -616,8 +616,8 @@ inline ConnErrType TcrConnection::receiveData(
       readHandshakeRawData, readHandShakeBytes, readHandShakeInt,
       readHandshakeString, all call TcrConnection::receiveData.
     */
-    LOGDEBUG("TcrConnection::receiveData length = %zu defaultWaitSecs = %z",
-             length, defaultWaitSecs.count());
+    LOGDEBUG("TcrConnection::receiveData length = %zu defaultWaitSecs = %s",
+             length, std::to_string(defaultWaitSecs.count()).c_str());
     if (m_poolDM != nullptr) {
       LOGDEBUG("TcrConnection::receiveData readBytes = %zu", readBytes);
       m_poolDM->getStats().incReceivedBytes(static_cast<int64_t>(readBytes));
@@ -645,9 +645,10 @@ inline ConnErrType TcrConnection::sendData(
   std::chrono::microseconds defaultWaitSecs = std::chrono::seconds(2);
   if (defaultWaitSecs > sendTimeout) defaultWaitSecs = sendTimeout;
   LOGDEBUG(
-      "before send len %zu sendTimeoutSec = %z checkConnected = %d m_connected "
+      "before send len %zu sendTimeoutSec = %s checkConnected = %d m_connected "
       "%d",
-      length, sendTimeout.count(), checkConnected, m_connected);
+      length, std::to_string(sendTimeout.count()).c_str(), checkConnected,
+      m_connected);
   while (length > 0 && sendTimeout > std::chrono::microseconds::zero()) {
     if (checkConnected && !m_connected) {
       return CONN_IOERR;

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -617,7 +617,7 @@ inline ConnErrType TcrConnection::receiveData(
       readHandshakeString, all call TcrConnection::receiveData.
     */
     LOGDEBUG("TcrConnection::receiveData length = %zu defaultWaitSecs = %s",
-             length, std::to_string(defaultWaitSecs.count()).c_str());
+             length, to_string(defaultWaitSecs).c_str());
     if (m_poolDM != nullptr) {
       LOGDEBUG("TcrConnection::receiveData readBytes = %zu", readBytes);
       m_poolDM->getStats().incReceivedBytes(static_cast<int64_t>(readBytes));
@@ -647,8 +647,7 @@ inline ConnErrType TcrConnection::sendData(
   LOGDEBUG(
       "before send len %zu sendTimeoutSec = %s checkConnected = %d m_connected "
       "%d",
-      length, std::to_string(sendTimeout.count()).c_str(), checkConnected,
-      m_connected);
+      length, to_string(sendTimeout).c_str(), checkConnected, m_connected);
   while (length > 0 && sendTimeout > std::chrono::microseconds::zero()) {
     if (checkConnected && !m_connected) {
       return CONN_IOERR;

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -185,9 +185,10 @@ GfErrType TcrEndpoint::createNewConnection(
     std::chrono::microseconds connectTimeout, int32_t timeoutRetries,
     bool appThreadRequest) {
   LOGFINE(
-      "TcrEndpoint::createNewConnection: connectTimeout =%z "
+      "TcrEndpoint::createNewConnection: connectTimeout =%s "
       "m_needToConnectInLock=%d appThreadRequest =%d",
-      connectTimeout.count(), m_needToConnectInLock, appThreadRequest);
+      std::to_string(connectTimeout.count()).c_str(), m_needToConnectInLock,
+      appThreadRequest);
   GfErrType err = GF_NOERR;
   newConn = nullptr;
   while (timeoutRetries-- >= 0) {
@@ -923,8 +924,8 @@ GfErrType TcrEndpoint::sendRequestWithRetry(
     } else if (conn == nullptr && useEPPool) {
       LOGFINER(
           "sendRequestWithRetry:: looking for connection in queue timeout = "
-          "%z ",
-          timeout.count());
+          "%s",
+          std::to_string(timeout.count()).c_str());
       // max wait time to get a connection
       conn = m_opConnections.getUntil(timeout);
     }
@@ -1051,9 +1052,9 @@ GfErrType TcrEndpoint::sendRequestWithRetry(
         } else {
           error = GF_NOTCON;
           LOGFINE(
-              "Returning without connection with %z seconds remaining "
+              "Returning without connection with %s seconds remaining "
               "for endpoint %s.",
-              timeout.count(), m_name.c_str());
+              std::to_string(timeout.count()).c_str(), m_name.c_str());
         }
       } else {
         LOGERROR("Unexpected failure while sending request to server.");

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -187,7 +187,7 @@ GfErrType TcrEndpoint::createNewConnection(
   LOGFINE(
       "TcrEndpoint::createNewConnection: connectTimeout =%s "
       "m_needToConnectInLock=%d appThreadRequest =%d",
-      std::to_string(connectTimeout.count()).c_str(), m_needToConnectInLock,
+      to_string(connectTimeout).c_str(), m_needToConnectInLock,
       appThreadRequest);
   GfErrType err = GF_NOERR;
   newConn = nullptr;
@@ -925,7 +925,7 @@ GfErrType TcrEndpoint::sendRequestWithRetry(
       LOGFINER(
           "sendRequestWithRetry:: looking for connection in queue timeout = "
           "%s",
-          std::to_string(timeout.count()).c_str());
+          to_string(timeout).c_str());
       // max wait time to get a connection
       conn = m_opConnections.getUntil(timeout);
     }

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -3016,19 +3016,21 @@ void ThinClientRegion::executeFunction(
         rc->clearResults();
         failedNodes->clear();
       } else if (err == GF_TIMEOUT) {
-        LOGINFO("function timeout. Name: %s, timeout: %z, params: %" PRIu8
+        LOGINFO("function timeout. Name: %s, timeout: %s, params: %" PRIu8
                 ", "
                 "retryAttempts: %d ",
-                func.c_str(), timeout.count(), getResult, retryAttempts);
+                func.c_str(), std::to_string(timeout.count()).c_str(),
+                getResult, retryAttempts);
         throwExceptionIfError("ExecuteOnRegion", GF_TIMEOUT);
       } else if (err == GF_CLIENT_WAIT_TIMEOUT ||
                  err == GF_CLIENT_WAIT_TIMEOUT_REFRESH_PRMETADATA) {
         LOGINFO(
             "function timeout, possibly bucket is not available or bucket "
-            "blacklisted. Name: %s, timeout: %z, params: %" PRIu8
+            "blacklisted. Name: %s, timeout: %s, params: %" PRIu8
             ", retryAttempts: "
             "%d ",
-            func.c_str(), timeout.count(), getResult, retryAttempts);
+            func.c_str(), std::to_string(timeout.count()).c_str(), getResult,
+            retryAttempts);
         throwExceptionIfError("ExecuteOnRegion", GF_CLIENT_WAIT_TIMEOUT);
       } else {
         LOGDEBUG("executeFunction err = %d ", err);

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -3598,10 +3598,10 @@ void ChunkedFunctionExecutionResponse::handleChunk(
     return;
   }
 
-  auto startLen =
+  auto startLen = static_cast<size_t>(
       input.getBytesRead() -
-      1;  // from here need to look value part + memberid AND -1 for array type
-  // iread adn gnore array length
+      1);  // from here need to look value part + memberid AND -1 for array type
+  // read and ignore array length
   input.readArrayLength();
 
   // read a byte to determine whether to read exception part for sendException

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -3019,8 +3019,8 @@ void ThinClientRegion::executeFunction(
         LOGINFO("function timeout. Name: %s, timeout: %s, params: %" PRIu8
                 ", "
                 "retryAttempts: %d ",
-                func.c_str(), std::to_string(timeout.count()).c_str(),
-                getResult, retryAttempts);
+                func.c_str(), to_string(timeout).c_str(), getResult,
+                retryAttempts);
         throwExceptionIfError("ExecuteOnRegion", GF_TIMEOUT);
       } else if (err == GF_CLIENT_WAIT_TIMEOUT ||
                  err == GF_CLIENT_WAIT_TIMEOUT_REFRESH_PRMETADATA) {
@@ -3029,8 +3029,7 @@ void ThinClientRegion::executeFunction(
             "blacklisted. Name: %s, timeout: %s, params: %" PRIu8
             ", retryAttempts: "
             "%d ",
-            func.c_str(), std::to_string(timeout.count()).c_str(), getResult,
-            retryAttempts);
+            func.c_str(), to_string(timeout).c_str(), getResult, retryAttempts);
         throwExceptionIfError("ExecuteOnRegion", GF_CLIENT_WAIT_TIMEOUT);
       } else {
         LOGDEBUG("executeFunction err = %d ", err);


### PR DESCRIPTION
- std::chrono 'Rep' type changes size based on platform
- when size mismatched to format spec in log call, bad things happen