### PR TITLE
GEODE-8157: Make SNITest.cpp compile

### DIFF
--- a/cppcache/acceptance-test/SNITest.cpp
+++ b/cppcache/acceptance-test/SNITest.cpp
@@ -81,7 +81,7 @@ class SNITest : public ::testing::Test {
     std::unique_ptr<FILE, decltype(&_pclose)> pipe(_popen(cstrCommand, "r"),
                                                    _pclose);
 #else
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cStrCommand, "r"),
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cstrCommand, "r"),
                                                   pclose);
 #endif
     std::array<char, 128> charBuff;


### PR DESCRIPTION
Bad variable name

Authored-by: M. Oleske <michael@oleske.engineer>

Since https://github.com/apache/geode-native/pull/674 was merged before it was allowed to finish testing, a broken build is now committed.  And then my CI got sad