### PR TITLE
GEODE-8470: Properly stop running containers in SNI

### DIFF
--- a/clicache/integration-test2/SNITests.cs
+++ b/clicache/integration-test2/SNITests.cs
@@ -58,10 +58,10 @@ namespace Apache.Geode.Client.IntegrationTests
         public void Dispose()
         {
 
-            var dockerComposeProc = Process.Start(@"docker-compose.exe", "stop");
+            var dockerComposeProc = Process.Start(@"docker-compose.exe", "-f " + Config.SniConfigPath + "/docker-compose.yml" + " stop");
             dockerComposeProc.WaitForExit();
 
-            var dockerProc = Process.Start(@"docker.exe", "container prune -f");
+            var dockerProc = Process.Start(@"docker.exe", "system prune -f");
             dockerProc.WaitForExit();
 
         }

--- a/cppcache/integration/test/SNITest.cpp
+++ b/cppcache/integration/test/SNITest.cpp
@@ -75,12 +75,15 @@ class SNITest : public ::testing::Test {
   }
 
   void TearDown() override {
-    auto systemRVal = std::system("docker-compose stop");
+    auto dockerComposeStopCommand = "docker-compose -f " +
+                                    sniConfigPath.string() +
+                                    "/docker-compose.yml" + " stop";
+    auto systemRVal = std::system(dockerComposeStopCommand.c_str());
     if (systemRVal == -1) {
       BOOST_LOG_TRIVIAL(error) << "std::system returned: " << systemRVal;
     }
 
-    systemRVal = std::system("docker container prune -f");
+    systemRVal = std::system("docker system prune -f");
     if (systemRVal == -1) {
       BOOST_LOG_TRIVIAL(error) << "std::system returned: " << systemRVal;
     }


### PR DESCRIPTION
-use docker system prune -f to clean up networks and stopped containers

Noticed when trying to `docker rmi` the downloaded images and it said there were still containers with them.