### PR TITLE
Add note that docker compose is needed

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,7 +7,8 @@
 * [OpenSSL](https://www.openssl.org) *(for building source documentation)*
 * Java 8 JDK *(for building server side java functions used in some of the integration tests)*
 * [Apache Geode](http://geode.apache.org/releases/) binaries installed or available to link against
-* [Docker](https://www.docker.com/ (for running SNI Test)
+* [Docker](https://www.docker.com/) (for running SNI Test)
+* [Docker Compose](https://docs.docker.com/compose/install/) (for running SNI Test)
 
 ### Platform-Specific Prerequisites
 


### PR DESCRIPTION
Docker Compose is installed on Mac and Windows when using Docker Desktop.  On Linux you install Docker and Docker Compose separately, so it should be called out in our docs