### PR TITLE
GEODE-8548 Avoid hostname resolution in TcpConn

### DIFF
--- a/cppcache/src/TcpConn.cpp
+++ b/cppcache/src/TcpConn.cpp
@@ -129,6 +129,7 @@ TcpConn::TcpConn(const std::string& address,
     : stream_(nullptr),
       maxBuffSizePool_(maxBuffSizePool),
       inetAddress_(address.c_str()),
+      endpoint_(address),
       timeout_(waitSeconds) {}
 
 TcpConn::TcpConn(const std::string& hostname, uint16_t port,
@@ -136,6 +137,7 @@ TcpConn::TcpConn(const std::string& hostname, uint16_t port,
     : stream_(nullptr),
       maxBuffSizePool_(maxBuffSizePool),
       inetAddress_(port, hostname.c_str()),
+      endpoint_(hostname + ":" + std::to_string(port)),
       timeout_(waitSeconds) {}
 
 void TcpConn::connect() {
@@ -143,9 +145,7 @@ void TcpConn::connect() {
 
   ACE_OS::signal(SIGPIPE, SIG_IGN);  // Ignore broken pipe
 
-  LOGFINER(std::string("Connecting plain socket stream to ") +
-           inetAddress_.get_host_name() + ":" +
-           std::to_string(inetAddress_.get_port_number()) + " waiting " +
+  LOGFINER("Connecting plain socket stream to " + endpoint_ + " waiting " +
            to_string(timeout_));
 
   const ACE_Time_Value aceTimeout(timeout_);

--- a/cppcache/src/TcpConn.hpp
+++ b/cppcache/src/TcpConn.hpp
@@ -49,6 +49,7 @@ class TcpConn : public Connector {
 
  protected:
   ACE_INET_Addr inetAddress_;
+  std::string endpoint_;
   std::chrono::microseconds timeout_;
   static const size_t kChunkSize;
 


### PR DESCRIPTION
 - Calling get_host_name() in TcpConn::connect involves a system call that
   might take several seconds to complete.
 - So endpoint is stored instead upon TcpConn construction and used later
   instead of making the system call.