### PR TITLE
GEODE-7509: Fix memory leaks in C++ client

### DIFF
--- a/cppcache/integration/test/CqTest.cpp
+++ b/cppcache/integration/test/CqTest.cpp
@@ -100,8 +100,12 @@ TEST(CqTest, testCqCreateUpdateDestroy) {
   attributesFactory.addCqListener(testListener);
   auto cqAttributes = attributesFactory.create();
 
+  // Using a query name with a specific non-ASCII character (U+10400) in order
+  // to also verify that the message String part conversion from
+  // Java modified UTF-8 to UTF-8 is performed correctly.
+  std::string queryName = u8"SimpleCQ\xF0\x90\x90\x80";
   auto query =
-      queryService->newCq("SimpleCQ", "SELECT * FROM /region", cqAttributes);
+      queryService->newCq(queryName, "SELECT * FROM /region", cqAttributes);
 
   query->execute();
 

--- a/cppcache/src/EntryExpiryHandler.cpp
+++ b/cppcache/src/EntryExpiryHandler.cpp
@@ -90,7 +90,7 @@ int EntryExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
 }
 
 int EntryExpiryHandler::handle_close(ACE_HANDLE, ACE_Reactor_Mask) {
-  //  we now delete the handler in GF_Timer_Heap_ImmediateReset_T
+  delete this;
   return 0;
 }
 

--- a/cppcache/src/ExpiryTaskManager.cpp
+++ b/cppcache/src/ExpiryTaskManager.cpp
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include "ExpiryTaskManager.hpp"
 
 #include "DistributedSystem.hpp"
@@ -39,12 +38,15 @@ const char* ExpiryTaskManager::NC_ETM_Thread = "NC ETM Thread";
 
 ExpiryTaskManager::ExpiryTaskManager() : m_reactorEventLoopRunning(false) {
   auto timer = new GF_Timer_Heap_ImmediateReset();
+  m_timer = std::unique_ptr<GF_Timer_Heap_ImmediateReset>(timer);
 #if defined(_WIN32)
-  m_reactor = new ACE_Reactor(new ACE_WFMO_Reactor(nullptr, timer), 1);
+  m_reactor = new ACE_Reactor(new ACE_WFMO_Reactor(nullptr, m_timer.get()), 1);
 #elif defined(WITH_ACE_Select_Reactor)
-  m_reactor = new ACE_Reactor(new ACE_Select_Reactor(nullptr, timer), 1);
+  m_reactor =
+      new ACE_Reactor(new ACE_Select_Reactor(nullptr, m_timer.get()), 1);
 #else
-  m_reactor = new ACE_Reactor(new ACE_Dev_Poll_Reactor(nullptr, timer) 1);
+  m_reactor =
+      new ACE_Reactor(new ACE_Dev_Poll_Reactor(nullptr, m_timer.get()) 1);
 #endif
 }
 

--- a/cppcache/src/ExpiryTaskManager.hpp
+++ b/cppcache/src/ExpiryTaskManager.hpp
@@ -22,6 +22,7 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <type_traits>
 
@@ -303,6 +304,8 @@ class APACHE_GEODE_EXPORT ExpiryTaskManager : public ACE_Task_Base {
 
   std::mutex m_mutex;
   std::condition_variable m_condition;
+
+  std::unique_ptr<GF_Timer_Heap_ImmediateReset> m_timer;
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -1286,7 +1286,7 @@ std::shared_ptr<CacheableStringArray> PdxInstanceImpl::getFieldNames() {
   auto pt = getPdxType();
   std::vector<std::shared_ptr<PdxFieldType>>* vectorOfFieldTypes =
       pt->getPdxFieldTypes();
-  size_t size = vectorOfFieldTypes->size();
+  auto size = vectorOfFieldTypes->size();
   if (size == 0) {
     return nullptr;
   }

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -1286,21 +1286,17 @@ std::shared_ptr<CacheableStringArray> PdxInstanceImpl::getFieldNames() {
   auto pt = getPdxType();
   std::vector<std::shared_ptr<PdxFieldType>>* vectorOfFieldTypes =
       pt->getPdxFieldTypes();
-  int size = static_cast<int>(vectorOfFieldTypes->size());
-  std::shared_ptr<CacheableString>* ptrArr = nullptr;
-  if (size > 0) {
-    ptrArr = new std::shared_ptr<CacheableString>[size];
-    for (int i = 0; i < size; i++) {
-      ptrArr[i] =
-          CacheableString::create((vectorOfFieldTypes->at(i))->getFieldName());
-    }
+  size_t size = vectorOfFieldTypes->size();
+  if (size == 0) {
+    return nullptr;
   }
-
-  if (size > 0) {
-    return CacheableStringArray::create(
-        std::vector<std::shared_ptr<CacheableString>>(ptrArr, ptrArr + size));
+  std::vector<std::shared_ptr<CacheableString>> tmpFieldNames;
+  tmpFieldNames.reserve(size);
+  for (auto&& fieldType : *vectorOfFieldTypes) {
+    tmpFieldNames.emplace_back(
+        CacheableString::create(fieldType->getFieldName()));
   }
-  return nullptr;
+  return CacheableStringArray::create(std::move(tmpFieldNames));
 }
 
 PdxFieldTypes PdxInstanceImpl::getFieldType(
@@ -1920,17 +1916,13 @@ void PdxInstanceImpl::setField(const std::string& fieldName, std::string* value,
                                 " or type of field not matched " +
                                 (pft != nullptr ? pft->toString() : ""));
   }
-  std::shared_ptr<CacheableString>* ptrArr = nullptr;
   if (length > 0) {
-    ptrArr = new std::shared_ptr<CacheableString>[length];
+    std::vector<std::shared_ptr<CacheableString>> tmpValues;
+    tmpValues.reserve(length);
     for (int32_t i = 0; i < length; ++i) {
-      ptrArr[i] = CacheableString::create(value[i]);
+      tmpValues.emplace_back(CacheableString::create(value[i]));
     }
-  }
-  if (length > 0) {
-    auto cacheableObject = CacheableStringArray::create(
-        std::vector<std::shared_ptr<CacheableString>>(ptrArr, ptrArr + length));
-    m_updatedFields[fieldName] = cacheableObject;
+    m_updatedFields[fieldName] = CacheableStringArray::create(tmpValues);
   }
 }
 

--- a/cppcache/src/PreservedDataExpiryHandler.cpp
+++ b/cppcache/src/PreservedDataExpiryHandler.cpp
@@ -62,6 +62,7 @@ int PreservedDataExpiryHandler::handle_timeout(const ACE_Time_Value&,
 }
 
 int PreservedDataExpiryHandler::handle_close(ACE_HANDLE, ACE_Reactor_Mask) {
+  delete this;
   return 0;
 }
 

--- a/cppcache/src/RegionExpiryHandler.cpp
+++ b/cppcache/src/RegionExpiryHandler.cpp
@@ -86,8 +86,7 @@ int RegionExpiryHandler::handle_timeout(const ACE_Time_Value& current_time,
 }
 
 int RegionExpiryHandler::handle_close(ACE_HANDLE, ACE_Reactor_Mask) {
-  //  we now delete the handler in GF_Timer_Heap_ImmediateReset_T
-  // delete this;
+  delete this;
   return 0;
 }
 

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -479,16 +479,15 @@ void TcrMessage::readLongPart(DataInput& input, uint64_t* intValue) {
 }
 
 const std::string TcrMessage::readStringPart(DataInput& input) {
-  char* stringBuffer;
   int32_t stringLength = input.readInt32();
-  stringBuffer = new char[stringLength + 1];
-  stringBuffer[stringLength] = '\0';
+  auto stringBuffer = std::unique_ptr<char[]>(new char[stringLength + 1]);
+  stringBuffer.get()[stringLength] = '\0';
   if (input.read()) {
     throw Exception("String is not an object");
   }
-  input.readBytesOnly(reinterpret_cast<int8_t*>(stringBuffer), stringLength);
-  std::string str = stringBuffer;
-  delete[] stringBuffer;
+  input.readBytesOnly(reinterpret_cast<int8_t*>(stringBuffer.get()),
+                      stringLength);
+  std::string str = stringBuffer.get();
   return str;
 }
 

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -480,14 +480,14 @@ void TcrMessage::readLongPart(DataInput& input, uint64_t* intValue) {
 
 const std::string TcrMessage::readStringPart(DataInput& input) {
   int32_t stringLength = input.readInt32();
-  auto stringBuffer = std::unique_ptr<char[]>(new char[stringLength + 1]);
-  stringBuffer.get()[stringLength] = '\0';
+  std::vector<char> stringBuffer(stringLength + 1);
+  stringBuffer[stringLength] = '\0';
   if (input.read()) {
     throw Exception("String is not an object");
   }
-  input.readBytesOnly(reinterpret_cast<int8_t*>(stringBuffer.get()),
+  input.readBytesOnly(reinterpret_cast<int8_t*>(stringBuffer.data()),
                       stringLength);
-  std::string str = stringBuffer.get();
+  std::string str = stringBuffer.data();
   return str;
 }
 

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -479,7 +479,7 @@ void TcrMessage::readLongPart(DataInput& input, uint64_t* intValue) {
 }
 
 const std::string TcrMessage::readStringPart(DataInput& input) {
-  int32_t stringLength = input.readInt32();
+  auto stringLength = input.readInt32();
   if (input.read()) {
     throw Exception("String is not an object");
   }

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -480,15 +480,14 @@ void TcrMessage::readLongPart(DataInput& input, uint64_t* intValue) {
 
 const std::string TcrMessage::readStringPart(DataInput& input) {
   int32_t stringLength = input.readInt32();
-  std::vector<char> stringBuffer(stringLength + 1);
-  stringBuffer[stringLength] = '\0';
   if (input.read()) {
     throw Exception("String is not an object");
   }
-  input.readBytesOnly(reinterpret_cast<int8_t*>(stringBuffer.data()),
-                      stringLength);
-  std::string str = stringBuffer.data();
-  return str;
+  auto jmutf8 = internal::JavaModifiedUtf8::decode(
+      reinterpret_cast<const char*>(input.currentBufferPosition()),
+      stringLength);
+  input.advanceCursor(stringLength);
+  return to_utf8(jmutf8);
 }
 
 void TcrMessage::readCqsPart(DataInput& input) {

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -157,6 +157,7 @@ ThinClientPoolDM::ThinClientPoolDM(const char* name,
       m_pingTaskId(-1),
       m_updateLocatorListTaskId(-1),
       m_connManageTaskId(-1),
+      m_clientOps(0),
       m_PoolStatsSampler(nullptr),
       m_clientMetadataService(nullptr),
       m_primaryServerQueueSize(PRIMARY_QUEUE_NOT_AVAILABLE) {

--- a/cppcache/src/TombstoneExpiryHandler.cpp
+++ b/cppcache/src/TombstoneExpiryHandler.cpp
@@ -82,7 +82,6 @@ int TombstoneExpiryHandler::handle_timeout(const ACE_Time_Value&, const void*) {
 }
 
 int TombstoneExpiryHandler::handle_close(ACE_HANDLE, ACE_Reactor_Mask) {
-  // we now delete the handler in GF_Timer_Heap_ImmediateReset_T
   return 0;
 }
 

--- a/cppcache/src/statistics/AtomicStatisticsImpl.hpp
+++ b/cppcache/src/statistics/AtomicStatisticsImpl.hpp
@@ -55,7 +55,7 @@ class AtomicStatisticsImpl : public Statistics, private client::NonCopyable {
   int64_t numericId;
 
   /** Are these statistics closed? */
-  bool closed;
+  bool closed = false;
 
   /** Uniquely identifies this instance */
   int64_t uniqueId;

--- a/cppcache/src/statistics/StatArchiveWriter.hpp
+++ b/cppcache/src/statistics/StatArchiveWriter.hpp
@@ -194,7 +194,7 @@ class APACHE_GEODE_EXPORT ResourceInst : private NonCopyable,
   int64_t *archivedStatValues;
   StatDataOutput *dataOut;
   /* To know whether the instance has come for the first time */
-  bool firstTime;
+  bool firstTime = true;
 };
 
 class HostStatSampler;

--- a/tests/cpp/fwklib/UDPIpc.hpp
+++ b/tests/cpp/fwklib/UDPIpc.hpp
@@ -160,11 +160,8 @@ class UDPMessageQueues : public SharedTaskObject {
   std::string m_label;
 
  public:
-  explicit UDPMessageQueues(std::string label) : m_label(label) {
-    m_cntInbound = 0;
-    m_cntOutbound = 0;
-    m_cntProcessed = 0;
-  }
+  explicit UDPMessageQueues(std::string label)
+      : m_cntInbound(), m_cntOutbound(0), m_cntProcessed(0), m_label(label) {}
   ~UDPMessageQueues() {
     FWKINFO(m_label << "MessageQueues::Inbound   count: " << m_cntInbound);
     FWKINFO(m_label << "MessageQueues::Processed count: " << m_cntProcessed);

--- a/tests/cpp/fwklib/UDPIpc.hpp
+++ b/tests/cpp/fwklib/UDPIpc.hpp
@@ -160,7 +160,11 @@ class UDPMessageQueues : public SharedTaskObject {
   std::string m_label;
 
  public:
-  explicit UDPMessageQueues(std::string label) : m_label(label) {}
+  explicit UDPMessageQueues(std::string label) : m_label(label) {
+    m_cntInbound = 0;
+    m_cntOutbound = 0;
+    m_cntProcessed = 0;
+  }
   ~UDPMessageQueues() {
     FWKINFO(m_label << "MessageQueues::Inbound   count: " << m_cntInbound);
     FWKINFO(m_label << "MessageQueues::Processed count: " << m_cntProcessed);

--- a/tests/cpp/testobject/NonPdxType.hpp
+++ b/tests/cpp/testobject/NonPdxType.hpp
@@ -247,9 +247,6 @@ class TESTOBJECT_EXPORT NonPdxType {
     m_doubleArray[1] = 4324235435.00;
 
     m_byteByteArray = new int8_t*[2];
-    // for(int i=0; i<2; i++){
-    //  m_byteByteArray[i] = new int8_t[1];
-    //}
     m_byteByteArray[0] = new int8_t[1];
     m_byteByteArray[1] = new int8_t[2];
     m_byteByteArray[0][0] = 0x23;
@@ -374,7 +371,16 @@ class TESTOBJECT_EXPORT NonPdxType {
     throw IllegalStateException("Not got expected value for bool type: ");
   }
 
-  virtual ~NonPdxType() {}
+  void deleteByteByteArray() {
+    if (m_byteByteArray == nullptr) {
+      return;
+    }
+    _GEODE_SAFE_DELETE_ARRAY(m_byteByteArray[0]);
+    _GEODE_SAFE_DELETE_ARRAY(m_byteByteArray[1]);
+    _GEODE_SAFE_DELETE_ARRAY(m_byteByteArray);
+  }
+
+  virtual ~NonPdxType() { deleteByteByteArray(); }
 
   char16_t getChar() { return m_char; }
 

--- a/tests/cpp/testobject/PdxType.cpp
+++ b/tests/cpp/testobject/PdxType.cpp
@@ -73,9 +73,10 @@ void PdxTests::PdxType::toData(PdxWriter& pw) const {
   // TODO:delete it later
 
   int* lengths = new int[2];
-
   lengths[0] = 1;
   lengths[1] = 2;
+  std::unique_ptr<int[]> lengthsSmartPtr(lengths);
+
   pw.writeArrayOfByteArrays("m_byteByteArray", m_byteByteArray, 2, lengths);
   pw.writeChar("m_char", m_char);
   pw.markIdentityField("m_char");


### PR DESCRIPTION
This commit solves some more memory leaks
and uninitialized memory accesses found
in the C++ client when running the integration
tests that were not solved by GEODE-7476
