### PR TITLE
GEODE-8676: Update Bookbindery

### DIFF
--- a/docs/docker/view-docs.sh
+++ b/docs/docker/view-docs.sh
@@ -53,7 +53,7 @@ docker run -i -t \
   -v "$PWD:${DOCS_DIR}" \
   -p 127.0.0.1:${PORT}:${PORT} \
   ${IMAGE_NAME}-${USER_NAME} \
-  /bin/bash -c "bundle install; rackup --host 0.0.0.0 -p ${PORT}"
+  /bin/bash -c "bundle install; bundle exec rackup --host 0.0.0.0 -p ${PORT}"
 
 popd 1> /dev/null
 


### PR DESCRIPTION
One change that I think should have been included in the previous PR for this ticket.
Adds a `bundle exec` prefix before `rackup` in the view-docs.sh script. Should improve the user experience.