### PR TITLE
GEODE-8713: .NET user guide - API reference links point to C++ API

### DIFF
--- a/docs/geode-native-book-cpp/redirects.rb
+++ b/docs/geode-native-book-cpp/redirects.rb
@@ -15,6 +15,7 @@
 
 # Links to API Documentation #
 r301 %r{/releases/latest/javadoc/(.*)}, 'https://geode.apache.org/releases/latest/javadoc/$1'
+r302 %r{/apidocs/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
 r302 %r{/cppdocs/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
 r302 %r{/dotnetdocs/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
 

--- a/docs/geode-native-book-dotnet/redirects.rb
+++ b/docs/geode-native-book-dotnet/redirects.rb
@@ -15,8 +15,9 @@
 
 # Links to API Documentation #
 r301 %r{/releases/latest/javadoc/(.*)}, 'https://geode.apache.org/releases/latest/javadoc/$1'
-r302 %r{/cppdocs/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
+r302 %r{/apidocs/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
 r302 %r{/dotnetdocs/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
+r302 %r{/cppdocs/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
 
 # Links to User Guides #
 rewrite '/', '/docs/geode-native/dotnet/113/about-client-users-guide.html'

--- a/docs/geode-native-docs-cpp/client-cache-ref.html.md.erb
+++ b/docs/geode-native-docs-cpp/client-cache-ref.html.md.erb
@@ -357,7 +357,7 @@ Use the `<expiration-attributes>` sub-element to specify duration and expiration
 
 A partition resolver is used for single-hop access to partitioned region entries on the server side. This resolver
 implementation must match that of the `PartitionResolver` on the server side.
-See the [API Class Reference](/cppdocs/hierarchy.html) for the **PartitionResolver** class.
+See the [API Class Reference](/apidocs/hierarchy.html) for the **PartitionResolver** class.
 
 For example:
 
@@ -370,26 +370,26 @@ For example:
 ## \<cache-loader\>
 
 \<cache-loader\> identifies a cache loader function by specifying `library-name` and `library-function-name`.
-See the [API Class Reference](/cppdocs/hierarchy.html) for the **CacheLoader** class.
+See the [API Class Reference](/apidocs/hierarchy.html) for the **CacheLoader** class.
 
 <a id="cache-listener-ref"></a>
 ## \<cache-listener\>
 
 \<cache-listener\> identifies a cache listener function by specifying `library-name` and `library-function-name`.
-See the [API Class Reference](/cppdocs/hierarchy.html) for the **CacheListener** class.
+See the [API Class Reference](/apidocs/hierarchy.html) for the **CacheListener** class.
 
 <a id="cache-writer-ref"></a>
 ## \<cache-writer\>
 
 \<cache-writer\> identifies a cache writer function by specifying `library-name` and `library-function-name`.
-See the [API Class Reference](/cppdocs/hierarchy.html) for the **CacheWriter** class.
+See the [API Class Reference](/apidocs/hierarchy.html) for the **CacheWriter** class.
 
 <a id="persistence-manager-ref"></a>
 ## \<persistence-manager\>
 
 For each region, if the disk-policy attribute is set to `overflows`, a persistence-manager plug-in
 must perform cache-to-disk and disk-to-cache operations.
-See the [API Class Reference](/cppdocs/hierarchy.html) for the **PersistenceManager** class.
+See the [API Class Reference](/apidocs/hierarchy.html) for the **PersistenceManager** class.
 
 \<persistence-manager\> identifies a persistence manager function by specifying `library-name` and `library-function-name`.
 You can also specify a set of properties to be passed to the function as parameters.

--- a/docs/geode-native-docs-dotnet/client-cache-ref.html.md.erb
+++ b/docs/geode-native-docs-dotnet/client-cache-ref.html.md.erb
@@ -357,7 +357,7 @@ Use the `<expiration-attributes>` sub-element to specify duration and expiration
 
 A partition resolver is used for single-hop access to partitioned region entries on the server side. This resolver
 implementation must match that of the `PartitionResolver` on the server side.
-See the [API Class Reference](/cppdocs/hierarchy.html) for the **PartitionResolver** class.
+See the [API Class Reference](/apidocs/hierarchy.html) for the **PartitionResolver** class.
 
 For example:
 
@@ -370,26 +370,26 @@ For example:
 ## \<cache-loader\>
 
 \<cache-loader\> identifies a cache loader function by specifying `library-name` and `library-function-name`.
-See the [API Class Reference](/cppdocs/hierarchy.html) for the **CacheLoader** class.
+See the [API Class Reference](/apidocs/hierarchy.html) for the **CacheLoader** class.
 
 <a id="cache-listener-ref"></a>
 ## \<cache-listener\>
 
 \<cache-listener\> identifies a cache listener function by specifying `library-name` and `library-function-name`.
-See the [API Class Reference](/cppdocs/hierarchy.html) for the **CacheListener** class.
+See the [API Class Reference](/apidocs/hierarchy.html) for the **CacheListener** class.
 
 <a id="cache-writer-ref"></a>
 ## \<cache-writer\>
 
 \<cache-writer\> identifies a cache writer function by specifying `library-name` and `library-function-name`.
-See the [API Class Reference](/cppdocs/hierarchy.html) for the **CacheWriter** class.
+See the [API Class Reference](/apidocs/hierarchy.html) for the **CacheWriter** class.
 
 <a id="persistence-manager-ref"></a>
 ## \<persistence-manager\>
 
 For each region, if the disk-policy attribute is set to `overflows`, a persistence-manager plug-in
 must perform cache-to-disk and disk-to-cache operations.
-See the [API Class Reference](/cppdocs/hierarchy.html) for the **PersistenceManager** class.
+See the [API Class Reference](/apidocs/hierarchy.html) for the **PersistenceManager** class.
 
 \<persistence-manager\> identifies a persistence manager function by specifying `library-name` and `library-function-name`.
 You can also specify a set of properties to be passed to the function as parameters.


### PR DESCRIPTION
Added a language-agnostic redirect to which the appropriate API reference can be assigned.
Applied the change to both .NET and C++ user guides, for consistency across-the-board.