### PR TITLE
Enforce header hygiene

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Wno-double-promotion #TODO fix
     -Wno-undefined-func-template #TODO fix
     -Wno-float-equal #TODO fix
-    -Wno-header-hygiene #TODO fix
     -Wno-conversion #TODO fix
     -Wno-reserved-id-macro #TODO fix
     -Wno-documentation # TODO fix


### PR DESCRIPTION
Authored-by: M. Oleske <michael@oleske.engineer>

Seems like we don't need this cop out any more!  Or at least on the mac, we'll see what Travis says about clang on linux