### PR TITLE
GEODE-8181: Fixes default value for statistic-sampling-enabled.

### DIFF
--- a/clicache/integration-test/ExpirationTestsN.cs
+++ b/clicache/integration-test/ExpirationTestsN.cs
@@ -51,6 +51,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       base.InitTests();
       Properties<string, string> config = new Properties<string, string>();
+      config.Insert("statistic-sampling-enabled", "true");
       CacheHelper.InitConfig(config);
     }
 

--- a/cppcache/include/geode/SystemProperties.hpp
+++ b/cppcache/include/geode/SystemProperties.hpp
@@ -88,10 +88,7 @@ class APACHE_GEODE_EXPORT SystemProperties {
   /**
    * Whether time stats are enabled for the statistics.
    */
-  bool getEnableTimeStatistics() const /*timestatisticsEnabled()*/
-  {
-    return m_timestatisticsEnabled;
-  } /*m_timestatisticsEnabled*/
+  bool getEnableTimeStatistics() const { return m_timestatisticsEnabled; }
 
   /**
    * Returns the path of the private key file for SSL use.

--- a/cppcache/integration-test/resources/system.properties
+++ b/cppcache/integration-test/resources/system.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 # All the configurable parameters.
 statistic-sample-rate=700s
-statistic-sampling-enabled=false
+statistic-sampling-enabled=true
 statistic-archive-file=stats.gfs
 log-file=geode-native.log
 #log-level=debug

--- a/cppcache/integration-test/testExpiration.cpp
+++ b/cppcache/integration-test/testExpiration.cpp
@@ -47,6 +47,7 @@ size_t getNumOfEntries(std::shared_ptr<Region> &R1) {
 void startDSandCreateCache(std::shared_ptr<Cache> &cache) {
   auto pp = Properties::create();
   auto cacheFactory = CacheFactory(pp);
+  cacheFactory.set("statistic-sampling-enabled", "true");
   cache = std::make_shared<Cache>(cacheFactory.create());
   ASSERT(cache != nullptr, "cache not equal to null expected");
 }
@@ -108,6 +109,9 @@ BEGIN_TEST(TEST_EXPIRATION)
     startDSandCreateCache(cache);
 
     ASSERT(cache != nullptr, "Expected cache to be NON-nullptr");
+
+    ASSERT(cache->getSystemProperties().statisticsEnabled(),
+           "Statistics must be enabled for expiration.");
 
     auto cacheImpl = CacheRegionHelper::getCacheImpl(cache.get());
 

--- a/cppcache/integration-test/testSystemProperties.cpp
+++ b/cppcache/integration-test/testSystemProperties.cpp
@@ -51,7 +51,7 @@ BEGIN_TEST(DEFAULT)
     ASSERT(
         systemProperties->statisticsSampleInterval() == std::chrono::seconds(1),
         "expected 1");
-    ASSERT(systemProperties->statisticsEnabled() == true, "expected true");
+    ASSERT(systemProperties->statisticsEnabled() == false, "expected false");
     LOG(systemProperties->statisticsArchiveFile());
     auto &&statisticsArchiveFileName =
         systemProperties->statisticsArchiveFile();
@@ -80,7 +80,7 @@ BEGIN_TEST(NEW_CONFIG)
                std::chrono::seconds(700),
            "expected 700");
 
-    ASSERT(systemProperties->statisticsEnabled() == false, "expected false");
+    ASSERT(systemProperties->statisticsEnabled() == true, "expected true");
 
     ASSERT(systemProperties->threadPoolSize() == 96,
            "max-fe-thread should be 96");

--- a/cppcache/src/LocalRegion.cpp
+++ b/cppcache/src/LocalRegion.cpp
@@ -128,10 +128,10 @@ void LocalRegion::updateAccessAndModifiedTime(bool modified) {
 }
 std::shared_ptr<CacheStatistics> LocalRegion::getStatistics() const {
   CHECK_DESTROY_PENDING(TryReadGuard, LocalRegion::getStatistics);
-  bool m_statisticsEnabled = true;
-  auto& props = m_cacheImpl->getDistributedSystem().getSystemProperties();
-  m_statisticsEnabled = props.statisticsEnabled();
-  if (!m_statisticsEnabled) {
+
+  if (!m_cacheImpl->getDistributedSystem()
+           .getSystemProperties()
+           .statisticsEnabled()) {
     throw StatisticsDisabledException(
         "LocalRegion::getStatistics statistics disabled for this region");
   }

--- a/cppcache/src/SystemProperties.cpp
+++ b/cppcache/src/SystemProperties.cpp
@@ -88,7 +88,7 @@ constexpr auto DefaultConnectWaitTimeout = std::chrono::seconds::zero();
 constexpr auto DefaultBucketWaitTimeout = std::chrono::seconds::zero();
 
 constexpr auto DefaultSamplingInterval = std::chrono::seconds(1);
-const bool DefaultSamplingEnabled = true;
+constexpr bool DefaultSamplingEnabled = false;
 
 const char DefaultStatArchive[] = "statArchive.gfs";
 const char DefaultLogFilename[] = "";  // stdout...

--- a/defaultSystem/geode.properties
+++ b/defaultSystem/geode.properties
@@ -39,7 +39,7 @@
 #
 # the rate is in seconds.
 #statistic-sample-rate=1
-#statistic-sampling-enabled=true
+#statistic-sampling-enabled=false
 #statistic-archive-file=statArchive.gfs
 # zero indicates use no limit.
 #archive-file-size-limit=0

--- a/docs/geode-native-docs-cpp/configuring/sysprops.html.md.erb
+++ b/docs/geode-native-docs-cpp/configuring/sysprops.html.md.erb
@@ -186,7 +186,7 @@ When the chunk handler is not operative (enable-chunk-handler=false), each appli
 <tr class="odd">
 <td>statistic-sampling-enabled</td>
 <td>Controls whether the process creates a statistic archive file.</td>
-<td>true</td>
+<td>false</td>
 </tr>
 <tr class="even">
 <td>statistic-archive-file</td>


### PR DESCRIPTION
GEODE-8181: Fixes default value for statistic-sampling-enabled.