### PR TITLE
GEODE-7490: Support Visual Studio 2019

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -87,6 +87,12 @@ The recommended generator on Windows is `Visual Studio 15 2017 Win64`:
 $ cmake .. -G "Visual Studio 15 2017 Win64" -Thost=x64
 ```
 
+Visual Studio 2019 is also supported. For this generator you must leave off the Win64:
+
+```console
+$ cmake .. -G "Visual Studio 16 2019" -Thost=x64
+```
+
 ### Build Parallelism
 For faster builds, use optional parallelism parameters in the last build step:
 

--- a/cppcache/src/ThinClientStickyManager.cpp
+++ b/cppcache/src/ThinClientStickyManager.cpp
@@ -130,9 +130,8 @@ void ThinClientStickyManager::cleanStaleStickyConnection() {
         if (auto temp = m_dm->getConnectionFromQueue(
                 false, &err, excludeServers, maxConnLimit)) {
           auto temp1 = *conn;
-          //*conn = temp; instead of setting in thread local put in queue,
-          // thread
-          // will come and pick it from there
+          //*conn = temp; instead of setting in thread local,
+          // put in queue, thread will come and pick it from there
           *conn = nullptr;
           m_dm->put(temp, false);
           temp1->close();

--- a/cppcache/src/ThinClientStickyManager.cpp
+++ b/cppcache/src/ThinClientStickyManager.cpp
@@ -119,8 +119,7 @@ void ThinClientStickyManager::cleanStaleStickyConnection() {
   LOGDEBUG("Cleaning sticky connections");
   std::set<ServerLocation> excludeServers;
   std::lock_guard<decltype(m_stickyLock)> keysGuard(m_stickyLock);
-  std::find_if(m_stickyConnList.begin(), m_stickyConnList.end(),
-               ThinClientStickyManager::isNULL);
+
   while (1) {
     std::set<TcrConnection**>::iterator it =
         std::find_if(m_stickyConnList.begin(), m_stickyConnList.end(),

--- a/cppcache/src/ThinClientStickyManager.hpp
+++ b/cppcache/src/ThinClientStickyManager.hpp
@@ -56,7 +56,6 @@ class ThinClientStickyManager {
   void getAnyConnection(TcrConnection*& conn);
 
  private:
-  static bool isNULL(TcrConnection** conn);
   ThinClientPoolDM* m_dm;
   std::set<TcrConnection**> m_stickyConnList;
   std::recursive_mutex m_stickyLock;

--- a/dependencies/ACE/CMakeLists.txt
+++ b/dependencies/ACE/CMakeLists.txt
@@ -50,12 +50,13 @@ if (${WIN32})
   else()
     set( _PLATFORM win32 )
   endif()
-
   if (MSVC_VERSION EQUAL 1900)
     set(_TYPE "vc14")
   elseif((MSVC_VERSION GREATER_EQUAL 1910) AND (MSVC_VERSION LESS_EQUAL 1919))
     set(_TYPE "vs2017")
-  endIF()
+  else()
+    set(_TYPE "vs2019")
+  endif()
 
   set ( _COMMAND_PREFIX ${CMAKE_COMMAND} -E chdir ace )
 


### PR DESCRIPTION
The only source code issue found with using Visual Studio 2019 was the removal of an unused function call which was declared NODISCARD. 

Also, the CMakeLists.txt for ACE needed to be told about the newer MSVC_VERSION.