### PR TITLE
GEODE-7520: Add convenient target to clangformat everything

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -151,6 +151,23 @@ To override `clang-tidy` options:
 ```console
 $ cmake … -DCMAKE_CXX_CLANG_TIDY=clang-tidy;<options> …
 ```
+#### Clang-format
+Individual targets in the build tree have their own dependency of the form `<<targetName>>_clangformat`, which uses the `clang-format` executable, wherever it is found, to format and modified files according to the rules specfied in the .clang-format file.  This is helpful when submitting changes to geode-native, because an improperly formatted file will fail Travis-CI and have to be fixed prior to merging any pull request.  If clang-format is not installed on your system, clangformat targets will not be added to your project files, and geode-native should build normally.  Under some circumstances, however, it may become necessary to disable `clang-format` on a system where it _is_ installed.
+
+To disable `clang-format` in the build:
+
+```
+$ cmake … -DClangFormat_EXECUTABLE='' …
+```
+
+On the other hand, it may also be desirable to run clang-format on the entire source tree.  This is also easily done via the `all-clangformat` _in a build with clang-format enabled_.  If clang-format has been disabled in the cmake configuration step, as above, the `all-clangformat` target will not exist, and the cmake configuration step will have to be re-run with clang-format enabled.
+
+To run clang-format on the entire source tree:
+
+```
+$ cmake --build . --target all-clangformat
+```
+
 
 ## Installing
 By default a system-specific location is used by CMake as the destination of the `install` target, e.g., `/usr/local` on UNIX system. To explicitly specify the location in which the Native Client will be installed, add `-DCMAKE_INSTALL_PREFIX=/path/to/installation/destination` to the _initial_ `cmake` execution command.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -152,7 +152,7 @@ To override `clang-tidy` options:
 $ cmake … -DCMAKE_CXX_CLANG_TIDY=clang-tidy;<options> …
 ```
 #### Clang-format
-Individual targets in the build tree have their own dependency of the form `<<targetName>>_clangformat`, which uses the `clang-format` executable, wherever it is found, to format and modified files according to the rules specfied in the .clang-format file.  This is helpful when submitting changes to geode-native, because an improperly formatted file will fail Travis-CI and have to be fixed prior to merging any pull request.  If clang-format is not installed on your system, clangformat targets will not be added to your project files, and geode-native should build normally.  Under some circumstances, however, it may become necessary to disable `clang-format` on a system where it _is_ installed.
+Individual targets in the build tree have their own dependency of the form `<<targetName>>-clangformat`, which uses the `clang-format` executable, wherever it is found, to format and modified files according to the rules specfied in the .clang-format file.  This is helpful when submitting changes to geode-native, because an improperly formatted file will fail Travis-CI and have to be fixed prior to merging any pull request.  If clang-format is not installed on your system, clangformat targets will not be added to your project files, and geode-native should build normally.  Under some circumstances, however, it may become necessary to disable `clang-format` on a system where it _is_ installed.
 
 To disable `clang-format` in the build:
 

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -17,6 +17,12 @@ set(ClangFormat_FLAGS "-style=file;-fallback-style=Google" CACHE STRING "Flags s
 
 find_package(ClangFormat QUIET)
 
+add_custom_target(clangformat-all)
+set_target_properties(clangformat-all PROPERTIES
+        EXCLUDE_FROM_ALL TRUE
+        EXCLUDE_FROM_DEFAULT_BUILD TRUE
+        )
+
 function(add_clangformat _target)
   if (ClangFormat_FOUND)
     if (NOT TARGET ${_target})
@@ -50,7 +56,6 @@ function(add_clangformat _target)
             COMMENT "Clang-Format ${_source}"
             COMMAND ${ClangFormat_EXECUTABLE} ${ClangFormat_FLAGS} -i ${_source_LOCATION}
             COMMAND ${CMAKE_COMMAND} -E touch ${_format_file})
-
         list(APPEND _clangformat_SOURCES ${_format_file})
       endif ()
     endforeach ()
@@ -60,8 +65,12 @@ function(add_clangformat _target)
           SOURCES ${_clangformat_SOURCES}
           COMMENT "Clang-Format for target ${_target}"
       )
-      set_target_properties(${_clangformat} PROPERTIES FOLDER clangformat)
-      add_dependencies(${_target} ${_clangformat})
+      set_target_properties(${_clangformat} PROPERTIES
+          FOLDER clangformat
+          EXCLUDE_FROM_ALL TRUE
+          EXCLUDE_FROM_DEFAULT_BUILD TRUE
+      )
+      add_dependencies(clangformat-all ${_clangformat})
     endif ()
 
   endif ()

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -17,8 +17,8 @@ set(ClangFormat_FLAGS "-style=file;-fallback-style=Google" CACHE STRING "Flags s
 
 find_package(ClangFormat QUIET)
 
-add_custom_target(clangformat-all)
-set_target_properties(clangformat-all PROPERTIES
+add_custom_target(all-clangformat)
+set_target_properties(all-clangformat PROPERTIES
         EXCLUDE_FROM_ALL TRUE
         EXCLUDE_FROM_DEFAULT_BUILD TRUE
         )
@@ -65,12 +65,9 @@ function(add_clangformat _target)
           SOURCES ${_clangformat_SOURCES}
           COMMENT "Clang-Format for target ${_target}"
       )
-      set_target_properties(${_clangformat} PROPERTIES
-          FOLDER clangformat
-          EXCLUDE_FROM_ALL TRUE
-          EXCLUDE_FROM_DEFAULT_BUILD TRUE
-      )
-      add_dependencies(clangformat-all ${_clangformat})
+      set_target_properties(${_clangformat} PROPERTIES FOLDER clangformat)
+      add_dependencies(${_target} ${_clangformat})
+      add_dependencies(all-clangformat ${_clangformat})
     endif ()
 
   endif ()


### PR DESCRIPTION
- Will save time on developer builds
- Stops breaking Windows builds when Visual Studio clang-format crashes

@mreddington @vfordpivotal @dihardman @davebarnes97 @karensmolermiller 