### PR TITLE
GEODE-8207: Enfore No Unknown Pragmas as Error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,6 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   target_compile_options(_WarningsAsError INTERFACE
     -Werror
     -Wall
-    -Wno-unknown-pragmas #TODO fix
     -Wno-unused-variable #TODO fix
     -Wpedantic
     # -Wshadow TODO fix
@@ -241,7 +240,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Werror
     -Wall
     -Wextra
-    -Wno-unknown-pragmas #TODO fix
     -Wno-unused-variable #TODO fix
     -Wno-unused-function #TODO fix
     -Wno-used-but-marked-unused #TODO fix

--- a/cppcache/integration/framework/GfshExecute.h
+++ b/cppcache/integration/framework/GfshExecute.h
@@ -26,12 +26,15 @@
 #include <string>
 
 #include <geode/Exception.hpp>
-
+#ifdef _SOLARIS
 #pragma error_messages(off, oklambdaretmulti, wvarhidemem, \
                        w_constexprnonlitret, explctspectypename)
+#endif
 #include <boost/process.hpp>
+#ifdef _SOLARIS
 #pragma error_messages(on, oklambdaretmulti, wvarhidemem, \
                        w_constexprnonlitret, explctspectypename)
+#endif
 
 #include "Gfsh.h"
 #include "TestConfig.h"

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -42,7 +42,9 @@
 #include "util/JavaModifiedUtf8.hpp"
 #include "util/string.hpp"
 
+#ifdef _SOLARIS
 #pragma error_messages(off, SEC_UNINITIALIZED_MEM_READ)
+#endif
 
 namespace apache {
 namespace geode {
@@ -3322,7 +3324,9 @@ TcrMessageHelper::ChunkObjectType TcrMessageHelper::readChunkPartHeader(
   return ChunkObjectType::OBJECT;
 }
 
+#ifdef _SOLARIS
 #pragma error_messages(default, SEC_UNINITIALIZED_MEM_READ)
+#endif
 
 }  // namespace client
 }  // namespace geode

--- a/cryptoimpl/SSLImpl.hpp
+++ b/cryptoimpl/SSLImpl.hpp
@@ -20,12 +20,17 @@
 #ifndef GEODE_CRYPTOIMPL_SSLIMPL_H_
 #define GEODE_CRYPTOIMPL_SSLIMPL_H_
 
+#ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable : 4311)
 #pragma warning(disable : 4302)
+#endif
+
 #pragma pack(push)
 
+#ifdef _WIN32
 #pragma error_messages(off, macroredef)
+#endif
 
 #include <ace/INET_Addr.h>
 #include <ace/OS.h>
@@ -35,7 +40,9 @@
 #include <ace/SSL/SSL_SOCK_Connector.h>
 #include <ace/Time_Value.h>
 
+#ifdef _WIN32
 #pragma error_messages(on, macroredef)
+#endif
 
 #pragma pack(pop)
 


### PR DESCRIPTION
I just used `__sun` and `_MSC_VER` as the check.  Worked for Windows, Mac, and Kubuntu 20.04.  Don't have a Sun based setup to test that one.  I checked the box for "Allow edits by maintainers" so just push up anything you might discover.