### PR TITLE
GEODE-8398: Add sni unittest for dotnet

### DIFF
--- a/clicache/src/Pool.cpp
+++ b/clicache/src/Pool.cpp
@@ -105,6 +105,32 @@ namespace Apache
       }
 
 
+      String^ Pool::SniProxyHost::get()
+      {
+        try
+        {
+          return marshal_as<String^>( m_nativeptr->get()->getSniProxyHost() );
+        }
+        finally
+        {
+          GC::KeepAlive(m_nativeptr);
+        }
+
+      }
+
+      Int32 Pool::SniProxyPort::get()
+      {
+        try
+        {
+          return m_nativeptr->get()->getSniProxyPort();
+        }
+        finally
+        {
+          GC::KeepAlive(m_nativeptr);
+        }
+
+      }
+
       Int32 Pool::MinConnections::get()
       {
         try

--- a/clicache/src/Pool.hpp
+++ b/clicache/src/Pool.hpp
@@ -91,6 +91,22 @@ namespace Apache
         }
 
         /// <summary>
+        /// Get the host name for the pool's SniProxy.
+        /// </summary>
+        property String^ SniProxyHost
+        {
+          String^ get();
+        }
+
+        /// <summary>
+        /// Get the host port for the pool's SniProxy.
+        /// </summary>
+        property Int32 SniProxyPort
+        {
+          Int32 get();
+        }
+
+        /// <summary>
         /// Get the minimum connections for this pool.
         /// </summary>
         property Int32 MinConnections

--- a/clicache/test2/Tests2.cs
+++ b/clicache/test2/Tests2.cs
@@ -127,9 +127,8 @@ namespace Apache.Geode.Client.UnitTests
     public void SetSniProxy()
     {
         PoolFactory poolFactory = _cacheOne.GetPoolFactory()
-                .AddLocator("localhost", 10334);
-
-        poolFactory.SetSniProxy("haproxy", 7777);
+                .AddLocator("localhost", 10334)
+                .SetSniProxy("haproxy", 7777);
 
         Pool pool = poolFactory.Create("testPool");
 
@@ -140,7 +139,7 @@ namespace Apache.Geode.Client.UnitTests
         Assert.Equal(sniProxyPort, 7777);
     }
 
-        private class DummyPdxSerializer : IPdxSerializer
+    private class DummyPdxSerializer : IPdxSerializer
     {
       public object FromData(string classname, IPdxReader reader)
       {

--- a/clicache/test2/Tests2.cs
+++ b/clicache/test2/Tests2.cs
@@ -123,7 +123,24 @@ namespace Apache.Geode.Client.UnitTests
       Assert.False(_pdxDelegate2Called);
     }
 
-    private class DummyPdxSerializer : IPdxSerializer
+    [Fact]
+    public void SetSniProxy()
+    {
+        PoolFactory poolFactory = _cacheOne.GetPoolFactory()
+                .AddLocator("localhost", 10334);
+
+        poolFactory.SetSniProxy("haproxy", 7777);
+
+        Pool pool = poolFactory.Create("testPool");
+
+        string sniProxyHost = pool.SniProxyHost;
+        int sniProxyPort = pool.SniProxyPort;
+
+        Assert.Equal(sniProxyHost, "haproxy");
+        Assert.Equal(sniProxyPort, 7777);
+    }
+
+        private class DummyPdxSerializer : IPdxSerializer
     {
       public object FromData(string classname, IPdxReader reader)
       {

--- a/cppcache/include/geode/Pool.hpp
+++ b/cppcache/include/geode/Pool.hpp
@@ -95,6 +95,18 @@ class APACHE_GEODE_EXPORT Pool : public std::enable_shared_from_this<Pool> {
   std::chrono::milliseconds getReadTimeout() const;
 
   /**
+   * Gets the host name of the SniProxy.
+   * @see PoolFactory#setSniProxy(string, int)
+   */
+  std::string getSniProxyHost() const;
+
+  /**
+   * Gets the port of the SniProxy.
+   * @see PoolFactory#setSniProxy(string, int)
+   */
+  int getSniProxyPort() const;
+
+  /**
    * Gets the minimum connections for this pool.
    * @see PoolFactory#setMinConnections(int)
    */

--- a/cppcache/src/Pool.cpp
+++ b/cppcache/src/Pool.cpp
@@ -45,6 +45,9 @@ std::chrono::milliseconds Pool::getReadTimeout() const {
   return m_attrs->getReadTimeout();
 }
 
+std::string Pool::getSniProxyHost() const { return m_attrs->getSniProxyHost(); }
+int Pool::getSniProxyPort() const { return m_attrs->getSniProxyPort(); }
+
 int Pool::getMinConnections() const { return m_attrs->getMinConnections(); }
 
 int Pool::getMaxConnections() const { return m_attrs->getMaxConnections(); }


### PR DESCRIPTION
Since the .NET API is a thin wrapper around the C++ API, all we really need to test in this layer is that the sni parameters are passed properly to the C++ layer.

This PR adds a new unit test in the new google test framework. Also includes new accessor functions to the pool API to get and set the sni parameters.  