### PR TITLE
GEODE-7511: Fix endpoint truncation bug

### DIFF
--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -579,8 +579,8 @@ std::string ThinClientPoolDM::selectEndpoint(
     getStats().setLocators((m_locHelper)->getCurLocatorsNum());
     getStats().incLoctorResposes();
 
-    char epNameStr[128] = {0};
-    std::snprintf(epNameStr, 128, "%s:%d", outEndpoint.getServerName().c_str(),
+    char epNameStr[256] = {0};
+    std::snprintf(epNameStr, 256, "%s:%d", outEndpoint.getServerName().c_str(),
                   outEndpoint.getPort());
     LOGFINE("ThinClientPoolDM: Locator returned endpoint [%s]", epNameStr);
     return epNameStr;

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -579,10 +579,10 @@ std::string ThinClientPoolDM::selectEndpoint(
     getStats().setLocators((m_locHelper)->getCurLocatorsNum());
     getStats().incLoctorResposes();
 
-    char epNameStr[256] = {0};
-    std::snprintf(epNameStr, 256, "%s:%d", outEndpoint.getServerName().c_str(),
-                  outEndpoint.getPort());
-    LOGFINE("ThinClientPoolDM: Locator returned endpoint [%s]", epNameStr);
+    std::string epNameStr = outEndpoint.getServerName() + ":" +
+                            std::to_string(outEndpoint.getPort());
+    LOGFINE("ThinClientPoolDM: Locator returned endpoint [%s]",
+            epNameStr.c_str());
     return epNameStr;
   } else if (!m_attrs->m_initServList.empty()) {
     // use specified server endpoints


### PR DESCRIPTION
When using a connection pool, the server endpoint name string was being limited to 128 characters. This prevented using the native client with PCF 1.9.1 which switched from IP addresses to DNS names. These names can often be greater than 128 characters as in: 

05b92a19-be8e-4b55-8bd6-db83073a375b.locator-server.nassau-services-subnet.service-instance-c0abaded-6ac6-4f6f-80b2-a141d01ac3f8.bosh