### PR TITLE
GEODE-8443: Disable Windows SNI test as intended

### DIFF
--- a/cppcache/integration/test/SNITest.cpp
+++ b/cppcache/integration/test/SNITest.cpp
@@ -118,7 +118,7 @@ class SNITest : public ::testing::Test {
 };
 
 #if defined(_WIN32)
-TEST_F(SNITest, DISABLE_connectViaProxyTest) {
+TEST_F(SNITest, DISABLED_connectViaProxyTest) {
 #else
 TEST_F(SNITest, connectViaProxyTest) {
 #endif


### PR DESCRIPTION
- It's being run in the test suite due to a typo