### PR TITLE
GEODE-8713: user guide API reference links - fix redirects for Geode website

### DIFF
--- a/docs/geode-native-book-cpp/redirects.rb
+++ b/docs/geode-native-book-cpp/redirects.rb
@@ -15,9 +15,12 @@
 
 # Links to API Documentation #
 r301 %r{/releases/latest/javadoc/(.*)}, 'https://geode.apache.org/releases/latest/javadoc/$1'
-r302 %r{/apidocs/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
-r302 %r{/cppdocs/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
-r302 %r{/dotnetdocs/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
+# preferred API redirects 12/8/2020
+r302 %r{/cppapiref/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
+r302 %r{/dotnetapiref/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
+# old redirects (/cppdocs, /dotnetdocs) deprecated due to recursion in geode .htaccess (delete when no longer needed)
+#r302 %r{/cppdocs/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
+#r302 %r{/dotnetdocs/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
 
 # Links to User Guides #
 rewrite '/', '/docs/geode-native/cpp/113/about-client-users-guide.html'

--- a/docs/geode-native-book-dotnet/redirects.rb
+++ b/docs/geode-native-book-dotnet/redirects.rb
@@ -15,9 +15,12 @@
 
 # Links to API Documentation #
 r301 %r{/releases/latest/javadoc/(.*)}, 'https://geode.apache.org/releases/latest/javadoc/$1'
-r302 %r{/apidocs/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
-r302 %r{/dotnetdocs/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
-r302 %r{/cppdocs/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
+# preferred API redirects 12/8/2020
+r302 %r{/cppapiref/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
+r302 %r{/dotnetapiref/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
+# old redirects (/cppdocs, /dotnetdocs) deprecated due to recursion in geode .htaccess (delete when no longer needed)
+#r302 %r{/cppdocs/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
+#r302 %r{/dotnetdocs/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
 
 # Links to User Guides #
 rewrite '/', '/docs/geode-native/dotnet/113/about-client-users-guide.html'

--- a/docs/geode-native-docs-cpp/about-client-users-guide.html.md.erb
+++ b/docs/geode-native-docs-cpp/about-client-users-guide.html.md.erb
@@ -25,8 +25,8 @@ The Apache Geode Native Client is a library that provides access for C++ and Mic
 
 See the API docs for API details:
 
-  - [C++ API docs](https://geode.apache.org/releases/latest/cppdocs/index.html)
-  - [.NET API docs](https://geode.apache.org/releases/latest/dotnetdocs/index.html)
+  - [C++ API docs](/cppapiref/index.html)
+  - [.NET API docs](/dotnetapiref/index.html)
 
 See the [_<%=vars.product_name_long%> User Guide_](serverman/about_<%=vars.product_name.downcase%>.html) for information regarding the server.
 

--- a/docs/geode-native-docs-cpp/client-cache-ref.html.md.erb
+++ b/docs/geode-native-docs-cpp/client-cache-ref.html.md.erb
@@ -357,7 +357,7 @@ Use the `<expiration-attributes>` sub-element to specify duration and expiration
 
 A partition resolver is used for single-hop access to partitioned region entries on the server side. This resolver
 implementation must match that of the `PartitionResolver` on the server side.
-See the [API Class Reference](/apidocs/hierarchy.html) for the **PartitionResolver** class.
+See the [API Class Reference](/cppapiref/hierarchy.html) for the **PartitionResolver** class.
 
 For example:
 
@@ -370,26 +370,26 @@ For example:
 ## \<cache-loader\>
 
 \<cache-loader\> identifies a cache loader function by specifying `library-name` and `library-function-name`.
-See the [API Class Reference](/apidocs/hierarchy.html) for the **CacheLoader** class.
+See the [API Class Reference](/cppapiref/hierarchy.html) for the **CacheLoader** class.
 
 <a id="cache-listener-ref"></a>
 ## \<cache-listener\>
 
 \<cache-listener\> identifies a cache listener function by specifying `library-name` and `library-function-name`.
-See the [API Class Reference](/apidocs/hierarchy.html) for the **CacheListener** class.
+See the [API Class Reference](/cppapiref/hierarchy.html) for the **CacheListener** class.
 
 <a id="cache-writer-ref"></a>
 ## \<cache-writer\>
 
 \<cache-writer\> identifies a cache writer function by specifying `library-name` and `library-function-name`.
-See the [API Class Reference](/apidocs/hierarchy.html) for the **CacheWriter** class.
+See the [API Class Reference](/cppapiref/hierarchy.html) for the **CacheWriter** class.
 
 <a id="persistence-manager-ref"></a>
 ## \<persistence-manager\>
 
 For each region, if the disk-policy attribute is set to `overflows`, a persistence-manager plug-in
 must perform cache-to-disk and disk-to-cache operations.
-See the [API Class Reference](/apidocs/hierarchy.html) for the **PersistenceManager** class.
+See the [API Class Reference](/cppapiref/hierarchy.html) for the **PersistenceManager** class.
 
 \<persistence-manager\> identifies a persistence manager function by specifying `library-name` and `library-function-name`.
 You can also specify a set of properties to be passed to the function as parameters.

--- a/docs/geode-native-docs-dotnet/about-client-users-guide.html.md.erb
+++ b/docs/geode-native-docs-dotnet/about-client-users-guide.html.md.erb
@@ -25,8 +25,8 @@ The Apache Geode Native Client is a library that provides access for C++ and Mic
 
 See the API docs for API details:
 
-  - [C++ API docs](https://geode.apache.org/releases/latest/cppdocs/index.html)
-  - [.NET API docs](https://geode.apache.org/releases/latest/dotnetdocs/index.html)
+  - [C++ API docs](/cppapiref/index.html)
+  - [.NET API docs](/dotnetapiref/index.html)
 
 See the [_<%=vars.product_name_long%> User Guide_](serverman/about_<%=vars.product_name.downcase%>.html) for information regarding the server.
 

--- a/docs/geode-native-docs-dotnet/client-cache-ref.html.md.erb
+++ b/docs/geode-native-docs-dotnet/client-cache-ref.html.md.erb
@@ -357,7 +357,7 @@ Use the `<expiration-attributes>` sub-element to specify duration and expiration
 
 A partition resolver is used for single-hop access to partitioned region entries on the server side. This resolver
 implementation must match that of the `PartitionResolver` on the server side.
-See the [API Class Reference](/apidocs/hierarchy.html) for the **PartitionResolver** class.
+See the [API Class Reference](/dotnetapiref/hierarchy.html) for the **PartitionResolver** class.
 
 For example:
 
@@ -370,26 +370,26 @@ For example:
 ## \<cache-loader\>
 
 \<cache-loader\> identifies a cache loader function by specifying `library-name` and `library-function-name`.
-See the [API Class Reference](/apidocs/hierarchy.html) for the **CacheLoader** class.
+See the [API Class Reference](/dotnetapiref/hierarchy.html) for the **CacheLoader** class.
 
 <a id="cache-listener-ref"></a>
 ## \<cache-listener\>
 
 \<cache-listener\> identifies a cache listener function by specifying `library-name` and `library-function-name`.
-See the [API Class Reference](/apidocs/hierarchy.html) for the **CacheListener** class.
+See the [API Class Reference](/dotnetapiref/hierarchy.html) for the **CacheListener** class.
 
 <a id="cache-writer-ref"></a>
 ## \<cache-writer\>
 
 \<cache-writer\> identifies a cache writer function by specifying `library-name` and `library-function-name`.
-See the [API Class Reference](/apidocs/hierarchy.html) for the **CacheWriter** class.
+See the [API Class Reference](/dotnetapiref/hierarchy.html) for the **CacheWriter** class.
 
 <a id="persistence-manager-ref"></a>
 ## \<persistence-manager\>
 
 For each region, if the disk-policy attribute is set to `overflows`, a persistence-manager plug-in
 must perform cache-to-disk and disk-to-cache operations.
-See the [API Class Reference](/apidocs/hierarchy.html) for the **PersistenceManager** class.
+See the [API Class Reference](/dotnetapiref/hierarchy.html) for the **PersistenceManager** class.
 
 \<persistence-manager\> identifies a persistence manager function by specifying `library-name` and `library-function-name`.
 You can also specify a set of properties to be passed to the function as parameters.


### PR DESCRIPTION
The previous fix failed when publishing to the Geode website (vs cf push to a PWS server).
Modified the website's `.htaccess` file to handle redirects there.
Changed `cppdocs` and `dotnetdocs` placeholders to `cppapiref` and `dotnetapiref`, respectively, to avoid recursion problems.
Updated source files (about* and client-cache-ref*) to use the new placeholders.
Tested locally and pushed to the Geode site to verify that it works in both environments.