### PR TITLE
GEODE-8441: AppDomainContext was initialized too late

### DIFF
--- a/clicache/src/CacheFactory.cpp
+++ b/clicache/src/CacheFactory.cpp
@@ -55,6 +55,7 @@ namespace Apache
 
       Cache^ CacheFactory::Create()
       {
+        native::createAppDomainContext = &Apache::Geode::Client::createAppDomainContext;
 				bool pdxIgnoreUnreadFields = false;
         bool pdxReadSerialized = false;
         _GF_MG_EXCEPTION_TRY2
@@ -70,14 +71,12 @@ namespace Apache
           pdxReadSerialized = nativeCache->getPdxReadSerialized();
 
           Log::SetLogLevel(static_cast<LogLevel>(native::Log::logLevel( )));
-          native::createAppDomainContext = &Apache::Geode::Client::createAppDomainContext;
-
 
           DistributedSystem::ManagedPostConnect(cache);
           DistributedSystem::registerCliCallback();
           auto&& cacheImpl = CacheRegionHelper::getCacheImpl(nativeCache.get());
           cacheImpl->getSerializationRegistry()->setPdxTypeHandler(new ManagedPdxTypeHandler());
-		  cacheImpl->getSerializationRegistry()->setDataSerializableHandler(new ManagedDataSerializableHandler());
+		      cacheImpl->getSerializationRegistry()->setDataSerializableHandler(new ManagedDataSerializableHandler());
 
           return cache;
         _GF_MG_EXCEPTION_CATCH_ALL2

--- a/clicache/src/CacheFactory.cpp
+++ b/clicache/src/CacheFactory.cpp
@@ -76,7 +76,7 @@ namespace Apache
           DistributedSystem::registerCliCallback();
           auto&& cacheImpl = CacheRegionHelper::getCacheImpl(nativeCache.get());
           cacheImpl->getSerializationRegistry()->setPdxTypeHandler(new ManagedPdxTypeHandler());
-		      cacheImpl->getSerializationRegistry()->setDataSerializableHandler(new ManagedDataSerializableHandler());
+          cacheImpl->getSerializationRegistry()->setDataSerializableHandler(new ManagedDataSerializableHandler());
 
           return cache;
         _GF_MG_EXCEPTION_CATCH_ALL2


### PR DESCRIPTION
This fixes a longstanding AppDomain bug that was introduced back in March 2017, wherein the AppDomainContext was being initialized after the cache was created.

I've tested the fix this by utilizing a simple Asp.NET web application running in IIS. Prior to the fix, the exception ("Cannot pass gchandle across AppDomains") appears in the log file. I have seen the exception occur in the following threads: "NC MC Thread" (Manage Connections) and "NC CMDService Thread". With the fix I can no longer generate this exception in IIS or IIS Express.