### PR TITLE
GEODE-8724: Fix compilation using docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && \
             openjdk-8-jdk \
             wget && \
         rm -rf /var/lib/apt/lists/* && \
+        ln -s /usr/lib/llvm-*/include/c++/v1/ /usr/include/c++/v1 && \
         update-alternatives --install /usr/bin/clang         clang         /usr/bin/clang-${CLANG_VERSION} 999 && \
         update-alternatives --install /usr/bin/clang++       clang++       /usr/bin/clang++-${CLANG_VERSION} 999 && \
         update-alternatives --install /usr/bin/cc            cc            /usr/bin/clang-${CLANG_VERSION} 999 && \


### PR DESCRIPTION
 - As latest tag for ubuntu base image was recently change from 18.04 to
   20.04 it seems that some libraries version changed, like for example
   libc++.
 - As it seems with this new version libc++ headers are either not
   anymore located within /usr/include/c++/v1 or the symlink is missing.
 - So in order to solve that a symlink is manually created to ensure
   clang is able to find libc++ headers.