### PR TITLE
GEODE-8063: Fixes access violation.

### DIFF
--- a/cppcache/include/geode/Cache.hpp
+++ b/cppcache/include/geode/Cache.hpp
@@ -257,8 +257,6 @@ class APACHE_GEODE_EXPORT Cache : public GeodeCache {
   std::unique_ptr<CacheImpl> m_cacheImpl;
 
  protected:
-  static bool isPoolInMultiuserMode(std::shared_ptr<Region> regionPtr);
-
   friend class CacheFactory;
   friend class CacheRegionHelper;
   friend class FunctionService;

--- a/cppcache/src/Cache.cpp
+++ b/cppcache/src/Cache.cpp
@@ -136,10 +136,6 @@ void Cache::initializeDeclarativeCache(const std::string& cacheXml) {
 
 void Cache::readyForEvents() { m_cacheImpl->readyForEvents(); }
 
-bool Cache::isPoolInMultiuserMode(std::shared_ptr<Region> regionPtr) {
-  return CacheImpl::isPoolInMultiuserMode(regionPtr);
-}
-
 bool Cache::getPdxIgnoreUnreadFields() const {
   return m_cacheImpl->getPdxIgnoreUnreadFields();
 }

--- a/cppcache/src/CacheImpl.cpp
+++ b/cppcache/src/CacheImpl.cpp
@@ -494,7 +494,7 @@ std::shared_ptr<Region> CacheImpl::getRegion(const std::string& path) {
     }
   }
 
-  if (region && isPoolInMultiuserMode(region)) {
+  if (region && isPoolInMultiuserMode(*region)) {
     LOGWARN("Pool " + region->getAttributes().getPoolName() +
             " attached with region " + region->getFullPath() +
             " is in multiuser authentication mode. Operations may fail as "
@@ -640,13 +640,13 @@ void CacheImpl::readyForEvents() {
   }
 }
 
-bool CacheImpl::isPoolInMultiuserMode(std::shared_ptr<Region> regionPtr) {
-  const auto& poolName = regionPtr->getAttributes().getPoolName();
+bool CacheImpl::isPoolInMultiuserMode(const Region& region) const {
+  const auto& poolName = region.getAttributes().getPoolName();
 
   if (!poolName.empty()) {
-    auto poolPtr = regionPtr->getCache().getPoolManager().find(poolName);
-    if (poolPtr != nullptr && !poolPtr->isDestroyed()) {
-      return poolPtr->getMultiuserAuthentication();
+    auto pool = m_poolManager->find(poolName);
+    if (pool && !pool->isDestroyed()) {
+      return pool->getMultiuserAuthentication();
     }
   }
 

--- a/cppcache/src/CacheImpl.hpp
+++ b/cppcache/src/CacheImpl.hpp
@@ -241,7 +241,7 @@ class APACHE_GEODE_EXPORT CacheImpl {
    */
   void readyForEvents();
 
-  static bool isPoolInMultiuserMode(std::shared_ptr<Region> regionPtr);
+  bool isPoolInMultiuserMode(const Region& region) const;
 
   //  TESTING: Durable clients. Not thread safe.
   bool getEndpointStatus(const std::string& endpoint);


### PR DESCRIPTION
The external Cache pointer is not valid when destruction has started. Use
internal CacheImpl from RegionInternal.