### PR TITLE
GEODE-8596: Enforce no old style cast

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Wno-missing-prototypes #TODO fix
     -Wno-sign-conversion #TODO fix
     -Wno-deprecated #TODO fix
-    -Wno-old-style-cast #TODO fix
     -Wno-format-nonliteral #TODO fix
     -Wno-double-promotion #TODO fix
     -Wno-undefined-func-template #TODO fix

--- a/cppcache/integration-test/fw_dunit.hpp
+++ b/cppcache/integration-test/fw_dunit.hpp
@@ -127,9 +127,11 @@ END_TASK(validate)
   }                                                    \
   } while(false)
 #define XASSERT(x)                                      \
+  do {                                                  \
   if (!(x)) {                                           \
     throw dunit::TestException(#x, __LINE__, __FILE__); \
-  }
+  }                                                     \
+  } while(false)
 #define FAIL(y) throw dunit::TestException(y, __LINE__, __FILE__)
 #define LOG(y) dunit::log(y, __LINE__, __FILE__)
 #define LOGCOORDINATOR(y) dunit::logCoordinator(y, __LINE__, __FILE__)

--- a/cppcache/integration-test/testDataOutput.cpp
+++ b/cppcache/integration-test/testDataOutput.cpp
@@ -57,11 +57,11 @@ BEGIN_TEST(Byte)
     dataOutput.write(static_cast<uint8_t>(0x11));
     const uint8_t *buffer = dataOutput.getBuffer();
 
-    ASSERT(buffer[0] == (uint8_t)0x11, "expected 0x11.");
+    ASSERT(buffer[0] == static_cast<uint8_t>(0x11), "expected 0x11.");
 
     DataInputInternal dataInput(buffer, dataOutput.getBufferLength(), nullptr);
     const auto result = dataInput.read();
-    ASSERT(result == (uint8_t)0x11, "expected 0x11");
+    ASSERT(result == static_cast<uint8_t>(0x11), "expected 0x11");
   }
 END_TEST(Byte)
 
@@ -73,8 +73,8 @@ BEGIN_TEST(Boolean)
     dataOutput.writeBoolean(false);
     const uint8_t *buffer = dataOutput.getBuffer();
 
-    ASSERT(buffer[0] == (uint8_t)0x1, "expected 0x1.");
-    ASSERT(buffer[1] == (uint8_t)0x0, "expected 0x0.");
+    ASSERT(buffer[0] == static_cast<uint8_t>(0x1), "expected 0x1.");
+    ASSERT(buffer[1] == static_cast<uint8_t>(0x0), "expected 0x0.");
 
     DataInputInternal dataInput(buffer, dataOutput.getBufferLength(), nullptr);
     auto result = dataInput.readBoolean();
@@ -90,8 +90,8 @@ BEGIN_TEST(Short)
 
     dataOutput.writeInt(static_cast<int16_t>(0x1122));
     const uint8_t *buffer = dataOutput.getBuffer();
-    ASSERT(buffer[0] == (uint8_t)0x11, "expected 0x11.");
-    ASSERT(buffer[1] == (uint8_t)0x22, "expected 0x11.");
+    ASSERT(buffer[0] == static_cast<uint8_t>(0x11), "expected 0x11.");
+    ASSERT(buffer[1] == static_cast<uint8_t>(0x22), "expected 0x22.");
 
     DataInputInternal dataInput(buffer, dataOutput.getBufferLength(), nullptr);
     int16_t result = dataInput.readInt16();
@@ -106,10 +106,10 @@ BEGIN_TEST(int_t)
     dataOutput.writeInt(static_cast<int32_t>(0x11223344));
     const uint8_t *buffer = dataOutput.getBuffer();
     dumpnbytes(buffer, 4);
-    ASSERT(buffer[0] == (uint8_t)0x11, "expected 0x11.");
-    ASSERT(buffer[1] == (uint8_t)0x22, "expected 0x22.");
-    ASSERT(buffer[2] == (uint8_t)0x33, "expected 0x33.");
-    ASSERT(buffer[3] == (uint8_t)0x44, "expected 0x44.");
+    ASSERT(buffer[0] == static_cast<uint8_t>(0x11), "expected 0x11.");
+    ASSERT(buffer[1] == static_cast<uint8_t>(0x22), "expected 0x22.");
+    ASSERT(buffer[2] == static_cast<uint8_t>(0x33), "expected 0x33.");
+    ASSERT(buffer[3] == static_cast<uint8_t>(0x44), "expected 0x44.");
 
     DataInputInternal dataInput(buffer, dataOutput.getBufferLength(), nullptr);
     int32_t result = dataInput.readInt32();
@@ -124,14 +124,14 @@ BEGIN_TEST(Long)
     int64_t value = ((static_cast<int64_t>(0x11223344)) << 32) | 0x55667788;
     dataOutput.writeInt(value);
     const uint8_t *buffer = dataOutput.getBuffer();
-    ASSERT(buffer[0] == (uint8_t)0x11, "expected 0x11.");
-    ASSERT(buffer[1] == (uint8_t)0x22, "expected 0x22.");
-    ASSERT(buffer[2] == (uint8_t)0x33, "expected 0x33.");
-    ASSERT(buffer[3] == (uint8_t)0x44, "expected 0x44.");
-    ASSERT(buffer[4] == (uint8_t)0x55, "expected 0x55.");
-    ASSERT(buffer[5] == (uint8_t)0x66, "expected 0x66.");
-    ASSERT(buffer[6] == (uint8_t)0x77, "expected 0x77.");
-    ASSERT(buffer[7] == (uint8_t)0x88, "expected 0x88.");
+    ASSERT(buffer[0] == static_cast<uint8_t>(0x11), "expected 0x11.");
+    ASSERT(buffer[1] == static_cast<uint8_t>(0x22), "expected 0x22.");
+    ASSERT(buffer[2] == static_cast<uint8_t>(0x33), "expected 0x33.");
+    ASSERT(buffer[3] == static_cast<uint8_t>(0x44), "expected 0x44.");
+    ASSERT(buffer[4] == static_cast<uint8_t>(0x55), "expected 0x55.");
+    ASSERT(buffer[5] == static_cast<uint8_t>(0x66), "expected 0x66.");
+    ASSERT(buffer[6] == static_cast<uint8_t>(0x77), "expected 0x77.");
+    ASSERT(buffer[7] == static_cast<uint8_t>(0x88), "expected 0x88.");
 
     DataInputInternal dataInput(buffer, dataOutput.getBufferLength(), nullptr);
     int64_t result = dataInput.readInt64();
@@ -145,10 +145,10 @@ BEGIN_TEST(Float)
 
     dataOutput.writeFloat(1.2f);
     const uint8_t *buffer = dataOutput.getBuffer();
-    ASSERT(buffer[0] == (uint8_t)0x3f, "expected 0x3f.");
-    ASSERT(buffer[1] == (uint8_t)0x99, "expected 0x99.");
-    ASSERT(buffer[2] == (uint8_t)0x99, "expected 0x99.");
-    ASSERT(buffer[3] == (uint8_t)0x9a, "expected 0x9a.");
+    ASSERT(buffer[0] == static_cast<uint8_t>(0x3f), "expected 0x3f.");
+    ASSERT(buffer[1] == static_cast<uint8_t>(0x99), "expected 0x99.");
+    ASSERT(buffer[2] == static_cast<uint8_t>(0x99), "expected 0x99.");
+    ASSERT(buffer[3] == static_cast<uint8_t>(0x9a), "expected 0x9a.");
 
     DataInputInternal dataInput(buffer, dataOutput.getBufferLength(), nullptr);
     float result = dataInput.readFloat();
@@ -162,14 +162,14 @@ BEGIN_TEST(Double)
 
     dataOutput.writeDouble(1.2);
     const uint8_t *buffer = dataOutput.getBuffer();
-    ASSERT(buffer[0] == (uint8_t)0x3f, "expected 0x3f.");
-    ASSERT(buffer[1] == (uint8_t)0xf3, "expected 0xf3.");
-    ASSERT(buffer[2] == (uint8_t)0x33, "expected 0x33.");
-    ASSERT(buffer[3] == (uint8_t)0x33, "expected 0x33.");
-    ASSERT(buffer[4] == (uint8_t)0x33, "expected 0x33.");
-    ASSERT(buffer[5] == (uint8_t)0x33, "expected 0x33.");
-    ASSERT(buffer[6] == (uint8_t)0x33, "expected 0x33.");
-    ASSERT(buffer[7] == (uint8_t)0x33, "expected 0x33.");
+    ASSERT(buffer[0] == static_cast<uint8_t>(0x3f), "expected 0x3f.");
+    ASSERT(buffer[1] == static_cast<uint8_t>(0xf3), "expected 0xf3.");
+    ASSERT(buffer[2] == static_cast<uint8_t>(0x33), "expected 0x33.");
+    ASSERT(buffer[3] == static_cast<uint8_t>(0x33), "expected 0x33.");
+    ASSERT(buffer[4] == static_cast<uint8_t>(0x33), "expected 0x33.");
+    ASSERT(buffer[5] == static_cast<uint8_t>(0x33), "expected 0x33.");
+    ASSERT(buffer[6] == static_cast<uint8_t>(0x33), "expected 0x33.");
+    ASSERT(buffer[7] == static_cast<uint8_t>(0x33), "expected 0x33.");
 
     DataInputInternal dataInput(buffer, dataOutput.getBufferLength(), nullptr);
     double result = dataInput.readDouble();

--- a/cppcache/integration-test/testOverflowPutGetSqLite.cpp
+++ b/cppcache/integration-test/testOverflowPutGetSqLite.cpp
@@ -161,7 +161,7 @@ void checkOverflowToken(std::shared_ptr<Region> &regionPtr, uint32_t lruLimit) {
   printf("Destoyed entries count is %d\n", destoyedCount);
   printf("Tombstone entries count is %d\n", tombstoneCount);
   printf("LRU entries limit is %d\n", lruLimit);
-  ASSERT(normalCount <= (int)lruLimit,
+  ASSERT(normalCount <= static_cast<int>(lruLimit),
          "Normal entries count should not exceed LRU entries limit.");
 }
 

--- a/cppcache/integration-test/testSerialization.cpp
+++ b/cppcache/integration-test/testSerialization.cpp
@@ -125,10 +125,11 @@ class OtherType : public DataSerializable {
 
     printf("double hex 0x%016" PRIX64 "\n", ot->m_struct.e);
 
-    XASSERT(ot->m_struct.a == (int)i);
+    XASSERT(ot->m_struct.a == static_cast<int>(i));
     XASSERT(ot->m_struct.b == ((i % 2 == 0) ? true : false));
-    XASSERT(ot->m_struct.c == (char)65 + i);
-    XASSERT((ot->m_struct.d == (((double)2.0) * (double)i)));
+    XASSERT(ot->m_struct.c == static_cast<char>(65) + i);
+    XASSERT((ot->m_struct.d ==
+             ((static_cast<double>(2.0)) * static_cast<double>(i))));
   }
 };
 

--- a/cppcache/integration-test/testThinClientRemoveOps.cpp
+++ b/cppcache/integration-test/testThinClientRemoveOps.cpp
@@ -625,10 +625,12 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
     putEntry(regionNames[1], keys[3], vals[3]);
     reg0->localInvalidate(keys[1]);
     reg1->localInvalidate(keys[3]);
-    ASSERT(reg0->remove(keys[1], (std::shared_ptr<Cacheable>)nullptr) == false,
+    ASSERT(reg0->remove(keys[1], static_cast<std::shared_ptr<Cacheable>>(
+                                     nullptr)) == false,
            "Result of remove should be false, as this value is not present "
            "locally, but present only on server.");
-    ASSERT(reg1->remove(keys[3], (std::shared_ptr<Cacheable>)nullptr) == false,
+    ASSERT(reg1->remove(keys[3], static_cast<std::shared_ptr<Cacheable>>(
+                                     nullptr)) == false,
            "Result of remove should be false, as this value is not present "
            "locally, but present only on server.");
     ASSERT(reg0->containsKey(keys[1]) == true, "containsKey should be true");
@@ -661,14 +663,14 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
 
     // Try removing a entry with a null value, which is not present on client as
     // well as server, result should be false.
-    ASSERT(
-        reg0->remove("NewKey1", (std::shared_ptr<Cacheable>)nullptr) == false,
-        "Result of remove should be false, as this value is not present "
-        "locally, and not present on server.");
-    ASSERT(
-        reg1->remove("NewKey3", (std::shared_ptr<Cacheable>)nullptr) == false,
-        "Result of remove should be false, as this value is not present "
-        "locally, and not present on server.");
+    ASSERT(reg0->remove("NewKey1", static_cast<std::shared_ptr<Cacheable>>(
+                                       nullptr)) == false,
+           "Result of remove should be false, as this value is not present "
+           "locally, and not present on server.");
+    ASSERT(reg1->remove("NewKey3", static_cast<std::shared_ptr<Cacheable>>(
+                                       nullptr)) == false,
+           "Result of remove should be false, as this value is not present "
+           "locally, and not present on server.");
     ASSERT(reg0->containsKey("NewKey1") == false,
            "containsKey should be false");
     ASSERT(reg0->containsKeyOnServer(keyPtr2) == false,
@@ -705,10 +707,12 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
     putEntry(regionNames[1], keys[3], nvals[3]);
     reg0->destroy(keys[1]);
     reg1->destroy(keys[3]);
-    ASSERT(reg0->remove(keys[1], (std::shared_ptr<Cacheable>)nullptr) == false,
+    ASSERT(reg0->remove(keys[1], static_cast<std::shared_ptr<Cacheable>>(
+                                     nullptr)) == false,
            "Result of remove should be false, as this value does not exist "
            "locally, but exists on server.");
-    ASSERT(reg1->remove(keys[3], (std::shared_ptr<Cacheable>)nullptr) == false,
+    ASSERT(reg1->remove(keys[3], static_cast<std::shared_ptr<Cacheable>>(
+                                     nullptr)) == false,
            "Result of remove should be false, as this value does not exist "
            "locally, but exists on server.");
     ASSERT(reg0->containsKey(keys[1]) == false, "containsKey should be false");
@@ -831,14 +835,14 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
     reg1->localPut(keys[3], vals[3]);
     reg0->invalidate(keys[1]);
     reg1->invalidate(keys[3]);
-    ASSERT(
-        reg0->localRemove(keys[1], (std::shared_ptr<Cacheable>)nullptr) == true,
-        "Result of remove should be true, as this value does not exists "
-        "locally.");
-    ASSERT(
-        reg1->localRemove(keys[3], (std::shared_ptr<Cacheable>)nullptr) == true,
-        "Result of remove should be true, as this value does not exists "
-        "locally.");
+    ASSERT(reg0->localRemove(keys[1], static_cast<std::shared_ptr<Cacheable>>(
+                                          nullptr)) == true,
+           "Result of remove should be true, as this value does not exists "
+           "locally.");
+    ASSERT(reg1->localRemove(keys[3], static_cast<std::shared_ptr<Cacheable>>(
+                                          nullptr)) == true,
+           "Result of remove should be true, as this value does not exists "
+           "locally.");
     ASSERT(reg0->containsKey(keys[1]) == false, "containsKey should be false");
     ASSERT(reg1->containsKey(keys[3]) == false, "containsKey should be false");
     LOG("Step6.13 complete.");
@@ -846,12 +850,12 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
     // Try locally removing an entry (value) with a nullptr.
     reg0->localPut(keys[1], vals[1]);
     reg1->localPut(keys[3], vals[3]);
-    ASSERT(reg0->localRemove(keys[1], (std::shared_ptr<Cacheable>)nullptr) ==
-               false,
+    ASSERT(reg0->localRemove(keys[1], static_cast<std::shared_ptr<Cacheable>>(
+                                          nullptr)) == false,
            "Result of remove should be false, as this value does not exists "
            "locally.");
-    ASSERT(reg1->localRemove(keys[3], (std::shared_ptr<Cacheable>)nullptr) ==
-               false,
+    ASSERT(reg1->localRemove(keys[3], static_cast<std::shared_ptr<Cacheable>>(
+                                          nullptr)) == false,
            "Result of remove should be false, as this value does not exists "
            "locally.");
     ASSERT(reg0->containsKey(keys[1]) == true, "containsKey should be true");
@@ -878,12 +882,12 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
     reg1->localPut(keys[3], vals[3]);
     reg0->localDestroy(keys[1]);
     reg1->localDestroy(keys[3]);
-    ASSERT(reg0->localRemove(keys[1], (std::shared_ptr<Cacheable>)nullptr) ==
-               false,
+    ASSERT(reg0->localRemove(keys[1], static_cast<std::shared_ptr<Cacheable>>(
+                                          nullptr)) == false,
            "Result of remove should be false, as this value does not exists "
            "locally.");
-    ASSERT(reg1->localRemove(keys[3], (std::shared_ptr<Cacheable>)nullptr) ==
-               false,
+    ASSERT(reg1->localRemove(keys[3], static_cast<std::shared_ptr<Cacheable>>(
+                                          nullptr)) == false,
            "Result of remove should be false, as this value does not exists "
            "locally.");
     ASSERT(reg0->containsKey(keys[1]) == false, "containsKey should be false");
@@ -970,10 +974,12 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepEight)
     reg->localDestroy(keys[0]);
     reg->localDestroy(keys[1]);
     SLEEP(10000);  // This is for expiration on server to execute.
-    ASSERT(reg->remove(keys[0], (std::shared_ptr<Cacheable>)nullptr) == true,
+    ASSERT(reg->remove(keys[0], static_cast<std::shared_ptr<Cacheable>>(
+                                    nullptr)) == true,
            "Result of remove should be true, as this value is not present "
            "locally, & not present on server.");
-    ASSERT(reg->remove(keys[1], (std::shared_ptr<Cacheable>)nullptr) == true,
+    ASSERT(reg->remove(keys[1], static_cast<std::shared_ptr<Cacheable>>(
+                                    nullptr)) == true,
            "Result of remove should be true, as this value is not present "
            "locally, & not present on server.");
     ASSERT(reg->containsKeyOnServer(keyPtr) == false,
@@ -1009,11 +1015,13 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepEight)
     putEntry(regionNames[2], keys[1], nvals[1]);
     SLEEP(10000);  // This is for expiration on server to execute.
     ASSERT(
-        reg->remove(keys[0], (std::shared_ptr<Cacheable>)nullptr) == false,
+        reg->remove(keys[0],
+                    static_cast<std::shared_ptr<Cacheable>>(nullptr)) == false,
         "Result of remove should be false, as this value is present locally, "
         "& not present on server.");
     ASSERT(
-        reg->remove(keys[1], (std::shared_ptr<Cacheable>)nullptr) == false,
+        reg->remove(keys[1],
+                    static_cast<std::shared_ptr<Cacheable>>(nullptr)) == false,
         "Result of remove should be false, as this value is present locally, "
         "& not present on server.");
     ASSERT(reg->containsKey(keys[0]) == true, "containsKey should be true");
@@ -1034,10 +1042,12 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepEight)
     reg->invalidate(keys[0]);
     reg->invalidate(keys[1]);
     SLEEP(10000);  // This is for expiration on server to execute.
-    ASSERT(reg->remove(keys[0], (std::shared_ptr<Cacheable>)nullptr) == true,
+    ASSERT(reg->remove(keys[0], static_cast<std::shared_ptr<Cacheable>>(
+                                    nullptr)) == true,
            "Result of remove should be true, as this value is not present "
            "locally, & not present on server.");
-    ASSERT(reg->remove(keys[1], (std::shared_ptr<Cacheable>)nullptr) == true,
+    ASSERT(reg->remove(keys[1], static_cast<std::shared_ptr<Cacheable>>(
+                                    nullptr)) == true,
            "Result of remove should be true, as this value is not present "
            "locally, & not present on server.");
     ASSERT(reg->containsKey(keys[0]) == false, "containsKey should be false");

--- a/cppcache/src/dllmain.cpp
+++ b/cppcache/src/dllmain.cpp
@@ -93,7 +93,7 @@ void DllMainGetPath(char *result, int) {
     return;
   }
   Dl_info dlInfo;
-  dladdr((void *)DllMainGetPath, &dlInfo);
+  dladdr(reinterpret_cast<void *>(DllMainGetPath), &dlInfo);
   if (realpath(dlInfo.dli_fname, result) == nullptr) {
     result[0] = '\0';
   }

--- a/cppcache/test/ByteArrayTest.cpp
+++ b/cppcache/test/ByteArrayTest.cpp
@@ -22,7 +22,8 @@ using apache::geode::client::ByteArray;
 TEST(ByteArrayTest, TestNoArgConstructor) {
   const ByteArray ba;
   EXPECT_EQ(0U, ba.size()) << "Zero size for no-arg constructor";
-  EXPECT_EQ((const uint8_t *)nullptr, (const uint8_t *)ba)
+  EXPECT_EQ(static_cast<const uint8_t *>(nullptr),
+            static_cast<const uint8_t *>(ba))
       << "Null pointer for no-arg constructor";
 }
 
@@ -30,7 +31,8 @@ TEST(ByteArrayTest, TestTwoArgConstructor) {
   const uint8_t bytes[] = {0xDE, 0xAD, 0xBE, 0xEF};
   const ByteArray ba(bytes, 4);
   EXPECT_EQ(4U, ba.size()) << "Correct size for two-arg constructor";
-  EXPECT_NE((const uint8_t *)nullptr, (const uint8_t *)ba)
+  EXPECT_NE(static_cast<const uint8_t *>(nullptr),
+            static_cast<const uint8_t *>(ba))
       << "Non-null pointer for two-arg constructor";
   EXPECT_EQ(0xDE, ba[0]) << "Correct zeroth byte for two-arg constructor";
   EXPECT_EQ(0xAD, ba[1]) << "Correct first byte for two-arg constructor";
@@ -43,7 +45,8 @@ TEST(ByteArrayTest, TestCopyConstructor) {
   const ByteArray ba1(bytes, 4U);
   const ByteArray ba2(ba1);
   EXPECT_EQ(4U, ba2.size()) << "Correct size for copy constructor";
-  EXPECT_NE((const uint8_t *)nullptr, (const uint8_t *)ba2)
+  EXPECT_NE(static_cast<const uint8_t *>(nullptr),
+            static_cast<const uint8_t *>(ba2))
       << "Non-null pointer for copy constructor";
   EXPECT_EQ(0xDE, ba2[0]) << "Correct zeroth byte for copy constructor";
   EXPECT_EQ(0xAD, ba2[1]) << "Correct first byte for copy constructor";
@@ -57,7 +60,8 @@ TEST(ByteArrayTest, TestAssignmentOperator) {
   const ByteArray ba1(bytes, 4U);
   ba2 = ba1;
   EXPECT_EQ(4U, ba2.size()) << "Correct size for assignment operator";
-  EXPECT_NE((const uint8_t *)nullptr, (const uint8_t *)ba2)
+  EXPECT_NE(static_cast<const uint8_t *>(nullptr),
+            static_cast<const uint8_t *>(ba2))
       << "Non-null pointer for assignment operator";
   EXPECT_EQ(0xDE, ba2[0]) << "Correct zeroth byte for assignment operator";
   EXPECT_EQ(0xAD, ba2[1]) << "Correct first byte for assignment operator";
@@ -69,7 +73,8 @@ TEST(ByteArrayTest, TestFromStringForEmpty) {
   const std::string empty;
   const ByteArray ba(ByteArray::fromString(empty));
   EXPECT_EQ(0U, ba.size()) << "Zero size for empty string";
-  EXPECT_EQ((const uint8_t *)nullptr, (const uint8_t *)ba)
+  EXPECT_EQ(static_cast<const uint8_t *>(nullptr),
+            static_cast<const uint8_t *>(ba))
       << "Null pointer for empty string";
 }
 
@@ -77,7 +82,8 @@ TEST(ByteArrayTest, TestFromStringForOneCharacter) {
   const std::string one("A");
   const ByteArray ba(ByteArray::fromString(one));
   EXPECT_EQ(1U, ba.size()) << "Correct size for one character";
-  EXPECT_NE((const uint8_t *)nullptr, (const uint8_t *)ba)
+  EXPECT_NE(static_cast<const uint8_t *>(nullptr),
+            static_cast<const uint8_t *>(ba))
       << "Non-null pointer for one character";
   EXPECT_EQ(0xA0, ba[0]) << "Correct zeroth byte for one character";
 }
@@ -86,7 +92,8 @@ TEST(ByteArrayTest, TestFromStringForEightCharacters) {
   const std::string eight("BABEFACE");
   const ByteArray ba(ByteArray::fromString(eight));
   EXPECT_EQ(4U, ba.size()) << "Correct size for eight characters";
-  EXPECT_NE((const uint8_t *)nullptr, (const uint8_t *)ba)
+  EXPECT_NE(static_cast<const uint8_t *>(nullptr),
+            static_cast<const uint8_t *>(ba))
       << "Non-null pointer for eight characters";
   EXPECT_EQ(0xBA, ba[0]) << "Correct zeroth byte for eight characters";
   EXPECT_EQ(0xBE, ba[1]) << "Correct first byte for eight characters";

--- a/cppcache/test/CacheableKeysTest.cpp
+++ b/cppcache/test/CacheableKeysTest.cpp
@@ -27,22 +27,26 @@ TEST(CacheableKeysTest, boolDifferentHashCodes) {
 }
 
 TEST(CacheableKeysTest, int8_tDifferentHashCodes) {
-  EXPECT_NE(hashcode((int8_t)37), hashcode((int8_t)42))
+  EXPECT_NE(hashcode(static_cast<int8_t>(37)),
+            hashcode(static_cast<int8_t>(42)))
       << "Two different int8_t values have different hashcodes";
 }
 
 TEST(CacheableKeysTest, int16_tDifferentHashCodes) {
-  EXPECT_NE(hashcode((int16_t)37), hashcode((int16_t)42))
+  EXPECT_NE(hashcode(static_cast<int8_t>(37)),
+            hashcode(static_cast<int8_t>(42)))
       << "Two different int16_t values have different hashcodes";
 }
 
 TEST(CacheableKeysTest, int32_tDifferentHashCodes) {
-  EXPECT_NE(hashcode((int32_t)37), hashcode((int32_t)42))
+  EXPECT_NE(hashcode(static_cast<int8_t>(37)),
+            hashcode(static_cast<int8_t>(42)))
       << "Two different int32_t values have different hashcodes";
 }
 
 TEST(CacheableKeysTest, int64_tDifferentHashCodes) {
-  EXPECT_NE(hashcode((int64_t)37), hashcode((int64_t)42))
+  EXPECT_NE(hashcode(static_cast<int8_t>(37)),
+            hashcode(static_cast<int8_t>(42)))
       << "Two different int64_t values have different hashcodes";
 }
 

--- a/cppcache/test/DataInputTest.cpp
+++ b/cppcache/test/DataInputTest.cpp
@@ -298,14 +298,14 @@ TEST_F(DataInputTest, TestReadUint8) {
   TestDataInput dataInput("37");
   uint8_t value = 0U;
   dataInput.read(&value);
-  EXPECT_EQ((uint8_t)55U, value) << "Correct uint8_t";
+  EXPECT_EQ(static_cast<int8_t>(55U), value) << "Correct uint8_t";
 }
 
 TEST_F(DataInputTest, TestReadInt8) {
   TestDataInput dataInput("37");
   int8_t value = 0;
   dataInput.read(&value);
-  EXPECT_EQ((int8_t)55, value) << "Correct int8_t";
+  EXPECT_EQ(static_cast<int8_t>(55), value) << "Correct int8_t";
 }
 
 TEST_F(DataInputTest, TestReadBoolean) {
@@ -320,10 +320,10 @@ TEST_F(DataInputTest, TestReadUint8_tBytesOnly) {
   uint8_t buffer[4];
   ::memset(buffer, 0U, 4 * sizeof(uint8_t));
   dataInput.readBytesOnly(buffer, 4);
-  EXPECT_EQ((uint8_t)186U, buffer[0]) << "Correct zeroth uint8_t";
-  EXPECT_EQ((uint8_t)190U, buffer[1]) << "Correct first uint8_t";
-  EXPECT_EQ((uint8_t)250U, buffer[2]) << "Correct second uint8_t";
-  EXPECT_EQ((uint8_t)206U, buffer[3]) << "Correct third uint8_t";
+  EXPECT_EQ(static_cast<uint8_t>(186U), buffer[0]) << "Correct zeroth uint8_t";
+  EXPECT_EQ(static_cast<uint8_t>(190U), buffer[1]) << "Correct first uint8_t";
+  EXPECT_EQ(static_cast<uint8_t>(250U), buffer[2]) << "Correct second uint8_t";
+  EXPECT_EQ(static_cast<uint8_t>(206U), buffer[3]) << "Correct third uint8_t";
 }
 
 TEST_F(DataInputTest, TestReadInt8_tBytesOnly) {
@@ -331,10 +331,10 @@ TEST_F(DataInputTest, TestReadInt8_tBytesOnly) {
   int8_t buffer[4];
   ::memset(buffer, 0, 4 * sizeof(int8_t));
   dataInput.readBytesOnly(buffer, 4);
-  EXPECT_EQ((int8_t)-34, buffer[0]) << "Correct zeroth int8_t";
-  EXPECT_EQ((int8_t)-83, buffer[1]) << "Correct first int8_t";
-  EXPECT_EQ((int8_t)-66, buffer[2]) << "Correct second int8_t";
-  EXPECT_EQ((int8_t)-17, buffer[3]) << "Correct third int8_t";
+  EXPECT_EQ(static_cast<int8_t>(-34), buffer[0]) << "Correct zeroth int8_t";
+  EXPECT_EQ(static_cast<int8_t>(-83), buffer[1]) << "Correct first int8_t";
+  EXPECT_EQ(static_cast<int8_t>(-66), buffer[2]) << "Correct second int8_t";
+  EXPECT_EQ(static_cast<int8_t>(-17), buffer[3]) << "Correct third int8_t";
 }
 
 TEST_F(DataInputTest, TestReadUint8_tBytes) {
@@ -342,12 +342,12 @@ TEST_F(DataInputTest, TestReadUint8_tBytes) {
   uint8_t *buffer = nullptr;
   int32_t len = 0;
   dataInput.readBytes(&buffer, &len);
-  EXPECT_NE((uint8_t *)nullptr, buffer) << "Non-null buffer";
+  EXPECT_NE(static_cast<uint8_t *>(nullptr), buffer) << "Non-null buffer";
   ASSERT_EQ(4, len) << "Correct length";
-  EXPECT_EQ((uint8_t)186U, buffer[0]) << "Correct zeroth uint8_t";
-  EXPECT_EQ((uint8_t)190U, buffer[1]) << "Correct first uint8_t";
-  EXPECT_EQ((uint8_t)250U, buffer[2]) << "Correct second uint8_t";
-  EXPECT_EQ((uint8_t)206U, buffer[3]) << "Correct third uint8_t";
+  EXPECT_EQ(static_cast<uint8_t>(186U), buffer[0]) << "Correct zeroth uint8_t";
+  EXPECT_EQ(static_cast<uint8_t>(190U), buffer[1]) << "Correct first uint8_t";
+  EXPECT_EQ(static_cast<uint8_t>(250U), buffer[2]) << "Correct second uint8_t";
+  EXPECT_EQ(static_cast<uint8_t>(206U), buffer[3]) << "Correct third uint8_t";
   _GEODE_SAFE_DELETE_ARRAY(buffer);
 }
 
@@ -356,50 +356,52 @@ TEST_F(DataInputTest, TestReadInt8_tBytes) {
   int8_t *buffer = nullptr;
   int32_t len = 0;
   dataInput.readBytes(&buffer, &len);
-  EXPECT_NE((int8_t *)nullptr, buffer) << "Non-null buffer";
+  EXPECT_NE(static_cast<int8_t *>(nullptr), buffer) << "Non-null buffer";
   ASSERT_EQ(4, len) << "Correct length";
-  EXPECT_EQ((int8_t)-34, buffer[0]) << "Correct zeroth int8_t";
-  EXPECT_EQ((int8_t)-83, buffer[1]) << "Correct first int8_t";
-  EXPECT_EQ((int8_t)-66, buffer[2]) << "Correct second int8_t";
-  EXPECT_EQ((int8_t)-17, buffer[3]) << "Correct third int8_t";
+  EXPECT_EQ(static_cast<int8_t>(-34), buffer[0]) << "Correct zeroth int8_t";
+  EXPECT_EQ(static_cast<int8_t>(-83), buffer[1]) << "Correct first int8_t";
+  EXPECT_EQ(static_cast<int8_t>(-66), buffer[2]) << "Correct second int8_t";
+  EXPECT_EQ(static_cast<int8_t>(-17), buffer[3]) << "Correct third int8_t";
   _GEODE_SAFE_DELETE_ARRAY(buffer);
 }
 
 TEST_F(DataInputTest, TestReadIntUint16) {
   TestDataInput dataInput("123456789ABCDEF0");
   uint16_t value = dataInput.readInt16();
-  EXPECT_EQ((uint16_t)4660U, value) << "Correct uint16_t";
+  EXPECT_EQ(static_cast<uint16_t>(4660U), value) << "Correct uint16_t";
 }
 
 TEST_F(DataInputTest, TestReadIntInt16) {
   TestDataInput dataInput("123456789ABCDEF0");
   int16_t value = dataInput.readInt16();
-  EXPECT_EQ((int16_t)4660, value) << "Correct int16_t";
+  EXPECT_EQ(static_cast<int16_t>(4660), value) << "Correct int16_t";
 }
 
 TEST_F(DataInputTest, TestReadIntUint32) {
   TestDataInput dataInput("123456789ABCDEF0");
   uint32_t value = dataInput.readInt32();
-  EXPECT_EQ((uint32_t)305419896U, value) << "Correct uint32_t";
+  EXPECT_EQ(static_cast<uint32_t>(305419896U), value) << "Correct uint32_t";
 }
 
 TEST_F(DataInputTest, TestReadIntInt32) {
   TestDataInput dataInput("123456789ABCDEF0");
   int32_t value = dataInput.readInt32();
-  EXPECT_EQ((int32_t)305419896, value) << "Correct int32_t";
+  EXPECT_EQ(static_cast<int32_t>(305419896), value) << "Correct int32_t";
 }
 
 TEST_F(DataInputTest, TestReadIntUint64) {
   TestDataInput dataInput("123456789ABCDEF0");
   uint64_t value = 0U;
   dataInput.readInt(&value);
-  EXPECT_EQ((uint64_t)1311768467463790320U, value) << "Correct uint64_t";
+  EXPECT_EQ(static_cast<uint64_t>(1311768467463790320U), value)
+      << "Correct uint64_t";
 }
 
 TEST_F(DataInputTest, TestReadIntInt64) {
   TestDataInput dataInput("123456789ABCDEF0");
   int64_t value = dataInput.readInt64();
-  EXPECT_EQ((int64_t)1311768467463790320, value) << "Correct int64_t";
+  EXPECT_EQ(static_cast<int64_t>(1311768467463790320), value)
+      << "Correct int64_t";
 }
 
 TEST_F(DataInputTest, TestReadArrayLen) {
@@ -438,7 +440,8 @@ TEST_F(DataInputTest, TestReadUnsignedVL) {
 
   TestDataInput dataInput("F0BDF3D589CF959A9200");
   int64_t value = dataInput.readUnsignedVL();
-  EXPECT_EQ((int64_t)1311768467463790320, value) << "Correct int64_t";
+  EXPECT_EQ(static_cast<int64_t>(1311768467463790320), value)
+      << "Correct int64_t";
 }
 
 TEST_F(DataInputTest, TestReadFloat) {
@@ -480,7 +483,7 @@ TEST_F(DataInputTest, TestReadNativeBool) {
 TEST_F(DataInputTest, TestReadNativeInt32) {
   TestDataInput dataInput("0012345678");
   const int32_t value = dataInput.readNativeInt32();
-  EXPECT_EQ((int32_t)305419896, value) << "Correct int32_t";
+  EXPECT_EQ(static_cast<int32_t>(305419896), value) << "Correct int32_t";
 }
 
 TEST_F(DataInputTest, TestReadDirectObject) {
@@ -587,16 +590,20 @@ TEST_F(DataInputTest, TestReadArrayOfByteArrays) {
   int32_t *elementLength = nullptr;
   dataInput.readArrayOfByteArrays(&arrayOfByteArrays, arrayLength,
                                   &elementLength);
-  EXPECT_NE((int8_t **)nullptr, arrayOfByteArrays)
+  EXPECT_NE(static_cast<int8_t **>(nullptr), arrayOfByteArrays)
       << "Non-null array of byte arrays";
   ASSERT_EQ(1, arrayLength) << "Correct array length";
-  EXPECT_NE((int8_t *)nullptr, arrayOfByteArrays[0])
+  EXPECT_NE(static_cast<int8_t *>(nullptr), arrayOfByteArrays[0])
       << "Non-null first byte array";
   ASSERT_EQ(4, elementLength[0]) << "Correct length";
-  EXPECT_EQ((int8_t)-34, arrayOfByteArrays[0][0]) << "Correct zeroth int8_t";
-  EXPECT_EQ((int8_t)-83, arrayOfByteArrays[0][1]) << "Correct first int8_t";
-  EXPECT_EQ((int8_t)-66, arrayOfByteArrays[0][2]) << "Correct second int8_t";
-  EXPECT_EQ((int8_t)-17, arrayOfByteArrays[0][3]) << "Correct third int8_t";
+  EXPECT_EQ(static_cast<int8_t>(-34), arrayOfByteArrays[0][0])
+      << "Correct zeroth int8_t";
+  EXPECT_EQ(static_cast<int8_t>(-83), arrayOfByteArrays[0][1])
+      << "Correct first int8_t";
+  EXPECT_EQ(static_cast<int8_t>(-66), arrayOfByteArrays[0][2])
+      << "Correct second int8_t";
+  EXPECT_EQ(static_cast<int8_t>(-17), arrayOfByteArrays[0][3])
+      << "Correct third int8_t";
   _GEODE_SAFE_DELETE_ARRAY(elementLength);
   _GEODE_SAFE_DELETE_ARRAY(arrayOfByteArrays);
 }

--- a/tests/cpp/fwklib/UDPIpc.hpp
+++ b/tests/cpp/fwklib/UDPIpc.hpp
@@ -54,7 +54,7 @@ namespace client {
 namespace testframework {
 
 #define UDP_HEADER_SIZE 8
-#define UDP_MSG_TAG (uint8_t)189
+#define UDP_MSG_TAG static_cast<uint8_t>(189)
 
 enum UdpCmds { Null, ACK, ACK_REQUEST, ADDR_REQUEST, ADDR_RESPONSE };
 


### PR DESCRIPTION
Authored-by: M. Oleske <michael@oleske.engineer>

Here's some flaky CI passes in [Windows](https://github.com/moleske/geode-native/actions/runs/298200790), [Ubuntu](https://github.com/moleske/geode-native/actions/runs/298200789), and [Mac ](https://github.com/moleske/geode-native/actions/runs/298200788)for showing it is working.

The `do...while` change in `fw_dunit.hpp` is because I got angry at some unneeded semicolons in one of the files so I went ahead and wrapped the macro.  If folks don't like it I guess I can revert it and be sad about it on my own.