### PR TITLE
GEODE-8053: Fixes lingering StatsManager after Cache close.

### DIFF
--- a/cppcache/src/CacheImpl.cpp
+++ b/cppcache/src/CacheImpl.cpp
@@ -305,6 +305,10 @@ void CacheImpl::close(bool keepalive) {
     _GEODE_SAFE_DELETE(m_cacheStats);
   }
 
+  if (m_statisticsManager) {
+    m_statisticsManager = nullptr;
+  }
+
   m_regions.clear();
   LOGDEBUG("CacheImpl::close( ): destroyed regions.");
 


### PR DESCRIPTION
While this was likely not a problem in C++ it was a big problem in .NET due to
the reliance on GC to destruct native objects. The StatsManager didn't stop
until it was destructed. This in turn stops the HostStatSampler. In .NET this
leaves the stats system trying to run on a closed but not destructed Cache
instance.