### PR TITLE
GEODE-8565: Remove bucketServerLocation if timeout error

### DIFF
--- a/cppcache/integration/test/PartitionRegionOpsTest.cpp
+++ b/cppcache/integration/test/PartitionRegionOpsTest.cpp
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
-
 #include <chrono>
 #include <future>
 #include <iostream>
@@ -49,10 +47,11 @@ using apache::geode::client::RegionShortcut;
 using std::chrono::minutes;
 
 std::string getClientLogName() {
-  std::string testSuiteName(
-      ::testing::UnitTest::GetInstance()->current_test_suite()->name());
+  std::string testSuiteName(::testing::UnitTest::GetInstance()
+                                ->current_test_info()
+                                ->test_case_name());
   std::string testCaseName(
-      ::testing::UnitTest::GetInstance()->current_test_case()->name());
+      ::testing::UnitTest::GetInstance()->current_test_info()->name());
   std::string logFileName(testSuiteName + "/" + testCaseName + "/client.log");
   return logFileName;
 }

--- a/cppcache/integration/test/PartitionRegionOpsTest.cpp
+++ b/cppcache/integration/test/PartitionRegionOpsTest.cpp
@@ -16,11 +16,11 @@
  */
 
 #include <chrono>
+#include <fstream>
 #include <future>
 #include <iostream>
 #include <random>
 #include <thread>
-#include <fstream>
 
 #include <gtest/gtest.h>
 

--- a/cppcache/integration/test/PartitionRegionOpsTest.cpp
+++ b/cppcache/integration/test/PartitionRegionOpsTest.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <random>
 #include <thread>
+#include <fstream>
 
 #include <gtest/gtest.h>
 
@@ -130,7 +131,7 @@ void verifyMetadataWasRemovedAtFirstError() {
       "Removing bucketServerLocation(.*)due to GF_TIMEOUT");
 
   if (testLog.is_open()) {
-    while (getline(testLog, fileLine)) {
+    while (std::getline(testLog, fileLine)) {
       if (std::regex_search(fileLine, timeoutRegex)) {
         timeoutErrors = true;
       } else if (std::regex_search(fileLine, ioErrRegex)) {

--- a/cppcache/integration/test/PartitionRegionOpsTest.cpp
+++ b/cppcache/integration/test/PartitionRegionOpsTest.cpp
@@ -103,7 +103,7 @@ void getEntries(std::shared_ptr<Region> region, int numEntries) {
 
 void removeLogFromPreviousExecution() {
   std::string logFileName(getClientLogName());
-  std::ifstream previousTestLog(logFileName);
+  std::ifstream previousTestLog(logFileName.c_str());
   if (previousTestLog.good()) {
     std::cout << "Removing log from previous execution: " << logFileName
               << std::endl;
@@ -112,7 +112,7 @@ void removeLogFromPreviousExecution() {
 }
 
 void verifyMetadataWasRemovedAtFirstError() {
-  std::ifstream testLog(getClientLogName());
+  std::ifstream testLog(getClientLogName().c_str());
   std::string fileLine;
   bool ioErrors = false;
   bool timeoutErrors = false;

--- a/cppcache/src/Log.cpp
+++ b/cppcache/src/Log.cpp
@@ -45,6 +45,9 @@
 #define GF_FILEEXISTS(x) _access_s(x, 00)
 #else
 #include <unistd.h>
+
+#include <iostream>
+
 #define GF_FILEEXISTS(x) access(x, F_OK)
 #endif
 
@@ -406,8 +409,7 @@ void Log::writeBanner() {
   std::string bannertext = geodeBanner::getBanner();
 
   if (g_logFile == nullptr) {
-    fprintf(stdout, "%s", bannertext.c_str());
-    fflush(stdout);
+    std::cerr << bannertext.c_str() << std::endl;
     return;
   }  // else
 
@@ -540,8 +542,7 @@ void Log::put(LogLevel level, const char* msg) {
   char fullpath[512] = {0};
 
   if (!g_logFile) {
-    fprintf(stdout, "%s%s\n", formatLogLine(buf, level), msg);
-    fflush(stdout);
+    std::cerr << formatLogLine(buf, level) << msg << std::endl;
     // TODO: ignoring for now; probably store the log-lines for possible
     // future logging if log-file gets initialized properly
 

--- a/cppcache/src/Log.cpp
+++ b/cppcache/src/Log.cpp
@@ -45,9 +45,6 @@
 #define GF_FILEEXISTS(x) _access_s(x, 00)
 #else
 #include <unistd.h>
-
-#include <iostream>
-
 #define GF_FILEEXISTS(x) access(x, F_OK)
 #endif
 
@@ -409,7 +406,8 @@ void Log::writeBanner() {
   std::string bannertext = geodeBanner::getBanner();
 
   if (g_logFile == nullptr) {
-    std::cerr << bannertext.c_str() << std::endl;
+    fprintf(stdout, "%s", bannertext.c_str());
+    fflush(stdout);
     return;
   }  // else
 
@@ -542,7 +540,8 @@ void Log::put(LogLevel level, const char* msg) {
   char fullpath[512] = {0};
 
   if (!g_logFile) {
-    std::cerr << formatLogLine(buf, level) << msg << std::endl;
+    fprintf(stdout, "%s%s\n", formatLogLine(buf, level), msg);
+    fflush(stdout);
     // TODO: ignoring for now; probably store the log-lines for possible
     // future logging if log-file gets initialized properly
 

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -2333,7 +2333,7 @@ TcrConnection* ThinClientPoolDM::getConnectionFromQueueW(
   if (theEP != nullptr) {
     conn = getFromEP(theEP);
     if (!conn) {
-      LOGFINER("Creating connection to endpint as not found in pool ");
+      LOGFINER("Creating connection to endpoint as not found in pool ");
       *error = createPoolConnectionToAEndPoint(conn, theEP, maxConnLimit, true);
       if (*error == GF_CLIENT_WAIT_TIMEOUT ||
           *error == GF_CLIENT_WAIT_TIMEOUT_REFRESH_PRMETADATA) {

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -1427,14 +1427,13 @@ GfErrType ThinClientPoolDM::sendSyncRequest(
             GF_SAFE_DELETE_CON(conn);
           }
           excludeServers.insert(ServerLocation(ep->name()));
-          if (error == GF_IOERR || error == GF_TIMEOUT) {
-            if (m_clientMetadataService) {
-              auto sl = std::make_shared<BucketServerLocation>(ep->name());
-              LOGINFO("Removing bucketServerLocation %s due to %s",
-                      sl->toString().c_str(),
-                      (error == GF_IOERR ? "GF_IOERR" : "GF_TIMEOUT"));
-              m_clientMetadataService->removeBucketServerLocation(sl);
-            }
+          if ((error == GF_IOERR || error == GF_TIMEOUT) &&
+              m_clientMetadataService) {
+            auto sl = std::make_shared<BucketServerLocation>(ep->name());
+            LOGINFO("Removing bucketServerLocation %s due to %s",
+                    sl->toString().c_str(),
+                    (error == GF_IOERR ? "GF_IOERR" : "GF_TIMEOUT"));
+            m_clientMetadataService->removeBucketServerLocation(sl);
           }
         }
       } else {
@@ -2352,14 +2351,13 @@ TcrConnection* ThinClientPoolDM::getConnectionFromQueueW(
                   version);
         }
         return nullptr;
-      } else if (*error == GF_IOERR || *error == GF_TIMEOUT) {
-        if (m_clientMetadataService) {
-          auto sl = std::make_shared<BucketServerLocation>(theEP->name());
-          LOGINFO("Removing bucketServerLocation %s due to %s",
-                  sl->toString().c_str(),
-                  (*error == GF_IOERR ? "GF_IOERR" : "GF_TIMEOUT"));
-          m_clientMetadataService->removeBucketServerLocation(sl);
-        }
+      } else if ((*error == GF_IOERR || *error == GF_TIMEOUT) &&
+                 m_clientMetadataService) {
+        auto sl = std::make_shared<BucketServerLocation>(theEP->name());
+        LOGINFO("Removing bucketServerLocation %s due to %s",
+                sl->toString().c_str(),
+                (*error == GF_IOERR ? "GF_IOERR" : "GF_TIMEOUT"));
+        m_clientMetadataService->removeBucketServerLocation(sl);
       }
     }
   }

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -1427,17 +1427,18 @@ GfErrType ThinClientPoolDM::sendSyncRequest(
             GF_SAFE_DELETE_CON(conn);
           }
           excludeServers.insert(ServerLocation(ep->name()));
-          if (error == GF_IOERR) {
+          if (error == GF_IOERR || error == GF_TIMEOUT) {
             if (m_clientMetadataService) {
               auto sl = std::make_shared<BucketServerLocation>(ep->name());
-              LOGINFO("Removing bucketServerLocation %s due to GF_IOERR",
-                      sl->toString().c_str());
+              LOGINFO("Removing bucketServerLocation %s due to %s",
+                      sl->toString().c_str(),
+                      (error == GF_IOERR ? "GF_IOERR" : "GF_TIMEOUT"));
               m_clientMetadataService->removeBucketServerLocation(sl);
             }
           }
         }
       } else {
-        return error;  // server exception while sending credentail message to
+        return error;  // server exception while sending credential message to
       }
       // server...
     }
@@ -2351,11 +2352,12 @@ TcrConnection* ThinClientPoolDM::getConnectionFromQueueW(
                   version);
         }
         return nullptr;
-      } else if (*error == GF_IOERR) {
+      } else if (*error == GF_IOERR || *error == GF_TIMEOUT) {
         if (m_clientMetadataService) {
           auto sl = std::make_shared<BucketServerLocation>(theEP->name());
-          LOGINFO("Removing bucketServerLocation %s due to GF_IOERR",
-                  sl->toString().c_str());
+          LOGINFO("Removing bucketServerLocation %s due to %s",
+                  sl->toString().c_str(),
+                  (*error == GF_IOERR ? "GF_IOERR" : "GF_TIMEOUT"));
           m_clientMetadataService->removeBucketServerLocation(sl);
         }
       }


### PR DESCRIPTION
This ticket is an improvement over GEODE-8231:

> If a C++ client connected to a cluster is sending operations to a partitioned region and one of the server goes down, the client keeps trying to send operations to the down server. This can be observed in the logs by a continuous flow of lines containing: "IO error in handshake with endpoint..."

After that improvement, the c++ client removes the metadata info of the failing server once the "IO error in handshake" is received.

But it has been observed that before that error is received, "timeout error" can be returned. So the client will try to reconnect until the "IO error in handshake" is received.

This ticket aims to extend the GEODE-8231 solution so the client removes the server metadata information when a timeout is received.
