### PR TITLE
GEODE-8678: Add missing API docs

### DIFF
--- a/clicache/src/Cache.hpp
+++ b/clicache/src/Cache.hpp
@@ -271,12 +271,15 @@ namespace Apache
         /// <summary>
         /// Returns a PoolFactory that can be used to create a Pool and that provides
         /// access to all Pool attributes.
-        /// @return the factory
+        /// @return the PoolFactory
         /// </summary>
         virtual PoolFactory^ GetPoolFactory();
 
+        /// <summary>
         /// Returns a PoolManager that provides for the configuration and creation
         /// of instances of PoolFactory.
+        /// @return the PoolManager
+        /// </summary>
         virtual PoolManager^ GetPoolManager();
 
         property Apache::Geode::Client::TypeRegistry^ TypeRegistry

--- a/clicache/src/Cache.hpp
+++ b/clicache/src/Cache.hpp
@@ -268,8 +268,15 @@ namespace Apache
         
         virtual DataOutput^ Cache::CreateDataOutput();
 
+        /// <summary>
+        /// Returns a PoolFactory that can be used to create a Pool and that provides
+        /// access to all Pool attributes.
+        /// @return the factory
+        /// </summary>
         virtual PoolFactory^ GetPoolFactory();
 
+        /// Returns a PoolManager that provides for the configuration and creation
+        /// of instances of PoolFactory.
         virtual PoolManager^ GetPoolManager();
 
         property Apache::Geode::Client::TypeRegistry^ TypeRegistry


### PR DESCRIPTION
Add missing documentation for Cache::GetPoolManager() and Cache::GetPoolFactory().