### PR TITLE
GEODE-8571: Enforce documentation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Wno-header-hygiene #TODO fix
     -Wno-conversion #TODO fix
     -Wno-reserved-id-macro #TODO fix
-    -Wno-documentation # TODO fix
     -Wno-range-loop-analysis
     -Wno-weak-vtables
     -Wno-weak-template-vtables

--- a/cppcache/include/geode/AuthInitialize.hpp
+++ b/cppcache/include/geode/AuthInitialize.hpp
@@ -52,7 +52,7 @@ class APACHE_GEODE_EXPORT AuthInitialize {
 
   /**@brief initialize with the given set of security properties
    * and return the credentials for the client as properties.
-   * @param props the set of security properties provided to the
+   * @param securityprops the set of security properties provided to the
    * <code>DistributedSystem.connect</code> method
    * @param server it is the ID of the current endpoint.
    * The format expected is "host:port".

--- a/cppcache/include/geode/AuthenticatedView.hpp
+++ b/cppcache/include/geode/AuthenticatedView.hpp
@@ -63,7 +63,6 @@ class APACHE_GEODE_EXPORT AuthenticatedView : public RegionService {
    * After this cache is closed, any further
    * method call on this cache or any region object will throw
    * <code>CacheClosedException</code>, unless otherwise noted.
-   * @param keepalive whether to keep a durable client's queue alive
    * @throws CacheClosedException,  if the cache is already closed.
    */
   void close() override;
@@ -85,9 +84,6 @@ class APACHE_GEODE_EXPORT AuthenticatedView : public RegionService {
    * Returns a set of root regions in the cache. This set is a snapshot and
    * is not backed by the Cache. The vector passed in is cleared and the
    * regions are added to it.
-   *
-   * @param regions the returned set of
-   * regions
    */
   std::vector<std::shared_ptr<Region>> rootRegions() const override;
 

--- a/cppcache/include/geode/Cache.hpp
+++ b/cppcache/include/geode/Cache.hpp
@@ -149,9 +149,6 @@ class APACHE_GEODE_EXPORT Cache : public GeodeCache {
    * Returns a set of root regions in the cache. This set is a snapshot and
    * is not backed by the Cache. The vector passed in is cleared and the
    * regions are added to it.
-   *
-   * @param regions the returned set of
-   * regions
    */
   std::vector<std::shared_ptr<Region>> rootRegions() const override;
 

--- a/cppcache/include/geode/CacheFactory.hpp
+++ b/cppcache/include/geode/CacheFactory.hpp
@@ -102,7 +102,7 @@ class APACHE_GEODE_EXPORT CacheFactory {
   /**
    * Sets the AuthInitializer defined by the user.
    * The AuthInitializer will be used to obtain credentials for a client.
-   * @param authInitialize
+   * @param authInitialize the authInitialize to set
    * @return this ClientCacheFactory
    */
   CacheFactory& setAuthInitialize(

--- a/cppcache/include/geode/CacheTransactionManager.hpp
+++ b/cppcache/include/geode/CacheTransactionManager.hpp
@@ -149,7 +149,7 @@ class APACHE_GEODE_EXPORT CacheTransactionManager {
    * transaction identifier is currently suspended locally. This method does not
    * check other members for transaction status.
    *
-   * @param transactionId
+   * @param transactionId transaction to check if is suspended
    * @return true if the transaction is in suspended state, false otherwise
    * @since 3.6.2
    * @see #exists(TransactionId)

--- a/cppcache/include/geode/CacheableEnum.hpp
+++ b/cppcache/include/geode/CacheableEnum.hpp
@@ -102,7 +102,7 @@ class APACHE_GEODE_EXPORT CacheableEnum
 
   /**
    * Factory method for creating an instance of CacheableEnum.
-   * @param className the name of the enum class that maps to the java enum
+   * @param enumClassName the name of the enum class that maps to the java enum
    * type.
    * @param enumName the name of the enum constant that maps to the java enum
    * type.

--- a/cppcache/include/geode/CqState.hpp
+++ b/cppcache/include/geode/CqState.hpp
@@ -29,7 +29,7 @@ namespace geode {
 namespace client {
 
 /**
- * @class CqState CqState.hpp
+ * @enum CqState CqState.hpp
  *
  * This interface gives information on the state of a CqQuery.
  * It is provided by the getState method of the CqQuery instance.

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -70,8 +70,6 @@ class APACHE_GEODE_EXPORT DataInput {
 
   /**
    * Read a boolean value from the <code>DataInput</code>.
-   *
-   * @param value output parameter to hold the boolean read from stream
    */
   inline bool readBoolean() {
     _GEODE_CHECK_BUFFER_SIZE(1);
@@ -172,9 +170,6 @@ class APACHE_GEODE_EXPORT DataInput {
 
   /**
    * Read a 32-bit signed integer from the <code>DataInput</code>.g
-   *
-   * @param value output parameter to hold the 32-bit signed integer
-   *   read from stream
    */
   inline int32_t readInt32() {
     _GEODE_CHECK_BUFFER_SIZE(4);
@@ -187,9 +182,6 @@ class APACHE_GEODE_EXPORT DataInput {
 
   /**
    * Read a 64-bit signed integer from the <code>DataInput</code>.
-   *
-   * @param value output parameter to hold the 64-bit signed integer
-   *   read from stream
    */
   inline int64_t readInt64() {
     _GEODE_CHECK_BUFFER_SIZE(8);
@@ -209,9 +201,6 @@ class APACHE_GEODE_EXPORT DataInput {
    * Read a 32-bit signed integer array length value from the
    * <code>DataInput</code> in a manner compatible with java server's
    * <code>DataSerializer.readArrayLength</code>.
-   *
-   * @param len output parameter to hold the 32-bit signed length
-   *   read from stream
    */
   inline int32_t readArrayLength() {
     const uint8_t code = read();
@@ -256,8 +245,6 @@ class APACHE_GEODE_EXPORT DataInput {
 
   /**
    * Read a float from the <code>DataInput</code>.
-   *
-   * @param value output parameter to hold the float read from stream
    */
   inline float readFloat() {
     _GEODE_CHECK_BUFFER_SIZE(4);
@@ -271,9 +258,6 @@ class APACHE_GEODE_EXPORT DataInput {
 
   /**
    * Read a double precision number from the <code>DataInput</code>.
-   *
-   * @param value output parameter to hold the double precision number
-   *   read from stream
    */
   inline double readDouble() {
     _GEODE_CHECK_BUFFER_SIZE(8);

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -74,7 +74,7 @@ class APACHE_GEODE_EXPORT DataOutput {
   /**
    * Write an array of unsigned bytes to the <code>DataOutput</code>.
    *
-   * @param value the array of unsigned bytes to be written
+   * @param bytes the array of unsigned bytes to be written
    * @param len the number of bytes from the start of array to be written
    */
   inline void writeBytes(const uint8_t* bytes, int32_t len) {
@@ -93,7 +93,7 @@ class APACHE_GEODE_EXPORT DataOutput {
   /**
    * Write an array of signed bytes to the <code>DataOutput</code>.
    *
-   * @param value the array of signed bytes to be written
+   * @param bytes the array of signed bytes to be written
    * @param len the number of bytes from the start of array to be written
    */
   inline void writeBytes(const int8_t* bytes, int32_t len) {
@@ -108,7 +108,7 @@ class APACHE_GEODE_EXPORT DataOutput {
    *   <code>DataInput::readBytesOnly</code> (unlike
    *   <code>DataInput::readBytes</code>) needs the length argument explicitly.
    *
-   * @param value the array of unsigned bytes to be written
+   * @param bytes the array of unsigned bytes to be written
    * @param len the number of bytes from the start of array to be written
    */
   inline void writeBytesOnly(const uint8_t* bytes, size_t len) {
@@ -125,7 +125,7 @@ class APACHE_GEODE_EXPORT DataOutput {
    *   <code>DataInput::readBytesOnly</code> (unlike
    *   <code>DataInput::readBytes</code>) needs the length argument explicitly.
    *
-   * @param value the array of signed bytes to be written
+   * @param bytes the array of signed bytes to be written
    * @param len the number of bytes from the start of array to be written
    */
   inline void writeBytesOnly(const int8_t* bytes, size_t len) {
@@ -216,7 +216,7 @@ class APACHE_GEODE_EXPORT DataOutput {
    * <code>DataOutput</code> in a manner compatible with java server's
    * <code>DataSerializer.writeArrayLength</code>.
    *
-   * @param value the 32-bit signed integer array length to be written
+   * @param len the 32-bit signed integer array length to be written
    */
   inline void writeArrayLen(int32_t len) {
     if (len == -1) {

--- a/cppcache/include/geode/DiskPolicyType.hpp
+++ b/cppcache/include/geode/DiskPolicyType.hpp
@@ -34,7 +34,7 @@ namespace geode {
 namespace client {
 
 /**
- * @class DiskPolicyType DiskPolicyType.hpp
+ * @enum DiskPolicyType DiskPolicyType.hpp
  * Enumerated type for disk policy.
  * @see RegionAttributes::getDiskPolicy
  * @see RegionAttributesFactory::setDiskPolicy

--- a/cppcache/include/geode/ExceptionTypes.hpp
+++ b/cppcache/include/geode/ExceptionTypes.hpp
@@ -474,7 +474,7 @@ class APACHE_GEODE_EXPORT DiskFailureException : public Exception {
 
 /**
  *@brief Thrown by the persistence manager when the data
- *@brief to be read from disk is corrupt.
+ * to be read from disk is corrupt.
  **/
 class APACHE_GEODE_EXPORT DiskCorruptException : public Exception {
  public:

--- a/cppcache/include/geode/ExpirationAction.hpp
+++ b/cppcache/include/geode/ExpirationAction.hpp
@@ -34,7 +34,7 @@ namespace geode {
 namespace client {
 
 /**
- * @class ExpirationAction ExpirationAction.hpp
+ * @enum ExpirationAction ExpirationAction.hpp
  * Enumerated type for expiration actions.
  *
  * @see ExpirationAttributes

--- a/cppcache/include/geode/PdxInstance.hpp
+++ b/cppcache/include/geode/PdxInstance.hpp
@@ -80,8 +80,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * out param. std::shared_ptr<Cacheable> type corresponds to the Java object
    * type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with std::shared_ptr<Cacheable>
-   * type.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    * For deserialization C++ Native Client requires the domain class to be
    * registered.
@@ -96,7 +94,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in bool type out param.
    * bool type corresponds to the Java boolean type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with bool type.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -107,7 +104,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in signed char type out param.
    * signed char type corresponds to the Java byte type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with signed char type.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -118,7 +114,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in int16_t type out param.
    * int16_t type corresponds to the Java short type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with int16_t type.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -129,7 +124,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in int32_t type out param.
    * int32_t type corresponds to the Java int type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with int32_t type.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    */
   virtual int32_t getIntField(const std::string& fieldname) const = 0;
@@ -138,7 +132,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in int64_t type out param.
    * int64_t type corresponds to the Java long type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with int64_t type.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -149,7 +142,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in float type out param.
    * float type corresponds to the Java float type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with float type.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -160,7 +152,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in double type out param.
    * double type corresponds to the Java double type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with double type.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -170,8 +161,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
   /**
    * Reads the named field and sets its value in char type out param.
    * char type corresponds to the Java char type.
-   * @param fieldname name of the field to read
-   * @param value value of the field to be set with char type.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -193,8 +182,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in bool array type out param.
    * bool* type corresponds to the Java boolean[] type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with bool array type.
-   * @param length length is set with number of bool elements.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -206,8 +193,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in signed char array type out
    * param. int8_t* type corresponds to the Java byte[] type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with int8_t array type.
-   * @param length length is set with number of int8_t elements.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -219,8 +204,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in int16_t array type out param.
    * int16_t* type corresponds to the Java short[] type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with int16_t array type.
-   * @param length length is set with number of int16_t elements.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -232,8 +215,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in int32_t array type out param.
    * int32_t* type corresponds to the Java int[] type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with int32_t array type.
-   * @param length length is set with number of int32_t elements.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -245,8 +226,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in int64_t array type out param.
    * int64_t* type corresponds to the Java long[] type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with int64_t array type.
-   * @param length length is set with number of int64_t elements.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -258,8 +237,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in float array type out param.
    * float* type corresponds to the Java float[] type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with float array type.
-   * @param length length is set with number of float elements.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -271,8 +248,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in double array type out param.
    * double* type corresponds to the Java double[] type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with double array type.
-   * @param length length is set with number of double elements.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -284,9 +259,7 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
   /**
    * Reads the named field and sets its value in char array type out param.
    * char16_t* type corresponds to the Java char[] type.
-   * @param fieldname name of the field to read
-   * @param value value of the field to be set with char array type.
-   * @param length length is set with number of char16_t* elements.
+   * @param fieldName name of the field to read
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
    * @see PdxInstance#hasField
@@ -310,7 +283,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * type out param. std::shared_ptr<CacheableDate> type is corresponding to
    * java Java.util.date type.
    * @param fieldname name of the field to read
-   * @param value value of the field to be set with
    * std::shared_ptr<CacheableDate> type.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
@@ -323,7 +295,7 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * Reads the named field and sets its value in array of byte arrays type out
    * param.
    * int8_t** type corresponds to the Java byte[][] type.
-   * @param fieldname name of the field to read.
+   * @param fieldName name of the field to read.
    * @param value value of the field to be set with array of byte arrays type.
    * @param arrayLength arrayLength is set to the number of byte arrays.
    * @param elementLength elementLength is set to individual byte array lengths.
@@ -342,7 +314,6 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
    * std::shared_ptr<CacheableObjectArray> type corresponds to the Java
    * Object[] type.
    * @param fieldname name of the field to read.
-   * @param value value of the field to be set with
    * std::shared_ptr<CacheableObjectArray> type.
    * @throws IllegalStateException if PdxInstance doesn't have the named field.
    *
@@ -467,13 +438,13 @@ class APACHE_GEODE_EXPORT PdxInstance : public PdxSerializable {
   /**
    * @brief serialize this object in geode PDX format. This is an internal
    * method.
-   * @param PdxWriter to serialize the PDX object
+   * @param output to serialize the PDX object
    */
   virtual void toData(PdxWriter& output) const override = 0;
 
   /**
    * @brief Deserialize this object. This is an internal method.
-   * @param PdxReader to deserialize the PDX object
+   * @param input to deserialize the PDX object
    */
   virtual void fromData(PdxReader& input) override = 0;
 

--- a/cppcache/include/geode/PdxInstanceFactory.hpp
+++ b/cppcache/include/geode/PdxInstanceFactory.hpp
@@ -231,7 +231,6 @@ class APACHE_GEODE_EXPORT PdxInstanceFactory {
    * <p>Java boolean[] is mapped to C++ bool*.</p>
    * @param fieldName the name of the field to write
    * @param value the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxInstanceFactory
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -245,7 +244,6 @@ class APACHE_GEODE_EXPORT PdxInstanceFactory {
    * <p>Java char[] is mapped to C++ char16_t*.</p>
    * @param fieldName the name of the field to write
    * @param value the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxInstanceFactory
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -259,7 +257,6 @@ class APACHE_GEODE_EXPORT PdxInstanceFactory {
    * <p>Java byte[] is mapped to C++ int8_t*.</p>
    * @param fieldName the name of the field to write
    * @param value the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxInstanceFactory
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -273,7 +270,6 @@ class APACHE_GEODE_EXPORT PdxInstanceFactory {
    * <p>Java short[] is mapped to C++ int16_t*.</p>
    * @param fieldName the name of the field to write
    * @param value the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxInstanceFactory
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -287,7 +283,6 @@ class APACHE_GEODE_EXPORT PdxInstanceFactory {
    * <p>Java int[] is mapped to C++ int32_t*.</p>
    * @param fieldName the name of the field to write
    * @param value the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxInstanceFactory
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -301,7 +296,6 @@ class APACHE_GEODE_EXPORT PdxInstanceFactory {
    * <p>Java long[] is mapped to C++ int64_t*.</p>
    * @param fieldName the name of the field to write
    * @param value the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxInstanceFactory
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -315,7 +309,6 @@ class APACHE_GEODE_EXPORT PdxInstanceFactory {
    * <p>Java float[] is mapped to C++ float*.</p>
    * @param fieldName the name of the field to write
    * @param value the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxInstanceFactory
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -329,7 +322,6 @@ class APACHE_GEODE_EXPORT PdxInstanceFactory {
    * <p>Java double[] is mapped to C++ double*.</p>
    * @param fieldName the name of the field to write
    * @param value the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxInstanceFactory
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -343,7 +335,6 @@ class APACHE_GEODE_EXPORT PdxInstanceFactory {
    * <p>Java String[] is mapped to C++ char**.</p>
    * @param fieldName the name of the field to write
    * @param value the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxInstanceFactory
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.

--- a/cppcache/include/geode/PdxReader.hpp
+++ b/cppcache/include/geode/PdxReader.hpp
@@ -183,7 +183,6 @@ class APACHE_GEODE_EXPORT PdxReader {
    * Read a char16_t* value from the <code>PdxReader</code> and sets array
    * length. <p>C++ char16_t* is mapped to Java char[].</p>
    * @param fieldName name of the field to read
-   * @param length length is set with number of char16_t elements.
    * @return value of type char16_t*.
    * @throws IllegalStateException if PdxReader doesn't have the named field.
    *
@@ -195,7 +194,6 @@ class APACHE_GEODE_EXPORT PdxReader {
    * Read a bool* value from the <code>PdxReader</code> and sets array length.
    * <p>C++ bool* is mapped to Java boolean[]</p>
    * @param fieldName name of the field to read
-   * @param length length is set with number of bool elements.
    * @throws IllegalStateException if PdxReader doesn't have the named field.
    *
    * @see PdxReader#hasField
@@ -206,7 +204,6 @@ class APACHE_GEODE_EXPORT PdxReader {
    * Read a int8_t* value from the <code>PdxReader</code> and sets array length.
    * <p>C++ int8_t* is mapped to Java byte[].</p>
    * @param fieldName name of the field to read
-   * @param length length is set with number of int8_t elements
    * @return value of type int8_t*.
    * @throws IllegalStateException if PdxReader doesn't have the named field.
    *
@@ -219,7 +216,6 @@ class APACHE_GEODE_EXPORT PdxReader {
    * length.
    * <p>C++ int16_t* is mapped to Java short[].</p>
    * @param fieldName name of the field to read
-   * @param length length is set with number of int16_t elements
    * @return value of type int16_t*.
    * @throws IllegalStateException if PdxReader doesn't have the named field.
    *
@@ -232,7 +228,6 @@ class APACHE_GEODE_EXPORT PdxReader {
    * length.
    * <p>C++ int32_t* is mapped to Java int[].</p>
    * @param fieldName name of the field to read
-   * @param length length is set with number of int32_t elements
    * @return value of type int32_t*.
    * @throws IllegalStateException if PdxReader doesn't have the named field.
    *
@@ -245,7 +240,6 @@ class APACHE_GEODE_EXPORT PdxReader {
    * length.
    * <p>C++ int64_t* is mapped to Java long[].</p>
    * @param fieldName name of the field to read
-   * @param length length is set with number of int64_t elements
    * @return value of type int64_t*.
    * @throws IllegalStateException if PdxReader doesn't have the named field.
    *
@@ -257,7 +251,6 @@ class APACHE_GEODE_EXPORT PdxReader {
    * Read a float* value from the <code>PdxReader</code> and sets array length.
    * <p>C++ float* is mapped to Java float[].</p>
    * @param fieldName name of the field to read
-   * @param length length is set with number of float elements
    * @return value of type float*.
    * @throws IllegalStateException if PdxReader doesn't have the named field.
    *
@@ -269,7 +262,6 @@ class APACHE_GEODE_EXPORT PdxReader {
    * Read a double* value from the <code>PdxReader</code> and sets array length.
    * <p>C++ double* is mapped to Java double[].</p>
    * @param fieldName name of the field to read
-   * @param length length is set with number of double elements
    * @return value of type double*.
    * @throws IllegalStateException if PdxReader doesn't have the named field.
    *
@@ -337,7 +329,7 @@ class APACHE_GEODE_EXPORT PdxReader {
    * Checks if the named field exists and returns the result.
    * This can be useful when writing code that handles more than one version of
    * a PDX class.
-   * @param fieldname the name of the field to check
+   * @param fieldName the name of the field to check
    * @return <code>true</code> if the named field exists; otherwise
    * <code>false</code>
    */

--- a/cppcache/include/geode/PdxSerializable.hpp
+++ b/cppcache/include/geode/PdxSerializable.hpp
@@ -50,13 +50,13 @@ class APACHE_GEODE_EXPORT PdxSerializable : public virtual Serializable,
 
   /**
    *@brief Serialize this object in Geode PDX format
-   *@param PdxWriter to serialize the PDX object
+   *@param output to serialize the PDX object
    **/
   virtual void toData(PdxWriter& output) const = 0;
 
   /**
    *@brief Deserialize this object
-   *@param PdxReader to deserialize the PDX object
+   *@param input to deserialize the PDX object
    **/
   virtual void fromData(PdxReader& input) = 0;
 

--- a/cppcache/include/geode/PdxSerializer.hpp
+++ b/cppcache/include/geode/PdxSerializer.hpp
@@ -53,7 +53,7 @@ class APACHE_GEODE_EXPORT PdxSerializer {
    * Deserialize this object.
    *
    * @param className the class name whose object needs to be de-serialized
-   * @param pr the PdxReader stream to use for reading the object data
+   * @param pdxReader the PdxReader stream to use for reading the object data
    */
   virtual std::shared_ptr<void> fromData(const std::string& className,
                                          PdxReader& pdxReader) = 0;
@@ -61,7 +61,7 @@ class APACHE_GEODE_EXPORT PdxSerializer {
   /**
    * Serializes this object in Geode PDX format.
    * @param userObject the object which needs to be serialized
-   * @param pw the PdxWriter object to use for serializing the object
+   * @param pdxWriter the PdxWriter object to use for serializing the object
    */
   virtual bool toData(const std::shared_ptr<const void>& userObject,
                       const std::string& className, PdxWriter& pdxWriter) = 0;

--- a/cppcache/include/geode/PdxWrapper.hpp
+++ b/cppcache/include/geode/PdxWrapper.hpp
@@ -60,8 +60,6 @@ class APACHE_GEODE_EXPORT PdxWrapper : public PdxSerializable {
    * PdxSerializer.
    * User code (such as in PdxSerializer) should cast it to a pointer of the
    * known user class.
-   * @param detach if set to true will release ownership of the object and
-   * future calls to getObject() return nullptr.
    */
   std::shared_ptr<void> getObject();
 

--- a/cppcache/include/geode/PdxWriter.hpp
+++ b/cppcache/include/geode/PdxWriter.hpp
@@ -156,7 +156,6 @@ class APACHE_GEODE_EXPORT PdxWriter {
    * The fields type is <code>CacheableDatePtr</code>.
    * <p>C++ std::shared_ptr<CacheableDate> is mapped to Java Date</p>
    * @param fieldName the name of the field to write
-   * @param value the value of the field to write
    * @return this PdxWriter
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty
@@ -203,7 +202,6 @@ class APACHE_GEODE_EXPORT PdxWriter {
    * <p>C++ bool* is mapped to Java boolean[]</p>
    * @param fieldName the name of the field to write
    * @param array the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxWriter
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -217,7 +215,6 @@ class APACHE_GEODE_EXPORT PdxWriter {
    * <p>C++ char16_t* is mapped to Java char[].</p>
    * @param fieldName the name of the field to write
    * @param array the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxWriter
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -231,7 +228,6 @@ class APACHE_GEODE_EXPORT PdxWriter {
    * <p>C++ int8_t* is mapped to Java byte[].</p>
    * @param fieldName the name of the field to write
    * @param array the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxWriter
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -245,7 +241,6 @@ class APACHE_GEODE_EXPORT PdxWriter {
    * <p>C++ int16_t* is mapped to Java short[].</p>
    * @param fieldName the name of the field to write
    * @param array the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxWriter
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -259,7 +254,6 @@ class APACHE_GEODE_EXPORT PdxWriter {
    * <p>C++ int32_t* is mapped to Java int[].</p>
    * @param fieldName the name of the field to write
    * @param array the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxWriter
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -273,7 +267,6 @@ class APACHE_GEODE_EXPORT PdxWriter {
    * <p>C++ int64_t* is mapped to Java long[].</p>
    * @param fieldName the name of the field to write
    * @param array the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxWriter
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -287,7 +280,6 @@ class APACHE_GEODE_EXPORT PdxWriter {
    * <p>C++ float* is mapped to Java float[].</p>
    * @param fieldName the name of the field to write
    * @param array the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxWriter
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -301,7 +293,6 @@ class APACHE_GEODE_EXPORT PdxWriter {
    * <p>C++ double* is mapped to Java double[].</p>
    * @param fieldName the name of the field to write
    * @param array the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxWriter
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.
@@ -315,7 +306,6 @@ class APACHE_GEODE_EXPORT PdxWriter {
    * <p>C++ std::vector<std::string> is mapped to Java String[].</p>
    * @param fieldName the name of the field to write
    * @param array the value of the field to write
-   * @param length the length of the array field to write
    * @return this PdxWriter
    * @throws IllegalStateException if the named field has already been written
    * or fieldName is nullptr or empty.

--- a/cppcache/include/geode/PersistenceManager.hpp
+++ b/cppcache/include/geode/PersistenceManager.hpp
@@ -63,7 +63,7 @@ class APACHE_GEODE_EXPORT PersistenceManager {
    * in this method by the class implementing this method.
    * @param key the key to write.
    * @param value the value to write
-   * @param PersistenceInfo related persistence information.
+   * @param persistenceInfo related persistence information.
    * @throws RegionDestroyedException is the region is already destroyed.
    * @throws OutofMemoryException if the disk is full
    * @throws DiskFailureException if the write fails due to disk fail.

--- a/cppcache/include/geode/QueryService.hpp
+++ b/cppcache/include/geode/QueryService.hpp
@@ -62,9 +62,9 @@ class APACHE_GEODE_EXPORT QueryService {
    * is invoked on the CqQuery. The name of the query will be used
    * to identify this query in statistics archival.
    *
-   * @param cqName the String name for this query
-   * @param queryString the OQL query
-   * @param cqAttributes the CqAttributes
+   * @param name the String name for this query
+   * @param querystr the OQL query
+   * @param cqAttr the CqAttributes
    * @param isDurable true if the CQ is durable
    * @return the newly created CqQuery object
    * @throws CqExistsException if a CQ by this name already exists on this
@@ -97,8 +97,8 @@ class APACHE_GEODE_EXPORT QueryService {
    * is invoked on the CqQuery. The name of the query will be used
    * to identify this query in statistics archival.
    *
-   * @param queryString the OQL query
-   * @param cqAttributes the CqAttributes
+   * @param querystr the OQL query
+   * @param cqAttr the CqAttributes
    * @param isDurable true if the CQ is durable
    * @return the newly created CqQuery object
    * @throws CqExistsException if a CQ by this name already exists on this

--- a/cppcache/include/geode/Region.hpp
+++ b/cppcache/include/geode/Region.hpp
@@ -256,7 +256,6 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    * subregions of the current region
    * @param recursive determines whether the method recursively fills in
    * subregions
-   * @param[out] sr subregions
    * @throws RegionDestroyedException
    */
   virtual std::vector<std::shared_ptr<Region>> subregions(
@@ -1223,9 +1222,6 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    *
    * @param regex The regular expression string.
    * @param isDurable flag to indicate whether this is a durable registration
-   * @param resultKeys If non-nullptr then the keys that match the regular
-   *   expression on the server are returned. The vector is cleared at the
-   *   start to discard any existing keys in the vector.
    * @param getInitialValues true to populate the cache with values of the keys
    *   that were registered on the server
    * @param receiveValues whether to act like notify-by-subscription is set

--- a/cppcache/include/geode/RegionAttributes.hpp
+++ b/cppcache/include/geode/RegionAttributes.hpp
@@ -135,7 +135,6 @@ class APACHE_GEODE_EXPORT RegionAttributes
   /** Gets the <code>idleTimeout</code> expiration attributes for entries in
    * this region.
    * @return the idleTimeout expiration attributes for entries in this region
-   * @tparam Duration std::chrono::duration type to return
    */
   std::chrono::seconds getEntryIdleTimeout() const;
 

--- a/cppcache/include/geode/RegionAttributesFactory.hpp
+++ b/cppcache/include/geode/RegionAttributesFactory.hpp
@@ -411,7 +411,7 @@ class APACHE_GEODE_EXPORT RegionAttributesFactory {
 
   /**
    * Sets cloning on region
-   * @param isClonable
+   * @param isClonable whether region is clonable or not
    * @return a reference to <code>this</code>
    * @see RegionAttributes#getCloningEnabled()
    */

--- a/cppcache/include/geode/RegionFactory.hpp
+++ b/cppcache/include/geode/RegionFactory.hpp
@@ -256,7 +256,7 @@ class APACHE_GEODE_EXPORT RegionFactory {
   /**
    * Enables or disables concurrent modification checks
    * @since 7.0
-   * @param concurrencyChecksEnabled whether to perform concurrency checks on
+   * @param enable whether to perform concurrency checks on
    * operations
    * @return a reference to <code>this</code>
    */

--- a/cppcache/include/geode/RegionService.hpp
+++ b/cppcache/include/geode/RegionService.hpp
@@ -103,9 +103,6 @@ class APACHE_GEODE_EXPORT RegionService {
    * Returns a set of root regions in the cache. This set is a snapshot and
    * is not backed by the Cache. The vector passed in is cleared and the
    * regions are added to it.
-   *
-   * @param regions the returned set of
-   * regions
    */
   virtual std::vector<std::shared_ptr<Region>> rootRegions() const = 0;
 

--- a/cppcache/include/geode/RegionShortcut.hpp
+++ b/cppcache/include/geode/RegionShortcut.hpp
@@ -25,7 +25,7 @@ namespace geode {
 namespace client {
 
 /**
- * @class RegionShortcut RegionShortcut.hpp
+ * @enum RegionShortcut RegionShortcut.hpp
  *
  * Each enum represents a predefined {@link RegionAttributes} in a {@link
  * Cache}.

--- a/cppcache/include/geode/ResultCollector.hpp
+++ b/cppcache/include/geode/ResultCollector.hpp
@@ -88,7 +88,7 @@ class APACHE_GEODE_EXPORT ResultCollector {
   /**
    * Adds a single function execution result to the ResultCollector
    *
-   * @param resultOfSingleExecution
+   * @param resultOfSingleExecution single function execution result to add
    * @since 5.8LA
    */
   virtual void addResult(

--- a/cppcache/include/geode/WritablePdxInstance.hpp
+++ b/cppcache/include/geode/WritablePdxInstance.hpp
@@ -232,8 +232,6 @@ class APACHE_GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    *          name of the field whose value will be set
    * @param value
    *          value that will be set to the field of type bool array
-   * @param length
-   *          The number of elements in bool array type.
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
@@ -250,8 +248,6 @@ class APACHE_GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    *          name of the field whose value will be set
    * @param value
    *          value that will be set to the field of type int8_t array
-   * @param length
-   *          The number of elements in int8_t array type.
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
@@ -268,8 +264,6 @@ class APACHE_GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    *          name of the field whose value will be set
    * @param value
    *          value that will be set to the field of type int16_t array
-   * @param length
-   *          The number of elements in int16_t array type.
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
@@ -286,8 +280,6 @@ class APACHE_GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    *          name of the field whose value will be set
    * @param value
    *          value that will be set to the field of type int32_t array
-   * @param length
-   *          The number of elements in int32_t array type.
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
@@ -304,8 +296,6 @@ class APACHE_GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    *          name of the field whose value will be set
    * @param value
    *          value that will be set to the field of type int64_t array
-   * @param length
-   *          The number of elements in int64_t array type.
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
@@ -322,8 +312,6 @@ class APACHE_GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    *          name of the field whose value will be set
    * @param value
    *          value that will be set to the field of type float array
-   * @param length
-   *          The number of elements in float array type.
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
@@ -340,8 +328,6 @@ class APACHE_GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    *          name of the field whose value will be set
    * @param value
    *          value that will be set to the field of type double array
-   * @param length
-   *          The number of elements in double array type.
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */
@@ -374,8 +360,6 @@ class APACHE_GEODE_EXPORT WritablePdxInstance : public PdxInstance {
    *          name of the field whose value will be set
    * @param value
    *          value that will be set to the field of type char16_t array
-   * @param length
-   *          The number of elements in char16_t array type.
    * @throws IllegalStateException if the named field does not exist
    * or if the type of the value is not compatible with the field.
    */

--- a/cppcache/include/geode/internal/chrono/duration.hpp
+++ b/cppcache/include/geode/internal/chrono/duration.hpp
@@ -145,8 +145,8 @@ inline
 /**
  * Converts std::chrono::duration to std::string.
  *
- * @tparam Rep
- * @tparam Period
+ * @tparam Rep the something that reps
+ * @tparam Period the something else that periods
  * @param duration to convert to std::string
  * @return std::string representing the given duration.
  */

--- a/cppcache/include/geode/internal/chrono/duration.hpp
+++ b/cppcache/include/geode/internal/chrono/duration.hpp
@@ -142,14 +142,6 @@ inline
   throw std::invalid_argument("Not a valid duration parsing '" + string + "'.");
 }
 
-/**
- * Converts std::chrono::duration to std::string.
- *
- * @tparam Rep the something that reps
- * @tparam Period the something else that periods
- * @param duration to convert to std::string
- * @return std::string representing the given duration.
- */
 template <class Rep, class Period>
 inline std::string to_string(
     const std::chrono::duration<Rep, Period>& duration) {

--- a/cppcache/src/CacheImpl.hpp
+++ b/cppcache/src/CacheImpl.hpp
@@ -168,7 +168,6 @@ class APACHE_GEODE_EXPORT CacheImpl {
    * full path starting at a root.
    *
    * @param path the path to the region
-   * @param[out] rptr the region pointer that is returned
    * @return the Region or null if not found
    * @throws IllegalArgumentException if path is null, the empty string, or "/"
    */
@@ -178,9 +177,6 @@ class APACHE_GEODE_EXPORT CacheImpl {
    * Returns a set of root regions in the cache. Does not cause any
    * shared regions to be mapped into the cache. This set is a snapshot and
    * is not backed by the Cache. The regions passed in are cleared.
-   *
-   * @param regions the region collection object containing the returned set of
-   * regions when the function returns
    */
   std::vector<std::shared_ptr<Region>> rootRegions();
 

--- a/cppcache/src/CqQueryImpl.hpp
+++ b/cppcache/src/CqQueryImpl.hpp
@@ -172,7 +172,7 @@ class CqQueryImpl : public CqQuery,
   void cleanup();
 
   /**
-   * @return Returns the cqListeners.
+   * Returns the cqListeners.
    */
   void getCqListeners(std::vector<std::shared_ptr<CqListener>>& cqListener);
 
@@ -198,7 +198,7 @@ class CqQueryImpl : public CqQuery,
   /**
    * This is called when the new server comes-up.
    * Executes the CQ on the given endpoint.
-   * @param endpoint
+   * @param requestType Tcr Message Type to request
    */
   bool executeCq(TcrMessage::MsgType requestType);
 

--- a/cppcache/src/CqService.hpp
+++ b/cppcache/src/CqService.hpp
@@ -211,8 +211,10 @@ class APACHE_GEODE_EXPORT CqService
    * Invokes the CqListeners for the given CQs.
    * @param cqs list of cqs with the cq operation from the Server.
    * @param messageType base operation
-   * @param key
-   * @param value
+   * @param key to invoke listeners with
+   * @param value to invoke listeners with
+   * @param deltaValue to invoke listeners with
+   * @param eventId to invoke listeners with
    */
   void invokeCqListeners(const std::map<std::string, int>* cqs,
                          uint32_t messageType,
@@ -222,7 +224,7 @@ class APACHE_GEODE_EXPORT CqService
                          std::shared_ptr<EventId> eventId);
   /**
    * Returns the Operation for the given EnumListenerEvent type.
-   * @param eventType
+   * @param eventType to find the operation
    * @return Operation
    */
   CqOperation getOperation(int eventType);

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -118,7 +118,6 @@ class TcrConnection {
    *    read one byte from server, it should be CLIENT_TO_SERVER
    *    Otherwise, construction fails.
    * @param     ports     List of local ports for connections to endpoint
-   * @param     numPorts  Size of ports list
    */
   bool initTcrConnection(
       TcrEndpoint* endpointObj, const char* endpoint,
@@ -199,11 +198,11 @@ class TcrConnection {
   /**
    * send a synchronized request to server for REGISTER_INTEREST_LIST.
    *
-   * @param      buffer the buffer to send
-   *             len length of the data to send
-   *             message vector, which will return chunked TcrMessage.
-   *             sendTimeoutSec write timeout in sec
-   *             receiveTimeoutSec read timeout in sec
+   * @param      request the buffer to send
+   * @param      len length of the data to send
+   * @param      message vector, which will return chunked TcrMessage.
+   * @param      sendTimeoutSec write timeout in sec
+   * @param      receiveTimeoutSec read timeout in sec
    * @exception  GeodeIOException  if an I/O error occurs (socket failure).
    * @exception  TimeoutException  if timeout happens at any of the 3 socket
    * operation: 1 write, 2 read
@@ -218,9 +217,8 @@ class TcrConnection {
    * we need to use it to send CLOSE_CONNECTION msg
    *
    * @param      buffer the buffer to send
-   *             len length of the data to send
-   *             sendTimeoutSec write timeout in sec
-   * @return     no return. Because it either succeeds, or throw exception.
+   * @param      len length of the data to send
+   * @param      sendTimeoutSec write timeout in sec
    * @exception  GeodeIOException  if an I/O error occurs (socket failure).
    * @exception  TimeoutException  if timeout happens at any of the 3 socket
    * operation: 1 write, 2 read

--- a/cppcache/src/statistics/StatArchiveWriter.hpp
+++ b/cppcache/src/statistics/StatArchiveWriter.hpp
@@ -232,7 +232,7 @@ class APACHE_GEODE_EXPORT StatArchiveWriter {
 
   /**
    * Opens the statArchiver by opening the file provided as a parameter.
-   * @param filename string representation of the file
+   * @param filename string representation of the file name
    */
   void openFile(std::string filename);
 

--- a/cppcache/src/statistics/StatArchiveWriter.hpp
+++ b/cppcache/src/statistics/StatArchiveWriter.hpp
@@ -232,9 +232,9 @@ class APACHE_GEODE_EXPORT StatArchiveWriter {
 
   /**
    * Opens the statArchiver by opening the file provided as a parameter.
-   * @param std::string filename.
+   * @param filename string representation of the file
    */
-  void openFile(std::string);
+  void openFile(std::string filename);
 
   /**
    * Returns the size of number of bytes written so far to this archive.

--- a/cppcache/src/statistics/StatisticDescriptorImpl.hpp
+++ b/cppcache/src/statistics/StatisticDescriptorImpl.hpp
@@ -69,25 +69,25 @@ class StatisticDescriptorImpl : public StatisticDescriptor {
   /**
    * Creates a new description of a statistic.
    *
-   * @param name
+   * @param statName
    *        The name of the statistic (for example,
    *        <code>"numDatabaseLookups"</code>)
-   * @param descriptorType
+   * @param statDescriptorType
    *        The type of the statistic.  This must be either
    *        <code>FieldType::INT_TYPE</code>, <code>FieldType::LONG_TYPE</code>,
    * or
    *        <code>FieldType::DOUBLE_TYPE</code>.
-   * @param description
+   * @param statDescription
    *        A description of the statistic (for example, <code>"The
    *        number of database lookups"</code>
-   * @param unit
+   * @param statUnit
    *        The units that this statistic is measured in (for example,
    *        <code>"milliseconds"</code>)
-   * @param isCounter
+   * @param statIsCounter
    *        Is this statistic a counter?  That is, does its value
    *        change monotonically (always increases or always
    *        decreases)?
-   * @param isLargerBetter
+   * @param statIsLargerBetter
    *        True if larger values indicate better performance.
    *
    */

--- a/cppcache/src/statistics/Statistics.hpp
+++ b/cppcache/src/statistics/Statistics.hpp
@@ -234,7 +234,7 @@ class APACHE_GEODE_EXPORT Statistics {
    *         if the statistic with name <code>name</code> is not of
    *         type <code>double</code>.
    */
-  virtual void setDouble(const std::string&, double value) = 0;
+  virtual void setDouble(const std::string& name, double value) = 0;
 
   ///////////////////////  get() Methods  ///////////////////////
 

--- a/cppcache/src/util/chrono/time_point.hpp
+++ b/cppcache/src/util/chrono/time_point.hpp
@@ -39,7 +39,7 @@ std::tm localtime(const time_t& time);
 
 /**
  * Wrapper around platform specific thread safe localtime functions.
- * @param time to get local time for
+ * @param time_point to get local time for
  * @return local time
  */
 std::tm localtime(const std::chrono::system_clock::time_point& time_point);

--- a/templates/security/UserPasswordAuthInit.hpp
+++ b/templates/security/UserPasswordAuthInit.hpp
@@ -51,7 +51,7 @@ class UserPasswordAuthInit : public AuthInitialize {
 
   /**@brief initialize with the given set of security properties
    * and return the credentials for the client as properties.
-   * @param props the set of security properties provided to the
+   * @param securityprops the set of security properties provided to the
    * <code>DistributedSystem.connect</code> method
    * @param server it is the ID of the current endpoint.
    * The format expected is "host:port".

--- a/tests/cpp/fwklib/FwkBB.hpp
+++ b/tests/cpp/fwklib/FwkBB.hpp
@@ -96,8 +96,7 @@ class FwkBBMessage {
   }
 
   /** @brief pass to data to parse onReceive message
-   * @param psData data pointer, not null terminated
-   * @param dataSize data size of message
+   * @param data string of data
    * @retval true = Success, false = Failed
    */
   void fromMessageStream(std::string data) {
@@ -140,7 +139,6 @@ class FwkBBMessage {
   }
 
   /** @brief get data stream to send
-   * @param sStream data stream
    * @retval true = Success, false = Failed
    */
   std::string& toMessageStream() {
@@ -168,22 +166,22 @@ class FwkBBMessage {
   }
 
   /** @brief set Id of message
-   * @param sId id of message
+   * @param id id of message
    */
   void setId(std::string id) { m_id = id; }
 
   /** @brief set command of message
-   * @param sCommand command of message
+   * @param cmd command of message
    */
   void setCommand(std::string cmd) { m_cmd = cmd; }
 
   /** @brief set result of message
-   * @param sResult result of message
+   * @param result result of message
    */
   void setResult(std::string result) { m_result = result; }
 
   /** @brief add parameter value to message
-   * @param sParameter parameter of message
+   * @param parameter parameter of message
    */
   void addParameter(std::string parameter) {
     m_parameterVector.push_back(parameter);

--- a/tests/cpp/fwklib/FwkBBClient.hpp
+++ b/tests/cpp/fwklib/FwkBBClient.hpp
@@ -147,7 +147,6 @@ class FwkBBClient {
    * @param BBName name of BB
    * @param Key name of counter
    * @param Value value to set
-   * @param piResult
    * @retval value after setIfGreater
    */
   int64_t setIfGreater(const std::string& BBName, const std::string& Key,

--- a/tests/cpp/fwklib/GsRandom.hpp
+++ b/tests/cpp/fwklib/GsRandom.hpp
@@ -148,7 +148,7 @@ class GsRandom {
    * Like randomString(), but returns only only alphanumeric,
    *   underscore, or space characters.
    *
-   * @param uSize the length of the random string to generate.
+   * @param size the length of the random string to generate.
    * @retval a bounded random string
    */
   static std::string getAlphanumericString(uint32_t size) {
@@ -168,7 +168,7 @@ class GsRandom {
    * Like randomString(), but returns only only alphanumeric,
    *   underscore, or space characters.
    *
-   * @param uSize the length of the random string to generate.
+   * @param size the length of the random string to generate.
    * @retval a bounded random string
    */
   static void getAlphanumericString(uint32_t size, char* buffer) {

--- a/tests/cpp/security/CredentialGenerator.hpp
+++ b/tests/cpp/security/CredentialGenerator.hpp
@@ -67,13 +67,6 @@ class CredentialGenerator;
  * Different implementations are there for different kinds of authentication/
  * authorization schemes.
  * <p>
- * Usage:
- *   auto cg = CredentialGenerator::create( schemeStr );
- *   @param schemeStr can be one of the following
- *    DUMMY - simple username/password authentication
- *    LDAP  - LDAP server based authentication.
- *    PKCS  - Digital signature based authentication
- *    NONE  - Disable security altogether.
  *
  * for client connection credentials
  *   cg->getAuthInit(prop);
@@ -118,6 +111,14 @@ class CredentialGenerator {
   }
 
  public:
+  /**
+   * @brief create new Credential Generator
+   * @param scheme can be one of the following
+   *    DUMMY - simple username/password authentication
+   *    LDAP  - LDAP server based authentication.
+   *    PKCS  - Digital signature based authentication
+   *    NONE  - Disable security altogether.
+   * **/
   static std::shared_ptr<CredentialGenerator> create(std::string scheme);
   static bool registerScheme(std::shared_ptr<CredentialGenerator> scheme) {
     // if not already registered...

--- a/tests/cpp/testobject/NoopAuthInit.hpp
+++ b/tests/cpp/testobject/NoopAuthInit.hpp
@@ -50,7 +50,7 @@ class NoopAuthInit : public AuthInitialize {
 
   /**@brief initialize with the given set of security properties
    * and return the credentials for the client as properties.
-   * @param props the set of security properties provided to the
+   * @param securityprops the set of security properties provided to the
    * <code>DistributedSystem.connect</code> method
    * @param server it is the ID of the current endpoint.
    * The format expected is "host:port".


### PR DESCRIPTION
Authored-by: M. Oleske <michael@oleske.engineer>

Ran on [Windows](https://github.com/moleske/geode-native/actions/runs/280909801) (Visual Studio 2017 and some on Visual Studio 2019) and [Ubuntu](https://github.com/moleske/geode-native/actions/runs/280909802) (16.04 and 18.04).  Ran it locally on my Mac with AppleClang 11.0.0.11000033

This does not fix content or incorrectness in the docs, I need some feedback/help on that.  I also made some questionable decisions, see if you can find them!  Since this is going to be mostly grammar/spell check/making sure they're not lying, it is probably easier just to push your suggestions directly if you have access (box is checked for allow edits by maintainers)