### PR TITLE
GEODE-7887: Remove reference to nonexistent API from docs

### DIFF
--- a/clicache/src/ISubscriptionService.hpp
+++ b/clicache/src/ISubscriptionService.hpp
@@ -42,8 +42,6 @@ namespace Apache
 
         /// <summary>
         /// Registers a collection of keys for getting updates from the server.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// </summary>
         /// <param name="keys">a collection of keys</param>
         /// <exception cref="IllegalArgumentException">
@@ -65,8 +63,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out
@@ -76,8 +73,6 @@ namespace Apache
 
         /// <summary>
         /// Registers a collection of keys for getting updates from the server.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// Should only be called for durable clients and with cache server version 5.5 onwards.
         /// </summary>
         /// <param name="keys">a collection of keys</param>
@@ -105,8 +100,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out
@@ -116,8 +110,6 @@ namespace Apache
 
         /// <summary>
         /// Registers a collection of keys for getting updates from the server.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// Should only be called for durable clients and with cache server version 5.5 onwards.
         /// </summary>
         /// <param name="keys">a collection of keys</param>
@@ -146,8 +138,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out
@@ -157,8 +148,6 @@ namespace Apache
 
         /// <summary>
         /// Unregisters a collection of keys to stop getting updates for them.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// </summary>
         /// <param name="keys">the collection of keys</param>
         /// <exception cref="IllegalArgumentException">
@@ -180,8 +169,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out
@@ -192,8 +180,6 @@ namespace Apache
         /// <summary>
         /// Register interest for all the keys of the region to get
         /// updates from the server.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// </summary>
         /// <exception cref="CacheServerException">
         /// If an exception is received from the Java cache server.
@@ -208,8 +194,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out
@@ -220,8 +205,6 @@ namespace Apache
         /// <summary>
         /// Register interest for all the keys of the region to get
         /// updates from the server.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// Should only be called for durable clients and with cache server version 5.5 onwards.
         /// </summary>
         /// <param name="isDurable">whether the registration should be durable</param>
@@ -238,8 +221,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out
@@ -250,8 +232,6 @@ namespace Apache
         /// <summary>
         /// Register interest for all the keys of the region to get
         /// updates from the server.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// Should only be called for durable clients and with cache server version 5.5 onwards.
         /// </summary>
         /// <param name="isDurable">whether the registration should be durable</param>
@@ -272,8 +252,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out
@@ -285,8 +264,6 @@ namespace Apache
         /// <summary>
         /// Register interest for all the keys of the region to get
         /// updates from the server.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// Should only be called for durable clients and with cache server version 5.5 onwards.
         /// </summary>
         /// <param name="isDurable">whether the registration should be durable</param>
@@ -308,8 +285,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out
@@ -332,8 +308,6 @@ namespace Apache
         /// <summary>
         /// Unregister interest for all the keys of the region to stop
         /// getting updates for them.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// </summary>
         /// <exception cref="IllegalStateException">
         /// If not previously registered all keys.
@@ -351,8 +325,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out
@@ -363,8 +336,6 @@ namespace Apache
         /// <summary>
         /// Register interest for the keys of the region that match the
         /// given regular expression to get updates from the server.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// </summary>
         /// <exception cref="IllegalArgumentException">
         /// If the regular expression string is empty.
@@ -387,8 +358,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out
@@ -399,8 +369,6 @@ namespace Apache
         /// <summary>
         /// Register interest for the keys of the region that match the
         /// given regular expression to get updates from the server.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// Should only be called for durable clients and with cache server version 5.5 onwards.
         /// </summary>
         /// <param name="regex">the regular expression to register</param>
@@ -426,8 +394,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out
@@ -438,8 +405,6 @@ namespace Apache
         /// <summary>
         /// Register interest for the keys of the region that match the
         /// given regular expression to get updates from the server.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// Should only be called for durable clients and with cache server version 5.5 onwards.
         /// </summary>
         /// <param name="regex">the regular expression to register</param>
@@ -469,8 +434,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out
@@ -481,8 +445,6 @@ namespace Apache
         /// <summary>
         /// Register interest for the keys of the region that match the
         /// given regular expression to get updates from the server.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// Should only be called for durable clients and with cache server version 5.5 onwards.
         /// </summary>
         /// <param name="regex">the regular expression to register</param>
@@ -513,8 +475,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out
@@ -528,8 +489,6 @@ namespace Apache
         /// given regular expression to stop getting updates for them.
         /// The regular expression must have been registered previously using
         /// a <c>RegisterRegex</c> call.
-        /// Valid only for a Native Client region when client notification
-        /// ( <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> ) is true.
         /// </summary>
         /// <exception cref="IllegalArgumentException">
         /// If the regular expression string is empty.
@@ -551,8 +510,7 @@ namespace Apache
         /// If region destroy is pending.
         /// </exception>
         /// <exception cref="UnsupportedOperationException">
-        /// If the region is not a Native Client region or
-        /// <see cref="RegionAttributesFactory.SetClientNotificationEnabled" /> is false.
+        /// If the region is not a Native Client region
         /// </exception>
         /// <exception cref="TimeoutException">
         /// if the operation timed out

--- a/cppcache/include/geode/Region.hpp
+++ b/cppcache/include/geode/Region.hpp
@@ -1103,8 +1103,6 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
 
   /**
    * Registers an array of keys for getting updates from the server.
-   * Valid only for a Native Client region when client notification
-   * ( {@link RegionAttributesFactory::setClientNotification} ) is true.
    *
    * @param keys the array of keys
    * @param isDurable flag to indicate whether this is a durable registration
@@ -1121,8 +1119,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    *   some other steps for the incomplete cache population then this is
    *   the exception that should be caught.
    * @throws UnsupportedOperationException If the region is not a Native Client
-   * region or
-   * {@link RegionAttributesFactory::setClientNotification} is false.
+   * region
    * @throws CacheServerException If an exception is received from the Java
    * cache server.
    * @throws NotConnectedException if it is not connected to the cache because
@@ -1143,16 +1140,13 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
 
   /**
    * Unregisters an array of keys to stop getting updates for them.
-   * Valid only for a Native Client region when client notification
-   * ( {@link RegionAttributesFactory::setClientNotification} ) is true.
    *
    * @param keys the array of keys
    *
    * @throws IllegalArgumentException If the array of keys is empty.
    * @throws IllegalStateException If no keys were previously registered.
    * @throws UnsupportedOperationException If the region is not a Native Client
-   * region or
-   * {@link RegionAttributesFactory::setClientNotification} is false.
+   * region
    * @throws CacheServerException If an exception is received from the Java
    * cache server.
    * @throws NotConnectedException if it is not connected to the cache because
@@ -1171,8 +1165,6 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
 
   /**
    * Registers to get updates for all keys from the server.
-   * Valid only for a Native Client region when client notification
-   * ( {@link RegionAttributesFactory::setClientNotification} ) is true.
    *
    * @param isDurable flag to indicate whether this is a durable registration
    * @param getInitialValues true to populate the cache with values of all keys
@@ -1186,8 +1178,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    *   some other steps for the incomplete cache population then this is
    *   the exception that should be caught.
    * @throws UnsupportedOperationException If the region is not a Native Client
-   * region or
-   * {@link RegionAttributesFactory::setClientNotification} is false.
+   * region
    * @throws CacheServerException If an exception is received from the Java
    * cache server.
    * @throws NotConnectedException if it is not connected to the cache because
@@ -1207,13 +1198,10 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
 
   /**
    * Registers to get updates for all keys from the server.
-   * Valid only for a Native Client region when client notification
-   * ( {@link RegionAttributesFactory::setClientNotification} ) is true.
    *
    * @throws IllegalStateException If not previously registered all keys.
    * @throws UnsupportedOperationException If the region is not a Native Client
-   * region or
-   * {@link RegionAttributesFactory::setClientNotification} is false.
+   * region
    * @throws CacheServerException If an exception is received from the Java
    * cache server.
    * @throws NotConnectedException if it is not connected to the cache because
@@ -1232,8 +1220,6 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
   /**
    * Registers a regular expression to match with keys to get updates from the
    * server.
-   * Valid only for a Native Client region when client notification
-   * ( {@link RegionAttributesFactory::setClientNotification} ) is true.
    *
    * @param regex The regular expression string.
    * @param isDurable flag to indicate whether this is a durable registration
@@ -1253,8 +1239,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    *   some other steps for the incomplete cache population then this is
    *   the exception that should be caught.
    * @throws UnsupportedOperationException If the region is not a Native Client
-   * region or
-   * {@link RegionAttributesFactory::setClientNotification} is false.
+   * region
    * @throws CacheServerException If an exception is received from the Java
    * cache server.
    * @throws NotConnectedException if it is not connected to the cache because
@@ -1279,8 +1264,6 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
   /**
    * Unregisters a regular expression to stop getting updates for keys from the
    * server.
-   * Valid only for a Native Client region when client notification
-   * ( {@link RegionAttributesFactory::setClientNotification} ) is true.
    *
    * @param regex The regular expression string.
    *
@@ -1288,8 +1271,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    * @throws IllegalStateException If not previously registered this regular
    * expression string.
    * @throws UnsupportedOperationException If the region is not a Native Client
-   * region or
-   * {@link RegionAttributesFactory::setClientNotification} is false.
+   * region
    * @throws CacheServerException If an exception is received from the Java
    * cache server.
    * @throws NotConnectedException if it is not connected to the cache because


### PR DESCRIPTION
- setClientNotificationEnabled is a protected method on an internal class, not part of the public API

@mreddington @vfordpivotal @dihardman @davebarnes97 @karensmolermiller 