### PR TITLE
GEODE-8578: Parse partition resolver in RESPONSE_CLIENT_PARTITION_ATTRIBUTES message

### DIFF
--- a/tools/gnmsg/server_messages.py
+++ b/tools/gnmsg/server_messages.py
@@ -36,16 +36,20 @@ def read_bucket_count(message_bytes, offset):
 
 
 def read_partition_attributes(properties, message_bytes, offset):
-    if properties["Parts"] != 2 and properties["Parts"] != 4:
-        raise Exception(
-            "Don't know how to parse a RESPONSE_CLIENT_PARTITION_ATTRIBUTES message with "
-            + properties["Parts"]
-            + " parts (should have 2 or 4 only)."
-        )
-
     (properties["BucketCount"], offset) = read_bucket_count(message_bytes, offset)
     (properties["ColocatedWith"], offset) = parse_key_or_value(message_bytes, offset)
-    # TODO: parse parts 3 and 4 (partition resolver and list of partition attributes), if they exist
+    if properties["Parts"] == 4:
+        (properties["PartitionResolverName"], offset) = parse_key_or_value(message_bytes, offset)
+        # TODO: parse part 4 (list of partition attributes)
+    elif properties["Parts"] == 3:
+        try:
+            (properties["PartitionResolverName"], offset) = parse_key_or_value(message_bytes, offset)
+        except:
+            raise Exception(
+                "Don't know how to parse a RESPONSE_CLIENT_PARTITION_ATTRIBUTES message with "
+                + "3 parts and fpa attribute."
+            )
+        # TODO: parse part 3 if it is not partition resolver but list of partition attributes
 
 
 server_message_parsers = {


### PR DESCRIPTION
I tried the gnmsg tool with a client log file connecting to a cluster that contains a partition region with a partition resolver, which caused an exception.

With this change, it is possible to parse the partition resolver name. Still pending to parse the list of fixed partition attributes, maybe in other ticket...

This is how the message looks like after parsing my log file:
```
{
  "message": {
    "Timestamp": "16:47:55.225776",
    "Connection": "0",
    "Direction": "<---",
    "Type": "RESPONSE_CLIENT_PARTITION_ATTRIBUTES",
    "Length": 80,
    "Parts": 3,
    "TransactionId": -1,
    "SecurityFlag": 0,
    "BucketCount": {
      "Size": 5,
      "IsObject": 1,
      "Data": {
        "DSCode": "CacheableInt32",
        "Value": 113
      }
    },
    "ColocatedWith": {
      "Size": 0,
      "IsObject": 0
    },
    "PartitionResolverName": {
      "Size": 60,
      "IsObject": 1,
      "Data": {
        "DSCode": "CacheableASCIIString",
        "StringLength": 57,
        "Value": "org.apache.geode.cache.util.StringPrefixPartitionResolver"
      }
    }
  }
}
```