### PR TITLE
GEODE-8307: Enforce No Shadow Field in Constructor as Error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Wno-header-hygiene #TODO fix
     -Wno-shorten-64-to-32 #TODO fix
     -Wno-conversion #TODO fix
-    -Wno-shadow-field-in-constructor #TODO fix
     -Wno-missing-variable-declarations #TODO fix
     -Wno-switch-enum #TODO fix
     -Wno-reserved-id-macro #TODO fix

--- a/cppcache/src/ClientProxyMembershipIDFactory.cpp
+++ b/cppcache/src/ClientProxyMembershipIDFactory.cpp
@@ -32,7 +32,7 @@ namespace client {
 
 ClientProxyMembershipIDFactory::ClientProxyMembershipIDFactory(
     std::string dsName)
-    : dsName(std::move(dsName)) {
+    : dsName_(std::move(dsName)) {
   static const auto alphabet =
       "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
   static const auto numChars = (sizeof(alphabet) / sizeof(char)) - 2;
@@ -41,16 +41,16 @@ ClientProxyMembershipIDFactory::ClientProxyMembershipIDFactory(
   std::default_random_engine rng(rd());
   std::uniform_int_distribution<> dist(0, numChars);
 
-  randString.reserve(7 + 10 + 15);
-  randString.append("Native_");
-  std::generate_n(std::back_inserter(randString), 10,
+  randString_.reserve(7 + 10 + 15);
+  randString_.append("Native_");
+  std::generate_n(std::back_inserter(randString_), 10,
                   [&]() { return alphabet[dist(rng)]; });
 
   auto pid = boost::this_process::get_id();
-  randString.append(std::to_string(pid));
+  randString_.append(std::to_string(pid));
 
   LOGINFO("Using %s as random data for ClientProxyMembershipID",
-          randString.c_str());
+          randString_.c_str());
 }
 
 std::unique_ptr<ClientProxyMembershipID> ClientProxyMembershipIDFactory::create(
@@ -59,7 +59,7 @@ std::unique_ptr<ClientProxyMembershipID> ClientProxyMembershipIDFactory::create(
   const auto hostname = boost::asio::ip::host_name();
   const ACE_INET_Addr address("", hostname.c_str(), "tcp");
   return std::unique_ptr<ClientProxyMembershipID>(
-      new ClientProxyMembershipID(dsName, randString, hostname, address, 0,
+      new ClientProxyMembershipID(dsName_, randString_, hostname, address, 0,
                                   durableClientId, durableClntTimeOut));
 }
 

--- a/cppcache/src/ClientProxyMembershipIDFactory.hpp
+++ b/cppcache/src/ClientProxyMembershipIDFactory.hpp
@@ -38,8 +38,8 @@ class ClientProxyMembershipIDFactory {
           std::chrono::seconds::zero());
 
  private:
-  std::string dsName;
-  std::string randString;
+  std::string dsName_;
+  std::string randString_;
 };
 
 }  // namespace client

--- a/cppcache/src/PdxTypeRegistry.hpp
+++ b/cppcache/src/PdxTypeRegistry.hpp
@@ -54,30 +54,30 @@ typedef std::unordered_map<std::shared_ptr<PdxType>, int32_t,
 class APACHE_GEODE_EXPORT PdxTypeRegistry
     : public std::enable_shared_from_this<PdxTypeRegistry> {
  private:
-  CacheImpl* cache;
+  CacheImpl* cache_;
 
-  TypeIdVsPdxType typeIdToPdxType;
+  TypeIdVsPdxType typeIdToPdxType_;
 
-  TypeIdVsPdxType remoteTypeIdToMergedPdxType;
+  TypeIdVsPdxType remoteTypeIdToMergedPdxType_;
 
-  TypeNameVsPdxType localTypeToPdxType;
+  TypeNameVsPdxType localTypeToPdxType_;
 
-  PdxTypeToTypeIdMap pdxTypeToTypeIdMap;
+  PdxTypeToTypeIdMap pdxTypeToTypeIdMap_;
 
   // TODO:: preserveData need to be of type WeakHashMap
-  PreservedHashMap preserveData;
+  PreservedHashMap preserveData_;
 
-  mutable ACE_RW_Thread_Mutex g_readerWriterLock;
+  mutable ACE_RW_Thread_Mutex g_readerWriterLock_;
 
-  mutable ACE_RW_Thread_Mutex g_preservedDataLock;
+  mutable ACE_RW_Thread_Mutex g_preservedDataLock_;
 
-  bool pdxIgnoreUnreadFields;
+  bool pdxIgnoreUnreadFields_;
 
-  bool pdxReadSerialized;
+  bool pdxReadSerialized_;
 
-  std::shared_ptr<CacheableHashMap> enumToInt;
+  std::shared_ptr<CacheableHashMap> enumToInt_;
 
-  std::shared_ptr<CacheableHashMap> intToEnum;
+  std::shared_ptr<CacheableHashMap> intToEnum_;
 
  public:
   explicit PdxTypeRegistry(CacheImpl* cache);
@@ -114,16 +114,16 @@ class APACHE_GEODE_EXPORT PdxTypeRegistry
   int32_t getPDXIdForType(const std::string& type, Pool* pool,
                           std::shared_ptr<PdxType> nType, bool checkIfThere);
 
-  bool getPdxIgnoreUnreadFields() const { return pdxIgnoreUnreadFields; }
+  bool getPdxIgnoreUnreadFields() const { return pdxIgnoreUnreadFields_; }
 
-  void setPdxIgnoreUnreadFields(bool value) { pdxIgnoreUnreadFields = value; }
+  void setPdxIgnoreUnreadFields(bool value) { pdxIgnoreUnreadFields_ = value; }
 
-  void setPdxReadSerialized(bool value) { pdxReadSerialized = value; }
+  void setPdxReadSerialized(bool value) { pdxReadSerialized_ = value; }
 
-  bool getPdxReadSerialized() const { return pdxReadSerialized; }
+  bool getPdxReadSerialized() const { return pdxReadSerialized_; }
 
   inline const PreservedHashMap& getPreserveDataMap() const {
-    return preserveData;
+    return preserveData_;
   }
 
   int32_t getEnumValue(std::shared_ptr<EnumInfo> ei);
@@ -133,7 +133,7 @@ class APACHE_GEODE_EXPORT PdxTypeRegistry
   int32_t getPDXIdForType(std::shared_ptr<PdxType> nType, Pool* pool);
 
   ACE_RW_Thread_Mutex& getPreservedDataLock() const {
-    return g_preservedDataLock;
+    return g_preservedDataLock_;
   }
 };
 

--- a/cppcache/src/statistics/StatArchiveWriter.hpp
+++ b/cppcache/src/statistics/StatArchiveWriter.hpp
@@ -179,18 +179,17 @@ class APACHE_GEODE_EXPORT ResourceInst {
 class HostStatSampler;
 
 class APACHE_GEODE_EXPORT StatArchiveWriter {
-  HostStatSampler *sampler;
-  StatDataOutput *dataBuffer;
-  CacheImpl *cache;
-  steady_clock::time_point previousTimeStamp;
-  int32_t resourceTypeId;
-  int32_t resourceInstId;
-  int32_t statResourcesModCount;
-  size_t bytesWrittenToFile;
-  size_t m_samplesize;
-  std::string archiveFile;
-  std::map<Statistics *, std::shared_ptr<ResourceInst>> resourceInstMap;
-  std::map<const StatisticsType *, const ResourceType *> resourceTypeMap;
+  HostStatSampler *sampler_;
+  StatDataOutput *dataBuffer_;
+  CacheImpl *cache_;
+  steady_clock::time_point previousTimeStamp_;
+  int32_t resourceTypeId_;
+  int32_t resourceInstId_;
+  size_t bytesWrittenToFile_;
+  size_t sampleSize_;
+  std::string archiveFile_;
+  std::map<Statistics *, std::shared_ptr<ResourceInst>> resourceInstMap_;
+  std::map<const StatisticsType *, const ResourceType *> resourceTypeMap_;
 
   void allocateResourceInst(Statistics *r);
   void sampleResources();

--- a/cppcache/test/ConnectionQueueTest.cpp
+++ b/cppcache/test/ConnectionQueueTest.cpp
@@ -44,16 +44,16 @@ struct TestObjectState {
 
 class TestObject {
  private:
-  TestObjectState* const state;
+  TestObjectState* const state_;
 
  public:
-  TestObject() : state(nullptr) {}
-  explicit TestObject(TestObjectState* state) : state(state) {}
+  TestObject() : state_(nullptr) {}
+  explicit TestObject(TestObjectState* state) : state_(state) {}
   ~TestObject() {
-    if (state) state->destructed = true;
+    if (state_) state_->destructed = true;
   }
   void close() {
-    if (state) state->closed = true;
+    if (state_) state_->closed = true;
   }
 };
 


### PR DESCRIPTION
Authored-by: M. Oleske <michael@oleske.engineer>

Seemed since we merged they enforce no shadow declarations might as well finish off the rest of shadow fields.  Also switched to `_` convention per style guide for member variables for files that needed fixed anyway