### PR TITLE
GEODE-8700: Add the ability to change PR

### DIFF
--- a/cppcache/include/geode/AttributesMutator.hpp
+++ b/cppcache/include/geode/AttributesMutator.hpp
@@ -197,16 +197,6 @@ class APACHE_GEODE_EXPORT AttributesMutator {
    * @param resolver PartitionResolver
    */
   void setPartitionResolver(std::shared_ptr<PartitionResolver> resolver);
-
-  /** Sets cache writer for region. The previous partition resolver will be
-   * replaced with the one created using the factory function provided in
-   * the given library.
-   * @param library_path path of the library containing partition resolver
-   * factory function.
-   * @param function factory function for creating a partition resolver.
-   */
-  void setPartitionResolver(const std::string& library_path,
-                            const std::string& function);
 };
 
 }  // namespace client

--- a/cppcache/include/geode/AttributesMutator.hpp
+++ b/cppcache/include/geode/AttributesMutator.hpp
@@ -40,6 +40,7 @@ class CacheListener;
 class CacheLoader;
 class CacheWriter;
 class Region;
+class PartitionResolver;
 
 /**
  * @class AttributesMutator AttributesMutator.hpp
@@ -190,6 +191,22 @@ class APACHE_GEODE_EXPORT AttributesMutator {
    */
   void setCacheWriter(const std::string& libpath,
                       const std::string& factoryFuncName);
+
+  /** Sets partition resolver writer for region. The previous partition resolver
+   * will be replaced with <code>resolver</code>.
+   * @param resolver PartitionResolver
+   */
+  void setPartitionResolver(std::shared_ptr<PartitionResolver> resolver);
+
+  /** Sets cache writer for region. The previous partition resolver will be
+   * replaced with the one created using the factory function provided in
+   * the given library.
+   * @param library_path path of the library containing partition resolver
+   * factory function.
+   * @param function factory function for creating a partition resolver.
+   */
+  void setPartitionResolver(const std::string& library_path,
+                            const std::string& function);
 };
 
 }  // namespace client

--- a/cppcache/src/AttributesMutator.cpp
+++ b/cppcache/src/AttributesMutator.cpp
@@ -122,12 +122,6 @@ void AttributesMutator::setPartitionResolver(
   auto impl = std::static_pointer_cast<RegionInternal>(m_region);
   impl->adjustPartitionResolver(std::move(resolver));
 }
-
-void AttributesMutator::setPartitionResolver(
-    const std::string& libpath, const std::string& factoryFuncName) {
-  auto impl = std::static_pointer_cast<RegionInternal>(m_region);
-  impl->adjustPartitionResolver(libpath, factoryFuncName);
-}
 }  // namespace client
 }  // namespace geode
 }  // namespace apache

--- a/cppcache/src/AttributesMutator.cpp
+++ b/cppcache/src/AttributesMutator.cpp
@@ -116,6 +116,18 @@ void AttributesMutator::setCacheWriter(const std::string& libpath,
   auto rImpl = std::static_pointer_cast<RegionInternal>(m_region);
   rImpl->adjustCacheWriter(libpath.c_str(), factoryFuncName.c_str());
 }
+
+void AttributesMutator::setPartitionResolver(
+    std::shared_ptr<PartitionResolver> resolver) {
+  auto impl = std::static_pointer_cast<RegionInternal>(m_region);
+  impl->adjustPartitionResolver(std::move(resolver));
+}
+
+void AttributesMutator::setPartitionResolver(
+    const std::string& libpath, const std::string& factoryFuncName) {
+  auto impl = std::static_pointer_cast<RegionInternal>(m_region);
+  impl->adjustPartitionResolver(libpath, factoryFuncName);
+}
 }  // namespace client
 }  // namespace geode
 }  // namespace apache

--- a/cppcache/src/LocalRegion.cpp
+++ b/cppcache/src/LocalRegion.cpp
@@ -3124,6 +3124,16 @@ void LocalRegion::adjustCacheWriter(const std::string& lib,
   m_writer = m_regionAttributes.getCacheWriter();
 }
 
+void LocalRegion::adjustPartitionResolver(
+    std::shared_ptr<PartitionResolver> resolver) {
+  setPartitionResolver(resolver);
+}
+
+void LocalRegion::adjustPartitionResolver(const std::string& lib,
+                                          const std::string& func) {
+  setPartitionResolver(lib, func);
+}
+
 void LocalRegion::evict(int32_t percentage) {
   TryReadGuard guard(m_rwLock, m_destroyPending);
   if (m_released || m_destroyPending) return;

--- a/cppcache/src/LocalRegion.cpp
+++ b/cppcache/src/LocalRegion.cpp
@@ -3129,11 +3129,6 @@ void LocalRegion::adjustPartitionResolver(
   setPartitionResolver(resolver);
 }
 
-void LocalRegion::adjustPartitionResolver(const std::string& lib,
-                                          const std::string& func) {
-  setPartitionResolver(lib, func);
-}
-
 void LocalRegion::evict(int32_t percentage) {
   TryReadGuard guard(m_rwLock, m_destroyPending);
   if (m_released || m_destroyPending) return;

--- a/cppcache/src/LocalRegion.hpp
+++ b/cppcache/src/LocalRegion.hpp
@@ -391,6 +391,12 @@ class APACHE_GEODE_EXPORT LocalRegion : public RegionInternal {
 
   void adjustCacheWriter(const std::string& libpath,
                          const std::string& factoryFuncName) override;
+
+  void adjustPartitionResolver(
+      std::shared_ptr<PartitionResolver> resolver) override;
+  void adjustPartitionResolver(const std::string& library_path,
+                               const std::string& function) override;
+
   CacheImpl* getCacheImpl() const override;
 
   void evict(int32_t percentage) override;

--- a/cppcache/src/LocalRegion.hpp
+++ b/cppcache/src/LocalRegion.hpp
@@ -394,8 +394,6 @@ class APACHE_GEODE_EXPORT LocalRegion : public RegionInternal {
 
   void adjustPartitionResolver(
       std::shared_ptr<PartitionResolver> resolver) override;
-  void adjustPartitionResolver(const std::string& library_path,
-                               const std::string& function) override;
 
   CacheImpl* getCacheImpl() const override;
 

--- a/cppcache/src/RegionInternal.hpp
+++ b/cppcache/src/RegionInternal.hpp
@@ -256,6 +256,10 @@ class RegionInternal : public Region {
       const std::shared_ptr<CacheWriter>& aWriter) = 0;
   virtual void adjustCacheWriter(const std::string& libpath,
                                  const std::string& factoryFuncName) = 0;
+  virtual void adjustPartitionResolver(
+      std::shared_ptr<PartitionResolver> resolver) = 0;
+  virtual void adjustPartitionResolver(const std::string& library_path,
+                                       const std::string& function) = 0;
 
   virtual RegionStats* getRegionStats() = 0;
   virtual bool cacheEnabled() = 0;

--- a/cppcache/src/RegionInternal.hpp
+++ b/cppcache/src/RegionInternal.hpp
@@ -256,10 +256,9 @@ class RegionInternal : public Region {
       const std::shared_ptr<CacheWriter>& aWriter) = 0;
   virtual void adjustCacheWriter(const std::string& libpath,
                                  const std::string& factoryFuncName) = 0;
+
   virtual void adjustPartitionResolver(
       std::shared_ptr<PartitionResolver> resolver) = 0;
-  virtual void adjustPartitionResolver(const std::string& library_path,
-                                       const std::string& function) = 0;
 
   virtual RegionStats* getRegionStats() = 0;
   virtual bool cacheEnabled() = 0;


### PR DESCRIPTION
 - Added setPartitionResolver method to region's attribute mutator, so the
   partition resolver can be changed after the region has been created.
 - Added UT to verify that PR is correctly changed.