### PR TITLE
GEODE-7601: Memory leaks in C++ native client found when running old integration-tests

### DIFF
--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -497,8 +497,12 @@ class APACHE_GEODE_EXPORT DataOutput {
   static void acquireLock();
   static void releaseLock();
 
+  struct FreeDeleter {
+    void operator()(uint8_t* p) { free(p); }
+  };
+
   // memory m_buffer to encode to.
-  std::unique_ptr<uint8_t[]> m_bytes;
+  std::unique_ptr<uint8_t, FreeDeleter> m_bytes;
   // cursor.
   uint8_t* m_buf;
   // size of m_bytes.

--- a/cppcache/integration-test/CacheHelper.cpp
+++ b/cppcache/integration-test/CacheHelper.cpp
@@ -80,6 +80,13 @@ CacheHelper &CacheHelper::getHelper() {
   return *singleton;
 }
 
+void CacheHelper::resetHelper() {
+  if (singleton != nullptr) {
+    delete singleton;
+    singleton = nullptr;
+  }
+}
+
 CacheHelper::CacheHelper(const char *,
                          const std::shared_ptr<Properties> &configPtr,
                          const bool noRootRegion) {
@@ -90,8 +97,6 @@ CacheHelper::CacheHelper(const char *,
 
   auto cacheFactory = CacheFactory(pp);
   cachePtr = std::make_shared<Cache>(cacheFactory.create());
-
-  m_doDisconnect = false;
 
   if (noRootRegion) return;
 
@@ -121,8 +126,6 @@ CacheHelper::CacheHelper(const char *, const char *cachexml,
   }
   auto cacheFactory = CacheFactory(pp);
   cachePtr = std::make_shared<Cache>(cacheFactory.create());
-
-  m_doDisconnect = false;
 }
 
 CacheHelper::CacheHelper(const std::shared_ptr<Properties> &configPtr,
@@ -138,8 +141,6 @@ CacheHelper::CacheHelper(const std::shared_ptr<Properties> &configPtr,
   auto poolFactory = cachePtr->getPoolManager().createFactory();
   addServerLocatorEPs("localhost:40404", poolFactory);
   poolFactory.create("__CACHE_HELPER_POOL__");
-
-  m_doDisconnect = false;
 
   if (noRootRegion) return;
 
@@ -165,7 +166,6 @@ CacheHelper::CacheHelper(const bool,
     LOG(" in cachehelper before createCacheFactory");
     auto cacheFactory = CacheFactory(pp).setAuthInitialize(authInitialize);
     cachePtr = std::make_shared<Cache>(cacheFactory.create());
-    m_doDisconnect = false;
   } catch (const Exception &excp) {
     LOG("Geode exception while creating cache, logged in following line");
     LOG(excp.what());
@@ -184,7 +184,6 @@ CacheHelper::CacheHelper(const bool,
   LOG(" in cachehelper before createCacheFactory");
   auto cacheFactory = CacheFactory(pp);
   cachePtr = std::make_shared<Cache>(cacheFactory.create());
-  m_doDisconnect = false;
 }
 
 CacheHelper::CacheHelper(const bool, bool pdxIgnoreUnreadFields,
@@ -202,7 +201,6 @@ CacheHelper::CacheHelper(const bool, bool pdxIgnoreUnreadFields,
     cfPtr.setPdxReadSerialized(pdxReadSerialized);
     cfPtr.setPdxIgnoreUnreadFields(pdxIgnoreUnreadFields);
     cachePtr = std::make_shared<Cache>(cfPtr.create());
-    m_doDisconnect = false;
   } catch (const Exception &excp) {
     LOG("Geode exception while creating cache, logged in following line");
     LOG(excp.what());
@@ -275,7 +273,6 @@ CacheHelper::CacheHelper(const int,
 
   auto cacheFac = CacheFactory(pp);
   cachePtr = std::make_shared<Cache>(cacheFac.create());
-  m_doDisconnect = false;
 }
 
 CacheHelper::~CacheHelper() {
@@ -881,8 +878,8 @@ std::shared_ptr<QueryService> CacheHelper::getQueryService() {
   return cachePtr->getQueryService();
 }
 
-const char *CacheHelper::getTcrEndpoints(bool &isLocalServer,
-                                         int numberOfServers) {
+const std::string CacheHelper::getTcrEndpoints(bool &isLocalServer,
+                                               int numberOfServers) {
   static char *gfjavaenv = ACE_OS::getenv("GFJAVA");
   std::string gfendpoints;
   static bool gflocalserver = false;
@@ -961,7 +958,7 @@ const char *CacheHelper::getTcrEndpoints(bool &isLocalServer,
   }
   isLocalServer = gflocalserver;
   printf("getHostPort :: %s \n", gfendpoints.c_str());
-  return (new std::string(gfendpoints.c_str()))->c_str();
+  return (gfendpoints);
 }
 
 const char *CacheHelper::getstaticLocatorHostPort1() {
@@ -982,8 +979,8 @@ const char *CacheHelper::getLocatorHostPort(int locPort) {
   ;
 }
 
-const char *CacheHelper::getTcrEndpoints2(bool &isLocalServer,
-                                          int numberOfServers) {
+const std::string CacheHelper::getTcrEndpoints2(bool &isLocalServer,
+                                                int numberOfServers) {
   static char *gfjavaenv = ACE_OS::getenv("GFJAVA");
   std::string gfendpoints;
   static bool gflocalserver = false;
@@ -1064,7 +1061,7 @@ const char *CacheHelper::getTcrEndpoints2(bool &isLocalServer,
   ASSERT(gfjavaenv != nullptr,
          "Environment variable GFJAVA for java build directory is not set.");
   isLocalServer = gflocalserver;
-  return (new std::string(gfendpoints.c_str()))->c_str();
+  return (gfendpoints);
 }
 
 const char *CacheHelper::getLocatorHostPort(bool &isLocator,

--- a/cppcache/integration-test/CacheHelper.hpp
+++ b/cppcache/integration-test/CacheHelper.hpp
@@ -54,11 +54,12 @@ class CacheHelper {
   static std::list<std::string> staticConfigFileList;
   std::shared_ptr<Cache> cachePtr;
   std::shared_ptr<Region> rootRegionPtr;
-  bool m_doDisconnect;
 
   std::shared_ptr<Cache> getCache();
 
   static CacheHelper& getHelper();
+
+  static void resetHelper();
 
   static std::string unitTestOutputFile();
   static int getNumLocatorListUpdates(const char* s);
@@ -282,7 +283,7 @@ class CacheHelper {
   static int staticHostPort3;
   static int staticHostPort4;
 
-  static const char* getTcrEndpoints(bool& isLocalServer,
+  static const std::string getTcrEndpoints(bool& isLocalServer,
                                      int numberOfServers = 1);
 
   static int staticLocatorHostPort1;
@@ -300,7 +301,7 @@ class CacheHelper {
   static const char* getLocatorHostPort(bool& isLocator, bool& isLocalServer,
                                         int numberOfLocators = 0);
 
-  static const char* getTcrEndpoints2(bool& isLocalServer,
+  static const std::string getTcrEndpoints2(bool& isLocalServer,
                                       int numberOfServers = 1);
 
   static std::list<int> staticServerInstanceList;

--- a/cppcache/integration-test/ThinClientDurableConnect.hpp
+++ b/cppcache/integration-test/ThinClientDurableConnect.hpp
@@ -46,7 +46,7 @@ timeout period and all the events are lost.
 #define SERVER1 s1p2
 
 bool isLocalServerList = false;
-const char* endPointsList = CacheHelper::getTcrEndpoints(isLocalServerList, 4);
+const std::string endPointsList = CacheHelper::getTcrEndpoints(isLocalServerList, 4);
 const char* durableId = "DurableId";
 
 #include "ThinClientDurableInit.hpp"

--- a/cppcache/integration-test/ThinClientFailover3.hpp
+++ b/cppcache/integration-test/ThinClientFailover3.hpp
@@ -38,7 +38,7 @@ using apache::geode::client::CacheableString;
 using apache::geode::client::CacheHelper;
 
 bool isLocalServer = false;
-const char* endPoints = CacheHelper::getTcrEndpoints(isLocalServer, 3);
+const std::string endPoints = CacheHelper::getTcrEndpoints(isLocalServer, 3);
 CacheHelper* cacheHelper = nullptr;
 
 #define CLIENT1 s1p1
@@ -242,21 +242,22 @@ void doNetsearch(const char* name, const char* key, const char* value) {
   LOG("Netsearch complete.");
 }
 
-std::vector<char*> storeEndPoints(const char* points) {
-  std::vector<char*> endpointNames;
-  if (points != nullptr) {
-    char* ep = strdup(points);
+std::vector<std::string> storeEndPoints(const std::string points) {
+  std::vector<std::string> endpointNames;
+  if (!points.empty()) {
+    char* ep = strdup(points.c_str());
     char* token = strtok(ep, ",");
     while (token) {
       endpointNames.push_back(token);
       token = strtok(nullptr, ",");
     }
+    free(ep);
   }
   ASSERT(endpointNames.size() == 3, "There should be 3 end points");
   return endpointNames;
 }
 
-std::vector<char*> endpointNames = storeEndPoints(endPoints);
+std::vector<std::string> endpointNames = storeEndPoints(endPoints);
 const char* keys[] = {"Key-1", "Key-2", "Key-3", "Key-4"};
 const char* vals[] = {"Value-1", "Value-2", "Value-3", "Value-4"};
 const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",

--- a/cppcache/integration-test/ThinClientFailover3.hpp
+++ b/cppcache/integration-test/ThinClientFailover3.hpp
@@ -244,14 +244,15 @@ void doNetsearch(const char* name, const char* key, const char* value) {
 
 std::vector<std::string> storeEndPoints(const std::string points) {
   std::vector<std::string> endpointNames;
-  if (!points.empty()) {
-    char* ep = strdup(points.c_str());
-    char* token = strtok(ep, ",");
-    while (token) {
-      endpointNames.push_back(token);
-      token = strtok(nullptr, ",");
+  size_t end = 0;
+  size_t start;
+  std::string delim = ",";
+  while ((start = points.find_first_not_of(delim, end)) != std::string::npos)  {
+    end = points.find(delim, start);
+    if (end == std::string::npos) {
+      end = points.length();
     }
-    free(ep);
+    endpointNames.push_back(points.substr(start, end - start));
   }
   ASSERT(endpointNames.size() == 3, "There should be 3 end points");
   return endpointNames;

--- a/cppcache/integration-test/ThinClientHelper.hpp
+++ b/cppcache/integration-test/ThinClientHelper.hpp
@@ -661,7 +661,7 @@ class RegionOperations {
       int keys = 1,
       const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) {
     char keybuf[100];
-    char valbuf[100];
+    char valbuf[100] = {0};
     for (int i = 1; i <= keys; i++) {
       sprintf(keybuf, "key%d", i);
       auto valPtr = CacheableString::create(valbuf);
@@ -672,7 +672,7 @@ class RegionOperations {
       int keys = 1,
       const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) {
     char keybuf[100];
-    char valbuf[100];
+    char valbuf[100] = {0};
     for (int i = 1; i <= keys; i++) {
       sprintf(keybuf, "key%d", i);
       auto valPtr = CacheableString::create(valbuf);
@@ -683,7 +683,7 @@ class RegionOperations {
       int keys = 1,
       const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) {
     char keybuf[100];
-    char valbuf[100];
+    char valbuf[100] = {0};
     for (int i = 1; i <= keys; i++) {
       sprintf(keybuf, "key%d", i);
       sprintf(valbuf, "value%d", i);

--- a/cppcache/integration-test/ThinClientInterest3.hpp
+++ b/cppcache/integration-test/ThinClientInterest3.hpp
@@ -35,7 +35,6 @@ using apache::geode::client::testing::TallyListener;
 using apache::geode::client::testing::TallyWriter;
 
 bool isLocalServer = true;
-const char* endPoint = CacheHelper::getTcrEndpoints(isLocalServer, 1);
 static bool isLocator = false;
 const char* locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);

--- a/cppcache/integration-test/ThinClientInterest3Cacheless.hpp
+++ b/cppcache/integration-test/ThinClientInterest3Cacheless.hpp
@@ -35,7 +35,6 @@ using apache::geode::client::testing::TallyListener;
 using apache::geode::client::testing::TallyWriter;
 
 bool isLocalServer = true;
-const char* endPoint = CacheHelper::getTcrEndpoints(isLocalServer, 1);
 static bool isLocator = false;
 const char* locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);

--- a/cppcache/integration-test/ThinClientPdxSerializer.hpp
+++ b/cppcache/integration-test/ThinClientPdxSerializer.hpp
@@ -328,7 +328,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, getAtVersion2_PS)
     auto key = CacheableKey::create(1);
 
     // New object
-    auto testDiffTpePdxSV2 = new PdxTests::TestDiffTypePdxSV2(true);
+    auto testDiffTpePdxSV2 = std::unique_ptr<PdxTests::TestDiffTypePdxSV2>(new PdxTests::TestDiffTypePdxSV2(true));
 
     // GET
     auto pdxWrapper2 = std::dynamic_pointer_cast<PdxWrapper>(region0->get(key));
@@ -343,7 +343,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, getAtVersion2_PS)
         "be equal");
 
     auto key2 = CacheableKey::create(2);
-    testDiffTpePdxSV2 = new PdxTests::TestDiffTypePdxSV2(true);
+    testDiffTpePdxSV2.reset(new PdxTests::TestDiffTypePdxSV2(true));
 
     pdxWrapper2 = std::dynamic_pointer_cast<PdxWrapper>(region0->get(key2));
     pRet = std::static_pointer_cast<PdxTests::TestDiffTypePdxSV2>(

--- a/cppcache/integration-test/ThinClientPdxSerializers.hpp
+++ b/cppcache/integration-test/ThinClientPdxSerializers.hpp
@@ -95,10 +95,13 @@ class TestPdxSerializer : public PdxSerializer {
     auto nonPdxType = std::make_shared<PdxTests::NonPdxType>();
 
     try {
-      auto Lengtharr = new int32_t[2];
+      int32_t *Lengtharr;
       int32_t arrLen = 0;
+      nonPdxType->deleteByteByteArray();
       nonPdxType->m_byteByteArray = pdxReader.readArrayOfByteArrays(
           "m_byteByteArray", arrLen, &Lengtharr);
+      _GEODE_SAFE_DELETE_ARRAY(Lengtharr);
+
       // TODO::need to write compareByteByteArray() and check for
       // m_byteByteArray elements
 
@@ -206,7 +209,7 @@ class TestPdxSerializer : public PdxSerializer {
         std::static_pointer_cast<const PdxTests::NonPdxType>(testObject);
 
     try {
-      int* lengthArr = new int[2];
+      int lengthArr[2];
 
       lengthArr[0] = 1;
       lengthArr[1] = 2;
@@ -265,10 +268,6 @@ class TestPdxSerializer : public PdxSerializer {
       pdxWriter.writeByteArray("m_sbyteArray", nonPdxType->m_sbyteArray);
       pdxWriter.markIdentityField("m_sbyteArray");
 
-      int* strlengthArr = new int[2];
-
-      strlengthArr[0] = 5;
-      strlengthArr[1] = 5;
       pdxWriter.writeStringArray("m_stringArray", nonPdxType->m_stringArray);
       pdxWriter.markIdentityField("m_stringArray");
       pdxWriter.writeShort("m_uint16", nonPdxType->m_uint16);

--- a/cppcache/integration-test/fw_dunit.hpp
+++ b/cppcache/integration-test/fw_dunit.hpp
@@ -198,7 +198,7 @@ END_TASK(validate)
 #define DUNIT_TASK_DEFINITION(x, y)                            \
   class DCLASSDEF(y) : virtual public dunit::Task {            \
    public:                                                     \
-    DCLASSDEF(y)() { init(x); }                                \
+    DCLASSDEF(y)() { init(x, true); }                                \
                                                                \
    public:                                                     \
     virtual void doTask() {                                    \
@@ -272,12 +272,15 @@ class Task {
  public:
   std::string m_taskName;
   int m_id;
+  bool m_isHeapAllocated;
 
   Task() {}
-  virtual ~Task() {}
+  virtual ~Task() { }
 
   /** register task with slave. */
   void init(int sId);
+
+  void init(int sId, bool isHeapAllocated);
 
   // defined by block of code in DUNIT_TASK macro usage.
   virtual void doTask() = 0;

--- a/cppcache/integration-test/testLRUList.cpp
+++ b/cppcache/integration-test/testLRUList.cpp
@@ -17,6 +17,8 @@
 
 #include <iostream>
 
+#include <vector>
+
 #include "fw_helper.hpp"
 
 #ifdef WIN32
@@ -59,7 +61,7 @@ BEGIN_TEST(LRUListTest)
   {
     LRUList<MyNode, MyNode> lruList;
     // Create 10 Nodes to keep track of.
-    std::shared_ptr<MyNode> *tenNodes = new std::shared_ptr<MyNode>[10];
+    std::vector<std::shared_ptr<MyNode> > tenNodes(10);
 
     for (int i = 0; i < 10; i++) {
       tenNodes[i] = std::shared_ptr<MyNode>(MyNode::create());

--- a/cppcache/integration-test/testRegionMap.cpp
+++ b/cppcache/integration-test/testRegionMap.cpp
@@ -94,7 +94,6 @@ BEGIN_TEST(TestRegionNoLRU)
     cacheHelper.showKeys(vecKeys);
     ASSERT(vecKeys.size() == (i + 1), "unexpected entries count");
   }
-
 #endif
 
 END_TEST(TestRegionNoLRU)
@@ -119,7 +118,6 @@ BEGIN_TEST(TestRegionLRULocal)
     auto&& vecKeys = regionPtr->keys();
     ASSERT(vecKeys.size() == (i < 10 ? i + 1 : 10), "expected more entries");
   }
-
 #endif
 END_TEST(TestRegionLRULocal)
 
@@ -168,7 +166,6 @@ BEGIN_TEST(TestRecentlyUsedBit)
     ASSERT(vecKeys.size() == 10, "expected more entries");
   }
   ASSERT(regionPtr->containsKey(key2) == false, "15 should have been evicted.");
-
 END_TEST(TestRecentlyUsedBit)
 
 BEGIN_TEST(TestEmptiedMap)
@@ -210,5 +207,7 @@ BEGIN_TEST(TestEmptiedMap)
   }
   vecKeys = regionPtr->keys();
   ASSERT(vecKeys.size() == 10, "expected more entries");
+
+  cacheHelper.resetHelper();
 
 END_TEST(TestEmptiedMap)

--- a/cppcache/integration-test/testThinClientCacheablesLimits.cpp
+++ b/cppcache/integration-test/testThinClientCacheablesLimits.cpp
@@ -77,12 +77,12 @@ T randomValue(T maxValue) {
   return std::uniform_int_distribution<T>{0, maxValue}(generator);
 }
 
-uint8_t *createRandByteArray(int size) {
-  uint8_t *ptr = new uint8_t[size];
+std::vector<int8_t> createRandByteArray(int size) {
+  std::vector<int8_t> byteArray(size);
   for (int i = 0; i < size; i++) {
-    ptr[i] = randomValue(255);
+    byteArray[i] = randomValue(255);
   }
-  return ptr;
+  return byteArray;
 }
 
 char *createRandCharArray(int size) {
@@ -115,12 +115,11 @@ DUNIT_TASK_DEFINITION(CLIENT1, PutsTask)
     int sizeArray = sizeof(keyArr) / sizeof(int);
     auto verifyReg = getHelper()->getRegion(_regionNames[1]);
     for (int count = 0; count < sizeArray; count++) {
-      uint8_t *ptr = createRandByteArray(keyArr[count]);
+      auto randByteArray = createRandByteArray(keyArr[count]);
       char *ptrChar = createRandCharArray(keyArr[count]);
 
       auto emptyBytesArr = CacheableBytes::create();
-      auto bytePtrSent =
-          CacheableBytes::create(std::vector<int8_t>(ptr, ptr + keyArr[count]));
+      auto bytePtrSent = CacheableBytes::create(randByteArray);
       auto stringPtrSent =
           CacheableString::create(std::string(ptrChar, keyArr[count]));
       std::free(ptrChar);

--- a/cppcache/integration-test/testThinClientPRSingleHop.cpp
+++ b/cppcache/integration-test/testThinClientPRSingleHop.cpp
@@ -54,7 +54,7 @@ using apache::geode::client::testing::CacheableWrapper;
 using apache::geode::client::testing::CacheableWrapperFactory;
 
 bool isLocalServer = false;
-const char *endPoints = CacheHelper::getTcrEndpoints(isLocalServer, 3);
+const std::string endPoints = CacheHelper::getTcrEndpoints(isLocalServer, 3);
 
 static bool isLocator = false;
 const char *locatorsG =
@@ -201,13 +201,13 @@ class putThread : public ACE_Task_Base {
 #endif
 #define KEYSIZE 256
 
-std::vector<char *> storeEndPoints(const char *points) {
-  std::vector<char *> endpointNames;
-  if (points != nullptr) {
-    char *ep = strdup(points);
+std::vector<std::string> storeEndPoints(const std::string points) {
+  std::vector<std::string> endpointNames;
+  if (!points.empty()) {
+    char *ep = strdup(points.c_str());
     char *token = strtok(ep, ",");
     while (token) {
-      endpointNames.push_back(token);
+      endpointNames.push_back(std::string(token));
       token = strtok(nullptr, ",");
     }
     free(ep);
@@ -216,7 +216,7 @@ std::vector<char *> storeEndPoints(const char *points) {
   return endpointNames;
 }
 
-std::vector<char *> endpointNames = storeEndPoints(endPoints);
+std::vector<std::string> endpointNames = storeEndPoints(endPoints);
 
 DUNIT_TASK_DEFINITION(SERVER1, CreateServer1)
   {

--- a/cppcache/integration-test/testThinClientPRSingleHop.cpp
+++ b/cppcache/integration-test/testThinClientPRSingleHop.cpp
@@ -203,14 +203,15 @@ class putThread : public ACE_Task_Base {
 
 std::vector<std::string> storeEndPoints(const std::string points) {
   std::vector<std::string> endpointNames;
-  if (!points.empty()) {
-    char *ep = strdup(points.c_str());
-    char *token = strtok(ep, ",");
-    while (token) {
-      endpointNames.push_back(std::string(token));
-      token = strtok(nullptr, ",");
+  size_t end = 0;
+  size_t start;
+  std::string delim = ",";
+  while ((start = points.find_first_not_of(delim, end)) != std::string::npos) {
+    end = points.find(delim, start);
+    if (end == std::string::npos) {
+      end = points.length();
     }
-    free(ep);
+    endpointNames.push_back(points.substr(start, end - start));
   }
   ASSERT(endpointNames.size() == 3, "There should be 3 end points");
   return endpointNames;

--- a/cppcache/integration-test/testThinClientPartitionResolver.cpp
+++ b/cppcache/integration-test/testThinClientPartitionResolver.cpp
@@ -71,14 +71,15 @@ const std::string endPoints = CacheHelper::getTcrEndpoints(isLocalServer, 3);
 
 std::vector<std::string> storeEndPoints(const std::string points) {
   std::vector<std::string> endpointNames;
-  if (!points.empty()) {
-    char *ep = strdup(points.c_str());
-    char *token = strtok(ep, ",");
-    while (token) {
-      endpointNames.push_back(std::string(token));
-      token = strtok(nullptr, ",");
+  size_t end = 0;
+  size_t start;
+  std::string delim = ",";
+  while ((start = points.find_first_not_of(delim, end)) != std::string::npos) {
+    end = points.find(delim, start);
+    if (end == std::string::npos) {
+      end = points.length();
     }
-    free(ep);
+    endpointNames.push_back(points.substr(start, end - start));
   }
   ASSERT(endpointNames.size() == 3, "There should be 3 end points");
   return endpointNames;
@@ -103,10 +104,6 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, CreatePoolAndRegions)
   {
     initClient(true);
-
-    char endpoints[1024] = {0};
-    sprintf(endpoints, "%s,%s,%s", endpointNames.at(0).c_str(),
-            endpointNames.at(1).c_str(), endpointNames.at(2).c_str());
 
     getHelper()->createPoolWithLocators("__TEST_POOL1__", nullptr);
     getHelper()->createRegionAndAttachPool2(regionNames[0], USE_ACK,

--- a/cppcache/integration-test/testThinClientPartitionResolver.cpp
+++ b/cppcache/integration-test/testThinClientPartitionResolver.cpp
@@ -67,15 +67,15 @@ std::shared_ptr<PartitionResolver> cptr(cpr);
 #define SERVER2 s1p2
 
 bool isLocalServer = false;
-const char *endPoints = CacheHelper::getTcrEndpoints(isLocalServer, 3);
+const std::string endPoints = CacheHelper::getTcrEndpoints(isLocalServer, 3);
 
-std::vector<char *> storeEndPoints(const char *points) {
-  std::vector<char *> endpointNames;
-  if (points != nullptr) {
-    char *ep = strdup(points);
+std::vector<std::string> storeEndPoints(const std::string points) {
+  std::vector<std::string> endpointNames;
+  if (!points.empty()) {
+    char *ep = strdup(points.c_str());
     char *token = strtok(ep, ",");
     while (token) {
-      endpointNames.push_back(token);
+      endpointNames.push_back(std::string(token));
       token = strtok(nullptr, ",");
     }
     free(ep);
@@ -84,7 +84,7 @@ std::vector<char *> storeEndPoints(const char *points) {
   return endpointNames;
 }
 
-std::vector<char *> endpointNames = storeEndPoints(endPoints);
+std::vector<std::string> endpointNames = storeEndPoints(endPoints);
 
 DUNIT_TASK_DEFINITION(SERVER1, CreateServer1)
   {
@@ -105,8 +105,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, CreatePoolAndRegions)
     initClient(true);
 
     char endpoints[1024] = {0};
-    sprintf(endpoints, "%s,%s,%s", endpointNames.at(0), endpointNames.at(1),
-            endpointNames.at(2));
+    sprintf(endpoints, "%s,%s,%s", endpointNames.at(0).c_str(),
+            endpointNames.at(1).c_str(), endpointNames.at(2).c_str());
 
     getHelper()->createPoolWithLocators("__TEST_POOL1__", nullptr);
     getHelper()->createRegionAndAttachPool2(regionNames[0], USE_ACK,

--- a/cppcache/integration-test/testThinClientPdxInstance.cpp
+++ b/cppcache/integration-test/testThinClientPdxInstance.cpp
@@ -1171,6 +1171,11 @@ DUNIT_TASK_DEFINITION(CLIENT2, accessPdxInstance)
     ASSERT(generic2DCompare(byteByteArrayVal, bytArray, byteArrayLen,
                             elementLength) == true,
            "byteByteArray should be equal");
+    for (auto i = 0; i < byteArrayLen; i++) {
+      delete[] byteByteArrayVal[i];
+    }
+    delete[] byteByteArrayVal;
+    delete[] elementLength;
     ASSERT(pIPtr->getFieldType("m_byteByteArray") ==
                PdxFieldTypes::ARRAY_OF_BYTE_ARRAYS,
            "Type Value ARRAY_OF_BYTE_ARRAYS Mismatch");
@@ -1823,7 +1828,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
     setbyteByteArray[3][0] = 0x34;
     setbyteByteArray[3][1] = 0x55;
     wpiPtr = pIPtr->createWriter();
-    int *lengthArr = new int[4];
+    int lengthArr[4];
     lengthArr[0] = 1;
     lengthArr[1] = 2;
     lengthArr[2] = 1;
@@ -1847,7 +1852,13 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
     ASSERT(generic2DCompare(getbyteByteArray, setbyteByteArray,
                             byteByteArrayLength, elementLength) == true,
            "byteByteArray should be equal");
-
+    for (auto i = 0; i < byteByteArrayLength; i++) {
+      delete[] getbyteByteArray[i];
+      delete[] setbyteByteArray[i];
+    }
+    delete[] getbyteByteArray;
+    delete[] setbyteByteArray;
+    delete[] elementLength;
     wpiPtr = pIPtr->createWriter();
     try {
       wpiPtr->setField("m_byteByteArray", linkedhashset);
@@ -1860,8 +1871,8 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
           "IllegalStateException");
     }
 
-    auto setStringArray = new std::string[3]{"test1", "test2", "test3"};
-    wpiPtr->setField("m_stringArray", setStringArray, 3);
+    std::vector<std::string> setStringArray = {"test1", "test2", "test3"};
+    wpiPtr->setField("m_stringArray", setStringArray.data(), 3);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));
     auto getStringArray = newPiPtr->getStringArrayField("m_stringArray");

--- a/cppcache/integration-test/testThinClientPoolExecuteHAFunction.cpp
+++ b/cppcache/integration-test/testThinClientPoolExecuteHAFunction.cpp
@@ -36,7 +36,6 @@ bool isLocalServer = false;
 bool isLocator = false;
 bool isPoolWithEndpoint = false;
 
-const char *endPoints1 = CacheHelper::getTcrEndpoints(isLocalServer, 3);
 const char *locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 const char *poolRegNames[] = {"partition_region", "PoolRegion2"};

--- a/cppcache/integration-test/testThinClientPoolRedundancy.cpp
+++ b/cppcache/integration-test/testThinClientPoolRedundancy.cpp
@@ -30,9 +30,6 @@
 
 bool isLocalServer = false;
 bool isLocator = false;
-const char *endPoints1 = CacheHelper::getTcrEndpoints(isLocalServer, 1);
-const char *endPoints2 = CacheHelper::getTcrEndpoints(isLocalServer, 2);
-const char *endPoints3 = CacheHelper::getTcrEndpoints(isLocalServer, 3);
 const char *locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 const char *poolRegNames[] = {"PoolRegion1", "PoolRegion2", "PoolRegion3"};

--- a/cppcache/src/ExecutionImpl.cpp
+++ b/cppcache/src/ExecutionImpl.cpp
@@ -498,10 +498,10 @@ std::shared_ptr<CacheableVector> ExecutionImpl::executeOnPool(
             tcrdm->getConnectionManager().getCacheImpl()->createDataOutput()),
         funcName, m_args, getResult, tcrdm, timeout);
     TcrMessageReply reply(true, tcrdm);
-    ChunkedFunctionExecutionResponse* resultCollector(
+    auto resultCollector = std::unique_ptr<ChunkedFunctionExecutionResponse>(
         new ChunkedFunctionExecutionResponse(reply, (getResult & 2) == 2,
                                              m_rc));
-    reply.setChunkedResultHandler(resultCollector);
+    reply.setChunkedResultHandler(resultCollector.get());
     reply.setTimeout(timeout);
 
     GfErrType err = GF_NOERR;
@@ -556,9 +556,6 @@ std::shared_ptr<CacheableVector> ExecutionImpl::executeOnPool(
     ==25848==    by 0x805F9EA: main (in
     /export/pnq-gst-dev01a/users/adongre/cedar_dev_Nov12/build-artifacts/linux/tests/cppcache/testThinClientPoolExecuteFunctionPrSHOP)
     */
-    delete resultCollector;
-    resultCollector = nullptr;
-
     return nullptr;
   }
   return nullptr;

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -1922,7 +1922,8 @@ void PdxInstanceImpl::setField(const std::string& fieldName, std::string* value,
     for (int32_t i = 0; i < length; ++i) {
       tmpValues.emplace_back(CacheableString::create(value[i]));
     }
-    m_updatedFields[fieldName] = CacheableStringArray::create(tmpValues);
+    m_updatedFields[fieldName] =
+        CacheableStringArray::create(std::move(tmpValues));
   }
 }
 

--- a/cppcache/src/PdxType.cpp
+++ b/cppcache/src/PdxType.cpp
@@ -180,6 +180,9 @@ void PdxType::initRemoteToLocal() {
         localPdxType->getPdxFieldTypes();
     int32_t fieldIdx = 0;
 
+    if (m_remoteToLocalFieldMap != nullptr) {
+      _GEODE_SAFE_DELETE_ARRAY(m_remoteToLocalFieldMap);
+    }
     m_remoteToLocalFieldMap = new int32_t[m_pdxFieldTypes->size()];
     LOGDEBUG(
         "PdxType::initRemoteToLocal m_pdxFieldTypes->size() =%zu AND "
@@ -242,6 +245,9 @@ void PdxType::initLocalToRemote() {
     // type which need to read/write should control local type
     int32_t localToRemoteFieldMapSize =
         static_cast<int32_t>(localPdxType->m_pdxFieldTypes->size());
+    if (m_localToRemoteFieldMap != nullptr) {
+      _GEODE_SAFE_DELETE_ARRAY(m_localToRemoteFieldMap);
+    }
     m_localToRemoteFieldMap = new int32_t[localToRemoteFieldMapSize];
 
     for (int32_t i = 0; i < localToRemoteFieldMapSize &&

--- a/cppcache/src/RemoteQuery.cpp
+++ b/cppcache/src/RemoteQuery.cpp
@@ -78,9 +78,10 @@ std::shared_ptr<SelectResults> RemoteQuery::execute(
   int64_t sampleStartNanos =
       enableTimeStatistics ? Utils::startStatOpTime() : 0;
   TcrMessageReply reply(true, tcdm);
-  auto* resultCollector = (new ChunkedQueryResponse(reply));
+  auto resultCollector =
+      std::unique_ptr<ChunkedQueryResponse>(new ChunkedQueryResponse(reply));
   reply.setChunkedResultHandler(
-      static_cast<TcrChunkedResult*>(resultCollector));
+      static_cast<TcrChunkedResult*>(resultCollector.get()));
   GfErrType err = executeNoThrow(timeout, reply, func, tcdm, paramList);
   throwExceptionIfError(func, err);
 
@@ -115,7 +116,6 @@ std::shared_ptr<SelectResults> RemoteQuery::execute(
                             pool->getStats().getQueryExecutionTimeId(),
                             sampleStartNanos);
   }
-  delete resultCollector;
   return sr;
 }
 

--- a/cppcache/src/SuspendedTxExpiryHandler.cpp
+++ b/cppcache/src/SuspendedTxExpiryHandler.cpp
@@ -50,6 +50,7 @@ int SuspendedTxExpiryHandler::handle_timeout(const ACE_Time_Value&,
 }
 
 int SuspendedTxExpiryHandler::handle_close(ACE_HANDLE, ACE_Reactor_Mask) {
+  delete this;
   return 0;
 }
 

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -1326,11 +1326,11 @@ std::shared_ptr<CacheableString> TcrConnection::readHandshakeString(
     return nullptr;
   }
 
-  auto recvMessage = std::unique_ptr<char>(new char[length + 1]);
-  recvMessage.get()[length] = '\0';
+  std::vector<char> recvMessage(length + 1);
+  recvMessage[length] = '\0';
 
-  if ((error = receiveData(recvMessage.get(), length, connectTimeout, false)) !=
-      CONN_NOERR) {
+  if ((error = receiveData(recvMessage.data(), length, connectTimeout,
+                           false)) != CONN_NOERR) {
     if (error & CONN_TIMEOUT) {
       GF_SAFE_DELETE_CON(m_conn);
       LOGFINE("Timeout receiving string data");
@@ -1345,9 +1345,9 @@ std::shared_ptr<CacheableString> TcrConnection::readHandshakeString(
                            "Handshake failure reading string bytes"));
     }
   } else {
-    LOGDEBUG(" Received string data [%s]", recvMessage.get());
+    LOGDEBUG(" Received string data [%s]", recvMessage.data());
     auto retval =
-        CacheableString::create(std::string(recvMessage.get(), length));
+        CacheableString::create(std::string(recvMessage.data(), length));
     return retval;
   }
 }

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -278,7 +278,7 @@ std::shared_ptr<CacheableBytes> TcrMessage::getDeltaBytes() {
   }
   auto retVal = CacheableBytes::create(
       std::vector<int8_t>(m_deltaBytes, m_deltaBytes + m_deltaBytesLen));
-  m_deltaBytes = nullptr;
+  _GEODE_SAFE_DELETE_ARRAY(m_deltaBytes);
   return retVal;
 }
 

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -816,13 +816,6 @@ void ThinClientPoolDM::destroy(bool keepAlive) {
     close();
     LOGDEBUG("ThinClientPoolDM::destroy( ): after close ");
 
-    for (const auto& iter : m_endpoints) {
-      auto ep = iter.second;
-      LOGFINE("ThinClientPoolDM: forcing endpoint delete for %s in destructor",
-              ep->name().c_str());
-      _GEODE_SAFE_DELETE(ep);
-    }
-
     // Close Stats
     getStats().close();
     cacheImpl->getStatisticsManager().forceSample();
@@ -834,6 +827,13 @@ void ThinClientPoolDM::destroy(bool keepAlive) {
     m_isDestroyed = true;
     LOGDEBUG("ThinClientPoolDM::destroy( ): after close m_isDestroyed = %d ",
              m_isDestroyed);
+
+    for (const auto& iter : m_endpoints) {
+      auto ep = iter.second;
+      LOGFINE("ThinClientPoolDM: forcing endpoint delete for %s in destructor",
+              ep->name().c_str());
+      _GEODE_SAFE_DELETE(ep);
+    }
   }
   if (m_poolSize != 0) {
     LOGFINE("Pool connection size is not zero %d", m_poolSize.load());

--- a/cppcache/src/ThinClientPoolHADM.cpp
+++ b/cppcache/src/ThinClientPoolHADM.cpp
@@ -35,8 +35,9 @@ ThinClientPoolHADM::ThinClientPoolHADM(const char* name,
       m_redundancySema(0),
       m_redundancyTask(nullptr),
       m_servermonitorTaskId(-1) {
-  m_redundancyManager = new ThinClientRedundancyManager(
-      &connManager, poolAttr->getSubscriptionRedundancy(), this);
+  m_redundancyManager = std::unique_ptr<ThinClientRedundancyManager>(
+      new ThinClientRedundancyManager(
+          &connManager, poolAttr->getSubscriptionRedundancy(), this));
 }
 
 void ThinClientPoolHADM::init() {
@@ -178,8 +179,6 @@ void ThinClientPoolHADM::destroy(bool keepAlive) {
     sendNotificationCloseMsgs();
 
     m_redundancyManager->close();
-    delete m_redundancyManager;
-    m_redundancyManager = nullptr;
 
     m_destroyPendingHADM = true;
     ThinClientPoolDM::destroy(keepAlive);

--- a/cppcache/src/ThinClientPoolHADM.hpp
+++ b/cppcache/src/ThinClientPoolHADM.hpp
@@ -104,7 +104,7 @@ class ThinClientPoolHADM : public ThinClientPoolDM {
   void startBackgroundThreads() override;
 
  private:
-  ThinClientRedundancyManager* m_redundancyManager;
+  std::unique_ptr<ThinClientRedundancyManager> m_redundancyManager;
 
   TcrConnectionManager& m_theTcrConnManager;
   ACE_Semaphore m_redundancySema;

--- a/cppcache/src/Utils.hpp
+++ b/cppcache/src/Utils.hpp
@@ -91,7 +91,9 @@ class APACHE_GEODE_EXPORT Utils {
     size_t len;
     char* demangledName = _gnuDemangledName(typeIdName, len);
     if (demangledName != nullptr) {
-      return std::string(demangledName, len);
+      auto str = std::string(demangledName, len);
+      free(demangledName);
+      return str;
     }
 #endif
     return std::string(typeIdName);

--- a/cppcache/src/statistics/StatArchiveWriter.hpp
+++ b/cppcache/src/statistics/StatArchiveWriter.hpp
@@ -214,7 +214,7 @@ class APACHE_GEODE_EXPORT StatArchiveWriter {
   int64_t bytesWrittenToFile;
   int64_t m_samplesize;
   std::string archiveFile;
-  std::map<Statistics *, ResourceInst *> resourceInstMap;
+  std::map<Statistics *, std::shared_ptr<ResourceInst>> resourceInstMap;
   std::map<const StatisticsType *, const ResourceType *> resourceTypeMap;
 
   /* private member functions */

--- a/sqliteimpl/SqLiteImpl.cpp
+++ b/sqliteimpl/SqLiteImpl.cpp
@@ -190,7 +190,7 @@ void SqLiteImpl::destroy(const std::shared_ptr<CacheableKey> &key,
   }
 }
 
-SqLiteImpl::SqLiteImpl() { m_sqliteHelper = new SqLiteHelper(); }
+SqLiteImpl::SqLiteImpl() { m_sqliteHelper = std::unique_ptr<SqLiteHelper>(new SqLiteHelper()); }
 
 void SqLiteImpl::close() {
   m_sqliteHelper->closeDB();

--- a/sqliteimpl/SqLiteImpl.hpp
+++ b/sqliteimpl/SqLiteImpl.hpp
@@ -135,7 +135,7 @@ class SqLiteImpl : public PersistenceManager {
    */
 
  private:
-  SqLiteHelper* m_sqliteHelper;
+  std::unique_ptr<SqLiteHelper> m_sqliteHelper;
 
   std::string m_regionDBFile;
   std::string m_regionDir;

--- a/tests/cpp/fwklib/UDPIpc.hpp
+++ b/tests/cpp/fwklib/UDPIpc.hpp
@@ -201,7 +201,7 @@ class Receiver : public ServiceTask {
   ACE_TSS<ACE_SOCK_Dgram> m_io;
   uint16_t m_basePort;
   ACE_thread_t m_listener;
-  std::atomic<uint16_t> m_offset;
+  std::atomic<uint16_t> m_offset{0};
   std::list<std::string> m_addrs;
   UDPMessageQueues* m_queues;
   ACE_Thread_Mutex m_mutex;
@@ -275,7 +275,7 @@ class Responder : public ServiceTask {
  private:
   ACE_TSS<ACE_SOCK_Dgram> m_io;
   uint16_t m_basePort;
-  std::atomic<uint16_t> m_offset;
+  std::atomic<uint16_t> m_offset{0};
   UDPMessageQueues* m_queues;
 
  public:

--- a/tests/cpp/testobject/NonPdxType.hpp
+++ b/tests/cpp/testobject/NonPdxType.hpp
@@ -169,7 +169,7 @@ class TESTOBJECT_EXPORT NonPdxType {
   int32_t m_byte65536Len;
   int32_t byteByteArrayLen;
 
-  int* lengthArr;
+  int lengthArr[2];
 
  public:
   bool selfCheck();
@@ -357,8 +357,6 @@ class TESTOBJECT_EXPORT NonPdxType {
     strLenArray = 2;
     charArrayLen = 2;
     byteByteArrayLen = 2;
-
-    lengthArr = new int[2];
 
     lengthArr[0] = 1;
     lengthArr[1] = 2;

--- a/tests/cpp/testobject/PdxType.cpp
+++ b/tests/cpp/testobject/PdxType.cpp
@@ -70,14 +70,12 @@ bool PdxTests::PdxType::generic2DCompare(T1** value1, T2** value2, int length,
 //}
 
 void PdxTests::PdxType::toData(PdxWriter& pw) const {
-  // TODO:delete it later
+  std::vector<int> lengths(2);
 
-  int* lengths = new int[2];
   lengths[0] = 1;
   lengths[1] = 2;
-  std::unique_ptr<int[]> lengthsSmartPtr(lengths);
-
-  pw.writeArrayOfByteArrays("m_byteByteArray", m_byteByteArray, 2, lengths);
+  pw.writeArrayOfByteArrays("m_byteByteArray", m_byteByteArray, 2,
+                            lengths.data());
   pw.writeChar("m_char", m_char);
   pw.markIdentityField("m_char");
   pw.writeBoolean("m_bool", m_bool);  // 1
@@ -170,7 +168,6 @@ void PdxTests::PdxType::toData(PdxWriter& pw) const {
   LOGDEBUG("PdxObject::writeObject() for enum Done......");
 
   LOGDEBUG("PdxObject::toData() Done......");
-  // TODO:delete it later
 }
 
 void PdxTests::PdxType::fromData(PdxReader& pr) {


### PR DESCRIPTION
Several memory leaks and other issues in memory
management have been fixed in the native client.
The issues were found when running the old integration
tests under valgrind.

Many issues in the testing framework have also been fixed
to make it easier to identify and fix the problems
in the native client.