### PR TITLE
Enforce no-sign-conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Weverything
     -Wno-non-virtual-dtor #TODO fix
     -Wno-missing-prototypes #TODO fix
-    -Wno-sign-conversion #TODO fix
     -Wno-deprecated #TODO fix
     -Wno-format-nonliteral #TODO fix
     -Wno-double-promotion #TODO fix


### PR DESCRIPTION
Authored-by: M. Oleske <michael@oleske.engineer>

Another Clang compiler warning that is not needed to be skipped anymore (assuming that travis ci works, it seemed alright on the local machine)