### PR TITLE
GEODE-8183: Update dockerfile versions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,10 @@
 # limitations under the License.
 
 FROM ubuntu
-LABEL maintainer Apache Geode <dev@geode.apache.org>
+LABEL maintainer="Apache Geode <dev@geode.apache.org>"
 
 ENV CLANG_VERSION 6.0
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
         apt-get install -y \
             libc++-dev \
@@ -41,7 +42,7 @@ RUN apt-get update && \
         update-alternatives --install /usr/bin/clang-tidy    clang-tidy    /usr/bin/clang-tidy-${CLANG_VERSION} 999 && \
         update-alternatives --install /usr/bin/clang-format  clang-format  /usr/bin/clang-format-${CLANG_VERSION} 999
 
-ENV GEODE_VERSION 1.9.0
+ENV GEODE_VERSION 1.12.0
 RUN wget "https://www.apache.org/dyn/closer.cgi?action=download&filename=geode/${GEODE_VERSION}/apache-geode-${GEODE_VERSION}.tgz" --quiet -O - | \
         tar xzf -
 
@@ -49,7 +50,7 @@ ENV RAT_VERSION 0.13
 RUN wget "https://www.apache.org/dyn/closer.cgi?action=download&filename=creadur/apache-rat-${RAT_VERSION}/apache-rat-${RAT_VERSION}-bin.tar.gz" --quiet -O - | \
         tar xzf -
 
-ENV CMAKE_VERSION 3.12.2
+ENV CMAKE_VERSION 3.12.4
 RUN wget "https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh" --quiet -O /tmp/cmake && \
         bash /tmp/cmake --skip-license --prefix=/usr/local && \
         rm -rf /tmp/cmake


### PR DESCRIPTION
- Geode from 1.9 to 1.12
- CMake from 3.12.2 to 3.12.4
- Set to noninteractive so that building doesn't require interaction
- Make key=value for LABEL clearer

I'm not really sure how the Travis dockerfile has stayed up to date.  I'm assuming it is part of the release process to update it, but changes never get ported here since this was trying to install 1.9 which you can't download anymore.