### PR TITLE
GEODE-8390: Geode Native Client guide - expose "Connection Pools" in nav

### DIFF
--- a/docs/geode-native-book-cpp/master_middleman/source/subnavs/geode-nc-nav.erb
+++ b/docs/geode-native-book-cpp/master_middleman/source/subnavs/geode-nc-nav.erb
@@ -66,6 +66,43 @@ limitations under the License.
     </li>
 
     <li class="has_submenu">
+        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/connection-pools.html">Using Connection Pools</a>
+        <ul>
+            <li class="has_submenu">
+                <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/client-load-balancing.html">How Client Load Balancing Works</a>
+                <ul>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/about-server-locators.html">Server Locators</a>
+                    </li>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/about-connection-pools.html">Connection Pools</a>
+                    </li>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/discovering-locators-dynamically.html">Discovering Locators Dynamically</a>
+                    </li>
+                </ul>
+            </li>
+            <li class="has_submenu">
+                <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/configuring-pools.html">Configuring Pools</a>
+                <ul>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/client-pool-api.html">Native Client Pool API</a>
+                    </li>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/configuring-pools-attributes-example.html">Pool Configuration Example and Settings</a>
+                    </li>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/subscription-properties.html">Subscription Properties</a>
+                    </li>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/running-connection-pool-code.html">Running the Connection Pool Code</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </li>
+
+<li class="has_submenu">
       <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/serialization/data-serialization.html">Serializing Data</a>
       <ul>
         <li class="has_submenu">

--- a/docs/geode-native-book-dotnet/master_middleman/source/subnavs/geode-nc-nav.erb
+++ b/docs/geode-native-book-dotnet/master_middleman/source/subnavs/geode-nc-nav.erb
@@ -66,6 +66,43 @@ limitations under the License.
     </li>
 
     <li class="has_submenu">
+        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/connection-pools.html">Using Connection Pools</a>
+        <ul>
+            <li class="has_submenu">
+                <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/client-load-balancing.html">How Client Load Balancing Works</a>
+                <ul>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/about-server-locators.html">Server Locators</a>
+                    </li>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/about-connection-pools.html">Connection Pools</a>
+                    </li>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/discovering-locators-dynamically.html">Discovering Locators Dynamically</a>
+                    </li>
+                </ul>
+            </li>
+            <li class="has_submenu">
+                <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/configuring-pools.html">Configuring Pools</a>
+                <ul>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/client-pool-api.html">Native Client Pool API</a>
+                    </li>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/configuring-pools-attributes-example.html">Pool Configuration Example and Settings</a>
+                    </li>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/subscription-properties.html">Subscription Properties</a>
+                    </li>
+                    <li>
+                        <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/connection-pools/running-connection-pool-code.html">Running the Connection Pool Code</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </li>
+
+    <li class="has_submenu">
       <a href="/docs/geode-native/<%=vars.product_language%>/<%=vars.product_version_nodot%>/serialization/data-serialization.html">Serializing Data</a>
       <ul>
         <li class="has_submenu">

--- a/docs/geode-native-docs-cpp/connection-pools/client-pool-api.html.md.erb
+++ b/docs/geode-native-docs-cpp/connection-pools/client-pool-api.html.md.erb
@@ -23,10 +23,7 @@ The native client API allows your clients to create and manage connection pools.
 
 This section lists the primary native client API for pool management. For complete information on the classes and interfaces described here, see the API documentation.
 
-**Note:**
-Only C\# versions of Pool API interfaces, classes, and methods are shown throughout the text in this section (example: `Pool.GetQueryService()`) . The code examples demonstrate both C++ and C\# versions.
-
-**Apache.Geode.Client.Cache**
+**apache::geode::client::cache**
 
 -   `Pool` interface. API to retrieve pool attributes.
 -   `PoolFactory` interface. API to configure pool attributes.

--- a/docs/geode-native-docs-cpp/connection-pools/running-connection-pool-code.html.md.erb
+++ b/docs/geode-native-docs-cpp/connection-pools/running-connection-pool-code.html.md.erb
@@ -19,22 +19,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-Examples demonstrate a simple procedure to create a pool factory and then create a pool instance in C++ and C\#. They also help you to execute a query.
+Examples demonstrate a simple procedure to create a pool factory and then create a pool instance in C++. They also help you to execute a query.
 
-The examples create a pool with locators. Ensure that you create a pool with locators or endpoints, but not both. The first example demonstrates creating a pool by adding locators. The second example demonstrates creating a pool by adding servers. For more information, see the example in the QuickStart Guide.
+Ensure that you create a pool with locators or endpoints, but not both. The first example demonstrates creating a pool by adding locators. The second example demonstrates creating a pool by adding servers.
 
-## Connection Pool Creation and Execution Using C++
+## C++ Connection Pool Creation and Execution Using Locators
 
-``` pre
+``` cpp
 PropertiesPtr prptr = Properties::create();
 systemPtr = CacheFactory::createCacheFactory(prptr);
 
 cachePtr = systemPtr->create();
 PoolFactoryPtr poolFacPtr = PoolManager::createFactory();
-//to create pool add either endpoints or add locators or servers
-//pool with endpoint, adding to pool factory
-//poolFacPtr->addServer("localhost", 12345 /*port number*/);
-//pool with locator, adding to pool factory
+// Add pool with locator to create pool factory
 poolFacPtr->addLocator("localhost", 34756 /*port number*/);
 PoolPtr pptr = NULLPTR;
 if ((PoolManager::find("examplePool")) == NULLPTR) {
@@ -49,28 +46,25 @@ regionPtr = regionFactory
 QueryServicePtr qs = cachePtr->getQueryService("examplePool");
 ```
 
-## Connection Pool Creation and Execution Using C\# .NET
+## C++ Connection Pool Creation and Execution Using Servers
 
-``` pre
-Properties prop = Properties.Create();
-CacheFactory cacheFactory = CacheFactory.CreateCacheFactory(prop);
-Cache cache = cacheFactory.Create();
+``` cpp
+PropertiesPtr prptr = Properties::create();
+systemPtr = CacheFactory::createCacheFactory(prptr);
 
-PoolFactory poolFact = PoolManager.CreateFactory();
-//to create pool add either endpoints or add locators
-//pool with endpoint, adding to pool factory.
-poolFact.AddServer("localhost", 40404 /*port number*/);
-//pool with locator, adding to pool factory
-//poolFact.AddLocator("hostname", 15000 /*port number*/);
-Pool pool = null;
-if (PoolManager.Find("poolName") == null) {
-  pool = poolFact.Create("poolName");
+cachePtr = systemPtr->create();
+PoolFactoryPtr poolFacPtr = PoolManager::createFactory();
+// Add pool with endpoint to create pool factory
+poolFacPtr->addServer("localhost", 12345 /*port number*/);
+PoolPtr pptr = NULLPTR;
+if ((PoolManager::find("examplePool")) == NULLPTR) {
+  // Pool with this name does not exist
+  pptr = poolFacPtr->create("examplePool");
 }
-int loadConditInterval = pool.LoadConditioningInterval;
-RegionFactory regionFactory =
-    cache.CreateRegionFactory(RegionShortcut.CACHING_PROXY);
-IRegion<string, string> region =
-    regionFactory.SetPoolName(poolName).Create<string, string>(regionName);
+RegionFactoryPtr regionFactory =
+    cachePtr->createRegionFactory(CACHING_PROXY);
+regionPtr = regionFactory
+    ->setPoolName("examplePool")
+    ->create("regionName");
+QueryServicePtr qs = cachePtr->getQueryService("examplePool");
 ```
-
-

--- a/docs/geode-native-docs-dotnet/connection-pools/running-connection-pool-code.html.md.erb
+++ b/docs/geode-native-docs-dotnet/connection-pools/running-connection-pool-code.html.md.erb
@@ -21,7 +21,7 @@ limitations under the License.
 
 Examples demonstrate a simple procedure to create a pool factory and then create a pool instance in C++ and C\#. They also help you to execute a query.
 
-The examples create a pool with locators. Ensure that you create a pool with locators or endpoints, but not both. The first example demonstrates creating a pool by adding locators. The second example demonstrates creating a pool by adding servers. For more information, see the example in the QuickStart Guide.
+The examples create a pool with locators. Ensure that you create a pool with locators or endpoints, but not both. The first example demonstrates creating a pool by adding locators. The second example demonstrates creating a pool by adding servers.
 
 ## Connection Pool Creation and Execution Using C++
 


### PR DESCRIPTION
Updated left-hand nav in both .NET and C++ guides to include "Using Connection Pools" and its subtopics
Made basic changes to text for language-specific books. Thorough update is the subject of another ticket.