### PR TITLE
GEODE-7612: Technical debt 01 - Fix logging

### DIFF
--- a/cppcache/src/Log.cpp
+++ b/cppcache/src/Log.cpp
@@ -726,13 +726,7 @@ void Log::exitFn(LogLevel level, const char* functionName) {
 }
 
 bool Log::enabled(LogLevel level) {
-#ifdef DEBUG
-  return (((level == LogLevel::Debug) || GEODE_HIGHEST_LOG_LEVEL >= level) &&
-          s_logLevel >= level);
-#else
-  return (((level != LogLevel::Debug) && GEODE_HIGHEST_LOG_LEVEL >= level) &&
-          s_logLevel >= level);
-#endif
+  return GEODE_HIGHEST_LOG_LEVEL >= level && s_logLevel >= level;
 }
 
 void Log::log(LogLevel level, const char* msg) {
@@ -871,12 +865,8 @@ void Log::finestCatch(const char* msg, const Exception& ex) {
 }
 
 bool Log::debugEnabled() {
-#ifdef DEBUG
-  return s_logLevel >= LogLevel::Debug;
-#else
-  return (GEODE_HIGHEST_LOG_LEVEL >= LogLevel::Debug) &&
+  return GEODE_HIGHEST_LOG_LEVEL >= LogLevel::Debug &&
          s_logLevel >= LogLevel::Debug;
-#endif
 }
 
 void Log::debug(const char* msg) {


### PR DESCRIPTION
This code was supposed to disable debug level logging for non-debug builds. Apparently it never worked. I fixed it when I moved it to the source file, but it broke the tests. That means release could log debug. That means it's out in the wild. Instead of arbitrarily disabling a log level and possibly hampering a customer, we decided to disable this compile-time feature altogether.