### PR TITLE
GEODE-8344: Add GatewaySenderEventCallbackArgument class

### DIFF
--- a/cppcache/integration/framework/Cluster.cpp
+++ b/cppcache/integration/framework/Cluster.cpp
@@ -39,6 +39,26 @@ Locator::Locator(Cluster &cluster, std::vector<Locator> &locators,
   locatorAddress_ = LocatorAddress{hostname, port};
 }
 
+Locator::Locator(Cluster &cluster, std::vector<Locator> &locators,
+                 std::string name, uint16_t jmxManagerPort, bool useIPv6,
+                 uint16_t port, std::vector<uint16_t> &remotePorts,
+                 uint16_t distributedSystemId)
+    : cluster_(cluster),
+      name_(std::move(name)),
+      locators_(locators),
+      jmxManagerPort_(jmxManagerPort),
+      distributedSystemId_(distributedSystemId){
+  auto hostname = "localhost";
+  if (useIPv6) {
+    hostname = "ip6-localhost";
+  }
+  locatorAddress_ = LocatorAddress{hostname, port};
+
+  for (uint16_t remotePort : remotePorts){
+    remoteLocatorsPorts_.push_back(remotePort);
+  }
+}
+
 Locator::~Locator() {
   try {
     if (started_) {
@@ -53,8 +73,10 @@ Locator::Locator(Locator &&move)
       name_(move.name_),
       locators_(move.locators_),
       locatorAddress_(move.locatorAddress_),
+      remoteLocatorsPorts_(move.remoteLocatorsPorts_),
       jmxManagerPort_(move.jmxManagerPort_),
-      started_(move.started_) {
+      started_(move.started_),
+      distributedSystemId_(move.distributedSystemId_){
   move.started_ = false;
 }
 
@@ -78,6 +100,8 @@ void Locator::start() {
                      .withName(safeName)
                      .withBindAddress(locatorAddress_.address)
                      .withPort(locatorAddress_.port)
+                     .withRemoteLocators(remoteLocatorsPorts_)
+                     .withDistributedSystemId(distributedSystemId_)
                      .withMaxHeap("256m")
                      .withJmxManagerPort(jmxManagerPort_)
                      .withHttpServicePort(0)
@@ -205,6 +229,50 @@ void Server::stop() {
   cluster_.getGfsh().stop().server().withDir(name_).execute();
 
   started_ = false;
+}
+
+Cluster::Cluster(LocatorCount initialLocators, ServerCount initialServers,
+                 std::vector<uint16_t> &locatorPorts, std::vector<uint16_t> &remoteLocatorPort,
+                 uint16_t distributedSystemId) : Cluster(
+    Name(std::string(::testing::UnitTest::GetInstance()
+                         ->current_test_info()
+                         ->test_case_name()) +
+         "/" +
+         ::testing::UnitTest::GetInstance()->current_test_info()->name()),
+    initialLocators, initialServers, locatorPorts, remoteLocatorPort, distributedSystemId) {}
+
+Cluster::Cluster(Name name, LocatorCount initialLocators,
+                 ServerCount initialServers, std::vector<uint16_t> &locatorPorts,
+                 std::vector<uint16_t> &remoteLocatorPort, uint16_t distributedSystemId)
+    : Cluster(Name(name.get()), Classpath(""), SecurityManager(""), User(""),
+              Password(""), initialLocators, initialServers, CacheXMLFiles({}),
+              locatorPorts, remoteLocatorPort, distributedSystemId) {}
+
+Cluster::Cluster(Name name, Classpath classpath,
+                 SecurityManager securityManager, User user, Password password,
+                 LocatorCount initialLocators, ServerCount initialServers,
+                 CacheXMLFiles cacheXMLFiles, std::vector<uint16_t> &locatorPorts,
+                 std::vector<uint16_t> &remoteLocatorPort, uint16_t distributedSystemId)
+    : name_(name.get()),
+      classpath_(classpath.get()),
+      securityManager_(securityManager.get()),
+      user_(user.get()),
+      password_(password.get()),
+      initialLocators_(initialLocators.get()),
+      initialServers_(initialServers.get()),
+      jmxManagerPort_(Framework::getAvailablePort()),
+      distributedSystemId_(distributedSystemId)
+      {
+  cacheXMLFiles_ = cacheXMLFiles.get();
+  useIPv6_ = false;
+
+  for(uint16_t port : locatorPorts){
+    locatorsPorts_.push_back(port);
+  }
+  for(uint16_t port : remoteLocatorPort){
+    remoteLocatorsPorts_.push_back(port);
+  }
+  removeServerDirectory();
 }
 
 Cluster::Cluster(LocatorCount initialLocators, ServerCount initialServers,
@@ -360,9 +428,17 @@ void Cluster::start() { start(std::function<void()>()); }
 void Cluster::start(std::function<void()> extraGfshCommands) {
   locators_.reserve(initialLocators_);
   for (size_t i = 0; i < initialLocators_; i++) {
+    uint16_t port;
+    if(locatorsPorts_.empty()){
+      port=Framework::getAvailablePort();
+    }else{
+      port=locatorsPorts_.at(i);
+    }
+
     locators_.push_back({*this, locators_,
                          name_ + "/locator/" + std::to_string(i),
-                         jmxManagerPort_, getUseIPv6()});
+                         jmxManagerPort_, getUseIPv6(), port,
+                         remoteLocatorsPorts_, distributedSystemId_});
   }
 
   servers_.reserve(initialServers_);

--- a/cppcache/integration/framework/Cluster.cpp
+++ b/cppcache/integration/framework/Cluster.cpp
@@ -237,16 +237,10 @@ Cluster::Cluster(LocatorCount initialLocators, ServerCount initialServers,
     Name(std::string(::testing::UnitTest::GetInstance()
                          ->current_test_info()
                          ->test_case_name()) +
-         "/" +
-         ::testing::UnitTest::GetInstance()->current_test_info()->name()),
-    initialLocators, initialServers, locatorPorts, remoteLocatorPort, distributedSystemId) {}
-
-Cluster::Cluster(Name name, LocatorCount initialLocators,
-                 ServerCount initialServers, std::vector<uint16_t> &locatorPorts,
-                 std::vector<uint16_t> &remoteLocatorPort, uint16_t distributedSystemId)
-    : Cluster(Name(name.get()), Classpath(""), SecurityManager(""), User(""),
-              Password(""), initialLocators, initialServers, CacheXMLFiles({}),
-              locatorPorts, remoteLocatorPort, distributedSystemId) {}
+         "/DS" + std::to_string(distributedSystemId) + "/" +
+         ::testing::UnitTest::GetInstance()->current_test_info()->name()), Classpath(""),
+         SecurityManager(""), User(""), Password(""), initialLocators, initialServers,
+         CacheXMLFiles({}), locatorPorts, remoteLocatorPort, distributedSystemId) {}
 
 Cluster::Cluster(Name name, Classpath classpath,
                  SecurityManager securityManager, User user, Password password,
@@ -286,13 +280,7 @@ Cluster::Cluster(LocatorCount initialLocators, ServerCount initialServers,
           initialLocators, initialServers, useIPv6) {}
 
 Cluster::Cluster(LocatorCount initialLocators, ServerCount initialServers)
-    : Cluster(
-          Name(std::string(::testing::UnitTest::GetInstance()
-                               ->current_test_info()
-                               ->test_case_name()) +
-               "/" +
-               ::testing::UnitTest::GetInstance()->current_test_info()->name()),
-          initialLocators, initialServers) {}
+    : Cluster(initialLocators, initialServers, UseIpv6(false)) {}
 
 Cluster::Cluster(LocatorCount initialLocators, ServerCount initialServers,
                  CacheXMLFiles cacheXMLFiles)

--- a/cppcache/integration/framework/Cluster.h
+++ b/cppcache/integration/framework/Cluster.h
@@ -43,6 +43,10 @@ class Locator {
   Locator(Cluster &cluster, std::vector<Locator> &locators, std::string name,
           uint16_t jmxManagerPort, bool useIPv6);
 
+  Locator(Cluster &cluster, std::vector<Locator> &locators, std::string name,
+          uint16_t jmxManagerPort, bool useIPv6, uint16_t port,
+          std::vector<uint16_t> &remotePorts, uint16_t distributedSystemId);
+
   ~Locator();
 
   Locator(const Locator &copy) = delete;
@@ -50,6 +54,7 @@ class Locator {
   Locator(Locator &&move);
 
   const LocatorAddress &getAddress() const;
+
   void start();
 
   void stop();
@@ -63,9 +68,13 @@ class Locator {
 
   LocatorAddress locatorAddress_;
 
+  std::vector<uint16_t> remoteLocatorsPorts_;
+
   uint16_t jmxManagerPort_;
 
   bool started_ = false;
+
+  uint16_t distributedSystemId_ = 0;
 };
 
 struct ServerAddress {
@@ -118,6 +127,10 @@ class Cluster {
   Cluster(LocatorCount initialLocators, ServerCount initialServers,
           UseIpv6 useIPv6);
 
+  Cluster(LocatorCount initialLocators, ServerCount initialServers,
+          std::vector<uint16_t> &locatorPorts, std::vector<uint16_t> &remoteLocatorPort,
+          uint16_t distributedSystemId);
+
   Cluster(LocatorCount initialLocators, ServerCount initialServers);
 
   Cluster(LocatorCount initialLocators, ServerCount initialServers,
@@ -126,12 +139,22 @@ class Cluster {
   Cluster(Name name, LocatorCount initialLocators, ServerCount initialServers,
           UseIpv6 useIPv6);
 
+  Cluster(Name name, LocatorCount initialLocators, ServerCount initialServers,
+          std::vector<uint16_t> &locatorPorts, std::vector<uint16_t> &remoteLocatorPort,
+          uint16_t distributedSystemId);
+
   Cluster(Name name, LocatorCount initialLocators, ServerCount initialServers);
 
   Cluster(Name name, Classpath classpath, SecurityManager securityManager,
           User user, Password password, LocatorCount initialLocators,
           ServerCount initialServers, CacheXMLFiles cacheXMLFiles,
           UseIpv6 useIPv6);
+
+  Cluster(Name name, Classpath classpath, SecurityManager securityManager,
+          User user, Password password, LocatorCount initialLocators,
+          ServerCount initialServers, CacheXMLFiles cacheXMLFiles,
+          std::vector<uint16_t> &locatorPorts, std::vector<uint16_t> &remoteLocatorPort,
+          uint16_t distributedSystemId);
 
   Cluster(Name name, Classpath classpath, SecurityManager securityManager,
           User user, Password password, LocatorCount initialLocators,
@@ -213,6 +236,8 @@ class Cluster {
 
   size_t initialLocators_;
   std::vector<Locator> locators_;
+  std::vector<uint16_t> locatorsPorts_;
+  std::vector<uint16_t> remoteLocatorsPorts_;
 
   size_t initialServers_;
   std::vector<Server> servers_;
@@ -236,6 +261,8 @@ class Cluster {
   std::string hostName_;
 
   bool useIPv6_ = false;
+
+  uint16_t distributedSystemId_ = 0;
 
   GfshExecute gfsh_;
 

--- a/cppcache/integration/framework/Cluster.h
+++ b/cppcache/integration/framework/Cluster.h
@@ -131,6 +131,12 @@ class Cluster {
           std::vector<uint16_t> &locatorPorts, std::vector<uint16_t> &remoteLocatorPort,
           uint16_t distributedSystemId);
 
+  Cluster(Name name, Classpath classpath, SecurityManager securityManager,
+          User user, Password password, LocatorCount initialLocators,
+          ServerCount initialServers, CacheXMLFiles cacheXMLFiles,
+          std::vector<uint16_t> &locatorPorts, std::vector<uint16_t> &remoteLocatorPort,
+          uint16_t distributedSystemId);
+
   Cluster(LocatorCount initialLocators, ServerCount initialServers);
 
   Cluster(LocatorCount initialLocators, ServerCount initialServers,
@@ -139,22 +145,12 @@ class Cluster {
   Cluster(Name name, LocatorCount initialLocators, ServerCount initialServers,
           UseIpv6 useIPv6);
 
-  Cluster(Name name, LocatorCount initialLocators, ServerCount initialServers,
-          std::vector<uint16_t> &locatorPorts, std::vector<uint16_t> &remoteLocatorPort,
-          uint16_t distributedSystemId);
-
   Cluster(Name name, LocatorCount initialLocators, ServerCount initialServers);
 
   Cluster(Name name, Classpath classpath, SecurityManager securityManager,
           User user, Password password, LocatorCount initialLocators,
           ServerCount initialServers, CacheXMLFiles cacheXMLFiles,
           UseIpv6 useIPv6);
-
-  Cluster(Name name, Classpath classpath, SecurityManager securityManager,
-          User user, Password password, LocatorCount initialLocators,
-          ServerCount initialServers, CacheXMLFiles cacheXMLFiles,
-          std::vector<uint16_t> &locatorPorts, std::vector<uint16_t> &remoteLocatorPort,
-          uint16_t distributedSystemId);
 
   Cluster(Name name, Classpath classpath, SecurityManager securityManager,
           User user, Password password, LocatorCount initialLocators,
@@ -227,6 +223,7 @@ class Cluster {
   bool getUseIPv6();
 
  private:
+
   std::string name_;
   std::string classpath_;
   std::string securityManager_;

--- a/cppcache/integration/framework/Gfsh.cpp
+++ b/cppcache/integration/framework/Gfsh.cpp
@@ -60,6 +60,31 @@ Gfsh::Start::Locator &Gfsh::Start::Locator::withPort(const uint16_t &port) {
   return *this;
 }
 
+Gfsh::Start::Locator &Gfsh::Start::Locator::withRemoteLocators(const std::vector<uint16_t> &locatorPorts) {
+  // Example: --J='-Dgemfire.remote-locators=localhost[9009],localhost[9010]'
+  if ( !locatorPorts.empty() ) {
+    command_ += " --J='-Dgemfire.remote-locators=";
+    bool firstLocator=true;
+    for (uint16_t locatorPort : locatorPorts) {
+      if (firstLocator){
+        command_ += "localhost[" + std::to_string(locatorPort) + "]";
+        firstLocator=false;
+      }else{
+        command_ += ",localhost[" + std::to_string(locatorPort) + "]";
+      }
+    }
+    command_ += "'";
+  }
+  return *this;
+}
+
+Gfsh::Start::Locator &Gfsh::Start::Locator::withDistributedSystemId(const uint16_t &dsId) {
+  if ( dsId != 0 ){
+    command_ += " --J=-Dgemfire.distributed-system-id="+std::to_string(dsId);
+  }
+  return *this;
+}
+
 Gfsh::Start::Locator &Gfsh::Start::Locator::withJmxManagerPort(
     const uint16_t &jmxManagerPort) {
   command_ +=
@@ -379,6 +404,29 @@ Gfsh::Create::Region &Gfsh::Create::Region::withBuckets(const std::string &total
   command_ += " --total-num-buckets=" + totalNumBuckets;
   return *this;
 }
+
+Gfsh::Create::Region &Gfsh::Create::Region::withGatewaySenderId(const std::string &gatewaySenderId) {
+  command_ += " --gateway-sender-id=" + gatewaySenderId;
+  return *this;
+}
+
+Gfsh::Create::GatewaySender Gfsh::Create::gatewaySender() { return GatewaySender{gfsh_}; }
+
+Gfsh::Create::GatewaySender::GatewaySender(Gfsh &gfsh) : Command(gfsh, "create gateway-sender") {}
+
+Gfsh::Create::GatewaySender &Gfsh::Create::GatewaySender::withId(const std::string &id){
+  command_ += " --id=" + id;
+  return *this;
+}
+
+Gfsh::Create::GatewaySender &Gfsh::Create::GatewaySender::withRemoteDSId(const std::string &remoteDSId){
+  command_ += " --remote-distributed-system-id=" + remoteDSId;
+  return *this;
+}
+
+Gfsh::Create::GatewayReceiver Gfsh::Create::gatewayReceiver() { return GatewayReceiver{gfsh_}; }
+
+Gfsh::Create::GatewayReceiver::GatewayReceiver(Gfsh &gfsh) : Command(gfsh, "create gateway-receiver") {}
 
 Gfsh::Connect::Connect(Gfsh &gfsh) : Command{gfsh, "connect"} {}
 

--- a/cppcache/integration/framework/Gfsh.h
+++ b/cppcache/integration/framework/Gfsh.h
@@ -21,6 +21,7 @@
 #define INTEGRATION_TEST_FRAMEWORK_GFSH_H
 
 #include <string>
+#include <vector>
 
 class Gfsh {
  public:
@@ -94,6 +95,10 @@ class Gfsh {
       Locator &withBindAddress(const std::string &bindAddress);
 
       Locator &withPort(const uint16_t &port);
+
+      Locator &withRemoteLocators(const std::vector<uint16_t> &locatorPorts);
+
+      Locator &withDistributedSystemId(const uint16_t &dsId);
 
       Locator &withJmxManagerPort(const uint16_t &jmxManagerPort);
 
@@ -226,6 +231,12 @@ class Gfsh {
     class Region;
     Region region();
 
+    class GatewaySender;
+    GatewaySender gatewaySender();
+
+    class GatewayReceiver;
+    GatewayReceiver gatewayReceiver();
+
     class Region : public Command<void> {
      public:
       explicit Region(Gfsh &gfsh);
@@ -237,6 +248,22 @@ class Gfsh {
       Region &withRedundantCopies(const std::string &copies);
 
       Region &withBuckets(const std::string &totalNumBuckets);
+
+      Region &withGatewaySenderId(const std::string &gatewaySenderId);
+    };
+
+    class GatewaySender : public Command<void> {
+     public:
+      explicit GatewaySender(Gfsh &gfsh);
+
+      GatewaySender &withId(const std::string &id);
+
+      GatewaySender &withRemoteDSId(const std::string &remoteDSId);
+    };
+
+    class GatewayReceiver : public Command<void> {
+     public:
+      explicit GatewayReceiver(Gfsh &gfsh);
     };
   };
 

--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -31,6 +31,8 @@ add_executable(cpp-integration-test
   PdxInstanceTest.cpp
   PdxJsonTypeTest.cpp
   PdxSerializerTest.cpp
+  Order.cpp
+  Order.hpp
   RegionGetAllTest.cpp
   RegionPutAllTest.cpp
   RegionPutGetAllTest.cpp
@@ -45,6 +47,7 @@ add_executable(cpp-integration-test
   SslTwoWayTest.cpp
   StructTest.cpp
   TransactionCleaningTest.cpp
+  WanDeserializationTest.cpp
 )
 
 target_compile_definitions(cpp-integration-test

--- a/cppcache/integration/test/ExampleTest.cpp
+++ b/cppcache/integration/test/ExampleTest.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<Region> setupRegion(Cache& cache) {
 
 /**
  * Example test using 2 servers and waiting for async tasks to synchronize using
- * furtures.
+ * futures.
  */
 TEST(ExampleTest, DISABLED_putAndGetWith2Servers) {
   Cluster cluster{LocatorCount{1}, ServerCount{2}};

--- a/cppcache/integration/test/Order.cpp
+++ b/cppcache/integration/test/Order.cpp
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Order.hpp"
+
+#include <geode/PdxReader.hpp>
+#include <geode/PdxWriter.hpp>
+
+namespace testGeode8344 {
+
+void Order::fromData(PdxReader& pdxReader) {
+  order_id_ = pdxReader.readInt(ORDER_ID_KEY_);
+  name_ = pdxReader.readString(NAME_KEY_);
+  quantity_ = pdxReader.readShort(QUANTITY_KEY_);
+}
+
+void Order::toData(PdxWriter& pdxWriter) const {
+  pdxWriter.writeInt(ORDER_ID_KEY_, order_id_);
+  pdxWriter.markIdentityField(ORDER_ID_KEY_);
+
+  pdxWriter.writeString(NAME_KEY_, name_);
+  pdxWriter.markIdentityField(NAME_KEY_);
+
+  pdxWriter.writeShort(QUANTITY_KEY_, quantity_);
+  pdxWriter.markIdentityField(QUANTITY_KEY_);
+}
+
+std::string Order::toString() const {
+  return "OrderID: " + std::to_string(order_id_) + " Product Name: " + name_ +
+         " Quantity: " + std::to_string(quantity_);
+}
+
+const std::string& Order::getClassName() const {
+  static const std::string CLASS_NAME = "com.example.Order";
+  return CLASS_NAME;
+}
+
+std::shared_ptr<PdxSerializable> Order::createDeserializable() {
+  return std::make_shared<Order>();
+}
+
+const std::string Order::ORDER_ID_KEY_ = "order_id";
+const std::string Order::NAME_KEY_ = "name";
+const std::string Order::QUANTITY_KEY_ = "quantity";
+
+}  // namespace testGeode8344

--- a/cppcache/integration/test/Order.cpp
+++ b/cppcache/integration/test/Order.cpp
@@ -20,7 +20,7 @@
 #include <geode/PdxReader.hpp>
 #include <geode/PdxWriter.hpp>
 
-namespace testGeode8344 {
+namespace WanDeserialization {
 
 void Order::fromData(PdxReader& pdxReader) {
   order_id_ = pdxReader.readInt(ORDER_ID_KEY_);
@@ -57,4 +57,4 @@ const std::string Order::ORDER_ID_KEY_ = "order_id";
 const std::string Order::NAME_KEY_ = "name";
 const std::string Order::QUANTITY_KEY_ = "quantity";
 
-}  // namespace testGeode8344
+}  // namespace WanDeserialization

--- a/cppcache/integration/test/Order.hpp
+++ b/cppcache/integration/test/Order.hpp
@@ -26,7 +26,9 @@
 
 namespace testGeode8344 {
 
-using namespace apache::geode::client;
+using apache::geode::client::PdxReader;
+using apache::geode::client::PdxSerializable;
+using apache::geode::client::PdxWriter;
 
 class Order : public PdxSerializable {
  public:

--- a/cppcache/integration/test/Order.hpp
+++ b/cppcache/integration/test/Order.hpp
@@ -24,7 +24,7 @@
 
 #include <geode/PdxSerializable.hpp>
 
-namespace testGeode8344 {
+namespace WanDeserialization {
 
 using apache::geode::client::PdxReader;
 using apache::geode::client::PdxSerializable;
@@ -65,6 +65,6 @@ class Order : public PdxSerializable {
   int16_t quantity_;
 };
 
-}  // namespace testGeode8344
+}  // namespace WanDeserialization
 
 #endif  // ORDER_H

--- a/cppcache/integration/test/Order.hpp
+++ b/cppcache/integration/test/Order.hpp
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef ORDER_H
+#define ORDER_H
+
+#include <string>
+
+#include <geode/PdxSerializable.hpp>
+
+namespace testGeode8344 {
+
+using namespace apache::geode::client;
+
+class Order : public PdxSerializable {
+ public:
+  inline Order() : Order(0, "", 0) {}
+
+  inline Order(int32_t order_id, std::string name, int16_t quantity)
+      : order_id_(order_id), name_(std::move(name)), quantity_(quantity) {}
+
+  ~Order() override = default;
+
+  inline const std::string& getName() const { return name_; }
+
+  using PdxSerializable::fromData;
+
+  using PdxSerializable::toData;
+
+  void fromData(PdxReader& pdxReader) override;
+
+  void toData(PdxWriter& pdxWriter) const override;
+
+  std::string toString() const override;
+
+  const std::string& getClassName() const override;
+
+  static std::shared_ptr<PdxSerializable> createDeserializable();
+
+ private:
+  static const std::string ORDER_ID_KEY_;
+  static const std::string NAME_KEY_;
+  static const std::string QUANTITY_KEY_;
+
+  int32_t order_id_;
+  std::string name_;
+  int16_t quantity_;
+};
+
+}  // namespace testGeode8344
+
+#endif  // ORDER_H

--- a/cppcache/integration/test/WanDeserializationTest.cpp
+++ b/cppcache/integration/test/WanDeserializationTest.cpp
@@ -36,6 +36,8 @@ using apache::geode::client::Cache;
 using apache::geode::client::Cacheable;
 using apache::geode::client::CacheableKey;
 using apache::geode::client::CacheableString;
+using apache::geode::client::CacheListener;
+using apache::geode::client::EntryEvent;
 using apache::geode::client::Pool;
 using apache::geode::client::Region;
 using apache::geode::client::RegionShortcut;

--- a/cppcache/integration/test/WanDeserializationTest.cpp
+++ b/cppcache/integration/test/WanDeserializationTest.cpp
@@ -40,7 +40,7 @@ using apache::geode::client::Pool;
 using apache::geode::client::Region;
 using apache::geode::client::RegionShortcut;
 using std::chrono::minutes;
-using testGeode8344::Order;
+using WanDeserialization::Order;
 
 class GeodeCacheListener : public CacheListener {
  public:
@@ -93,7 +93,7 @@ std::shared_ptr<Region> setupRegion(
   return region;
 }
 
-TEST(WanDeserializationTest, testGeode8344) {
+TEST(WanDeserializationTest, testEventsAreDeserializedCorrectly) {
   uint16_t portSiteA = Framework::getAvailablePort();
   uint16_t portSiteB = Framework::getAvailablePort();
 

--- a/cppcache/integration/test/WanDeserializationTest.cpp
+++ b/cppcache/integration/test/WanDeserializationTest.cpp
@@ -28,8 +28,6 @@
 
 #include "Order.hpp"
 
-using namespace testGeode8344;
-
 namespace {
 
 using apache::geode::client::Cache;
@@ -42,6 +40,7 @@ using apache::geode::client::Pool;
 using apache::geode::client::Region;
 using apache::geode::client::RegionShortcut;
 using std::chrono::minutes;
+using testGeode8344::Order;
 
 class GeodeCacheListener : public CacheListener {
  public:

--- a/cppcache/integration/test/WanDeserializationTest.cpp
+++ b/cppcache/integration/test/WanDeserializationTest.cpp
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <framework/Cluster.h>
+#include <framework/Framework.h>
+#include <framework/Gfsh.h>
+
+#include <geode/Cache.hpp>
+#include <geode/EntryEvent.hpp>
+#include <geode/PoolManager.hpp>
+#include <geode/RegionFactory.hpp>
+#include <geode/RegionShortcut.hpp>
+#include <geode/TypeRegistry.hpp>
+
+#include "Order.hpp"
+
+using namespace testGeode8344;
+
+namespace {
+
+using apache::geode::client::Cache;
+using apache::geode::client::Cacheable;
+using apache::geode::client::CacheableKey;
+using apache::geode::client::CacheableString;
+using apache::geode::client::Pool;
+using apache::geode::client::Region;
+using apache::geode::client::RegionShortcut;
+using std::chrono::minutes;
+
+class GeodeCacheListener : public CacheListener {
+ public:
+  void afterCreate(const EntryEvent& event) override {
+    numEvents++;
+    auto region = event.getRegion();
+    std::cout << "GeodeCacheListener::afterCreate  " << region->getName()
+              << std::endl;
+  }
+
+  int getNumEvents() { return numEvents; }
+
+ private:
+  int numEvents = 0;
+};  // class GeodeCacheListener
+
+const std::string regionName = "region";
+
+Cache createCache(std::string durableClientId) {
+  using apache::geode::client::CacheFactory;
+
+  auto cache = CacheFactory()
+                   .set("log-level", "debug")
+                   .set("statistic-sampling-enabled", "false")
+                   .setPdxReadSerialized(true)
+                   .set("durable-client-id", durableClientId)
+                   .set("durable-timeout", "300s")
+                   .create();
+
+  return cache;
+}
+
+std::shared_ptr<Pool> createPool(Cluster& cluster, Cache& cache,
+                                 std::string poolName) {
+  auto poolFactory = cache.getPoolManager().createFactory();
+  cluster.applyLocators(poolFactory);
+  poolFactory.setPRSingleHopEnabled(true);
+  poolFactory.setSubscriptionEnabled(true);
+  return poolFactory.create(poolName);
+}
+
+std::shared_ptr<Region> setupRegion(
+    Cache& cache, const std::shared_ptr<Pool>& pool,
+    std::shared_ptr<GeodeCacheListener> cacheListener) {
+  auto region = cache.createRegionFactory(RegionShortcut::CACHING_PROXY)
+                    .setPoolName(pool->getName())
+                    .setCacheListener(cacheListener)
+                    .create(regionName);
+  region->registerAllKeys(true, true, true);
+  return region;
+}
+
+TEST(WanDeserializationTest, testGeode8344) {
+  uint16_t portSiteA = Framework::getAvailablePort();
+  uint16_t portSiteB = Framework::getAvailablePort();
+
+  std::vector<uint16_t> locatorPortsSiteA = {portSiteA};
+  std::vector<uint16_t> locatorPortsSiteB = {portSiteB};
+
+  std::vector<uint16_t> remoteLocatorPortsA = {portSiteB};
+  std::vector<uint16_t> remoteLocatorPortsB = {portSiteA};
+
+  Cluster clusterA{LocatorCount{1}, ServerCount{1}, locatorPortsSiteA,
+                   remoteLocatorPortsA, 1};
+  clusterA.start();
+
+  Cluster clusterB{LocatorCount{1}, ServerCount{1}, locatorPortsSiteB,
+                   remoteLocatorPortsB, 2};
+  clusterB.start();
+
+  // Create gw receivers
+  clusterA.getGfsh().create().gatewayReceiver().execute();
+  clusterB.getGfsh().create().gatewayReceiver().execute();
+
+  // Create gw senders
+  clusterA.getGfsh()
+      .create()
+      .gatewaySender()
+      .withId("A-to-B")
+      .withRemoteDSId("2")
+      .execute();
+  clusterB.getGfsh()
+      .create()
+      .gatewaySender()
+      .withId("B-to-A")
+      .withRemoteDSId("1")
+      .execute();
+
+  // Create regions
+  clusterA.getGfsh()
+      .create()
+      .region()
+      .withName(regionName)
+      .withType("PARTITION")
+      .withGatewaySenderId("A-to-B")
+      .execute();
+  clusterB.getGfsh()
+      .create()
+      .region()
+      .withName(regionName)
+      .withType("PARTITION")
+      .withGatewaySenderId("B-to-A")
+      .execute();
+
+  auto cacheA = createCache("clientA");
+  auto poolA = createPool(clusterA, cacheA, "poolSiteA");
+  std::shared_ptr<GeodeCacheListener> cacheListenerA =
+      std::make_shared<GeodeCacheListener>();
+  auto regionA = setupRegion(cacheA, poolA, cacheListenerA);
+
+  auto cacheB = createCache("clientB");
+  auto poolB = createPool(clusterB, cacheB, "poolSiteB");
+  std::shared_ptr<GeodeCacheListener> cacheListenerB =
+      std::make_shared<GeodeCacheListener>();
+  auto regionB = setupRegion(cacheB, poolB, cacheListenerB);
+
+  cacheA.getTypeRegistry().registerPdxType(Order::createDeserializable);
+  cacheA.readyForEvents();
+
+  cacheB.getTypeRegistry().registerPdxType(Order::createDeserializable);
+  cacheB.readyForEvents();
+
+  auto order = std::make_shared<Order>(2, "product y", 37);
+  regionA->put("order", order);
+
+  sleep(5);  // wait for the event to be sent
+  ASSERT_EQ(cacheListenerA->getNumEvents(), 1);
+  ASSERT_EQ(cacheListenerB->getNumEvents(), 1);
+
+}  // TEST
+
+}  // namespace

--- a/cppcache/src/GatewaySenderEventCallbackArgument.cpp
+++ b/cppcache/src/GatewaySenderEventCallbackArgument.cpp
@@ -15,43 +15,28 @@
  * limitations under the License.
  */
 
-#ifndef NATIVECLIENT_DSFIXEDID_HPP
-#define NATIVECLIENT_DSFIXEDID_HPP
+#include "GatewaySenderEventCallbackArgument.hpp"
+
+#include <geode/internal/DSFixedId.hpp>
 
 namespace apache {
 namespace geode {
 namespace client {
-namespace internal {
 
-enum class DSFid : int32_t {
-  GatewaySenderEventCallbackArgument = -135,
-  ClientHealthStats = -126,
-  VersionTag = -120,
-  CollectionTypeImpl = -59,
-  LocatorListRequest = -54,
-  ClientConnectionRequest = -53,
-  QueueConnectionRequest = -52,
-  LocatorListResponse = -51,
-  ClientConnectionResponse = -50,
-  QueueConnectionResponse = -49,
-  ClientReplacementRequest = -48,
-  GetAllServersRequest = -43,
-  GetAllServersResponse = -42,
-  VersionedObjectPartList = 7,
-  EnumInfo = 9,
-  CacheableObjectPartList = 25,
-  CacheableUndefined = 31,
-  Struct = 32,
-  EventId = 36,
-  InternalDistributedMember = 92,
-  TXCommitMessage = 110,
-  DiskVersionTag = 2131,
-  DiskStoreId = 2133
-};
+using internal::DSFid;
 
-}  // namespace internal
+void GatewaySenderEventCallbackArgument::fromData(DataInput &input) {
+  originatingDSId = input.readNativeInt32();
+  int numElements = input.readInt32();
+  for (int i = 0; i < numElements; i++) {
+    recipientDSIds.push_back(input.readInt32());
+  }
+}
+
+DSFid GatewaySenderEventCallbackArgument::getDSFID() const {
+  return DSFid::GatewaySenderEventCallbackArgument;
+}
+
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
-
-#endif  // NATIVECLIENT_DSFIXEDID_HPP

--- a/cppcache/src/GatewaySenderEventCallbackArgument.hpp
+++ b/cppcache/src/GatewaySenderEventCallbackArgument.hpp
@@ -15,43 +15,38 @@
  * limitations under the License.
  */
 
-#ifndef NATIVECLIENT_DSFIXEDID_HPP
-#define NATIVECLIENT_DSFIXEDID_HPP
+#ifndef GEODE_GATEWAYSENDEREVENTCALLBACKARGUMENT_H_
+#define GEODE_GATEWAYSENDEREVENTCALLBACKARGUMENT_H_
+
+#include <geode/DataInput.hpp>
+#include <geode/internal/DSFixedId.hpp>
+#include <geode/internal/DataSerializableFixedId.hpp>
 
 namespace apache {
 namespace geode {
 namespace client {
-namespace internal {
 
-enum class DSFid : int32_t {
-  GatewaySenderEventCallbackArgument = -135,
-  ClientHealthStats = -126,
-  VersionTag = -120,
-  CollectionTypeImpl = -59,
-  LocatorListRequest = -54,
-  ClientConnectionRequest = -53,
-  QueueConnectionRequest = -52,
-  LocatorListResponse = -51,
-  ClientConnectionResponse = -50,
-  QueueConnectionResponse = -49,
-  ClientReplacementRequest = -48,
-  GetAllServersRequest = -43,
-  GetAllServersResponse = -42,
-  VersionedObjectPartList = 7,
-  EnumInfo = 9,
-  CacheableObjectPartList = 25,
-  CacheableUndefined = 31,
-  Struct = 32,
-  EventId = 36,
-  InternalDistributedMember = 92,
-  TXCommitMessage = 110,
-  DiskVersionTag = 2131,
-  DiskStoreId = 2133
+using internal::DSFid;
+
+class GatewaySenderEventCallbackArgument
+    : public internal::DataSerializableFixedId {
+ public:
+  GatewaySenderEventCallbackArgument() {}
+  void fromData(DataInput& input) override;
+  void toData(DataOutput&) const final {}
+  DSFid getDSFID() const override;
+  static std::shared_ptr<Serializable> create() {
+    return std::make_shared<GatewaySenderEventCallbackArgument>();
+  }
+  ~GatewaySenderEventCallbackArgument() override = default;
+
+ private:
+  int originatingDSId;
+  std::vector<int> recipientDSIds;
 };
 
-}  // namespace internal
 }  // namespace client
 }  // namespace geode
 }  // namespace apache
 
-#endif  // NATIVECLIENT_DSFIXEDID_HPP
+#endif  // GEODE_GATEWAYSENDEREVENTCALLBACKARGUMENT_H_

--- a/cppcache/src/GatewaySenderEventCallbackArgument.hpp
+++ b/cppcache/src/GatewaySenderEventCallbackArgument.hpp
@@ -31,16 +31,20 @@ using internal::DSFid;
 class GatewaySenderEventCallbackArgument
     : public internal::DataSerializableFixedId {
  public:
-  GatewaySenderEventCallbackArgument() {}
+  GatewaySenderEventCallbackArgument()
+      : originatingDSId(GwSenderDefaultDistributedSystemId) {}
   void fromData(DataInput& input) override;
   void toData(DataOutput&) const final {}
   DSFid getDSFID() const override;
+  int getOriginatingDSId() { return originatingDSId; }
+  std::vector<int> getRecipientDSIds() { return recipientDSIds; }
   static std::shared_ptr<Serializable> create() {
     return std::make_shared<GatewaySenderEventCallbackArgument>();
   }
   ~GatewaySenderEventCallbackArgument() override = default;
 
  private:
+  const int GwSenderDefaultDistributedSystemId = -1;
   int originatingDSId;
   std::vector<int> recipientDSIds;
 };

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -1335,7 +1335,7 @@ void PdxInstanceImpl::toDataMutable(PdxWriter& writer) {
         m_cacheImpl.createDataInput(m_buffer.data(), m_buffer.size());
     for (size_t i = 0; i < pdxFieldList->size(); i++) {
       auto currPf = pdxFieldList->at(i);
-      LOGDEBUG("toData filedname = %s , isVarLengthType = %d ",
+      LOGDEBUG("toData fieldName = %s , isVarLengthType = %d ",
                currPf->getFieldName().c_str(), currPf->IsVariableLengthType());
       std::shared_ptr<Cacheable> value = nullptr;
 
@@ -1364,7 +1364,7 @@ void PdxInstanceImpl::toDataMutable(PdxWriter& writer) {
   } else {
     for (size_t i = 0; i < pdxFieldList->size(); i++) {
       auto currPf = pdxFieldList->at(i);
-      LOGDEBUG("toData1 filedname = %s , isVarLengthType = %d ",
+      LOGDEBUG("toData1 fieldName = %s , isVarLengthType = %d ",
                currPf->getFieldName().c_str(), currPf->IsVariableLengthType());
       auto value = m_updatedFields[currPf->getFieldName()];
       writeField(writer, currPf->getFieldName(), currPf->getTypeId(), value);

--- a/cppcache/src/SerializationRegistry.cpp
+++ b/cppcache/src/SerializationRegistry.cpp
@@ -43,6 +43,7 @@
 #include "DiskStoreId.hpp"
 #include "EnumInfo.hpp"
 #include "EventId.hpp"
+#include "GatewaySenderEventCallbackArgument.hpp"
 #include "GetAllServersResponse.hpp"
 #include "LocatorListResponse.hpp"
 #include "PdxHelper.hpp"
@@ -136,6 +137,7 @@ void TheTypeMap::setup() {
   bindDataSerializableFixedId(GetAllServersResponse::create);
   bindDataSerializableFixedId(EnumInfo::createDeserializable);
   bindDataSerializableFixedId(DiskStoreId::createDeserializable);
+  bindDataSerializableFixedId(GatewaySenderEventCallbackArgument::create);
 }
 
 /** This starts at reading the typeid.. assumes the length has been read. */

--- a/cppcache/test/CMakeLists.txt
+++ b/cppcache/test/CMakeLists.txt
@@ -56,7 +56,8 @@ add_executable(apache-geode_unittests
   util/synchronized_mapTest.cpp
   util/synchronized_setTest.cpp
   util/TestableRecursiveMutex.hpp
-  util/chrono/durationTest.cpp)
+  util/chrono/durationTest.cpp
+  GatewaySenderEventCallbackArgumentTest.cpp)
 
 target_compile_definitions(apache-geode_unittests
   PUBLIC

--- a/cppcache/test/GatewaySenderEventCallbackArgumentTest.cpp
+++ b/cppcache/test/GatewaySenderEventCallbackArgumentTest.cpp
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "GatewaySenderEventCallbackArgument.hpp"
+
+using apache::geode::client::GatewaySenderEventCallbackArgument;
+
+TEST(GatewaySenderEventCallbackArgument, testDefaultValues) {
+  GatewaySenderEventCallbackArgument object;
+  EXPECT_EQ(-1, object.getOriginatingDSId());
+  EXPECT_EQ(0, object.getRecipientDSIds().size());
+}


### PR DESCRIPTION
It was observed that when having two sites, with a client connected to each site, there were serialization errors in the clients when handling received events. The cause is that GatewaySenderEventCallbackArgument objects are sent as part of the events, but this class is not known by the C++ client.
This PR allows the C++ clients to deserialize the class.

Using the same setup with using two java clients, I have observed that the GatewaySenderEventCallbackArgument objects are received and deserialized correctly, but it seems they are not used. This is why this PR is not including any other code related with the GatewaySenderEventCallbackArgument in the C++ clients. 