### PR TITLE
GEODE-8449: Cleanup containers before each test

### DIFF
--- a/clicache/acceptance-test/SNITests.cs
+++ b/clicache/acceptance-test/SNITests.cs
@@ -34,7 +34,7 @@ namespace Apache.Geode.Client.IntegrationTests
 
         public SNITests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
         {
-			Dispose();
+			CleanupDocker();
 
             currentWorkingDirectory = Directory.GetCurrentDirectory();
             var clientTruststore = Config.SslClientKeyPath + @"/truststore_sni.pem";
@@ -58,13 +58,16 @@ namespace Apache.Geode.Client.IntegrationTests
 
         public void Dispose()
         {
+			CleanupDocker();
+		}
 
+		private void CleanupDocker()
+		{
 			var dockerComposeProc = Process.Start(@"docker-compose.exe", "-f " + Config.SniConfigPath + "/docker-compose.yml" + " stop");
 			dockerComposeProc.WaitForExit();
 
 			var dockerProc = Process.Start(@"docker.exe", "system prune -f");
 			dockerProc.WaitForExit();
-
 		}
 
         private string RunDockerCommand(string dockerCommand)

--- a/clicache/acceptance-test/SNITests.cs
+++ b/clicache/acceptance-test/SNITests.cs
@@ -34,6 +34,8 @@ namespace Apache.Geode.Client.IntegrationTests
 
         public SNITests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
         {
+			Dispose();
+
             currentWorkingDirectory = Directory.GetCurrentDirectory();
             var clientTruststore = Config.SslClientKeyPath + @"/truststore_sni.pem";
 
@@ -57,13 +59,13 @@ namespace Apache.Geode.Client.IntegrationTests
         public void Dispose()
         {
 
-            var dockerComposeProc = Process.Start(@"docker-compose.exe", "-f " + Config.SniConfigPath + "/docker-compose.yml" + " stop");
-            dockerComposeProc.WaitForExit();
+			var dockerComposeProc = Process.Start(@"docker-compose.exe", "-f " + Config.SniConfigPath + "/docker-compose.yml" + " stop");
+			dockerComposeProc.WaitForExit();
 
-            var dockerProc = Process.Start(@"docker.exe", "system prune -f");
-            dockerProc.WaitForExit();
+			var dockerProc = Process.Start(@"docker.exe", "system prune -f");
+			dockerProc.WaitForExit();
 
-        }
+		}
 
         private string RunDockerCommand(string dockerCommand)
         {

--- a/cppcache/acceptance-test/SNITest.cpp
+++ b/cppcache/acceptance-test/SNITest.cpp
@@ -52,6 +52,8 @@ class SNITest : public ::testing::Test {
   ~SNITest() override = default;
 
   void SetUp() override {
+    TearDown();
+
     auto systemRVal = 0;
     std::string dockerComposeCmd = "docker-compose -f " +
                                    sniConfigPath.string() +

--- a/cppcache/acceptance-test/SNITest.cpp
+++ b/cppcache/acceptance-test/SNITest.cpp
@@ -76,7 +76,9 @@ class SNITest : public ::testing::Test {
     }
   }
 
-  void TearDown() override {
+  void TearDown() override { cleanupDocker(); }
+
+  void cleanupDocker() {
     auto dockerComposeStopCommand = "docker-compose -f " +
                                     sniConfigPath.string() +
                                     "/docker-compose.yml" + " stop";


### PR DESCRIPTION
This cleans up any docker containers at the beginning of each test in case of a test failure that leaves docker containers up.