### PR TITLE
GEODE-6641: Add ClientTransactionXATest to run

### DIFF
--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -15,7 +15,10 @@
 
 add_executable(cpp-integration-test
   AuthInitializeTest.cpp
+  BasicIPv6Test.cpp
   CacheXmlTest.cpp
+  CleanIdleConnections.cpp
+  ClientTransactionXATest.cpp
   CommitConflictExceptionTest.cpp
   CqPlusAuthInitializeTest.cpp
   CqTest.cpp
@@ -39,8 +42,6 @@ add_executable(cpp-integration-test
   SslTwoWayTest.cpp
   StructTest.cpp
   TransactionCleaningTest.cpp
-  CleanIdleConnections.cpp
-  BasicIPv6Test.cpp
 )
 
 target_compile_definitions(cpp-integration-test

--- a/cppcache/integration/test/ClientTransactionXATest.cpp
+++ b/cppcache/integration/test/ClientTransactionXATest.cpp
@@ -15,9 +15,6 @@
  * limitations under the License.
  */
 
-#include <gmock/gmock.h>
-
-#include <future>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -44,6 +41,9 @@ std::shared_ptr<apache::geode::client::Region> setupRegion(
 
 TEST(ClientTransactionXATest, interTxand2PCTx) {
   Cluster cluster{LocatorCount{1}, ServerCount{1}};
+
+  cluster.start();
+
   cluster.getGfsh()
       .create()
       .region()


### PR DESCRIPTION
- sort integration tests in CMakeLists

#486 Added this test, but since it was never added to CMakeLists it didn't run in the integration tests.  I sorted the CMakeLists entries in hopes that it'll be easier to see missing tests.  I only ran this test on Kubuntu 20.04 since my Windows build has been failing for awhile building with VS2019 (some sort of ACE building error).  Also it was missing `cluster.start()` so the test wasn't initially working.