### PR TITLE
Add notes about docker requirement

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,6 +7,7 @@
 * [OpenSSL](https://www.openssl.org) *(for building source documentation)*
 * Java 8 JDK *(for building server side java functions used in some of the integration tests)*
 * [Apache Geode](http://geode.apache.org/releases/) binaries installed or available to link against
+* [Docker](https://www.docker.com/ (for running SNI Test)
 
 ### Platform-Specific Prerequisites
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ For example: `$ ctest --timeout 2000 -L STABLE -C Release -R testCacheless -j1`
 .NET integration tests can be executed similarly from `build/clicache/integration-test`.
 
 #### Running Google Test integration test suite
+Make sure Docker is installed as it is required for SNI Tests
 ```bash
 $ cd <clone>
 $ cd build/cppcache/integration/test


### PR DESCRIPTION
Authored-by: M. Oleske <michael@oleske.engineer>

Test `42: SNITest.connectViaProxyTest` requires docker running on your machine, otherwise it fails.  This means docker should be mentioned as a required install now