### PR TITLE
GEODE-7785: Remove hard-coded path in (unused) global test variables

### DIFF
--- a/cppcache/integration/test/SslOneWayTest.cpp
+++ b/cppcache/integration/test/SslOneWayTest.cpp
@@ -34,10 +34,6 @@ using apache::geode::client::CacheFactory;
 using apache::geode::client::Exception;
 using apache::geode::client::RegionShortcut;
 
-const auto badClientTruststore = boost::filesystem::path(
-    "/Users/pivotal/Workspace/geode-native-install/examples/build/cpp/"
-    "sslputget/ClientSslKeys/client_truststore.pem");
-
 class SslOneWayTest : public ::testing::Test {
  protected:
   // You can remove any or all of the following functions if their bodies would

--- a/cppcache/integration/test/SslTwoWayTest.cpp
+++ b/cppcache/integration/test/SslTwoWayTest.cpp
@@ -34,10 +34,6 @@ using apache::geode::client::CacheFactory;
 using apache::geode::client::Exception;
 using apache::geode::client::RegionShortcut;
 
-const auto badClientTruststore = boost::filesystem::path(
-    "/Users/pivotal/Workspace/geode-native-install/examples/build/cpp/"
-    "sslputget/ClientSslKeys/client_truststore.pem");
-
 class SslTwoWayTest : public ::testing::Test {
  protected:
   // You can remove any or all of the following functions if their bodies would


### PR DESCRIPTION
These snuck in with the addition of SslOneWayTest.cpp and SslTwoWayTest.cpp.  Most likely they were overlooked because they were new files rather than changes to existing ones, and because this was supposed to be just a “port” of the SSL test work done in a private branch.

@vfordpivotal @mreddington @dihardman @davebarnes97 