### PR TITLE
GEODE-8580: Don't throw pointers in GfshExecute

### DIFF
--- a/cppcache/integration/framework/GfshExecute.cpp
+++ b/cppcache/integration/framework/GfshExecute.cpp
@@ -83,7 +83,7 @@ void GfshExecute::execute(const std::string &command, const std::string &user,
   BOOST_LOG_TRIVIAL(debug) << "Gfsh::execute: exit:" << exit_code;
 
   if (exit_code) {
-    throw new GfshExecuteException("gfsh error", exit_code);
+    throw GfshExecuteException("gfsh error", exit_code);
   }
   extractConnectionCommand(command, user, password, keyStorePath, trustStorePath, keyStorePassword, trustStorePassword);
 }


### PR DESCRIPTION
This is a fix to the new C++ test framework. We were throwing pointers.