### PR TITLE
GEODE-7883: Add a test to verify native client handles unnamed pool…

### DIFF
--- a/cppcache/integration-test/resources/unnamed_pool.xml
+++ b/cppcache/integration-test/resources/unnamed_pool.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+
+<!-- Well-formed and valid xml file -->
+<client-cache
+    xmlns="http://geode.apache.org/schema/cpp-cache"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://geode.apache.org/schema/cpp-cache
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
+    version="1.0">
+
+  <pdx ignore-unread-fields="true" />
+  <region name = "test_region" >
+    <region-attributes caching-enabled="true" pool-name="test_pool" />
+  </region>
+  <pool>
+    <locator host="localhost" port="10334" />
+  </pool>
+
+</client-cache>

--- a/cppcache/integration/test/CacheXmlTest.cpp
+++ b/cppcache/integration/test/CacheXmlTest.cpp
@@ -36,6 +36,7 @@
 namespace {
 
 using apache::geode::client::Cache;
+using apache::geode::client::CacheXmlException;
 
 apache::geode::client::Cache createCacheUsingXmlConfig(
     const std::string& xmlFile) {
@@ -74,4 +75,20 @@ TEST(CacheXmlTest, loadCacheXmlWithBadSchema) {
   EXPECT_NO_THROW(createCacheUsingXmlConfig(cacheXml));
 }
 
+TEST(CacheXmlTest, loadCacheWithUnnamedPool) {
+  Cluster cluster{LocatorCount{1}, ServerCount{2}};
+  auto cacheXml =
+      std::string(getFrameworkString(FrameworkVariable::TestCacheXmlDir)) +
+      "/unnamed_pool.xml";
+
+  cluster.start();
+
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("PARTITION")
+      .execute();
+  EXPECT_THROW(createCacheUsingXmlConfig(cacheXml), CacheXmlException);
+}
 }  // namespace


### PR DESCRIPTION
…in cache XML.  Previously had a report that this would core dump in old versions.
- Added new test CacheXmlTest.loadCacheWithUnnamedPool to verify
- As expected, test passes.  XML file fails to load, and native client returns a CacheXmlException with text to the effect of "pool tag is missing name attribute"
