### PR TITLE
Remove  GemFireVersion.getBuildDate()

### DIFF
--- a/tests/javaobject/LatestProp.java
+++ b/tests/javaobject/LatestProp.java
@@ -24,7 +24,6 @@ import org.apache.geode.internal.*;
 
 public class LatestProp {
   public static void main(String[] args){
-    System.out.println("build.date=" + GemFireVersion.getBuildDate());
     System.out.println("build.jdk=" + GemFireVersion.getBuildJavaVersion());
     System.out.println("build.version=" + GemFireVersion.getBuildJavaVersion());
     try{


### PR DESCRIPTION
This [commit](https://github.com/apache/geode/commit/d9d13100ae11e2eba8a6428fad29007388680b43#diff-a377b15d2036a2fc9072c1915c7f0ed4L83) removed getBuildDate() in the java code, causing geode native develop to fail to compile with geode develop