### PR TITLE
GEODE-7794: Checking for null result and falling back to PdxInstance deserialization.

### DIFF
--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(cpp-integration-test
   TransactionCleaningTest.cpp
   CleanIdleConnections.cpp
   BasicIPv6Test.cpp
+  Book.cpp
 )
 
 target_compile_definitions(cpp-integration-test

--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -41,7 +41,6 @@ add_executable(cpp-integration-test
   TransactionCleaningTest.cpp
   CleanIdleConnections.cpp
   BasicIPv6Test.cpp
-  Book.cpp
 )
 
 target_compile_definitions(cpp-integration-test

--- a/cppcache/src/PdxHelper.cpp
+++ b/cppcache/src/PdxHelper.cpp
@@ -176,6 +176,15 @@ std::shared_ptr<PdxSerializable> PdxHelper::deserializePdx(DataInput& dataInput,
                 ->getExpiryTaskManager());  // it will set data in weakhashmap
       }
       prr.moveStream();
+
+      if (auto pdxWrapper =
+              std::dynamic_pointer_cast<PdxWrapper>(pdxObjectptr)) {
+        if (!pdxWrapper->getObject()) {
+          // No serializer was registered to deserialize this type.
+          // Fall back to PdxInstance
+          return nullptr;
+        }
+      }
     }
   } else {
     // type not found; need to get from server

--- a/cppcache/src/PdxType.hpp
+++ b/cppcache/src/PdxType.hpp
@@ -43,7 +43,7 @@ typedef std::map<std::string, std::shared_ptr<PdxFieldType>> NameVsPdxType;
 class PdxType;
 class PdxTypeRegistry;
 
-class APACHE_GEODE_EXPORT PdxType
+class PdxType
     : public internal::DataSerializableInternal,
       public std::enable_shared_from_this<PdxType>,
       private NonCopyable,

--- a/cppcache/src/PdxType.hpp
+++ b/cppcache/src/PdxType.hpp
@@ -43,10 +43,11 @@ typedef std::map<std::string, std::shared_ptr<PdxFieldType>> NameVsPdxType;
 class PdxType;
 class PdxTypeRegistry;
 
-class PdxType : public internal::DataSerializableInternal,
-                public std::enable_shared_from_this<PdxType>,
-                private NonCopyable,
-                private NonAssignable {
+class APACHE_GEODE_EXPORT PdxType
+    : public internal::DataSerializableInternal,
+      public std::enable_shared_from_this<PdxType>,
+      private NonCopyable,
+      private NonAssignable {
  private:
   ACE_RW_Thread_Mutex m_lockObj;
 


### PR DESCRIPTION
If deserialization in the PdxHelper fails, fall back to PdxInstance deserialization a la Jake.