### PR TITLE
GEODE-8604: Fix documentation errors on Mac build

### DIFF
--- a/cppcache/src/AuthenticatedView.cpp
+++ b/cppcache/src/AuthenticatedView.cpp
@@ -53,7 +53,6 @@ bool AuthenticatedView::isClosed() const { return m_isAuthenticatedViewClosed; }
  * After this cache is closed, any further
  * method call on this cache or any region object will throw
  * <code>CacheClosedException</code>, unless otherwise noted.
- * @param keepalive whether to keep the durable client's queue
  * @throws CacheClosedException,  if the cache is already closed.
  */
 void AuthenticatedView::close() {
@@ -119,8 +118,6 @@ std::shared_ptr<Region> AuthenticatedView::getRegion(
  * shared regions to be mapped into the cache. This set is a snapshot and
  * is not backed by the Cache. The regions passed in are cleared.
  *
- * @param regions the region collection object containing the returned set of
- * regions when the function returns
  */
 std::shared_ptr<QueryService> AuthenticatedView::getQueryService() {
   if (!m_isAuthenticatedViewClosed) {

--- a/cppcache/src/Cache.cpp
+++ b/cppcache/src/Cache.cpp
@@ -79,9 +79,6 @@ std::shared_ptr<Region> Cache::getRegion(const std::string& path) const {
  * Returns a set of root regions in the cache. Does not cause any
  * shared regions to be mapped into the cache. This set is a snapshot and
  * is not backed by the Cache. The regions passed in are cleared.
- *
- * @param regions the region collection object containing the returned set of
- * regions when the function returns
  */
 std::vector<std::shared_ptr<Region>> Cache::rootRegions() const {
   return m_cacheImpl->rootRegions();

--- a/cppcache/src/CqQueryImpl.cpp
+++ b/cppcache/src/CqQueryImpl.cpp
@@ -240,7 +240,7 @@ std::shared_ptr<CqAttributes> CqQueryImpl::getCqAttributes() const {
 void CqQueryImpl::cleanup() { removeFromCqMap(); }
 
 /**
- * @return Returns the cqListeners.
+ * @param cqListener - on success, refers to the current listener
  */
 void CqQueryImpl::getCqListeners(
     CqAttributes::listener_container_type& cqListener) {

--- a/cppcache/src/CqService.cpp
+++ b/cppcache/src/CqService.cpp
@@ -392,8 +392,10 @@ void CqService::receiveNotification(TcrMessage* msg) {
  * Invokes the CqListeners for the given CQs.
  * @param cqs list of cqs with the cq operation from the Server.
  * @param messageType base operation
- * @param key
- * @param value
+ * @param key key to notify for
+ * @param value associated value
+ * @param deltaValue if delta, contains delta bytes
+ * @param eventId event to send
  */
 void CqService::invokeCqListeners(const std::map<std::string, int>* cqs,
                                   uint32_t messageType,
@@ -504,7 +506,7 @@ void CqService::invokeCqConnectedListeners(const std::string& poolName,
 
 /**
  * Returns the Operation for the given EnumListenerEvent type.
- * @param eventType
+ * @param eventType event type to translate to opType
  * @return Operation
  */
 CqOperation CqService::getOperation(int eventType) {

--- a/cppcache/src/statistics/OsStatisticsImpl.cpp
+++ b/cppcache/src/statistics/OsStatisticsImpl.cpp
@@ -64,13 +64,13 @@ std::string OsStatisticsImpl::calcTextId(StatisticsFactory* system,
 /**
  * Creates a new statistics instance of the given type
  *
- * @param type
+ * @param typeArg
  *        A description of the statistics
- * @param textId
+ * @param textIdArg
  *        Text that identifies this statistic when it is monitored
- * @param numericId
+ * @param numericIdArg
  *        A number that displayed when this statistic is monitored
- * @param uniqueId
+ * @param uniqueIdArg
  *        A number that uniquely identifies this instance
  * @param system
  *        The distributed system that determines whether or not these

--- a/cppcache/src/statistics/Statistics.cpp
+++ b/cppcache/src/statistics/Statistics.cpp
@@ -102,9 +102,6 @@ double Statistics::getDouble(const std::string&) const { return 0; }
  * Increments the value of the identified statistic of type <code>int</code>
  * by the given amount.
  *
- * @param id a statistic id obtained with {@link #nameToId}
- * or {@link StatisticsType#nameToId}.
- *
  * @return The value of the statistic after it has been incremented
  *
  * @throws IllegalArgumentException


### PR DESCRIPTION
MacOS apparently flags more of these than our Linux builds, so this fixes up Mac builds.

@mreddington @davebarnes97 @dihardman