### PR TITLE
GEODE-7646: Remove need for LD_LIBRARY_PATH on Linux.

### DIFF
--- a/examples/cpp/sslputget/CMakeLists.txt.in
+++ b/examples/cpp/sslputget/CMakeLists.txt.in
@@ -47,7 +47,8 @@ file(GLOB SSL_CERTIFICATES
 
 file(INSTALL ${SSL_CERTIFICATES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-# This is needed on Linux to force libcryptoImpl.so to be linked in
+# This is needed on Linux to force libcryptoImpl.so to be linked in.
+# Not currently supported in latest cmake, but ticket created: https://gitlab.kitware.com/cmake/cmake/issues/20174
 if ("Linux" STREQUAL ${CMAKE_SYSTEM_NAME} )
   set_target_properties(${PROJECT_NAME} PROPERTIES
     LINK_WHAT_YOU_USE TRUE)

--- a/examples/cpp/sslputget/CMakeLists.txt.in
+++ b/examples/cpp/sslputget/CMakeLists.txt.in
@@ -47,14 +47,16 @@ file(GLOB SSL_CERTIFICATES
 
 file(INSTALL ${SSL_CERTIFICATES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
+# This is needed on Linux to force libcryptoImpl.so to be linked in
+if ("Linux" STREQUAL ${CMAKE_SYSTEM_NAME} )
+  set_target_properties(${PROJECT_NAME} PROPERTIES
+    LINK_WHAT_YOU_USE TRUE)
+endif()
+  
 target_link_libraries(${PROJECT_NAME}
-    PUBLIC
-    @PRODUCT_NAME_NOSPACE@::cpp)
-
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy
-    $<SHELL_PATH:$<TARGET_FILE:GeodeNative::crypto>>
-    $<SHELL_PATH:$<TARGET_FILE_DIR:${PROJECT_NAME}>>
+  PUBLIC
+    @PRODUCT_NAME_NOSPACE@::cpp
+    @PRODUCT_NAME_NOSPACE@::crypto
 )
 
 if(WIN32)

--- a/examples/cpp/sslputget/README.md
+++ b/examples/cpp/sslputget/README.md
@@ -14,13 +14,6 @@ This example illustrates how to use SSL encryption for all traffic between a cli
     ```console
     $ cd workspace/examples/build/cpp/sslputget
     ```
-    For Linux, extend your library path.
-
-    For Bash:
-
-    ```console
-    $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GeodeNative_ROOT/lib
-    ```
 
 2. Run the `startserver` script to start the Geode cluster with authentication and create a region.
 
@@ -33,7 +26,7 @@ This example illustrates how to use SSL encryption for all traffic between a cli
    For Windows Powershell:
 
     ```console
-    $ startserver.ps1
+    PS> startserver.ps1
     ```
 
    For Bash:


### PR DESCRIPTION
This removes the need to set LD_LIBRARY_PATH on Linux when running apps which are using SSL. Since OSX ignores LD_LIBRARY_PATH (unless SIP is disabled), this fix allows identical setup of SSL enabled native client apps on OSX and Linux.

Also updates the README.md for the sslputget example to remove the LD_LIBRARY_PATH requirement.