### PR TITLE
GEODE-8647: Stop leaking buffer in CLI DataInput 

### DIFF
--- a/clicache/integration-test2/CMakeLists.txt
+++ b/clicache/integration-test2/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library( ${PROJECT_NAME} SHARED
   ClusterTest.cs
   Config.cs.in
   ${CMAKE_CURRENT_BINARY_DIR}/Config.cs
+  DataInputTest.cs
   GfshTest.cs
   GfshExecuteTest.cs
   Gfsh.cs

--- a/clicache/integration-test2/DataInputTest.cs
+++ b/clicache/integration-test2/DataInputTest.cs
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Apache.Geode.Client.IntegrationTests
+{
+    [Trait("Category", "Integration")]
+    public class DataInputTest : TestBase
+    {
+        public DataInputTest(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
+        const int __1K__ = 1024;
+        const int __1M__ = __1K__ * __1K__;
+
+        [Fact]
+        public void CreateDisposeAndCheckForMemoryLeaks()
+        {
+            using (var cluster = new Cluster(output, CreateTestCaseDirectoryName(), 1, 1))
+            {
+                Assert.True(cluster.Start());
+                Assert.Equal(0, cluster.Gfsh
+                    .create()
+                    .region()
+                    .withName("testRegion1")
+                    .withType("PARTITION")
+                    .execute());
+
+                var cacheFactory = new CacheFactory()
+                    .Set("log-level", "none");
+
+                var cache = cacheFactory.Create();
+                try
+                {
+                    cluster.ApplyLocators(cache.GetPoolFactory()).Create("default");
+                    var buffer = new Byte[__1M__];
+
+                    Process currentProc = Process.GetCurrentProcess();
+                    var startingSize = currentProc.PrivateMemorySize64;
+
+                    for (var i = 0; i < 1000; i++)
+                    {
+                        using (var di = new DataInput(buffer, cache))
+                        {
+
+                        }
+                    }
+
+                    var endingSize = currentProc.PrivateMemorySize64;
+                    //
+                    // DataInput CLI object once had a leak of the internal buffer if you
+                    // used the 2-parameter ctor we used above.  1000 iterations each leaking
+                    // 1MB should be a humongous leak, so test for a < 10MB heap usage diff
+                    // here, to allow some wiggle room due to GC etc. and we're still certain
+                    // we're not leaking the buffer any more.
+                    //
+                    Assert.True(System.Math.Abs(endingSize - startingSize) < 10 * __1M__);
+                }
+                finally
+                {
+                    cache.Close();
+                }
+            }
+        }
+    }
+}

--- a/clicache/integration-test2/DataInputTest.cs
+++ b/clicache/integration-test2/DataInputTest.cs
@@ -63,7 +63,7 @@ namespace Apache.Geode.Client.IntegrationTests
                         // Declaring this variable in a using block will ensure the
                         // Dispose method is called when it goes out of scope, which
                         // is the whole point here, since that used to leak memory.
-                        // lgtm
+                        // lgtm[cs/useless-assignment-to-local]
                         using (var di = new DataInput(buffer, __1M__, cache))
                         {
                         }
@@ -72,7 +72,7 @@ namespace Apache.Geode.Client.IntegrationTests
                     // Disable warning for 'call to GC.Collect()'.  This test will fail
                     // with some regularity if we don't collect garbage prior to
                     // re-checking memory usage.
-                    // lgtm
+                    // lgtm[cs/call-to-gc]
                     System.GC.Collect();
                     System.GC.WaitForPendingFinalizers();
                     var endingSize = Process.GetCurrentProcess().PrivateMemorySize64;
@@ -94,7 +94,7 @@ namespace Apache.Geode.Client.IntegrationTests
                         // Declaring this variable in a using block will ensure the
                         // Dispose method is called when it goes out of scope, which
                         // is the whole point here, since that used to leak memory.
-                        // lgtm
+                        // lgtm[cs/useless-assignment-to-local]
                         using (var di = new DataInput(buffer, cache))
                         {
                         }
@@ -103,7 +103,7 @@ namespace Apache.Geode.Client.IntegrationTests
                     // Disable warning for 'call to GC.Collect()'.  This test will fail
                     // with some regularity if we don't collect garbage prior to
                     // re-checking memory usage.
-                    // lgtm
+                    // lgtm[cs/call-to-gc]
                     System.GC.Collect();
                     System.GC.WaitForPendingFinalizers();
                     endingSize = Process.GetCurrentProcess().PrivateMemorySize64;

--- a/clicache/integration-test2/DataInputTest.cs
+++ b/clicache/integration-test2/DataInputTest.cs
@@ -59,11 +59,20 @@ namespace Apache.Geode.Client.IntegrationTests
 
                     for (var i = 0; i < 1000; i++)
                     {
+                        // Disable warning for 'useless assignment to local variable'.
+                        // Declaring this variable in a using block will ensure the
+                        // Dispose method is called when it goes out of scope, which
+                        // is the whole point here, since that used to leak memory.
+                        // lgtm
                         using (var di = new DataInput(buffer, __1M__, cache))
                         {
                         }
                     }
 
+                    // Disable warning for 'call to GC.Collect()'.  This test will fail
+                    // with some regularity if we don't collect garbage prior to
+                    // re-checking memory usage.
+                    // lgtm
                     System.GC.Collect();
                     System.GC.WaitForPendingFinalizers();
                     var endingSize = Process.GetCurrentProcess().PrivateMemorySize64;
@@ -81,11 +90,20 @@ namespace Apache.Geode.Client.IntegrationTests
 
                     for (var i = 0; i < 1000; i++)
                     {
+                        // Disable warning for 'useless assignment to local variable'.
+                        // Declaring this variable in a using block will ensure the
+                        // Dispose method is called when it goes out of scope, which
+                        // is the whole point here, since that used to leak memory.
+                        // lgtm
                         using (var di = new DataInput(buffer, cache))
                         {
                         }
                     }
 
+                    // Disable warning for 'call to GC.Collect()'.  This test will fail
+                    // with some regularity if we don't collect garbage prior to
+                    // re-checking memory usage.
+                    // lgtm
                     System.GC.Collect();
                     System.GC.WaitForPendingFinalizers();
                     endingSize = Process.GetCurrentProcess().PrivateMemorySize64;

--- a/clicache/integration-test2/DataInputTest.cs
+++ b/clicache/integration-test2/DataInputTest.cs
@@ -63,8 +63,7 @@ namespace Apache.Geode.Client.IntegrationTests
                         // Declaring this variable in a using block will ensure the
                         // Dispose method is called when it goes out of scope, which
                         // is the whole point here, since that used to leak memory.
-                        // lgtm[cs/useless-assignment-to-local]
-                        using (var di = new DataInput(buffer, __1M__, cache))
+                        using (var di = new DataInput(buffer, __1M__, cache)) // lgtm[cs/useless-assignment-to-local]
                         {
                         }
                     }
@@ -72,8 +71,7 @@ namespace Apache.Geode.Client.IntegrationTests
                     // Disable warning for 'call to GC.Collect()'.  This test will fail
                     // with some regularity if we don't collect garbage prior to
                     // re-checking memory usage.
-                    // lgtm[cs/call-to-gc]
-                    System.GC.Collect();
+                    System.GC.Collect(); // lgtm[cs/call-to-gc]
                     System.GC.WaitForPendingFinalizers();
                     var endingSize = Process.GetCurrentProcess().PrivateMemorySize64;
 
@@ -94,8 +92,7 @@ namespace Apache.Geode.Client.IntegrationTests
                         // Declaring this variable in a using block will ensure the
                         // Dispose method is called when it goes out of scope, which
                         // is the whole point here, since that used to leak memory.
-                        // lgtm[cs/useless-assignment-to-local]
-                        using (var di = new DataInput(buffer, cache))
+                        using (var di = new DataInput(buffer, cache)) // lgtm[cs/useless-assignment-to-local]
                         {
                         }
                     }
@@ -103,8 +100,7 @@ namespace Apache.Geode.Client.IntegrationTests
                     // Disable warning for 'call to GC.Collect()'.  This test will fail
                     // with some regularity if we don't collect garbage prior to
                     // re-checking memory usage.
-                    // lgtm[cs/call-to-gc]
-                    System.GC.Collect();
+                    System.GC.Collect(); // lgtm[cs/call-to-gc]
                     System.GC.WaitForPendingFinalizers();
                     endingSize = Process.GetCurrentProcess().PrivateMemorySize64;
 

--- a/clicache/src/DataInput.cpp
+++ b/clicache/src/DataInput.cpp
@@ -132,11 +132,10 @@ namespace Apache
               "DataInput.ctor(): given length {0} is zero or greater than "
               "size of buffer {1}", len, buffer->Length));
           }
-          //m_bytes = gcnew array<Byte>(len);
-          //System::Array::Copy(buffer, 0, m_bytes, 0, len);
           _GF_MG_EXCEPTION_TRY2
 
-            _GEODE_NEW(m_buffer, System::Byte[len]);
+          m_ownedBuffer = make_native_unique<System::Byte[]>(len);
+          m_buffer = m_ownedBuffer->get();
           pin_ptr<const Byte> pin_buffer = &buffer[0];
           memcpy(m_buffer, (void*)pin_buffer, len);
           m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(
@@ -878,8 +877,6 @@ namespace Apache
 
       void DataInput::Cleanup()
       {
-        //TODO:
-        //GF_SAFE_DELETE_ARRAY(m_buffer);
       }
 
       void DataInput::ReadDictionary(System::Collections::IDictionary^ dict)

--- a/clicache/src/DataInput.cpp
+++ b/clicache/src/DataInput.cpp
@@ -876,10 +876,6 @@ namespace Apache
         SetBuffer();
       }
 
-      void DataInput::Cleanup()
-      {
-      }
-
       void DataInput::ReadDictionary(System::Collections::IDictionary^ dict)
       {
         int len = this->ReadArrayLen();

--- a/clicache/src/DataInput.cpp
+++ b/clicache/src/DataInput.cpp
@@ -132,10 +132,11 @@ namespace Apache
               "DataInput.ctor(): given length {0} is zero or greater than "
               "size of buffer {1}", len, buffer->Length));
           }
+          //m_bytes = gcnew array<Byte>(len);
+          //System::Array::Copy(buffer, 0, m_bytes, 0, len);
           _GF_MG_EXCEPTION_TRY2
 
-          m_ownedBuffer = make_native_unique<System::Byte[]>(len);
-          m_buffer = m_ownedBuffer->get();
+            _GEODE_NEW(m_buffer, System::Byte[len]);
           pin_ptr<const Byte> pin_buffer = &buffer[0];
           memcpy(m_buffer, (void*)pin_buffer, len);
           m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(
@@ -877,6 +878,8 @@ namespace Apache
 
       void DataInput::Cleanup()
       {
+        //TODO:
+        //GF_SAFE_DELETE_ARRAY(m_buffer);
       }
 
       void DataInput::ReadDictionary(System::Collections::IDictionary^ dict)

--- a/clicache/src/DataInput.cpp
+++ b/clicache/src/DataInput.cpp
@@ -93,7 +93,7 @@ namespace Apache
         if (buffer != nullptr && buffer->Length > 0) {
           _GF_MG_EXCEPTION_TRY2
 
-          System::Int32 len = buffer->Length;
+          auto len = buffer->Length;
           m_ownedBuffer = make_native_unique<System::Byte[]>(len);
           m_buffer = m_ownedBuffer->get();
           pin_ptr<const Byte> pin_buffer = &buffer[0];

--- a/clicache/src/DataInput.cpp
+++ b/clicache/src/DataInput.cpp
@@ -93,8 +93,9 @@ namespace Apache
         if (buffer != nullptr && buffer->Length > 0) {
           _GF_MG_EXCEPTION_TRY2
 
-            System::Int32 len = buffer->Length;
-          _GEODE_NEW(m_buffer, System::Byte[len]);
+          System::Int32 len = buffer->Length;
+          m_ownedBuffer = make_native_unique<System::Byte[]>(len);
+          m_buffer = m_ownedBuffer->get();
           pin_ptr<const Byte> pin_buffer = &buffer[0];
           memcpy(m_buffer, (void*)pin_buffer, len);
           m_nativeptr = gcnew native_conditional_unique_ptr<native::DataInput>(

--- a/clicache/src/DataInput.hpp
+++ b/clicache/src/DataInput.hpp
@@ -24,6 +24,7 @@
 #include "end_native.hpp"
 
 #include "native_conditional_unique_ptr.hpp"
+#include "native_unique_ptr.hpp"
 #include "Log.hpp"
 #include "ExceptionTypes.hpp"
 
@@ -663,7 +664,7 @@ namespace Apache
           m_buffer = const_cast<System::Byte*>(nativeptr->currentBufferPosition());
           if ( m_buffer != NULL) {
             m_bufferLength = static_cast<decltype(m_bufferLength)>(nativeptr->getBytesRemaining());
-					}
+          }
           else {
             m_bufferLength = 0;
           }
@@ -691,6 +692,7 @@ namespace Apache
         bool m_isRootObjectPdx;
         Apache::Geode::Client::Cache^ m_cache;
         System::Byte* m_buffer;
+        native_unique_ptr<System::Byte[]>^ m_ownedBuffer;
         size_t m_bufferLength;
         size_t m_cursor;
         bool m_isManagedObject;

--- a/clicache/src/DataInput.hpp
+++ b/clicache/src/DataInput.hpp
@@ -80,12 +80,12 @@ namespace Apache
         /// <summary>
         /// Dispose: frees the internal buffer.
         /// </summary>
-        ~DataInput( ) { Cleanup( ); }
+        ~DataInput( ) { }
 
         /// <summary>
         /// Finalizer: frees the internal buffer.
         /// </summary>
-        !DataInput( ) { Cleanup( ); }      
+        !DataInput( ) { }
 
         /// <summary>
         /// Read a signed byte from the stream.
@@ -699,8 +699,6 @@ namespace Apache
         array<Char>^ m_forStringDecode;
 
         native_conditional_unique_ptr<native::DataInput>^ m_nativeptr;
-      
-        void Cleanup( );
       };
     }  // namespace Client
   }  // namespace Geode

--- a/clicache/src/DataInput.hpp
+++ b/clicache/src/DataInput.hpp
@@ -24,7 +24,6 @@
 #include "end_native.hpp"
 
 #include "native_conditional_unique_ptr.hpp"
-#include "native_unique_ptr.hpp"
 #include "Log.hpp"
 #include "ExceptionTypes.hpp"
 
@@ -664,7 +663,7 @@ namespace Apache
           m_buffer = const_cast<System::Byte*>(nativeptr->currentBufferPosition());
           if ( m_buffer != NULL) {
             m_bufferLength = static_cast<decltype(m_bufferLength)>(nativeptr->getBytesRemaining());
-          }
+					}
           else {
             m_bufferLength = 0;
           }
@@ -692,7 +691,6 @@ namespace Apache
         bool m_isRootObjectPdx;
         Apache::Geode::Client::Cache^ m_cache;
         System::Byte* m_buffer;
-        native_unique_ptr<System::Byte[]>^ m_ownedBuffer;
         size_t m_bufferLength;
         size_t m_cursor;
         bool m_isManagedObject;

--- a/clicache/src/native_unique_ptr.hpp
+++ b/clicache/src/native_unique_ptr.hpp
@@ -29,13 +29,14 @@ namespace Apache
     namespace Client
     {
 
-      template <class _T>
+      template <class _T, class _D = std::default_delete<_T>>
       public ref class native_unique_ptr sealed {
       private:
-        std::unique_ptr<_T>* ptr;
+        std::unique_ptr<_T, _D>* ptr;
 
       public:
-        native_unique_ptr(std::unique_ptr<_T> ptr) : ptr(new std::unique_ptr<_T>(std::move(ptr))) {}
+        native_unique_ptr(std::unique_ptr<_T, _D>&& ptr) :
+          ptr(new std::unique_ptr<_T, _D>(ptr.release(), std::forward<_D>(ptr.get_deleter()))) {}
 
         ~native_unique_ptr() {
           native_unique_ptr::!native_unique_ptr();
@@ -50,6 +51,45 @@ namespace Apache
         }
 
       };
+
+      
+      template <class _T, class _D>
+      public ref class native_unique_ptr<_T[], _D> sealed {
+      private:
+        std::unique_ptr<_T[], _D>* ptr;
+
+      public:
+        native_unique_ptr(std::unique_ptr<_T[], _D>&& ptr) :
+          ptr(new std::unique_ptr<_T[], _D>(ptr.release(), std::forward<_D>(ptr.get_deleter()))) {}
+
+        native_unique_ptr(_T* ptr) :
+          ptr(new std::unique_ptr<_T[], _D>(ptr)) {}
+
+        ~native_unique_ptr() {
+          native_unique_ptr::!native_unique_ptr();
+        }
+
+        !native_unique_ptr() {
+          delete ptr;
+        }
+
+        inline _T* get() {
+          return ptr->get();
+        }
+
+      };
+
+      template<class _T, class... _Args,
+        std::enable_if_t<!std::is_array_v<_T>, int> = 0>
+      inline native_unique_ptr<_T>^ make_unique(_Args&&... args) {
+        return gcnew native_unique_ptr<_T>(std::make_unique<_T>(std::forward<_Args>(args)...));
+      }
+
+      template <class _T, std::enable_if_t<std::is_array_v<_T> && std::extent_v<_T> == 0, int> = 0>
+      inline native_unique_ptr<_T>^ make_native_unique(std::size_t size) {
+        return gcnew native_unique_ptr<_T>(std::make_unique<_T>(size));
+      }
+      
     }
   }
 }

--- a/clicache/src/native_unique_ptr.hpp
+++ b/clicache/src/native_unique_ptr.hpp
@@ -29,14 +29,13 @@ namespace Apache
     namespace Client
     {
 
-      template <class _T, class _D = std::default_delete<_T>>
+      template <class _T>
       public ref class native_unique_ptr sealed {
       private:
-        std::unique_ptr<_T, _D>* ptr;
+        std::unique_ptr<_T>* ptr;
 
       public:
-        native_unique_ptr(std::unique_ptr<_T, _D>&& ptr) :
-          ptr(new std::unique_ptr<_T, _D>(ptr.release(), std::forward<_D>(ptr.get_deleter()))) {}
+        native_unique_ptr(std::unique_ptr<_T> ptr) : ptr(new std::unique_ptr<_T>(std::move(ptr))) {}
 
         ~native_unique_ptr() {
           native_unique_ptr::!native_unique_ptr();
@@ -51,45 +50,6 @@ namespace Apache
         }
 
       };
-
-      
-      template <class _T, class _D>
-      public ref class native_unique_ptr<_T[], _D> sealed {
-      private:
-        std::unique_ptr<_T[], _D>* ptr;
-
-      public:
-        native_unique_ptr(std::unique_ptr<_T[], _D>&& ptr) :
-          ptr(new std::unique_ptr<_T[], _D>(ptr.release(), std::forward<_D>(ptr.get_deleter()))) {}
-
-        native_unique_ptr(_T* ptr) :
-          ptr(new std::unique_ptr<_T[], _D>(ptr)) {}
-
-        ~native_unique_ptr() {
-          native_unique_ptr::!native_unique_ptr();
-        }
-
-        !native_unique_ptr() {
-          delete ptr;
-        }
-
-        inline _T* get() {
-          return ptr->get();
-        }
-
-      };
-
-      template<class _T, class... _Args,
-        std::enable_if_t<!std::is_array_v<_T>, int> = 0>
-      inline native_unique_ptr<_T>^ make_unique(_Args&&... args) {
-        return gcnew native_unique_ptr<_T>(std::make_unique<_T>(std::forward<_Args>(args)...));
-      }
-
-      template <class _T, std::enable_if_t<std::is_array_v<_T> && std::extent_v<_T> == 0, int> = 0>
-      inline native_unique_ptr<_T>^ make_native_unique(std::size_t size) {
-        return gcnew native_unique_ptr<_T>(std::make_unique<_T>(size));
-      }
-      
     }
   }
 }


### PR DESCRIPTION
The CLI DataInput object has two ctors, one of which copies the passed-in buffer parameter via new[] and one of which doesn't.  In the event that the former is called, the buffer is leaked when the object is deleted/Disposed.

@mreddington @dihardman @karensmolermiller @davebarnes97 