### PR TITLE
GEODE-8442: Exception in server not identified correctly in client

### DIFF
--- a/cppcache/integration-test/resources/cacheserver1_fpr_transaction.xml
+++ b/cppcache/integration-test/resources/cacheserver1_fpr_transaction.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<cache xmlns="http://geode.apache.org/schema/cache"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+       version="1.0">
+	<cache-server port="40401"/>
+
+  <region name="region">
+    <region-attributes data-policy="partition">
+      <partition-attributes>
+        <partition-resolver>
+          <class-name>javaobject.CustomFixedPartitionResolver1</class-name>
+        </partition-resolver>
+		<fixed-partition-attributes partition-name="P1" is-primary="true" num-buckets="15"/>				
+		<fixed-partition-attributes partition-name="P6" is-primary="true" num-buckets="15"/>
+      </partition-attributes>
+      <cache-writer>
+        <class-name>javaobject.CacheWriterTransactionDelay</class-name>
+      </cache-writer>
+    </region-attributes>
+  </region>
+</cache>

--- a/cppcache/integration-test/resources/cacheserver2_fpr_transaction.xml
+++ b/cppcache/integration-test/resources/cacheserver2_fpr_transaction.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<cache xmlns="http://geode.apache.org/schema/cache"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+       version="1.0">
+	<cache-server port="40402"/>
+
+  <region name="region">
+    <region-attributes data-policy="partition">
+      <partition-attributes>
+        <partition-resolver>
+          <class-name>javaobject.CustomFixedPartitionResolver1</class-name>
+        </partition-resolver>	
+		<fixed-partition-attributes partition-name="P2" is-primary="true" num-buckets="15"/>
+		<fixed-partition-attributes partition-name="P4" is-primary="true" num-buckets="15"/>
+      </partition-attributes>
+      <cache-writer>
+        <class-name>javaobject.CacheWriterTransactionDelay</class-name>
+      </cache-writer>
+    </region-attributes>
+  </region>
+</cache>

--- a/cppcache/integration-test/resources/cacheserver3_fpr_transaction.xml
+++ b/cppcache/integration-test/resources/cacheserver3_fpr_transaction.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<cache xmlns="http://geode.apache.org/schema/cache"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+       version="1.0">
+	<cache-server port="40403"/>
+
+  <region name="region">
+    <region-attributes data-policy="partition">
+      <partition-attributes>
+        <partition-resolver>
+          <class-name>javaobject.CustomFixedPartitionResolver1</class-name>
+        </partition-resolver>
+		<fixed-partition-attributes partition-name="P3" is-primary="true" num-buckets="15"/>		
+		<fixed-partition-attributes partition-name="P5" is-primary="true" num-buckets="15"/>
+      </partition-attributes>
+      <cache-writer>
+        <class-name>javaobject.CacheWriterTransactionDelay</class-name>
+      </cache-writer>
+    </region-attributes>
+  </region>
+</cache>

--- a/cppcache/integration/framework/Cluster.cpp
+++ b/cppcache/integration/framework/Cluster.cpp
@@ -186,6 +186,8 @@ Server::Server(Server &&move)
   move.started_ = false;
 }
 
+const ServerAddress &Server::getAddress() const { return serverAddress_; }
+
 void Server::start() {
   auto safeName = name_;
   std::replace(safeName.begin(), safeName.end(), '/', '_');
@@ -391,6 +393,11 @@ void Cluster::applyLocators(apache::geode::client::PoolFactory &poolFactory) {
     poolFactory.addLocator(locator.getAddress().address,
                            locator.getAddress().port);
   }
+}
+
+void Cluster::applyServer(apache::geode::client::PoolFactory &poolFactory, 
+                   ServerAddress oneServer) {
+  poolFactory.addServer(oneServer.address, oneServer.port);
 }
 
 Gfsh &Cluster::getGfsh() { return gfsh_; }

--- a/cppcache/integration/framework/Cluster.h
+++ b/cppcache/integration/framework/Cluster.h
@@ -95,6 +95,8 @@ class Server {
   Server &operator=(const Server &other) = delete;
   Server(Server &&move);
 
+  const ServerAddress &getAddress() const;
+
   void start();
 
   void stop();
@@ -184,6 +186,9 @@ class Cluster {
       bool subscriptionEnabled);
 
   void applyLocators(apache::geode::client::PoolFactory &poolFactory);
+
+  void applyServer(apache::geode::client::PoolFactory &poolFactory, 
+            ServerAddress server);
 
   void useSsl(const bool requireSslAuthentication, const std::string keystore,
               const std::string truststore, const std::string keystorePassword,

--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(cpp-integration-test
   PdxInstanceFactoryTest.cpp
   CacheWriterTest.cpp
   TransactionsTest.cpp
+  ContainsKeyOnServerExceptionTest.cpp
 )
 
 target_compile_definitions(cpp-integration-test

--- a/cppcache/integration/test/ContainsKeyOnServerExceptionTest.cpp
+++ b/cppcache/integration/test/ContainsKeyOnServerExceptionTest.cpp
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <framework/Cluster.h>
+#include <framework/TestConfig.h>
+
+#include <geode/Cache.hpp>
+#include <geode/CacheFactory.hpp>
+#include <geode/CacheTransactionManager.hpp>
+#include <geode/Region.hpp>
+#include <geode/RegionFactory.hpp>
+#include <geode/RegionShortcut.hpp>
+
+namespace {
+using apache::geode::client::Cache;
+using apache::geode::client::CacheableKey;
+using apache::geode::client::CacheableString;
+using apache::geode::client::CacheFactory;
+using apache::geode::client::CacheTransactionManager;
+using apache::geode::client::Pool;
+using apache::geode::client::Region;
+using apache::geode::client::RegionShortcut;
+
+std::string disconnectingStr("Disconnecting from the endpoint");
+
+std::string getClientLogName() {
+  std::string testSuiteName(::testing::UnitTest::GetInstance()
+                                ->current_test_info()
+                                ->test_case_name());
+  std::string testCaseName(
+      ::testing::UnitTest::GetInstance()->current_test_info()->name());
+  std::string logFileName(testSuiteName + "/" + testCaseName + "/client.log");
+  return logFileName;
+}
+
+std::shared_ptr<Cache> createCache() {
+  auto cache = CacheFactory()
+                   .set("log-level", "none")
+                   .set("log-file", getClientLogName())
+                   .create();
+  return std::make_shared<Cache>(std::move(cache));
+}
+
+void executeTestCaseHandleException() {
+  Cluster cluster{
+      LocatorCount{1}, ServerCount{3},
+      CacheXMLFiles({
+          std::string(getFrameworkString(FrameworkVariable::TestCacheXmlDir)) +
+              "/cacheserver1_fpr_transaction.xml",
+          std::string(getFrameworkString(FrameworkVariable::TestCacheXmlDir)) +
+              "/cacheserver2_fpr_transaction.xml",
+          std::string(getFrameworkString(FrameworkVariable::TestCacheXmlDir)) +
+              "/cacheserver3_fpr_transaction.xml",
+      })};
+  cluster.start([&]() {
+    cluster.getGfsh()
+        .deploy()
+        .jar(getFrameworkString(FrameworkVariable::JavaObjectJarPath))
+        .execute();
+  });
+
+  auto cache = createCache();
+  auto poolFactory = cache->getPoolManager().createFactory();
+  ServerAddress serverAddress = cluster.getServers()[0].getAddress();
+  serverAddress.port = 40401;
+  cluster.applyServer(poolFactory, serverAddress);
+  auto pool = poolFactory.create("default");
+  auto region = cache->createRegionFactory(RegionShortcut::PROXY)
+                    .setPoolName("default")
+                    .create("region");
+
+  auto transactionManager = cache->getCacheTransactionManager();
+
+  // this key will be always routed towards server[1]
+  int theKey = 7;
+  std::string theValue = "theValue";
+  try {
+    transactionManager->begin();
+    region->put(theKey, theValue);
+    transactionManager->commit();
+  } catch (...) {
+    try {
+      region->containsKeyOnServer(CacheableKey::create(7));
+    } catch (
+        apache::geode::client::TransactionDataNodeHasDepartedException& ex) {
+      std::cerr << "Caught exception: " << ex.what() << std::endl;
+    }
+  }
+
+  EXPECT_FALSE(region->containsKey(7));
+
+}  // executeTestCaseHandleException
+
+TEST(ContainsKeyOnServerExceptionTest, handleException) {
+  executeTestCaseHandleException();
+}
+
+}  // namespace

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -799,7 +799,8 @@ bool ThinClientRegion::containsKeyOnServer(
 
   auto rptr = CacheableBoolean::create(ret);
 
-  rptr = std::dynamic_pointer_cast<CacheableBoolean>(handleReplay(err, rptr));
+  // rptr = std::dynamic_pointer_cast<CacheableBoolean>(handleReplay(err,
+  // rptr));
   throwExceptionIfError("Region::containsKeyOnServer ", err);
   return rptr->value();
 }
@@ -846,7 +847,8 @@ bool ThinClientRegion::containsValueForKey_remote(
 
   auto rptr = CacheableBoolean::create(ret);
 
-  rptr = std::dynamic_pointer_cast<CacheableBoolean>(handleReplay(err, rptr));
+  // rptr = std::dynamic_pointer_cast<CacheableBoolean>(handleReplay(err,
+  // rptr));
 
   throwExceptionIfError("Region::containsValueForKey ", err);
   return rptr->value();

--- a/tests/javaobject/CacheWriterTransactionDelay.java
+++ b/tests/javaobject/CacheWriterTransactionDelay.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package javaobject;
+
+import java.util.*;
+import org.apache.geode.cache.CacheWriter;
+import org.apache.geode.cache.CacheWriterException;
+import org.apache.geode.cache.EntryEvent;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionEvent;
+import org.apache.geode.cache.RegionService;
+
+public class CacheWriterTransactionDelay implements CacheWriter<String, String> {
+
+  public CacheWriterTransactionDelay() {}
+
+  public void beforeCreate(EntryEvent<String, String> event) {
+    final RegionService cache = event.getRegion().getRegionService();
+    cache.close();
+  }
+
+  public void beforeUpdate(EntryEvent<String, String> event) {}
+
+  public void beforeDestroy(EntryEvent<String, String> event) {}
+
+  public void beforeRegionDestroy(RegionEvent<String, String> event) {}
+
+  public void beforeRegionClear(RegionEvent<String, String> event) {}
+
+  public void close() {}
+}


### PR DESCRIPTION
HandleReplay is already commented in other functions as replay is unsupported, this change will not translate the real exception to UnknownException.
User will got correct exception and will know how to handle it.