### PR TITLE
GEODE-2484: More ACE Removal

### DIFF
--- a/cppcache/src/ClientProxyMembershipIDFactory.hpp
+++ b/cppcache/src/ClientProxyMembershipIDFactory.hpp
@@ -22,8 +22,6 @@
 
 #include <string>
 
-#include <ace/INET_Addr.h>
-
 #include "ClientProxyMembershipID.hpp"
 
 namespace apache {

--- a/cppcache/src/ClientProxyMembershipIDFactory.hpp
+++ b/cppcache/src/ClientProxyMembershipIDFactory.hpp
@@ -22,6 +22,8 @@
 
 #include <string>
 
+#include <ace/INET_Addr.h>
+
 #include "ClientProxyMembershipID.hpp"
 
 namespace apache {

--- a/cppcache/src/CppCacheLibrary.cpp
+++ b/cppcache/src/CppCacheLibrary.cpp
@@ -17,6 +17,7 @@
 
 #include "CppCacheLibrary.hpp"
 
+#include <ace/ACE.h>
 #include <ace/Init_ACE.h>
 
 #include "Utils.hpp"

--- a/cppcache/src/CppCacheLibrary.cpp
+++ b/cppcache/src/CppCacheLibrary.cpp
@@ -17,7 +17,6 @@
 
 #include "CppCacheLibrary.hpp"
 
-#include <ace/ACE.h>
 #include <ace/Init_ACE.h>
 
 #include "Utils.hpp"

--- a/cppcache/src/CqService.hpp
+++ b/cppcache/src/CqService.hpp
@@ -24,8 +24,6 @@
 #include <mutex>
 #include <string>
 
-#include <ace/Semaphore.h>
-
 #include <geode/CacheableKey.hpp>
 #include <geode/CqOperation.hpp>
 #include <geode/CqQuery.hpp>

--- a/cppcache/src/CqService.hpp
+++ b/cppcache/src/CqService.hpp
@@ -24,6 +24,8 @@
 #include <mutex>
 #include <string>
 
+#include <ace/Semaphore.h>
+
 #include <geode/CacheableKey.hpp>
 #include <geode/CqOperation.hpp>
 #include <geode/CqQuery.hpp>

--- a/cppcache/src/EntryExpiryHandler.cpp
+++ b/cppcache/src/EntryExpiryHandler.cpp
@@ -17,6 +17,13 @@
 
 #include "EntryExpiryHandler.hpp"
 
+#include <ace/Reactor.h>
+#include <ace/Timer_Heap.h>
+#include <ace/Timer_Heap_T.h>
+#include <ace/Timer_Queue.h>
+#include <ace/Timer_Queue_Adapters.h>
+#include <ace/svc_export.h>
+
 #include "CacheImpl.hpp"
 #include "ExpiryTaskManager.hpp"
 #include "RegionInternal.hpp"

--- a/cppcache/src/EntryExpiryHandler.cpp
+++ b/cppcache/src/EntryExpiryHandler.cpp
@@ -17,13 +17,6 @@
 
 #include "EntryExpiryHandler.hpp"
 
-#include <ace/Reactor.h>
-#include <ace/Timer_Heap.h>
-#include <ace/Timer_Heap_T.h>
-#include <ace/Timer_Queue.h>
-#include <ace/Timer_Queue_Adapters.h>
-#include <ace/svc_export.h>
-
 #include "CacheImpl.hpp"
 #include "ExpiryTaskManager.hpp"
 #include "RegionInternal.hpp"

--- a/cppcache/src/EventSource.cpp
+++ b/cppcache/src/EventSource.cpp
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-#include <ace/ACE.h>
-
 #include "EventIdMap.hpp"
 
 namespace apache {
@@ -55,8 +53,10 @@ void EventSource::clear() {
 }
 
 char* EventSource::getSrcId() { return m_srcId; }
+const char* EventSource::getSrcId() const { return m_srcId; }
 
 int32_t EventSource::getSrcIdLen() { return m_srcIdLen; }
+int32_t EventSource::getSrcIdLen() const { return m_srcIdLen; }
 
 char* EventSource::getMemId() { return m_srcId; }
 
@@ -65,15 +65,7 @@ int32_t EventSource::getMemIdLen() { return m_srcIdLen - sizeof(m_thrId); }
 int64_t EventSource::getThrId() { return m_thrId; }
 
 int32_t EventSource::hashcode() const {
-  if (m_srcId == nullptr || m_srcIdLen <= 0) {
-    return 0;
-  }
-
-  if (m_hash == 0) {
-    m_hash = ACE::hash_pjw(m_srcId, m_srcIdLen);
-  }
-
-  return m_hash;
+  return static_cast<int32_t>(std::hash<EventSource>{}(*this));
 }
 
 bool EventSource::operator==(const EventSource& rhs) const {

--- a/cppcache/src/EventSource.hpp
+++ b/cppcache/src/EventSource.hpp
@@ -57,7 +57,9 @@ class APACHE_GEODE_EXPORT EventSource {
   // Accessors
 
   char *getSrcId();
+  const char *getSrcId() const;
   int32_t getSrcIdLen();
+  int32_t getSrcIdLen() const;
   char *getMemId();
   int32_t getMemIdLen();
   int64_t getThrId();
@@ -106,7 +108,8 @@ struct hash<apache::geode::client::EventSource> {
   typedef apache::geode::client::EventSource argument_type;
   typedef size_t result_type;
   size_t operator()(const apache::geode::client::EventSource &val) const {
-    return apache::geode::client::EventSource::hash{}(val);
+    return std::hash<std::string>{}(
+        std::string(val.getSrcId(), val.getSrcIdLen()));
   }
 };
 

--- a/cppcache/src/FairQueue.hpp
+++ b/cppcache/src/FairQueue.hpp
@@ -22,6 +22,8 @@
 
 #include <deque>
 
+#include <ace/ACE.h>
+#include <ace/Condition_T.h>
 #include <ace/Guard_T.h>
 #include <ace/Thread_Mutex.h>
 #include <ace/Time_Value.h>

--- a/cppcache/src/FairQueue.hpp
+++ b/cppcache/src/FairQueue.hpp
@@ -22,8 +22,6 @@
 
 #include <deque>
 
-#include <ace/ACE.h>
-#include <ace/Condition_T.h>
 #include <ace/Guard_T.h>
 #include <ace/Thread_Mutex.h>
 #include <ace/Time_Value.h>

--- a/cppcache/src/LocalRegion.hpp
+++ b/cppcache/src/LocalRegion.hpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <unordered_map>
 
+#include <ace/RW_Thread_Mutex.h>
+
 #include <geode/AttributesMutator.hpp>
 #include <geode/Cache.hpp>
 #include <geode/CacheListener.hpp>

--- a/cppcache/src/LocalRegion.hpp
+++ b/cppcache/src/LocalRegion.hpp
@@ -23,8 +23,6 @@
 #include <string>
 #include <unordered_map>
 
-#include <ace/RW_Thread_Mutex.h>
-
 #include <geode/AttributesMutator.hpp>
 #include <geode/Cache.hpp>
 #include <geode/CacheListener.hpp>

--- a/cppcache/src/Log.cpp
+++ b/cppcache/src/Log.cpp
@@ -29,14 +29,7 @@
 #include <vector>
 
 #include <ace/ACE.h>
-#include <ace/Dirent.h>
 #include <ace/Dirent_Selector.h>
-#include <ace/OS.h>
-#include <ace/OS_NS_Thread.h>
-#include <ace/OS_NS_sys_stat.h>
-#include <ace/OS_NS_sys_time.h>
-#include <ace/OS_NS_time.h>
-#include <ace/OS_NS_unistd.h>
 #include <boost/process/environment.hpp>
 
 #include <geode/ExceptionTypes.hpp>

--- a/cppcache/src/MemberListForVersionStamp.hpp
+++ b/cppcache/src/MemberListForVersionStamp.hpp
@@ -23,8 +23,6 @@
 #include <memory>
 #include <unordered_map>
 
-#include <ace/RW_Thread_Mutex.h>
-
 #include <geode/internal/geode_globals.hpp>
 
 #include "DSMemberForVersionStamp.hpp"

--- a/cppcache/src/PdxType.hpp
+++ b/cppcache/src/PdxType.hpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include <ace/RW_Thread_Mutex.h>
+
 #include <geode/CacheableBuiltins.hpp>
 #include <geode/PdxFieldTypes.hpp>
 #include <geode/Serializable.hpp>

--- a/cppcache/src/PdxType.hpp
+++ b/cppcache/src/PdxType.hpp
@@ -25,8 +25,6 @@
 #include <string>
 #include <vector>
 
-#include <ace/RW_Thread_Mutex.h>
-
 #include <geode/CacheableBuiltins.hpp>
 #include <geode/PdxFieldTypes.hpp>
 #include <geode/Serializable.hpp>

--- a/cppcache/src/PdxTypeRegistry.hpp
+++ b/cppcache/src/PdxTypeRegistry.hpp
@@ -23,8 +23,6 @@
 #include <map>
 #include <unordered_map>
 
-#include <ace/RW_Thread_Mutex.h>
-
 #include <geode/Cache.hpp>
 #include <geode/PdxSerializable.hpp>
 #include <geode/internal/functional.hpp>

--- a/cppcache/src/PdxTypeRegistry.hpp
+++ b/cppcache/src/PdxTypeRegistry.hpp
@@ -23,6 +23,8 @@
 #include <map>
 #include <unordered_map>
 
+#include <ace/RW_Thread_Mutex.h>
+
 #include <geode/Cache.hpp>
 #include <geode/PdxSerializable.hpp>
 #include <geode/internal/functional.hpp>

--- a/cppcache/src/PoolFactory.cpp
+++ b/cppcache/src/PoolFactory.cpp
@@ -15,11 +15,8 @@
  * limitations under the License.
  */
 
-#include <ace/INET_Addr.h>
-
 #include <geode/Pool.hpp>
 #include <geode/PoolFactory.hpp>
-#include <geode/PoolManager.hpp>
 #include <geode/SystemProperties.hpp>
 
 #include "CacheImpl.hpp"

--- a/cppcache/src/PoolFactory.cpp
+++ b/cppcache/src/PoolFactory.cpp
@@ -15,8 +15,11 @@
  * limitations under the License.
  */
 
+#include <ace/INET_Addr.h>
+
 #include <geode/Pool.hpp>
 #include <geode/PoolFactory.hpp>
+#include <geode/PoolManager.hpp>
 #include <geode/SystemProperties.hpp>
 
 #include "CacheImpl.hpp"

--- a/cppcache/src/PreservedDataExpiryHandler.cpp
+++ b/cppcache/src/PreservedDataExpiryHandler.cpp
@@ -22,13 +22,6 @@
  */
 #include "PreservedDataExpiryHandler.hpp"
 
-#include <ace/Reactor.h>
-#include <ace/Timer_Heap.h>
-#include <ace/Timer_Heap_T.h>
-#include <ace/Timer_Queue.h>
-#include <ace/Timer_Queue_Adapters.h>
-#include <ace/svc_export.h>
-
 #include "PdxTypeRegistry.hpp"
 
 namespace apache {

--- a/cppcache/src/PreservedDataExpiryHandler.cpp
+++ b/cppcache/src/PreservedDataExpiryHandler.cpp
@@ -22,6 +22,13 @@
  */
 #include "PreservedDataExpiryHandler.hpp"
 
+#include <ace/Reactor.h>
+#include <ace/Timer_Heap.h>
+#include <ace/Timer_Heap_T.h>
+#include <ace/Timer_Queue.h>
+#include <ace/Timer_Queue_Adapters.h>
+#include <ace/svc_export.h>
+
 #include "PdxTypeRegistry.hpp"
 
 namespace apache {

--- a/cppcache/src/PutAllPartialResult.hpp
+++ b/cppcache/src/PutAllPartialResult.hpp
@@ -22,6 +22,9 @@
 
 #include <mutex>
 
+#include <ace/RW_Thread_Mutex.h>
+#include <ace/Task.h>
+
 #include <geode/CacheableString.hpp>
 #include <geode/Serializable.hpp>
 

--- a/cppcache/src/PutAllPartialResult.hpp
+++ b/cppcache/src/PutAllPartialResult.hpp
@@ -22,9 +22,6 @@
 
 #include <mutex>
 
-#include <ace/RW_Thread_Mutex.h>
-#include <ace/Task.h>
-
 #include <geode/CacheableString.hpp>
 #include <geode/Serializable.hpp>
 

--- a/cppcache/src/ReadWriteLock.cpp
+++ b/cppcache/src/ReadWriteLock.cpp
@@ -17,8 +17,6 @@
 
 #include "ReadWriteLock.hpp"
 
-#include <ace/Guard_T.h>
-
 namespace apache {
 namespace geode {
 namespace client {

--- a/cppcache/src/ReadWriteLock.cpp
+++ b/cppcache/src/ReadWriteLock.cpp
@@ -17,6 +17,8 @@
 
 #include "ReadWriteLock.hpp"
 
+#include <ace/Guard_T.h>
+
 namespace apache {
 namespace geode {
 namespace client {

--- a/cppcache/src/RegionExpiryHandler.cpp
+++ b/cppcache/src/RegionExpiryHandler.cpp
@@ -17,13 +17,6 @@
 
 #include "RegionExpiryHandler.hpp"
 
-#include <ace/Reactor.h>
-#include <ace/Timer_Heap.h>
-#include <ace/Timer_Heap_T.h>
-#include <ace/Timer_Queue.h>
-#include <ace/Timer_Queue_Adapters.h>
-#include <ace/svc_export.h>
-
 #include "CacheImpl.hpp"
 #include "ExpiryTaskManager.hpp"
 #include "RegionInternal.hpp"

--- a/cppcache/src/RegionExpiryHandler.cpp
+++ b/cppcache/src/RegionExpiryHandler.cpp
@@ -17,6 +17,13 @@
 
 #include "RegionExpiryHandler.hpp"
 
+#include <ace/Reactor.h>
+#include <ace/Timer_Heap.h>
+#include <ace/Timer_Heap_T.h>
+#include <ace/Timer_Queue.h>
+#include <ace/Timer_Queue_Adapters.h>
+#include <ace/svc_export.h>
+
 #include "CacheImpl.hpp"
 #include "ExpiryTaskManager.hpp"
 #include "RegionInternal.hpp"

--- a/cppcache/src/RegionExpiryHandler.hpp
+++ b/cppcache/src/RegionExpiryHandler.hpp
@@ -20,9 +20,6 @@
 #ifndef GEODE_REGIONEXPIRYHANDLER_H_
 #define GEODE_REGIONEXPIRYHANDLER_H_
 
-#include <ace/Event_Handler.h>
-#include <ace/Time_Value_T.h>
-
 #include <geode/ExpirationAction.hpp>
 #include <geode/Region.hpp>
 #include <geode/internal/geode_globals.hpp>

--- a/cppcache/src/RemoteQueryService.hpp
+++ b/cppcache/src/RemoteQueryService.hpp
@@ -23,6 +23,8 @@
 #include <memory>
 #include <string>
 
+#include <ace/RW_Thread_Mutex.h>
+
 #include <geode/QueryService.hpp>
 #include <geode/internal/geode_globals.hpp>
 

--- a/cppcache/src/RemoteQueryService.hpp
+++ b/cppcache/src/RemoteQueryService.hpp
@@ -23,8 +23,6 @@
 #include <memory>
 #include <string>
 
-#include <ace/RW_Thread_Mutex.h>
-
 #include <geode/QueryService.hpp>
 #include <geode/internal/geode_globals.hpp>
 

--- a/cppcache/src/SslSockStream.cpp
+++ b/cppcache/src/SslSockStream.cpp
@@ -17,6 +17,8 @@
 
 #include "SslSockStream.hpp"
 
+#include <ace/OS.h>
+
 #include <geode/ExceptionTypes.hpp>
 
 #include "util/Log.hpp"

--- a/cppcache/src/SslSockStream.cpp
+++ b/cppcache/src/SslSockStream.cpp
@@ -17,8 +17,6 @@
 
 #include "SslSockStream.hpp"
 
-#include <ace/OS.h>
-
 #include <geode/ExceptionTypes.hpp>
 
 #include "util/Log.hpp"

--- a/cppcache/src/SslSockStream.hpp
+++ b/cppcache/src/SslSockStream.hpp
@@ -20,6 +20,7 @@
  * limitations under the License.
  */
 
+#include <ace/ACE.h>
 #include <ace/DLL.h>
 #include <ace/INET_Addr.h>
 

--- a/cppcache/src/SslSockStream.hpp
+++ b/cppcache/src/SslSockStream.hpp
@@ -20,7 +20,6 @@
  * limitations under the License.
  */
 
-#include <ace/ACE.h>
 #include <ace/DLL.h>
 #include <ace/INET_Addr.h>
 

--- a/cppcache/src/SuspendedTxExpiryHandler.cpp
+++ b/cppcache/src/SuspendedTxExpiryHandler.cpp
@@ -16,6 +16,13 @@
  */
 #include "SuspendedTxExpiryHandler.hpp"
 
+#include <ace/Reactor.h>
+#include <ace/Timer_Heap.h>
+#include <ace/Timer_Heap_T.h>
+#include <ace/Timer_Queue.h>
+#include <ace/Timer_Queue_Adapters.h>
+#include <ace/svc_export.h>
+
 #include "CacheImpl.hpp"
 #include "ExpiryTaskManager.hpp"
 

--- a/cppcache/src/SuspendedTxExpiryHandler.cpp
+++ b/cppcache/src/SuspendedTxExpiryHandler.cpp
@@ -16,13 +16,6 @@
  */
 #include "SuspendedTxExpiryHandler.hpp"
 
-#include <ace/Reactor.h>
-#include <ace/Timer_Heap.h>
-#include <ace/Timer_Heap_T.h>
-#include <ace/Timer_Queue.h>
-#include <ace/Timer_Queue_Adapters.h>
-#include <ace/svc_export.h>
-
 #include "CacheImpl.hpp"
 #include "ExpiryTaskManager.hpp"
 

--- a/cppcache/src/TcpConn.cpp
+++ b/cppcache/src/TcpConn.cpp
@@ -21,18 +21,13 @@
 #include <memory>
 #include <thread>
 
-#include <ace/INET_Addr.h>
-#include <ace/OS.h>
 #include <ace/SOCK_Acceptor.h>
 #include <ace/SOCK_Connector.h>
-#include <ace/SOCK_IO.h>
 
-#include <geode/SystemProperties.hpp>
 #include <geode/internal/chrono/duration.hpp>
 
 #include "CacheImpl.hpp"
 #include "DistributedSystem.hpp"
-#include "config.h"
 #include "util/Log.hpp"
 
 namespace apache {

--- a/cppcache/src/TcpConn.cpp
+++ b/cppcache/src/TcpConn.cpp
@@ -21,13 +21,18 @@
 #include <memory>
 #include <thread>
 
+#include <ace/INET_Addr.h>
+#include <ace/OS.h>
 #include <ace/SOCK_Acceptor.h>
 #include <ace/SOCK_Connector.h>
+#include <ace/SOCK_IO.h>
 
+#include <geode/SystemProperties.hpp>
 #include <geode/internal/chrono/duration.hpp>
 
 #include "CacheImpl.hpp"
 #include "DistributedSystem.hpp"
+#include "config.h"
 #include "util/Log.hpp"
 
 namespace apache {

--- a/cppcache/src/TcpConn.hpp
+++ b/cppcache/src/TcpConn.hpp
@@ -20,7 +20,6 @@
 #ifndef GEODE_TCPCONN_H_
 #define GEODE_TCPCONN_H_
 
-#include <ace/OS.h>
 #include <ace/SOCK_Stream.h>
 #include <boost/interprocess/mapped_region.hpp>
 

--- a/cppcache/src/TcpConn.hpp
+++ b/cppcache/src/TcpConn.hpp
@@ -20,6 +20,7 @@
 #ifndef GEODE_TCPCONN_H_
 #define GEODE_TCPCONN_H_
 
+#include <ace/OS.h>
 #include <ace/SOCK_Stream.h>
 #include <boost/interprocess/mapped_region.hpp>
 

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -19,6 +19,9 @@
 
 #include <cinttypes>
 
+#include <ace/INET_Addr.h>
+#include <ace/OS.h>
+
 #include <geode/AuthInitialize.hpp>
 #include <geode/SystemProperties.hpp>
 

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -19,9 +19,6 @@
 
 #include <cinttypes>
 
-#include <ace/INET_Addr.h>
-#include <ace/OS.h>
-
 #include <geode/AuthInitialize.hpp>
 #include <geode/SystemProperties.hpp>
 

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -23,8 +23,6 @@
 #include <atomic>
 #include <chrono>
 
-#include <ace/Semaphore.h>
-
 #include <geode/CacheableBuiltins.hpp>
 #include <geode/ExceptionTypes.hpp>
 #include <geode/internal/geode_globals.hpp>

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -23,6 +23,8 @@
 #include <atomic>
 #include <chrono>
 
+#include <ace/Semaphore.h>
+
 #include <geode/CacheableBuiltins.hpp>
 #include <geode/ExceptionTypes.hpp>
 #include <geode/internal/geode_globals.hpp>

--- a/cppcache/src/TcrConnectionManager.cpp
+++ b/cppcache/src/TcrConnectionManager.cpp
@@ -21,6 +21,8 @@
 #include <set>
 #include <thread>
 
+#include <ace/INET_Addr.h>
+
 #include <geode/SystemProperties.hpp>
 
 #include "CacheImpl.hpp"

--- a/cppcache/src/TcrConnectionManager.cpp
+++ b/cppcache/src/TcrConnectionManager.cpp
@@ -21,8 +21,6 @@
 #include <set>
 #include <thread>
 
-#include <ace/INET_Addr.h>
-
 #include <geode/SystemProperties.hpp>
 
 #include "CacheImpl.hpp"

--- a/cppcache/src/TcrConnectionManager.hpp
+++ b/cppcache/src/TcrConnectionManager.hpp
@@ -26,9 +26,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <ace/Semaphore.h>
-#include <ace/config-lite.h>
-
 #include <geode/internal/geode_globals.hpp>
 
 #include "ExpiryTaskManager.hpp"

--- a/cppcache/src/TcrConnectionManager.hpp
+++ b/cppcache/src/TcrConnectionManager.hpp
@@ -26,6 +26,9 @@
 #include <unordered_map>
 #include <vector>
 
+#include <ace/Semaphore.h>
+#include <ace/config-lite.h>
+
 #include <geode/internal/geode_globals.hpp>
 
 #include "ExpiryTaskManager.hpp"

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -20,8 +20,6 @@
 #include <chrono>
 #include <thread>
 
-#include <ace/OS.h>
-
 #include <geode/AuthInitialize.hpp>
 #include <geode/SystemProperties.hpp>
 

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -20,6 +20,8 @@
 #include <chrono>
 #include <thread>
 
+#include <ace/OS.h>
+
 #include <geode/AuthInitialize.hpp>
 #include <geode/SystemProperties.hpp>
 

--- a/cppcache/src/TcrEndpoint.hpp
+++ b/cppcache/src/TcrEndpoint.hpp
@@ -27,8 +27,6 @@
 #include <string>
 #include <unordered_set>
 
-#include <ace/Semaphore.h>
-
 #include <geode/internal/geode_base.hpp>
 #include <geode/internal/geode_globals.hpp>
 

--- a/cppcache/src/TcrEndpoint.hpp
+++ b/cppcache/src/TcrEndpoint.hpp
@@ -27,6 +27,8 @@
 #include <string>
 #include <unordered_set>
 
+#include <ace/Semaphore.h>
+
 #include <geode/internal/geode_base.hpp>
 #include <geode/internal/geode_globals.hpp>
 

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -20,6 +20,8 @@
 #include <algorithm>
 #include <thread>
 
+#include <ace/INET_Addr.h>
+
 #include <geode/AuthInitialize.hpp>
 #include <geode/PoolManager.hpp>
 #include <geode/ResultCollector.hpp>

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -20,8 +20,6 @@
 #include <algorithm>
 #include <thread>
 
-#include <ace/INET_Addr.h>
-
 #include <geode/AuthInitialize.hpp>
 #include <geode/PoolManager.hpp>
 #include <geode/ResultCollector.hpp>

--- a/cppcache/src/ThinClientPoolDM.hpp
+++ b/cppcache/src/ThinClientPoolDM.hpp
@@ -28,8 +28,6 @@
 #include <vector>
 
 #include <ace/Condition_Recursive_Thread_Mutex.h>
-#include <ace/Recursive_Thread_Mutex.h>
-#include <ace/Semaphore.h>
 
 #include <geode/Pool.hpp>
 #include <geode/ResultCollector.hpp>

--- a/cppcache/src/ThinClientRedundancyManager.hpp
+++ b/cppcache/src/ThinClientRedundancyManager.hpp
@@ -28,6 +28,9 @@
 #include <set>
 #include <string>
 
+#include <ace/Semaphore.h>
+#include <ace/Time_Value.h>
+
 #include "ErrType.hpp"
 #include "EventIdMap.hpp"
 #include "ExpiryTaskManager.hpp"

--- a/cppcache/src/ThinClientRedundancyManager.hpp
+++ b/cppcache/src/ThinClientRedundancyManager.hpp
@@ -28,9 +28,6 @@
 #include <set>
 #include <string>
 
-#include <ace/Semaphore.h>
-#include <ace/Time_Value.h>
-
 #include "ErrType.hpp"
 #include "EventIdMap.hpp"
 #include "ExpiryTaskManager.hpp"

--- a/cppcache/src/ThinClientRegion.hpp
+++ b/cppcache/src/ThinClientRegion.hpp
@@ -23,6 +23,9 @@
 #include <mutex>
 #include <unordered_map>
 
+#include <ace/RW_Thread_Mutex.h>
+#include <ace/Task.h>
+
 #include <geode/ResultCollector.hpp>
 #include <geode/internal/functional.hpp>
 

--- a/cppcache/src/ThinClientRegion.hpp
+++ b/cppcache/src/ThinClientRegion.hpp
@@ -23,9 +23,6 @@
 #include <mutex>
 #include <unordered_map>
 
-#include <ace/RW_Thread_Mutex.h>
-#include <ace/Task.h>
-
 #include <geode/ResultCollector.hpp>
 #include <geode/internal/functional.hpp>
 

--- a/cppcache/src/TombstoneExpiryHandler.cpp
+++ b/cppcache/src/TombstoneExpiryHandler.cpp
@@ -17,13 +17,6 @@
 
 #include "TombstoneExpiryHandler.hpp"
 
-#include <ace/Reactor.h>
-#include <ace/Timer_Heap.h>
-#include <ace/Timer_Heap_T.h>
-#include <ace/Timer_Queue.h>
-#include <ace/Timer_Queue_Adapters.h>
-#include <ace/svc_export.h>
-
 #include "CacheImpl.hpp"
 #include "ExpiryTaskManager.hpp"
 #include "MapEntry.hpp"

--- a/cppcache/src/TombstoneExpiryHandler.cpp
+++ b/cppcache/src/TombstoneExpiryHandler.cpp
@@ -17,6 +17,13 @@
 
 #include "TombstoneExpiryHandler.hpp"
 
+#include <ace/Reactor.h>
+#include <ace/Timer_Heap.h>
+#include <ace/Timer_Heap_T.h>
+#include <ace/Timer_Queue.h>
+#include <ace/Timer_Queue_Adapters.h>
+#include <ace/svc_export.h>
+
 #include "CacheImpl.hpp"
 #include "ExpiryTaskManager.hpp"
 #include "MapEntry.hpp"


### PR DESCRIPTION
- Replace a call to ACE::hash_pjw with std::hash
- Remove all ACE includes in product code that aren't required to build

@mreddington @vfordpivotal @dihardman @davebarnes97 @karensmolermiller 