### PR TITLE
GEODE-8530: Fix for coredump during tx commit

### DIFF
--- a/cppcache/integration-test/resources/cacheWriterTransaction1.xml
+++ b/cppcache/integration-test/resources/cacheWriterTransaction1.xml
@@ -19,18 +19,16 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
        version="1.0">
-	<cache-server port="40404"/>
-	<region name="partition_region">
-		<region-attributes data-policy="partition">
-		<partition-attributes redundant-copies="1"/>
+    <cache-server port="40404"/>
+    <region name="partition_region">
+       <region-attributes data-policy="partition">
           <cache-writer>
             <class-name>javaobject.CacheWriterTransaction</class-name>
           </cache-writer>
         </region-attributes>
-	</region>
-	<region name="shadow_region">
-		<region-attributes data-policy="partition">
-		<partition-attributes redundant-copies="1"/>
+    </region>
+    <region name="shadow_region">
+      <region-attributes data-policy="partition">
       </region-attributes>
-	</region>
-</cache> 
+    </region>
+</cache>

--- a/cppcache/integration-test/resources/cacheWriterTransaction1.xml
+++ b/cppcache/integration-test/resources/cacheWriterTransaction1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<cache xmlns="http://geode.apache.org/schema/cache"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+       version="1.0">
+	<cache-server port="40404"/>
+	<region name="partition_region">
+		<region-attributes data-policy="partition">
+		<partition-attributes redundant-copies="1"/>
+          <cache-writer>
+            <class-name>javaobject.CacheWriterTransaction</class-name>
+          </cache-writer>
+        </region-attributes>
+	</region>
+	<region name="shadow_region">
+		<region-attributes data-policy="partition">
+		<partition-attributes redundant-copies="1"/>
+      </region-attributes>
+	</region>
+</cache> 

--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(cpp-integration-test
   TransactionCleaningTest.cpp
   WanDeserializationTest.cpp
   PdxInstanceFactoryTest.cpp
+  CacheWriterTest.cpp
 )
 
 target_compile_definitions(cpp-integration-test

--- a/cppcache/integration/test/CacheWriterTest.cpp
+++ b/cppcache/integration/test/CacheWriterTest.cpp
@@ -1,0 +1,90 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more *
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <geode/Cache.hpp>
+#include <geode/CacheFactory.hpp>
+#include <geode/CacheListener.hpp>
+#include <geode/CacheTransactionManager.hpp>
+#include <geode/PoolManager.hpp>
+#include <geode/RegionFactory.hpp>
+#include <geode/RegionShortcut.hpp>
+
+#include "framework/Cluster.h"
+#include "framework/Framework.h"
+#include "framework/Gfsh.h"
+
+namespace {
+
+using apache::geode::client::Cache;
+using apache::geode::client::CacheableString;
+using apache::geode::client::CacheFactory;
+using apache::geode::client::CacheTransactionManager;
+using apache::geode::client::CacheWriter;
+using apache::geode::client::Region;
+using apache::geode::client::RegionShortcut;
+
+/*
+ * Verify that it is possible to write in region from CacheWriter listener that
+ * is triggered by transaction. Region is not defined on client, but only on a
+ * server.
+ */
+TEST(CacheWriterTest, WriteInRegionFromCacheWriterTriggeredByTransaction) {
+  Cluster cluster{
+      LocatorCount{1}, ServerCount{1},
+      CacheXMLFiles(
+          {std::string(getFrameworkString(FrameworkVariable::TestCacheXmlDir)) +
+               "/cacheWriterTransaction1.xml",
+           std::string(getFrameworkString(FrameworkVariable::TestCacheXmlDir)) +
+               "/cacheWriterTransaction1.xml"})};
+  cluster.start([&]() {
+    cluster.getGfsh()
+        .deploy()
+        .jar(getFrameworkString(FrameworkVariable::JavaObjectJarPath))
+        .execute();
+  });
+
+  CacheFactory cacheFactory;
+  auto cache = cacheFactory.set("log-level", "none")
+                   .set("statistic-sampling-enabled", "false")
+                   .create();
+
+  auto poolFactory = cache.getPoolManager().createFactory();
+  cluster.applyLocators(poolFactory);
+
+  auto pool = poolFactory.create("pool");
+  auto regionFactory = cache.createRegionFactory(RegionShortcut::CACHING_PROXY);
+  auto region = regionFactory.setPoolName("pool").create("partition_region");
+
+  auto transactionManager = cache.getCacheTransactionManager();
+  transactionManager->begin();
+  auto key = CacheableString::create("key1");
+  auto value = CacheableString::create("value1");
+  region->put(key, value);
+  transactionManager->commit();
+
+  auto v1 = std::dynamic_pointer_cast<CacheableString>(region->get("key1"));
+  EXPECT_EQ("value1", v1->value());
+
+  // check that CacheWriter has successfully put data in shadow_region
+  auto shadow_region =
+      regionFactory.setPoolName("pool").create("shadow_region");
+
+  auto v2 = std::dynamic_pointer_cast<CacheableString>(region->get("key1"));
+  EXPECT_EQ("value1", v2->value());
+}
+}  // namespace

--- a/cppcache/src/RegionCommit.cpp
+++ b/cppcache/src/RegionCommit.cpp
@@ -51,9 +51,14 @@ void RegionCommit::apply(Cache* cache) {
   for (auto& entryOp : m_farSideEntryOps) {
     auto region = cache->getRegion(m_regionPath->value().c_str());
     if (region == nullptr && m_parentRegionPath != nullptr) {
-      region = cache->getRegion(m_parentRegionPath->value().c_str());
+      std::string parentRegionPath = m_parentRegionPath->value().c_str();
+      if (!parentRegionPath.empty()) {
+        region = cache->getRegion(parentRegionPath);
+      }
     }
-    std::static_pointer_cast<FarSideEntryOp>(entryOp)->apply(region);
+    if (region != nullptr) {
+      std::static_pointer_cast<FarSideEntryOp>(entryOp)->apply(region);
+    }
   }
 }
 

--- a/cppcache/src/RegionCommit.cpp
+++ b/cppcache/src/RegionCommit.cpp
@@ -51,7 +51,7 @@ void RegionCommit::apply(Cache* cache) {
   for (auto& entryOp : m_farSideEntryOps) {
     auto region = cache->getRegion(m_regionPath->value().c_str());
     if (region == nullptr && m_parentRegionPath != nullptr) {
-      std::string parentRegionPath = m_parentRegionPath->value().c_str();
+      const auto parentRegionPath = m_parentRegionPath->value();
       if (!parentRegionPath.empty()) {
         region = cache->getRegion(parentRegionPath);
       }

--- a/tests/javaobject/CacheWriterTransaction.java
+++ b/tests/javaobject/CacheWriterTransaction.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package javaobject;
+import java.util.*;
+import org.apache.geode.cache.CacheWriter;
+import org.apache.geode.cache.CacheWriterException;
+import org.apache.geode.cache.EntryEvent;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionEvent;
+import org.apache.geode.cache.RegionService;
+
+public class CacheWriterTransaction implements CacheWriter<String, String> {
+
+  public CacheWriterTransaction() {}
+  
+  public void beforeCreate(EntryEvent<String, String> event) {
+    final RegionService cache = event.getRegion().getRegionService();
+    Region<String, String> region = cache.getRegion("shadow_region");
+    region.put("key1", "value1");	         
+  }
+  
+  public void beforeUpdate(EntryEvent<String, String> event) 
+  {}
+   
+  public void beforeDestroy(EntryEvent<String, String> event) 
+  {}
+   
+  public void beforeRegionDestroy(RegionEvent<String, String> event) 
+  {}
+
+  public void beforeRegionClear(RegionEvent<String, String> event) 
+  {}
+
+  public void close()
+  {}
+}
+


### PR DESCRIPTION
Client is fixed in a way that ignores all regions enlisted within
transaction that client doesn't have configured. This behavior is
aligned with the java client, since same thing is done there.