### PR TITLE
GEODE-8436: Several threads calling PdxInstanceFactory::create() causes seg fault

### DIFF
--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(cpp-integration-test
   StructTest.cpp
   TransactionCleaningTest.cpp
   WanDeserializationTest.cpp
+  PdxInstanceFactoryTest.cpp
 )
 
 target_compile_definitions(cpp-integration-test

--- a/cppcache/integration/test/PdxInstanceFactoryTest.cpp
+++ b/cppcache/integration/test/PdxInstanceFactoryTest.cpp
@@ -52,7 +52,7 @@ std::shared_ptr<Region> createRegion(Cluster& cluster,
   auto poolFactory = cache->getPoolManager().createFactory();
   cluster.applyLocators(poolFactory);
   poolFactory.setPRSingleHopEnabled(true);
-  
+
   auto pool = poolFactory.create("pool");
   auto regionFactory = cache->createRegionFactory(RegionShortcut::PROXY);
   auto region = regionFactory.setPoolName("pool").create(regionName);

--- a/cppcache/integration/test/PdxInstanceFactoryTest.cpp
+++ b/cppcache/integration/test/PdxInstanceFactoryTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <framework/Cluster.h>
+#include <framework/Framework.h>
+#include <framework/Gfsh.h>
+
+#include <thread>
+
+#include <geode/CacheFactory.hpp>
+#include <geode/CacheTransactionManager.hpp>
+#include <geode/RegionFactory.hpp>
+#include <geode/RegionShortcut.hpp>
+
+namespace {
+
+using apache::geode::client::Cache;
+using apache::geode::client::CacheableString;
+using apache::geode::client::CacheFactory;
+using apache::geode::client::CacheTransactionManager;
+using apache::geode::client::Pool;
+using apache::geode::client::Region;
+using apache::geode::client::RegionShortcut;
+using std::chrono::minutes;
+
+const std::string regionName = "my_region";
+
+std::shared_ptr<Cache> createCache() {
+  auto cache = CacheFactory()
+                   .set("log-level", "debug")
+                   .setPdxReadSerialized(true)
+                   .create();
+  return std::make_shared<Cache>(std::move(cache));
+}
+
+std::shared_ptr<Region> createRegion(Cluster& cluster,
+                                     std::shared_ptr<Cache> cache) {
+  auto poolFactory = cache->getPoolManager().createFactory();
+  cluster.applyLocators(poolFactory);
+  poolFactory.setPRSingleHopEnabled(true);
+  
+  auto pool = poolFactory.create("pool");
+  auto regionFactory = cache->createRegionFactory(RegionShortcut::PROXY);
+  auto region = regionFactory.setPoolName("pool").create(regionName);
+
+  return region;
+}
+
+void doPut(std::shared_ptr<Cache> cache, std::shared_ptr<Region> region) {
+  auto factory = cache->createPdxInstanceFactory(
+      "name.string,surname.string,email.string,address.string");
+  factory.writeObject("name", CacheableString::create("John"));
+  factory.writeObject("surname", CacheableString::create("Johnson"));
+  factory.writeObject("email", CacheableString::create("john@johnson.mail"));
+  factory.writeObject("address", CacheableString::create("Fake St 123"));
+
+  auto pdxInstance = factory.create();
+  region->put(100, pdxInstance);
+}
+
+TEST(PdxInstanceFactoryTest, testConcurrentCreateCalls) {
+  const int NUM_THREADS = 8;
+
+  Cluster cluster{LocatorCount{1}, ServerCount{2}};
+
+  cluster.start();
+
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName(regionName)
+      .withType("PARTITION")
+      .execute();
+
+  auto cache = createCache();
+  auto region = createRegion(cluster, cache);
+
+  std::vector<std::thread> clientThreads;
+
+  for (int i = 0; i < NUM_THREADS; i++) {
+    std::thread th(doPut, cache, region);
+    clientThreads.push_back(std::move(th));
+  }
+
+  for (std::thread& th : clientThreads) {
+    if (th.joinable()) {
+      th.join();
+    }
+  }
+  cache->close();
+}  // test
+
+}  // namespace

--- a/cppcache/src/PdxTypeRegistry.cpp
+++ b/cppcache/src/PdxTypeRegistry.cpp
@@ -88,7 +88,7 @@ int32_t PdxTypeRegistry::getPDXIdForType(std::shared_ptr<PdxType> nType,
 
     typeId = cache_->getSerializationRegistry()->GetPDXIdForType(pool, nType);
     nType->setTypeId(typeId);
-    pdxTypeToTypeIdMap_.emplace(nType,typeId);
+    pdxTypeToTypeIdMap_.emplace(nType, typeId);
     typeIdToPdxType_.emplace(typeId, nType);
   }
   return typeId;

--- a/cppcache/src/PdxTypeRegistry.cpp
+++ b/cppcache/src/PdxTypeRegistry.cpp
@@ -88,8 +88,8 @@ int32_t PdxTypeRegistry::getPDXIdForType(std::shared_ptr<PdxType> nType,
 
     typeId = cache_->getSerializationRegistry()->GetPDXIdForType(pool, nType);
     nType->setTypeId(typeId);
-    pdxTypeToTypeIdMap_.insert(std::make_pair(nType, typeId));
-    typeIdToPdxType_.insert(std::make_pair(typeId, nType));
+    pdxTypeToTypeIdMap_.emplace(nType,typeId);
+    typeIdToPdxType_.emplace(typeId, nType);
   }
   return typeId;
 }
@@ -118,8 +118,7 @@ void PdxTypeRegistry::clear() {
 void PdxTypeRegistry::addPdxType(int32_t typeId,
                                  std::shared_ptr<PdxType> pdxType) {
   WriteGuard guard(g_readerWriterLock_);
-  std::pair<int32_t, std::shared_ptr<PdxType>> pc(typeId, pdxType);
-  typeIdToPdxType_.insert(pc);
+  typeIdToPdxType_.emplace(typeId, pdxType);
 }
 
 std::shared_ptr<PdxType> PdxTypeRegistry::getPdxType(int32_t typeId) const {

--- a/cppcache/src/PdxTypeRegistry.cpp
+++ b/cppcache/src/PdxTypeRegistry.cpp
@@ -89,8 +89,8 @@ int32_t PdxTypeRegistry::getPDXIdForType(std::shared_ptr<PdxType> nType,
     typeId = cache_->getSerializationRegistry()->GetPDXIdForType(pool, nType);
     nType->setTypeId(typeId);
     pdxTypeToTypeIdMap_.insert(std::make_pair(nType, typeId));
+    typeIdToPdxType_.insert(std::make_pair(typeId, nType));
   }
-  addPdxType(typeId, nType);
   return typeId;
 }
 


### PR DESCRIPTION
A segmentation fault is produced when `PdxInstanceFactory::create()` is called by several threads that are registering the same new pdx type.

The core is produced here:
```
void PdxInstanceImpl::toDataMutable(PdxWriter& writer) {
   auto pt = getPdxType();
   std::vector<std::shared_ptr<PdxFieldType>>* pdxFieldList =
       pt->getPdxFieldTypes();
```
`getPdxType()` returns `nullptr`, so in the next line, there is segmentation fault when calling `pt->getPdxFieldTypes()`.

I have seen the problem appears when `PdxInstanceImpl::getPdxType()` calls `PdxTypeRegistry::getPdxType()` and this method returns `nullptr` due to it is not able to found an entry in its `typeIdToPdxType_` map. But I have verified that at that point, the corresponding entry in `pdxTypeToTypeId_` map exists, so the maps were not aligned.

I checked how they are updated, and I realized that two different locks are being used to update `pdxTypeToTypeId_` map first and `typeIdToPdxType_` after. So it seems the error is caused due to `typeIdToPdxType_` is checked before it is updated.

The test case implemented does not fail every time it is executed (I have not been able to find a configuration to make it fail always) but I have not seen it failing after the change I have introduced in PdxTypeRegistry.
