### PR TITLE
GEODE-7447: Fix test breakage on Windows

### DIFF
--- a/cppcache/include/geode/internal/chrono/duration.hpp
+++ b/cppcache/include/geode/internal/chrono/duration.hpp
@@ -57,12 +57,6 @@ template <>
 struct _suffix<std::micro> {
   static constexpr char const* value = "us";
 };
-#ifdef WIN32
-template <>
-struct _suffix<std::ratio<10000000>> {
-  static constexpr char const* value = "ticks";
-};
-#endif
 template <>
 struct _suffix<std::nano> {
   static constexpr char const* value = "ns";

--- a/cppcache/include/geode/internal/chrono/duration.hpp
+++ b/cppcache/include/geode/internal/chrono/duration.hpp
@@ -35,7 +35,7 @@ namespace duration {
 
 template <class Period>
 struct _suffix {
-  static constexpr char const* value = nullptr;
+  static constexpr char const* value = "<<unknown units>>";
 };
 template <>
 struct _suffix<std::ratio<3600>> {
@@ -57,6 +57,12 @@ template <>
 struct _suffix<std::micro> {
   static constexpr char const* value = "us";
 };
+#ifdef WIN32
+template <>
+struct _suffix<std::ratio<10000000>> {
+  static constexpr char const* value = "ticks";
+};
+#endif
 template <>
 struct _suffix<std::nano> {
   static constexpr char const* value = "ns";

--- a/cppcache/src/EntryExpiryHandler.cpp
+++ b/cppcache/src/EntryExpiryHandler.cpp
@@ -57,20 +57,18 @@ int EntryExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
 
     auto elapsed = curr_time - lastTimeForExp;
 
-    LOGDEBUG(
-        "Entered entry expiry task handler for key [%s] of region [%s]",
-        Utils::nullSafeToString(key).c_str(),
-        m_regionPtr->getFullPath().c_str());
+    LOGDEBUG("Entered entry expiry task handler for key [%s] of region [%s]",
+             Utils::nullSafeToString(key).c_str(),
+             m_regionPtr->getFullPath().c_str());
     if (elapsed >= m_duration) {
       DoTheExpirationAction(key);
     } else {
       // reset the task after
       // (lastAccessTime + entryExpiryDuration - curr_time) in seconds
       auto remaining = m_duration - elapsed;
-      LOGDEBUG(
-          "Resetting expiry task for key [%s] of region [%s]",
-          Utils::nullSafeToString(key).c_str(),
-          m_regionPtr->getFullPath().c_str());
+      LOGDEBUG("Resetting expiry task for key [%s] of region [%s]",
+               Utils::nullSafeToString(key).c_str(),
+               m_regionPtr->getFullPath().c_str());
       m_regionPtr->getCacheImpl()->getExpiryTaskManager().resetTask(
           expProps.getExpiryTaskId(), remaining);
       return 0;

--- a/cppcache/src/EntryExpiryHandler.cpp
+++ b/cppcache/src/EntryExpiryHandler.cpp
@@ -55,27 +55,21 @@ int EntryExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
       lastTimeForExp = expProps.getLastModifiedTime();
     }
 
-    auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
-        curr_time - lastTimeForExp);
+    auto (curr_time - lastTimeForExp);
+
     LOGDEBUG(
-        "Entered entry expiry task handler for key [%s] of region [%s]: "
-        "%s,%s,%s,%s",
+        "Entered entry expiry task handler for key [%s] of region [%s]",
         Utils::nullSafeToString(key).c_str(),
-        m_regionPtr->getFullPath().c_str(),
-        to_string(curr_time.time_since_epoch()).c_str(),
-        to_string(lastTimeForExp.time_since_epoch()).c_str(),
-        to_string(m_duration).c_str(), to_string(elapsed).c_str());
+        m_regionPtr->getFullPath().c_str());
     if (elapsed >= m_duration) {
       DoTheExpirationAction(key);
     } else {
       // reset the task after
       // (lastAccessTime + entryExpiryDuration - curr_time) in seconds
-      auto remaining = std::chrono::duration_cast<std::chrono::seconds>(
-          m_duration - elapsed);
-      auto remainingStr = to_string(remaining);
+      auto remaining = m_duration - elapsed;
       LOGDEBUG(
-          "Resetting expiry task %s secs later for key [%s] of region [%s]",
-          remainingStr.c_str(), Utils::nullSafeToString(key).c_str(),
+          "Resetting expiry task for key [%s] of region [%s]",
+          Utils::nullSafeToString(key).c_str(),
           m_regionPtr->getFullPath().c_str());
       m_regionPtr->getCacheImpl()->getExpiryTaskManager().resetTask(
           expProps.getExpiryTaskId(), remaining);

--- a/cppcache/src/EntryExpiryHandler.cpp
+++ b/cppcache/src/EntryExpiryHandler.cpp
@@ -55,7 +55,8 @@ int EntryExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
       lastTimeForExp = expProps.getLastModifiedTime();
     }
 
-    auto elapsed = curr_time - lastTimeForExp;
+    auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+        curr_time - lastTimeForExp);
     LOGDEBUG(
         "Entered entry expiry task handler for key [%s] of region [%s]: "
         "%s,%s,%s,%s",
@@ -69,7 +70,8 @@ int EntryExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
     } else {
       // reset the task after
       // (lastAccessTime + entryExpiryDuration - curr_time) in seconds
-      auto remaining = m_duration - elapsed;
+      auto remaining = std::chrono::duration_cast<std::chrono::seconds>(
+          m_duration - elapsed);
       auto remainingStr = to_string(remaining);
       LOGDEBUG(
           "Resetting expiry task %s secs later for key [%s] of region [%s]",

--- a/cppcache/src/EntryExpiryHandler.cpp
+++ b/cppcache/src/EntryExpiryHandler.cpp
@@ -55,7 +55,7 @@ int EntryExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
       lastTimeForExp = expProps.getLastModifiedTime();
     }
 
-    auto (curr_time - lastTimeForExp);
+    auto elapsed = curr_time - lastTimeForExp;
 
     LOGDEBUG(
         "Entered entry expiry task handler for key [%s] of region [%s]",

--- a/cppcache/test/util/chrono/durationTest.cpp
+++ b/cppcache/test/util/chrono/durationTest.cpp
@@ -47,6 +47,9 @@ TEST(util_chrono_durationTest, to_string) {
   EXPECT_EQ("42ns", to_string(std::chrono::nanoseconds(42)));
   EXPECT_EQ("0ns", to_string(std::chrono::nanoseconds(0)));
   EXPECT_EQ("-42ns", to_string(std::chrono::nanoseconds(-42)));
+
+  EXPECT_EQ("100<<unknown units>>",
+            to_string(std::chrono::duration<int, std::ratio<1, 100000>>(100)));
 }
 
 TEST(util_chrono_durationTest, from_string) {


### PR DESCRIPTION
- std::chrono for things like system time on Windows return a
non-standard ratio corresponding to 'ticks' (100ns units)
- This unit was blowing up our string conversion code, which defaulted
to nullptr for string value of unrecognized units

Fix is threefold, for redundancy:
- Normalize the units in the place where the tests were choking on it, since the base value was in seconds to begin with
- Don't return nullptr in the default case, to avoid the crash in other places we may have missed
- Add "ticks" units for Windows, which in obscure cases may help us distinguish between this specific problem and a units problem we may hit on another platform

@mreddington @dihardman @davebarnes97 @vfordpivotal