### PR TITLE
GEODE-8569: Add missing method to ClientMessageDecoder

### DIFF
--- a/tools/gnmsg/client_messages.py
+++ b/tools/gnmsg/client_messages.py
@@ -410,4 +410,8 @@ client_message_parsers = {
 def parse_client_message(properties, message_bytes):
     offset = CHARS_IN_MESSAGE_HEADER
     if properties["Type"] in client_message_parsers.keys():
-        client_message_parsers[properties["Type"]](properties, message_bytes, offset)
+        try:
+            client_message_parsers[properties["Type"]](properties, message_bytes, offset)
+        except:
+            properties["ERROR"] = "Exception reading message - probably incomplete"
+            return

--- a/tools/gnmsg/server_message_decoder.py
+++ b/tools/gnmsg/server_message_decoder.py
@@ -36,6 +36,7 @@ class ServerMessageDecoder(DecoderBase):
         self.nc_version_ = None
         self.get_receive_trace_parts_functions_ = {
             "0.0.42": self.get_receive_trace_header_base,
+            "10.0.3": self.get_receive_trace_header_base,
             "10.1.1": self.get_receive_trace_header_base,
             "10.1.2": self.get_receive_trace_header_base,
             "10.1.3": self.get_receive_trace_header_base,
@@ -43,6 +44,7 @@ class ServerMessageDecoder(DecoderBase):
         }
         self.receive_trace_parsers_ = {
             "0.0.42": self.parse_response_fields_base,
+            "10.0.3": self.parse_response_fields_base,
             "10.1.1": self.parse_response_fields_base,
             "10.1.2": self.parse_response_fields_base,
             "10.1.3": self.parse_response_fields_base,


### PR DESCRIPTION
- This would be called, and thus throw an exception, for client logs using AuthInitialize
- Also added a new entry to version lookup for regex function dispatcher.

@mreddington @davebarnes97 @dihardman @karensmolermiller @alb3rtobr 