### PR TITLE
GEODE-8157: Add DropProxy acceptance test for .NET

### DIFF
--- a/clicache/acceptance-test/SNITests.cs
+++ b/clicache/acceptance-test/SNITests.cs
@@ -49,10 +49,10 @@ namespace Apache.Geode.Client.IntegrationTests
 
             cache_ = cacheFactory.Create();
 
-            var rVal = RunProcess("docker-compose",
+            RunProcess("docker-compose",
                 "-f " + Config.SniConfigPath + "/docker-compose.yml" +
                 " up -d");
-            rVal = RunProcess("docker",
+            RunProcess("docker",
                 "exec -t geode " +
                 "gfsh run --file=/geode/scripts/geode-starter.gfsh");
         }
@@ -64,18 +64,18 @@ namespace Apache.Geode.Client.IntegrationTests
 
         private void CleanupDocker()
         {
-            var rVal = RunProcess("docker", "stop geode");
-            rVal = RunProcess("docker", "stop haproxy");
-            rVal = RunProcess("docker", "container prune -f");
+            RunProcess("docker", "stop geode");
+            RunProcess("docker", "stop haproxy");
+            RunProcess("docker", "container prune -f");
         }
 
-        private string RunProcess(string processFile, string dockerCommand)
+        private string RunProcess(string processFile, string processArgs)
         {
             ProcessStartInfo startInfo = new ProcessStartInfo();
             startInfo.RedirectStandardOutput = true;
             startInfo.UseShellExecute = false;
             startInfo.FileName = processFile;
-            startInfo.Arguments = dockerCommand;
+            startInfo.Arguments = processArgs;
             Process process = Process.Start(startInfo);
             String rVal = process.StandardOutput.ReadToEnd();
             process.WaitForExit();
@@ -148,8 +148,8 @@ namespace Apache.Geode.Client.IntegrationTests
 
             Assert.Equal("one", value);
 
-            var rVal = RunProcess("docker", "stop haproxy");
-            rVal = RunProcess("docker", "container prune -f");
+            RunProcess("docker", "stop haproxy");
+            RunProcess("docker", "container prune -f");
 
             Assert.Throws<NotConnectedException>(() =>
             {
@@ -161,7 +161,7 @@ namespace Apache.Geode.Client.IntegrationTests
                 "-f " + Config.SniConfigPath + "/docker-compose.yml " +
                 "run -d --name haproxy " +
                 "--publish " + proxyPort.ToString() + ":15443 haproxy";
-            rVal = RunProcess("docker-compose", startProxyArgs);
+            RunProcess("docker-compose", startProxyArgs);
 
             region.Put("3", "three");
             value = region.Get("3");

--- a/clicache/acceptance-test/SNITests.cs
+++ b/clicache/acceptance-test/SNITests.cs
@@ -31,8 +31,8 @@ namespace Apache.Geode.Client.IntegrationTests
     public class SNITests : TestBase, IDisposable
     {
         string currentWorkingDirectory;
-        Process dockerProcess;
         private readonly Cache cache_;
+        private int proxyPort = -1;
 
         public SNITests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
         {
@@ -40,8 +40,6 @@ namespace Apache.Geode.Client.IntegrationTests
 
             currentWorkingDirectory = Directory.GetCurrentDirectory();
             var clientTruststore = Config.SslClientKeyPath + @"/truststore_sni.pem";
-
-
 
             var cacheFactory = new CacheFactory();
             cacheFactory.Set("log-level", "none");
@@ -51,11 +49,12 @@ namespace Apache.Geode.Client.IntegrationTests
 
             cache_ = cacheFactory.Create();
 
-            var dc = Process.Start(@"docker-compose.exe", "-f " + Config.SniConfigPath + "/docker-compose.yml" + " up -d");
-            dc.WaitForExit();
-
-            var d = Process.Start(@"docker.exe", "exec -t geode gfsh run --file=/geode/scripts/geode-starter.gfsh");
-            d.WaitForExit();
+            var rVal = RunProcess("docker-compose",
+                "-f " + Config.SniConfigPath + "/docker-compose.yml" +
+                " up -d");
+            rVal = RunProcess("docker",
+                "exec -t geode " +
+                "gfsh run --file=/geode/scripts/geode-starter.gfsh");
         }
 
         public void Dispose()
@@ -65,23 +64,21 @@ namespace Apache.Geode.Client.IntegrationTests
 
         private void CleanupDocker()
         {
-            var dockerComposeProc = Process.Start(@"docker-compose.exe", "-f " + Config.SniConfigPath + "/docker-compose.yml" + " stop");
-            dockerComposeProc.WaitForExit();
-
-            var dockerProc = Process.Start(@"docker.exe", "system prune -f");
-            dockerProc.WaitForExit();
+            var rVal = RunProcess("docker", "stop geode");
+            rVal = RunProcess("docker", "stop haproxy");
+            rVal = RunProcess("docker", "container prune -f");
         }
 
-        private string RunDockerCommand(string dockerCommand)
+        private string RunProcess(string processFile, string dockerCommand)
         {
             ProcessStartInfo startInfo = new ProcessStartInfo();
             startInfo.RedirectStandardOutput = true;
             startInfo.UseShellExecute = false;
-            startInfo.FileName = @"docker.exe";
+            startInfo.FileName = processFile;
             startInfo.Arguments = dockerCommand;
-            dockerProcess = Process.Start(startInfo);
-            String rVal = dockerProcess.StandardOutput.ReadToEnd();
-            dockerProcess.WaitForExit();
+            Process process = Process.Start(startInfo);
+            String rVal = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
             return rVal;
         }
 
@@ -92,20 +89,15 @@ namespace Apache.Geode.Client.IntegrationTests
             return Int32.Parse(portNumberString);
         }
 
-        private Task PutAsync(IRegion<string, string> region, string key, string value)
-        {
-            return Task.Run(() => region.Put(key, value));
-        }
-
         [Fact]
         public void ConnectViaProxy()
         {
-            var portString = RunDockerCommand("port haproxy");
-            var portNumber = ParseProxyPort(portString);
+            var portString = RunProcess("docker", "port haproxy");
+            proxyPort = ParseProxyPort(portString);
 
             cache_.GetPoolManager()
                 .CreateFactory()
-                .SetSniProxy("localhost", portNumber)
+                .SetSniProxy("localhost", proxyPort)
                 .AddLocator("locator-maeve", 10334)
                 .Create("pool");
 
@@ -138,12 +130,12 @@ namespace Apache.Geode.Client.IntegrationTests
         [Fact]
         public void DropProxy()
         {
-            var portString = RunDockerCommand("port haproxy");
-            var portNumber = ParseProxyPort(portString);
+            var portString = RunProcess("docker", "port haproxy");
+            proxyPort = ParseProxyPort(portString);
 
             cache_.GetPoolManager()
                 .CreateFactory()
-                .SetSniProxy("localhost", portNumber)
+                .SetSniProxy("localhost", proxyPort)
                 .AddLocator("locator-maeve", 10334)
                 .Create("pool");
 
@@ -151,20 +143,30 @@ namespace Apache.Geode.Client.IntegrationTests
                               .SetPoolName("pool")
                               .Create<string, string>("jellyfish");
 
-            var rVal = RunDockerCommand("pause haproxy");
-
-            Task putTask = PutAsync(region, "1", "one");
-            bool putCompleted = putTask.Wait(10000);
-            Assert.False(putCompleted);
-
-            rVal = RunDockerCommand("unpause haproxy");
-
-            putCompleted = putTask.Wait(10000);
-            Assert.True(putCompleted);
-
+            region.Put("1", "one");
             var value = region.Get("1");
 
             Assert.Equal("one", value);
+
+            var rVal = RunProcess("docker", "stop haproxy");
+            rVal = RunProcess("docker", "container prune -f");
+
+            Assert.Throws<NotConnectedException>(() =>
+            {
+                region.Put("2", "two");
+                value = region.Get("2");
+            });
+
+            string startProxyArgs =
+                "-f " + Config.SniConfigPath + "/docker-compose.yml " +
+                "run -d --name haproxy " +
+                "--publish " + proxyPort.ToString() + ":15443 haproxy";
+            rVal = RunProcess("docker-compose", startProxyArgs);
+
+            region.Put("3", "three");
+            value = region.Get("3");
+            Assert.Equal("three", value);
+
             cache_.Close();
         }
     }

--- a/cppcache/acceptance-test/SNITest.cpp
+++ b/cppcache/acceptance-test/SNITest.cpp
@@ -55,52 +55,34 @@ class SNITest : public ::testing::Test {
   void SetUp() override {
     TearDown();
 
-    auto systemRVal = 0;
     std::string dockerComposeCmd = "docker-compose -f " +
                                    sniConfigPath.string() +
                                    "/docker-compose.yml" + " up -d";
-    const char* dcc = dockerComposeCmd.c_str();
 
-    systemRVal = std::system(dcc);
-    if (systemRVal == -1) {
-      BOOST_LOG_TRIVIAL(error)
-          << "std::system(\"docker-compose\") returned: " << systemRVal;
-    }
+    runProcess(dockerComposeCmd);
 
-    systemRVal = std::system(
+    runProcess(
         "docker exec -t geode gfsh run "
         "--file=/geode/scripts/geode-starter.gfsh");
-    if (systemRVal == -1) {
-      BOOST_LOG_TRIVIAL(error)
-          << "std::system(\"docker exec -t geode gfsh run\") returned: "
-          << systemRVal;
-    }
   }
 
   void TearDown() override { cleanupDocker(); }
 
   void cleanupDocker() {
-    auto dockerComposeStopCommand = "docker-compose -f " +
-                                    sniConfigPath.string() +
-                                    "/docker-compose.yml" + " stop";
-    auto systemRVal = std::system(dockerComposeStopCommand.c_str());
-    if (systemRVal == -1) {
-      BOOST_LOG_TRIVIAL(error) << "std::system returned: " << systemRVal;
-    }
-
-    systemRVal = std::system("docker system prune -f");
-    if (systemRVal == -1) {
-      BOOST_LOG_TRIVIAL(error) << "std::system returned: " << systemRVal;
-    }
+    runProcess("docker stop geode");
+    runProcess("docker stop haproxy");
+    runProcess("docker container prune -f");
   }
 
-  std::string runDockerCommand(const char* command) {
+  std::string runProcess(std::string command) {
+    const char* cstrCommand = command.c_str();
     std::string commandOutput;
 #if defined(_WIN32)
-    std::unique_ptr<FILE, decltype(&_pclose)> pipe(_popen(command, "r"),
+    std::unique_ptr<FILE, decltype(&_pclose)> pipe(_popen(cstrCommand, "r"),
                                                    _pclose);
 #else
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command, "r"), pclose);
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cStrCommand, "r"),
+                                                  pclose);
 #endif
     std::array<char, 128> charBuff;
     if (!pipe) {
@@ -125,7 +107,7 @@ class SNITest : public ::testing::Test {
   boost::filesystem::path sniConfigPath;
 };
 
-TEST_F(SNITest, connectViaProxyTest) {
+TEST_F(SNITest, connectViaProxy) {
   const auto clientTruststore =
       (clientSslKeysDir / boost::filesystem::path("/truststore_sni.pem"));
 
@@ -136,7 +118,7 @@ TEST_F(SNITest, connectViaProxyTest) {
                    .set("ssl-truststore", clientTruststore.string())
                    .create();
 
-  auto portString = runDockerCommand("docker port haproxy");
+  auto portString = runProcess("docker port haproxy");
   auto portNumber = parseProxyPort(portString);
 
   cache.getPoolManager()
@@ -150,6 +132,8 @@ TEST_F(SNITest, connectViaProxyTest) {
                     .create("jellyfish");
 
   region->put("1", "one");
+  auto val = std::dynamic_pointer_cast<CacheableString>(region->get("1"));
+  EXPECT_EQ("one", val->value());
 
   cache.close();
 }
@@ -179,7 +163,7 @@ TEST_F(SNITest, connectWithoutProxyFails) {
   cache.close();
 }
 
-TEST_F(SNITest, dropSNIProxyTest) {
+TEST_F(SNITest, dropSNIProxy) {
   const auto clientTruststore =
       (clientSslKeysDir / boost::filesystem::path("/truststore_sni.pem"));
 
@@ -190,12 +174,12 @@ TEST_F(SNITest, dropSNIProxyTest) {
                    .set("ssl-truststore", clientTruststore.string())
                    .create();
 
-  auto portString = runDockerCommand("docker port haproxy");
-  auto portNumber = parseProxyPort(portString);
+  auto portString = runProcess("docker port haproxy");
+  auto proxyPort = parseProxyPort(portString);
 
   cache.getPoolManager()
       .createFactory()
-      .setSniProxy("localhost", portNumber)
+      .setSniProxy("localhost", proxyPort)
       .addLocator("locator-maeve", 10334)
       .create("pool");
 
@@ -203,27 +187,26 @@ TEST_F(SNITest, dropSNIProxyTest) {
                     .setPoolName("pool")
                     .create("jellyfish");
 
-  auto systemRVal = std::system("docker pause haproxy");
-  if (systemRVal == -1) {
-    BOOST_LOG_TRIVIAL(error) << "std::system returned: " << systemRVal;
-  }
+  region->put("1", "one");
+  auto val = std::dynamic_pointer_cast<CacheableString>(region->get("1"));
+  EXPECT_EQ("one", val->value());
 
-  auto f =
-      std::async(std::launch::async, [&region] { region->put("1", "one"); });
+  runProcess("docker stop haproxy");
+  runProcess("docker container prune -f");
 
-  // Insure the put times out (default is 15 seconds).
-  std::this_thread::sleep_for(std::chrono::seconds(16));
+  EXPECT_THROW(region->put("1", "one"),
+               apache::geode::client::NotConnectedException);
 
-  systemRVal = std::system("docker unpause haproxy");
-  if (systemRVal == -1) {
-    BOOST_LOG_TRIVIAL(error) << "std::system returned: " << systemRVal;
-  }
+  std::string startProxyArgs = "-f " + sniConfigPath.string() +
+                               "/docker-compose.yml "
+                               "run -d --name haproxy "
+                               "--publish " +
+                               std::to_string(proxyPort) + ":15443 haproxy";
 
-  f.wait();
+  runProcess("docker-compose " + startProxyArgs);
 
-  EXPECT_EQ(
-      std::dynamic_pointer_cast<CacheableString>(region->get("1"))->value(),
-      "one");
+  val = std::dynamic_pointer_cast<CacheableString>(region->get("1"));
+  EXPECT_EQ("one", val->value());
 
   cache.close();
 }

--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -70,6 +70,7 @@ target_link_libraries(cpp-integration-test
     ACE::ACE
     GTest::gtest
     GTest::gtest_main
+    GTest::gmock
     Boost::boost
     Boost::system
     Boost::log


### PR DESCRIPTION
This adds a new DropProxy test to the docker based acceptance tests for .NET.

Note: This test will only run on Windows platforms that have docker and docker-compose installed.