### PR TITLE
GEODE-7930: Fix endpoint name truncation bug

### DIFF
--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -1966,11 +1966,8 @@ GfErrType ThinClientPoolDM::sendRequestToEP(const TcrMessage& request,
 }
 
 TcrEndpoint* ThinClientPoolDM::addEP(ServerLocation& serverLoc) {
-  std::string serverName = serverLoc.getServerName();
-  int port = serverLoc.getPort();
-  char endpointName[100];
-  std::snprintf(endpointName, 100, "%s:%d", serverName.c_str(), port);
-
+  std::string endpointName = serverLoc.getServerName() + ":"
+                             + std::to_string(serverLoc.getPort());
   return addEP(endpointName);
 }
 
@@ -1982,7 +1979,7 @@ TcrEndpoint* ThinClientPoolDM::addEP(const std::string& endpointName) {
     LOGFINE("Created new endpoint %s for pool %s", endpointName.c_str(),
             m_poolName.c_str());
     ep = createEP(endpointName.c_str());
-    if (m_endpoints.emplace(endpointName, ep).second) {
+    if (!m_endpoints.emplace(endpointName, ep).second) {
       LOGERROR("Failed to add endpoint %s to pool %s", endpointName.c_str(),
                m_poolName.c_str());
     }

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -1966,8 +1966,8 @@ GfErrType ThinClientPoolDM::sendRequestToEP(const TcrMessage& request,
 }
 
 TcrEndpoint* ThinClientPoolDM::addEP(ServerLocation& serverLoc) {
-  std::string endpointName = serverLoc.getServerName() + ":"
-                             + std::to_string(serverLoc.getPort());
+  const auto endpointName =
+      serverLoc.getServerName() + ":" + std::to_string(serverLoc.getPort());
   return addEP(endpointName);
 }
 


### PR DESCRIPTION
  - Removed truncation of endpoint when exceedes 99 chars
  - Also, fixed wrong logging of error when endpoint is successfully
    added to the pool

Related to solution, I haven't found any limitation checks e.g. if host name exceeds full domain maximum length (see JIRA for more info) in cases that work on native client (e.g. subscription is "disabled"), so I didn't put any restrictions of that kind in addEP function.

Related to integration test, I think that it would be hard to create generic tests to verify maximum supported length of host name name (see JIRA for more info), since host name depends on environment where the tests are executed. I only tested this manually.