### PR TITLE
GEODE-8532: parse chunked responses in gnmsg tool

### DIFF
--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -678,7 +678,7 @@ char* TcrConnection::readMessage(size_t* recvLen,
   }
 
   LOGDEBUG(
-      "TcrConnection::readMessage: [%p] received header from endpoint %s; "
+      "TcrConnection::readMessage(%p): received header from endpoint %s; "
       "bytes: %s",
       this, m_endpointObj->name().c_str(),
       Utils::convertBytesToString(msg_header, HEADER_LENGTH).c_str());
@@ -815,9 +815,13 @@ chunkedResponseHeader TcrConnection::readResponseHeader(
   }
 
   LOGDEBUG(
-      "TcrConnection::readResponseHeader: received header from "
+      "TcrConnection::readResponseHeader(%p): received header from "
       "endpoint %s; bytes: %s",
+<<<<<<< HEAD
       m_endpointObj->name().c_str(),
+=======
+      this, m_endpoint,
+>>>>>>> GEODE-8532: Add connection to chunked message logging
       Utils::convertBytesToString(receiveBuffer, HEADER_LENGTH).c_str());
 
   auto input = m_connectionManager.getCacheImpl()->createDataInput(
@@ -828,7 +832,7 @@ chunkedResponseHeader TcrConnection::readResponseHeader(
   header.header.chunkLength = input.readInt32();
   header.header.flags = input.read();
   LOGDEBUG(
-      "TcrConnection::readResponseHeader: "
+      "TcrConnection::readResponseHeader(%p): "
       "messageType=%" PRId32 ", numberOfParts=%" PRId32
       ", transactionId=%" PRId32 ", chunkLength=%" PRId32
       ", lastChunkAndSecurityFlags=0x%" PRIx8,
@@ -867,9 +871,9 @@ chunkHeader TcrConnection::readChunkHeader(std::chrono::microseconds timeout) {
   header.chunkLength = input.readInt32();
   header.flags = input.read();
   LOGDEBUG(
-      "TcrConnection::readChunkHeader: "
+      "TcrConnection::readChunkHeader(%p): "
       ", chunkLen=%" PRId32 ", lastChunkAndSecurityFlags=0x%" PRIx8,
-      header.chunkLength, header.flags);
+      this, header.chunkLength, header.flags);
 
   return header;
 }
@@ -892,9 +896,13 @@ std::vector<uint8_t> TcrConnection::readChunkBody(
   }
 
   LOGDEBUG(
-      "TcrConnection::readChunkBody: received chunk body from endpoint "
+      "TcrConnection::readChunkBody(%p): received chunk body from endpoint "
       "%s; bytes: %s",
+<<<<<<< HEAD
       m_endpointObj->name().c_str(),
+=======
+      this, m_endpoint,
+>>>>>>> GEODE-8532: Add connection to chunked message logging
       Utils::convertBytesToString(chunkBody.data(), chunkLength).c_str());
   return chunkBody;
 }

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -836,7 +836,7 @@ chunkedResponseHeader TcrConnection::readResponseHeader(
       "messageType=%" PRId32 ", numberOfParts=%" PRId32
       ", transactionId=%" PRId32 ", chunkLength=%" PRId32
       ", lastChunkAndSecurityFlags=0x%" PRIx8,
-      header.messageType, header.numberOfParts, header.transactionId,
+      this, header.messageType, header.numberOfParts, header.transactionId,
       header.header.chunkLength, header.header.flags);
 
   return header;

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -817,11 +817,7 @@ chunkedResponseHeader TcrConnection::readResponseHeader(
   LOGDEBUG(
       "TcrConnection::readResponseHeader(%p): received header from "
       "endpoint %s; bytes: %s",
-<<<<<<< HEAD
-      m_endpointObj->name().c_str(),
-=======
-      this, m_endpoint,
->>>>>>> GEODE-8532: Add connection to chunked message logging
+      this, m_endpointObj->name().c_str(),
       Utils::convertBytesToString(receiveBuffer, HEADER_LENGTH).c_str());
 
   auto input = m_connectionManager.getCacheImpl()->createDataInput(
@@ -898,11 +894,7 @@ std::vector<uint8_t> TcrConnection::readChunkBody(
   LOGDEBUG(
       "TcrConnection::readChunkBody(%p): received chunk body from endpoint "
       "%s; bytes: %s",
-<<<<<<< HEAD
-      m_endpointObj->name().c_str(),
-=======
-      this, m_endpoint,
->>>>>>> GEODE-8532: Add connection to chunked message logging
+      this, m_endpointObj->name().c_str(),
       Utils::convertBytesToString(chunkBody.data(), chunkLength).c_str());
   return chunkBody;
 }

--- a/tools/gnmsg/chunked_message_decoder.py
+++ b/tools/gnmsg/chunked_message_decoder.py
@@ -44,12 +44,7 @@ class ChunkedResponseDecoder:
             (chunk_size, offset) = call_reader_function(header, offset, read_int_value)
             (flags, offset) = call_reader_function(header, offset, read_byte_value)
             self.chunked_message["ChunkInfo"] = []
-            key = "Chunk" + str(self.chunk_index)
-            inner_item = dict(ChunkLength=chunk_size, Flags=flags)
-            outer_item = {}
-            outer_item[key] = inner_item
-            self.chunked_message["ChunkInfo"].append(outer_item)
-            self.chunk_flags = flags
+            self.add_chunk_header(chunk_size, flags)
         else:
             raise IndexError("Chunked message header should be " + str(CHUNKED_MESSAGE_HEADER_LENGTH) + " bytes")
 
@@ -83,4 +78,4 @@ class ChunkedResponseDecoder:
         self.chunked_message = {}
         self.complete = False
         self.chunk_flags = 0xff
-        self.chunk_index = 0
+        self.chunk_index = -1

--- a/tools/gnmsg/chunked_message_decoder.py
+++ b/tools/gnmsg/chunked_message_decoder.py
@@ -25,7 +25,7 @@ class ChunkedResponseDecoder:
     def __init__(self):
         self.reset()
 
-    def add_header(self, header):
+    def add_header(self, connection, header):
         if len(self.chunked_message) > 0:
             raise Exception("Previous chunked message is not completed, can't process another header")
 
@@ -35,7 +35,7 @@ class ChunkedResponseDecoder:
             (message_type, offset) = call_reader_function(header, offset, read_int_value)
             self.chunked_message["Type"] = message_types[message_type]
             # TODO: pass connection value in as a parameter
-            self.chunked_message["Connection"] = ""
+            self.chunked_message["Connection"] = connection
             self.chunked_message["Direction"] = "<---"
             (self.chunked_message["Parts"], offset) = call_reader_function(header, offset, read_int_value)
             (self.chunked_message["TransactionId"], offset) = call_reader_function(header, offset, read_int_value)
@@ -54,7 +54,7 @@ class ChunkedResponseDecoder:
             raise Exception("Can't add chunk header before message header")
 
         key = "Chunk" + str(self.chunk_index)
-        inner_item = dict(ChunkLength=chunk_size, Flags=flags)
+        inner_item = dict(ChunkLength=int(chunk_size), Flags=flags)
         outer_item = {}
         outer_item[key] = inner_item
         self.chunked_message["ChunkInfo"].append(outer_item)

--- a/tools/gnmsg/chunked_message_decoder.py
+++ b/tools/gnmsg/chunked_message_decoder.py
@@ -1,0 +1,86 @@
+#!/usr/local/bin/python3
+
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+import struct
+
+from message_types import message_types
+from read_values import read_int_value, read_byte_value, call_reader_function
+
+CHUNKED_MESSAGE_HEADER_LENGTH = 17
+
+class ChunkedResponseDecoder:
+    def __init__(self):
+        self.reset()
+
+    def add_header(self, header):
+        if len(self.chunked_message) > 0:
+            raise Exception("Previous chunked message is not completed, can't process another header")
+
+        if len(header) == 2 * CHUNKED_MESSAGE_HEADER_LENGTH:
+            offset = 0
+            message_type = ""
+            (message_type, offset) = call_reader_function(header, offset, read_int_value)
+            self.chunked_message["Type"] = message_types[message_type]
+            # TODO: pass connection value in as a parameter
+            self.chunked_message["Connection"] = ""
+            self.chunked_message["Direction"] = "<---"
+            (self.chunked_message["Parts"], offset) = call_reader_function(header, offset, read_int_value)
+            (self.chunked_message["TransactionId"], offset) = call_reader_function(header, offset, read_int_value)
+            chunk_size = 0
+            flags = 0
+            (chunk_size, offset) = call_reader_function(header, offset, read_int_value)
+            (flags, offset) = call_reader_function(header, offset, read_byte_value)
+            self.chunked_message["ChunkInfo"] = []
+            key = "Chunk" + str(self.chunk_index)
+            inner_item = dict(ChunkLength=chunk_size, Flags=flags)
+            outer_item = {}
+            outer_item[key] = inner_item
+            self.chunked_message["ChunkInfo"].append(outer_item)
+            self.chunk_flags = flags
+        else:
+            raise IndexError("Chunked message header should be " + str(CHUNKED_MESSAGE_HEADER_LENGTH) + " bytes")
+
+    def add_chunk_header(self, chunk_size, flags):
+        self.chunk_index += 1
+        if len(self.chunked_message) == 0:
+            raise Exception("Can't add chunk header before message header")
+
+        key = "Chunk" + str(self.chunk_index)
+        inner_item = dict(ChunkLength=chunk_size, Flags=flags)
+        outer_item = {}
+        outer_item[key] = inner_item
+        self.chunked_message["ChunkInfo"].append(outer_item)
+        self.chunk_flags = flags
+
+    def add_chunk(self, chunk):
+        if len(self.chunked_message) == 0:
+            raise Exception("Can't add chunks before message header")
+
+        self.message_body += chunk
+
+    def is_complete_message(self):
+        return self.chunk_flags & 0x1
+
+    def get_decoded_message(self):
+        return self.chunked_message
+
+    def reset(self):
+        self.header = ""
+        self.message_body = ""
+        self.chunked_message = {}
+        self.complete = False
+        self.chunk_flags = 0xff
+        self.chunk_index = 0

--- a/tools/gnmsg/server_message_decoder.py
+++ b/tools/gnmsg/server_message_decoder.py
@@ -307,12 +307,12 @@ class ServerMessageDecoder(DecoderBase):
         elif self.get_add_security_trace_parts(line, parts):
             connection = parts[1]
         elif self.get_response_header(line, parts):
-            self.chunk_decoder.add_header(parts[3])
+            self.chunk_decoder.add_header(parts[1], parts[3])
         elif self.get_chunk_header(line, parts):
             flags = 0xff
             size = 0
             (flags, size) = read_number_from_hex_string(parts[3], 2, len(parts[3]) - 2)
-            self.chunk_decoder.add_chunk_header(parts[1], flags)
+            self.chunk_decoder.add_chunk_header(parts[2], flags)
         elif self.get_chunk_bytes(line, parts):
             self.chunk_decoder.add_chunk(parts[3])
             if self.chunk_decoder.is_complete_message():


### PR DESCRIPTION
- This is still not a complete implementation, but it's close enough to go in, I think.  It should handle all except cases where an app has chunked responses coming in on multiple simultaneous threads, which is (I think) kind of an obscure scenario at the moment.
- The tool doesn't yet attempt to parse any of the content of a chunked response, but rather just prints a summary of the chunk info, e.g.:

```
{
  "message": {
    "Type": "RESPONSE",
    "Connection": "0x7fe7e9704320",
    "Direction": "<---",
    "Parts": 1,
    "TransactionId": -1,
    "ChunkInfo": [
      {
        "Chunk0": {
          "ChunkLength": 2410,
          "Flags": 0
        }
      },
      {
        "Chunk1": {
          "ChunkLength": 682,
          "Flags": 1
        }
      }
    ]
  }
}
```
@mreddington @albertogpz 