### PR TITLE
GEODE-8426: Enforce warning no-shorten-64-to-32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Wno-undefined-func-template #TODO fix
     -Wno-float-equal #TODO fix
     -Wno-header-hygiene #TODO fix
-    -Wno-shorten-64-to-32 #TODO fix
     -Wno-conversion #TODO fix
     -Wno-missing-variable-declarations #TODO fix
     -Wno-switch-enum #TODO fix


### PR DESCRIPTION
Authored-by: M. Oleske <michael@oleske.engineer>

curious if this is needed since quick test on my machine was compiling (so figured I'd make travis check real quick)

edit - will make a Jira when I bother to log into Jira next time