### PR TITLE
GEODE-8775: Add gfsh execute function support to new C++ test framework

### DIFF
--- a/clicache/integration-test2/SerializationTests.cs
+++ b/clicache/integration-test2/SerializationTests.cs
@@ -835,7 +835,7 @@ namespace Apache.Geode.Client.IntegrationTests
 
                 var cache = cluster.CreateCache();
 
-                cache.TypeRegistry.RegisterType(PositionKey.CreateDeserializable, 77);
+                cache.TypeRegistry.RegisterType(PositionKey.CreateDeserializable, 21);
                 cache.TypeRegistry.RegisterType(Position.CreateDeserializable, 22);
 
                 var region = cache.CreateRegionFactory(RegionShortcut.PROXY)

--- a/cppcache/integration/framework/Gfsh.cpp
+++ b/cppcache/integration/framework/Gfsh.cpp
@@ -29,6 +29,8 @@ Gfsh::Shutdown Gfsh::shutdown() { return Shutdown{*this}; }
 
 Gfsh::Deploy Gfsh::deploy() { return Deploy(*this); }
 
+Gfsh::ExecuteFunction Gfsh::executeFunction() { return ExecuteFunction(*this); }
+
 Gfsh::Verb::Verb(Gfsh &gfsh) : gfsh_(gfsh) {}
 
 Gfsh::Start::Start(Gfsh &gfsh) : gfsh_(gfsh) {}
@@ -508,4 +510,19 @@ void Gfsh::Command<void>::execute(const std::string &user,
 template <>
 void Gfsh::Command<void>::execute() {
   gfsh_.execute(command_, "", "", "", "", "", "");
+}
+
+Gfsh::ExecuteFunction::ExecuteFunction(Gfsh &gfsh) : Command{gfsh, "execute function"} {}
+
+Gfsh::ExecuteFunction &Gfsh::ExecuteFunction::withId(const std::string &functionId) {
+  command_ += " --id=" + functionId;
+
+  return *this;
+}
+
+Gfsh::ExecuteFunction &Gfsh::ExecuteFunction::withMember(
+    const std::string &memberName) {
+  command_ += " --member=" + memberName;
+
+  return *this;
 }

--- a/cppcache/integration/framework/Gfsh.h
+++ b/cppcache/integration/framework/Gfsh.h
@@ -46,6 +46,9 @@ class Gfsh {
   class Deploy;
   Deploy deploy();
 
+  class ExecuteFunction;
+  ExecuteFunction executeFunction();
+
   class Verb {
    public:
    protected:
@@ -300,6 +303,14 @@ class Gfsh {
     explicit Deploy(Gfsh &gfsh);
 
     Deploy &jar(const std::string &jarFile);
+  };
+
+  class ExecuteFunction : public Command<void> {
+   public:
+    explicit ExecuteFunction(Gfsh &gfsh);
+
+    ExecuteFunction &withId(const std::string &functionName);
+    ExecuteFunction &withMember(const std::string &withMember);
   };
 
  protected:

--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -36,6 +36,10 @@ add_executable(cpp-integration-test
   PdxSerializerTest.cpp
   Order.cpp
   Order.hpp
+  Position.cpp
+  Position.hpp
+  PositionKey.cpp
+  PositionKey.hpp
   RegionGetAllTest.cpp
   RegionPutAllTest.cpp
   RegionPutGetAllTest.cpp

--- a/cppcache/integration/test/DataSerializableTest.cpp
+++ b/cppcache/integration/test/DataSerializableTest.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <list>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -22,19 +23,23 @@
 #include <geode/DataInput.hpp>
 #include <geode/DataOutput.hpp>
 #include <geode/DataSerializable.hpp>
+#include <geode/FunctionService.hpp>
 #include <geode/RegionFactory.hpp>
 #include <geode/RegionShortcut.hpp>
 #include <geode/TypeRegistry.hpp>
 
+#include "Position.hpp"
+#include "PositionKey.hpp"
 #include "framework/Cluster.h"
 
-namespace {
+namespace DataSerializableTest {
 
 using apache::geode::client::CacheableString;
 using apache::geode::client::CacheableStringArray;
 using apache::geode::client::DataInput;
 using apache::geode::client::DataOutput;
 using apache::geode::client::DataSerializable;
+using apache::geode::client::FunctionService;
 using apache::geode::client::RegionShortcut;
 
 class Simple : public DataSerializable {
@@ -162,4 +167,62 @@ TEST(DataSerializableTest, isSerializableAndDeserializable) {
               returnedArray->operator[](index)->toString());
   }
 }
-}  // namespace
+
+TEST(DataSerializableTest, ClassAsKey) {
+  Cluster cluster{LocatorCount{1}, ServerCount{1}};
+
+  cluster.start();
+
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("PARTITION")
+      .execute();
+
+  cluster.getGfsh()
+      .deploy()
+      .jar(getFrameworkString(FrameworkVariable::JavaObjectJarPath))
+      .execute();
+
+  cluster.getGfsh()
+      .executeFunction()
+      .withId("InstantiateDataSerializable")
+      .withMember("DataSerializableTest_ClassAsKey_server_0")
+      .execute();
+
+  auto cache = cluster.createCache();
+  auto region = cache.createRegionFactory(RegionShortcut::PROXY)
+                    .setPoolName("default")
+                    .create("region");
+
+  cache.getTypeRegistry().registerType(PositionKey::createDeserializable, 21);
+  cache.getTypeRegistry().registerType(Position::createDeserializable, 22);
+
+  auto key1 = std::make_shared<PositionKey>(1000);
+  auto key2 = std::make_shared<PositionKey>(1000000);
+  auto key3 = std::make_shared<PositionKey>(1000000000);
+
+  auto pos1 = std::make_shared<Position>("GOOG", 23);
+  auto pos2 = std::make_shared<Position>("IBM", 37);
+  auto pos3 = std::make_shared<Position>("PVTL", 101);
+
+  region->put(key1, pos1);
+  region->put(key2, pos2);
+  region->put(key3, pos3);
+
+  auto res1 = std::dynamic_pointer_cast<Position>(region->get(key1));
+  auto res2 = std::dynamic_pointer_cast<Position>(region->get(key2));
+  auto res3 = std::dynamic_pointer_cast<Position>(region->get(key3));
+
+  EXPECT_EQ(res1->getSecId()->value(), pos1->getSecId()->value());
+  EXPECT_EQ(res1->getSharesOutstanding(), pos1->getSharesOutstanding());
+
+  EXPECT_EQ(res2->getSecId()->value(), pos2->getSecId()->value());
+  EXPECT_EQ(res2->getSharesOutstanding(), pos2->getSharesOutstanding());
+
+  EXPECT_EQ(res3->getSecId()->value(), pos3->getSecId()->value());
+  EXPECT_EQ(res3->getSharesOutstanding(), pos3->getSharesOutstanding());
+}
+
+}  // namespace DataSerializableTest

--- a/cppcache/integration/test/Position.cpp
+++ b/cppcache/integration/test/Position.cpp
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "Position.hpp"
+
+#include <wchar.h>
+
+#include <cwchar>
+
+#include <geode/DataInput.hpp>
+#include <geode/DataOutput.hpp>
+
+namespace DataSerializableTest {
+
+int32_t Position::cnt = 0;
+
+Position::Position() { init(); }
+
+Position::Position(const char* id, int32_t out) {
+  init();
+  secId = CacheableString::create(id);
+  qty = out - (cnt % 2 == 0 ? 1000 : 100);
+  mktValue = qty * 1.2345998;
+  sharesOutstanding = out;
+  secType = L"a";
+  pid = cnt++;
+}
+
+// This constructor is just for some internal data validation test
+Position::Position(int32_t iForExactVal) {
+  init();
+  char* id = new char[iForExactVal + 2];
+  for (int i = 0; i <= iForExactVal; i++) {
+    id[i] = 'a';
+  }
+  id[iForExactVal + 1] = '\0';
+  secId = CacheableString::create(id);
+  delete[] id;
+  qty = (iForExactVal % 2 == 0 ? 1000 : 100);
+  mktValue = qty * 2;
+  sharesOutstanding = iForExactVal;
+  secType = L"a";
+  pid = iForExactVal;
+}
+
+void Position::init() {
+  avg20DaysVol = 0;
+  bondRating = nullptr;
+  convRatio = 0.0;
+  country = nullptr;
+  delta = 0.0;
+  industry = 0;
+  issuer = 0;
+  mktValue = 0.0;
+  qty = 0.0;
+  secId = nullptr;
+  secLinks = nullptr;
+  secType = L"";
+  sharesOutstanding = 0;
+  underlyer = nullptr;
+  volatility = 0;
+  pid = 0;
+}
+
+void Position::toData(apache::geode::client::DataOutput& output) const {
+  output.writeInt(avg20DaysVol);
+  output.writeObject(bondRating);
+  output.writeDouble(convRatio);
+  output.writeObject(country);
+  output.writeDouble(delta);
+  output.writeInt(industry);
+  output.writeInt(issuer);
+  output.writeDouble(mktValue);
+  output.writeDouble(qty);
+  output.writeObject(secId);
+  output.writeObject(secLinks);
+  output.writeUTF(secType);
+  output.writeInt(sharesOutstanding);
+  output.writeObject(underlyer);
+  output.writeInt(volatility);
+  output.writeInt(pid);
+}
+
+void Position::fromData(apache::geode::client::DataInput& input) {
+  avg20DaysVol = input.readInt64();
+  bondRating = std::dynamic_pointer_cast<CacheableString>(input.readObject());
+  convRatio = input.readDouble();
+  country = std::dynamic_pointer_cast<CacheableString>(input.readObject());
+  delta = input.readDouble();
+  industry = input.readInt64();
+  issuer = input.readInt64();
+  mktValue = input.readDouble();
+  qty = input.readDouble();
+  secId = std::dynamic_pointer_cast<CacheableString>(input.readObject());
+  secLinks = std::dynamic_pointer_cast<CacheableString>(input.readObject());
+  secType = input.readUTF<wchar_t>();
+  sharesOutstanding = input.readInt32();
+  underlyer = std::dynamic_pointer_cast<CacheableString>(input.readObject());
+  volatility = input.readInt64();
+  pid = input.readInt32();
+}
+std::string Position::toString() const {
+  char buf[2048];
+  sprintf(buf,
+          "Position Object:[ secId=%s type=%ls sharesOutstanding=%d id=%d ]",
+          secId->toString().c_str(), this->secType.c_str(),
+          this->sharesOutstanding, this->pid);
+  return buf;
+}
+
+}  // namespace DataSerializableTest

--- a/cppcache/integration/test/Position.hpp
+++ b/cppcache/integration/test/Position.hpp
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef POSITION_H
+#define POSITION_H
+
+/*
+ * @brief User class for testing the put functionality for object.
+ */
+
+#include <string>
+
+#include <geode/CacheableString.hpp>
+#include <geode/DataSerializable.hpp>
+
+namespace DataSerializableTest {
+
+using apache::geode::client::CacheableString;
+using apache::geode::client::DataInput;
+using apache::geode::client::DataOutput;
+using apache::geode::client::DataSerializable;
+
+class Position : public DataSerializable {
+ private:
+  int64_t avg20DaysVol;
+  std::shared_ptr<CacheableString> bondRating;
+  double convRatio;
+  std::shared_ptr<CacheableString> country;
+  double delta;
+  int64_t industry;
+  int64_t issuer;
+  double mktValue;
+  double qty;
+  std::shared_ptr<CacheableString> secId;
+  std::shared_ptr<CacheableString> secLinks;
+  // wchar_t* secType;
+  std::wstring secType;
+  int32_t sharesOutstanding;
+  std::shared_ptr<CacheableString> underlyer;
+  int64_t volatility;
+  int32_t pid;
+
+  inline size_t getObjectSize(const std::shared_ptr<Serializable>& obj) const {
+    return (obj == nullptr ? 0 : obj->objectSize());
+  }
+
+ public:
+  static int32_t cnt;
+
+  Position();
+  Position(const char* id, int32_t out);
+  // This constructor is just for some internal data validation test
+  explicit Position(int32_t iForExactVal);
+  ~Position() override = default;
+  void toData(DataOutput& output) const override;
+  void fromData(DataInput& input) override;
+  std::string toString() const override;
+
+  size_t objectSize() const override {
+    auto objectSize = sizeof(Position);
+    objectSize += getObjectSize(bondRating);
+    objectSize += getObjectSize(country);
+    objectSize += getObjectSize(secId);
+    objectSize += getObjectSize(secLinks);
+    objectSize += secType.size() * sizeof(decltype(secType)::value_type);
+    objectSize += getObjectSize(underlyer);
+    return objectSize;
+  }
+
+  static void resetCounter() { cnt = 0; }
+  std::shared_ptr<CacheableString> getSecId() { return secId; }
+  int32_t getId() { return pid; }
+  int32_t getSharesOutstanding() { return sharesOutstanding; }
+  static std::shared_ptr<Serializable> createDeserializable() {
+    return std::make_shared<Position>();
+  }
+
+ private:
+  void init();
+};
+
+}  // namespace DataSerializableTest
+
+#endif  // POSITION_H

--- a/cppcache/integration/test/PositionKey.cpp
+++ b/cppcache/integration/test/PositionKey.cpp
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "PositionKey.hpp"
+
+#include <wchar.h>
+
+#include <cwchar>
+
+#include <geode/DataInput.hpp>
+#include <geode/DataOutput.hpp>
+
+namespace DataSerializableTest {
+
+void PositionKey::toData(DataOutput& output) const {
+  output.writeInt(m_positionId);
+}
+
+void PositionKey::fromData(apache::geode::client::DataInput& input) {
+  m_positionId = input.readInt64();
+}
+
+bool PositionKey::operator==(const CacheableKey& other) const {
+  return m_positionId == ((PositionKey&)other).getPositionId();
+}
+
+int PositionKey::hashcode() const {
+  int hash = 11;
+  hash = 31 * hash + (int)m_positionId;
+  return hash;
+}
+
+}  // namespace DataSerializableTest

--- a/cppcache/integration/test/PositionKey.hpp
+++ b/cppcache/integration/test/PositionKey.hpp
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef POSITIONKEY_H_
+#define POSITIONKEY_H_
+
+#include <string>
+
+#include <geode/CacheableString.hpp>
+#include <geode/DataSerializable.hpp>
+
+namespace DataSerializableTest {
+
+using apache::geode::client::CacheableKey;
+using apache::geode::client::DataInput;
+using apache::geode::client::DataOutput;
+using apache::geode::client::DataSerializable;
+
+class PositionKey : public DataSerializable, public CacheableKey {
+ private:
+  int64_t m_positionId;
+
+ public:
+  PositionKey() {}
+  PositionKey(int64_t positionId) { m_positionId = positionId; }
+  ~PositionKey() override = default;
+
+  bool operator==(const CacheableKey& other) const;
+  int32_t hashcode() const;
+
+  void toData(DataOutput& output) const override;
+  void fromData(DataInput& input) override;
+
+  int64_t getPositionId() { return m_positionId; }
+  static std::shared_ptr<Serializable> createDeserializable() {
+    return std::make_shared<PositionKey>();
+  }
+};
+
+}  // namespace DataSerializableTest
+
+#endif  // POSITIONKEY_H_

--- a/tests/javaobject/cli/InstantiateDataSerializable.java
+++ b/tests/javaobject/cli/InstantiateDataSerializable.java
@@ -32,15 +32,16 @@ import org.apache.geode.cache.partition.PartitionRegionHelper;
 public class InstantiateDataSerializable extends FunctionAdapter implements Declarable{
 
 public void execute(FunctionContext context) {
-  Instantiator.register(new Instantiator(javaobject.cli.Position.class, 22) {
+
+  Instantiator.register(new Instantiator(javaobject.cli.PositionKey.class, 21) {
     public DataSerializable newInstance() {
-      return new javaobject.cli.Position();
+      return new javaobject.cli.PositionKey();
     }
   });
 
-  Instantiator.register(new Instantiator(javaobject.cli.PositionKey.class, 77) {
+  Instantiator.register(new Instantiator(javaobject.cli.Position.class, 22) {
     public DataSerializable newInstance() {
-      return new javaobject.cli.PositionKey();
+      return new javaobject.cli.Position();
     }
   });
 

--- a/tests/javaobject/cli/PositionKey.java
+++ b/tests/javaobject/cli/PositionKey.java
@@ -26,7 +26,7 @@ public class PositionKey implements DataSerializable {
   private long positionId;
 
   static {
-     Instantiator.register(new Instantiator(javaobject.cli.PositionKey.class, (byte) 77) {
+     Instantiator.register(new Instantiator(javaobject.cli.PositionKey.class, (byte) 21) {
      public DataSerializable newInstance() {
         return new PositionKey();
      }


### PR DESCRIPTION
This functionality is currently in the new .NET test framework but missing in the new C++ test framework. This was discovered during the course of adding a new ClassAsKey test for C++ client.