### PR TITLE
GEODE-8562: Adds new C++ test for using a class as a key

### DIFF
--- a/clicache/integration-test2/SerializationTests.cs
+++ b/clicache/integration-test2/SerializationTests.cs
@@ -896,7 +896,7 @@ namespace Apache.Geode.Client.IntegrationTests
 
 				var cache = cluster.CreateCache();
 
-				cache.TypeRegistry.RegisterType(PositionKey.CreateDeserializable, 77);
+				cache.TypeRegistry.RegisterType(PositionKey.CreateDeserializable, 21);
 				cache.TypeRegistry.RegisterType(TestClassA.CreateDeserializable, 100);
 				cache.TypeRegistry.RegisterType(TestClassB.CreateDeserializable, 101);
 				cache.TypeRegistry.RegisterType(TestClassC.CreateDeserializable, 102);

--- a/clicache/integration-test2/SerializationTests.cs
+++ b/clicache/integration-test2/SerializationTests.cs
@@ -835,7 +835,7 @@ namespace Apache.Geode.Client.IntegrationTests
 
                 var cache = cluster.CreateCache();
 
-                cache.TypeRegistry.RegisterType(PositionKey.CreateDeserializable, 77);
+                cache.TypeRegistry.RegisterType(PositionKey.CreateDeserializable, 21);
                 cache.TypeRegistry.RegisterType(Position.CreateDeserializable, 22);
 
                 var region = cache.CreateRegionFactory(RegionShortcut.PROXY)

--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -36,6 +36,10 @@ add_executable(cpp-integration-test
   PdxSerializerTest.cpp
   Order.cpp
   Order.hpp
+  Position.cpp
+  Position.hpp
+  PositionKey.cpp
+  PositionKey.hpp
   RegionGetAllTest.cpp
   RegionPutAllTest.cpp
   RegionPutGetAllTest.cpp

--- a/cppcache/integration/test/DataSerializableTest.cpp
+++ b/cppcache/integration/test/DataSerializableTest.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <list>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -22,19 +23,23 @@
 #include <geode/DataInput.hpp>
 #include <geode/DataOutput.hpp>
 #include <geode/DataSerializable.hpp>
+#include <geode/FunctionService.hpp>
 #include <geode/RegionFactory.hpp>
 #include <geode/RegionShortcut.hpp>
 #include <geode/TypeRegistry.hpp>
 
+#include "Position.hpp"
+#include "PositionKey.hpp"
 #include "framework/Cluster.h"
 
-namespace {
+namespace DataSerializableTest {
 
 using apache::geode::client::CacheableString;
 using apache::geode::client::CacheableStringArray;
 using apache::geode::client::DataInput;
 using apache::geode::client::DataOutput;
 using apache::geode::client::DataSerializable;
+using apache::geode::client::FunctionService;
 using apache::geode::client::RegionShortcut;
 
 class Simple : public DataSerializable {
@@ -162,4 +167,62 @@ TEST(DataSerializableTest, isSerializableAndDeserializable) {
               returnedArray->operator[](index)->toString());
   }
 }
-}  // namespace
+
+TEST(DataSerializableTest, ClassAsKey) {
+  Cluster cluster{LocatorCount{1}, ServerCount{1}};
+
+  cluster.start();
+
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("PARTITION")
+      .execute();
+
+  cluster.getGfsh()
+      .deploy()
+      .jar(getFrameworkString(FrameworkVariable::JavaObjectJarPath))
+      .execute();
+
+  cluster.getGfsh()
+      .executeFunction()
+      .withId("InstantiateDataSerializable")
+      .withMember("DataSerializableTest_ClassAsKey_server_0")
+      .execute();
+
+  auto cache = cluster.createCache();
+  auto region = cache.createRegionFactory(RegionShortcut::PROXY)
+                    .setPoolName("default")
+                    .create("region");
+
+  cache.getTypeRegistry().registerType(PositionKey::createDeserializable, 21);
+  cache.getTypeRegistry().registerType(Position::createDeserializable, 22);
+
+  auto key1 = std::make_shared<PositionKey>(1000);
+  auto key2 = std::make_shared<PositionKey>(1000000);
+  auto key3 = std::make_shared<PositionKey>(1000000000);
+
+  auto pos1 = std::make_shared<Position>("GOOG", 23);
+  auto pos2 = std::make_shared<Position>("IBM", 37);
+  auto pos3 = std::make_shared<Position>("PVTL", 101);
+
+  region->put(key1, pos1);
+  region->put(key2, pos2);
+  region->put(key3, pos3);
+
+  auto res1 = std::dynamic_pointer_cast<Position>(region->get(key1));
+  auto res2 = std::dynamic_pointer_cast<Position>(region->get(key2));
+  auto res3 = std::dynamic_pointer_cast<Position>(region->get(key3));
+
+  EXPECT_EQ(res1->getSecId()->value(), pos1->getSecId()->value());
+  EXPECT_EQ(res1->getSharesOutstanding(), pos1->getSharesOutstanding());
+
+  EXPECT_EQ(res2->getSecId()->value(), pos2->getSecId()->value());
+  EXPECT_EQ(res2->getSharesOutstanding(), pos2->getSharesOutstanding());
+
+  EXPECT_EQ(res3->getSecId()->value(), pos3->getSecId()->value());
+  EXPECT_EQ(res3->getSharesOutstanding(), pos3->getSharesOutstanding());
+}
+
+}  // namespace DataSerializableTest

--- a/cppcache/integration/test/DataSerializableTest.cpp
+++ b/cppcache/integration/test/DataSerializableTest.cpp
@@ -215,13 +215,13 @@ TEST(DataSerializableTest, ClassAsKey) {
   auto res2 = std::dynamic_pointer_cast<Position>(region->get(key2));
   auto res3 = std::dynamic_pointer_cast<Position>(region->get(key3));
 
-  EXPECT_EQ(res1->getSecId()->value(), pos1->getSecId()->value());
+  EXPECT_EQ(res1->getSecId(), pos1->getSecId());
   EXPECT_EQ(res1->getSharesOutstanding(), pos1->getSharesOutstanding());
 
-  EXPECT_EQ(res2->getSecId()->value(), pos2->getSecId()->value());
+  EXPECT_EQ(res2->getSecId(), pos2->getSecId());
   EXPECT_EQ(res2->getSharesOutstanding(), pos2->getSharesOutstanding());
 
-  EXPECT_EQ(res3->getSecId()->value(), pos3->getSecId()->value());
+  EXPECT_EQ(res3->getSecId(), pos3->getSecId());
   EXPECT_EQ(res3->getSharesOutstanding(), pos3->getSharesOutstanding());
 }
 

--- a/cppcache/integration/test/DataSerializableTest.cpp
+++ b/cppcache/integration/test/DataSerializableTest.cpp
@@ -215,13 +215,13 @@ TEST(DataSerializableTest, ClassAsKey) {
   auto res2 = std::dynamic_pointer_cast<Position>(region->get(key2));
   auto res3 = std::dynamic_pointer_cast<Position>(region->get(key3));
 
-  EXPECT_EQ(res1->getSecId(), pos1->getSecId());
+  EXPECT_EQ(res1->getSecurityId(), pos1->getSecurityId());
   EXPECT_EQ(res1->getSharesOutstanding(), pos1->getSharesOutstanding());
 
-  EXPECT_EQ(res2->getSecId(), pos2->getSecId());
+  EXPECT_EQ(res2->getSecurityId(), pos2->getSecurityId());
   EXPECT_EQ(res2->getSharesOutstanding(), pos2->getSharesOutstanding());
 
-  EXPECT_EQ(res3->getSecId(), pos3->getSecId());
+  EXPECT_EQ(res3->getSecurityId(), pos3->getSecurityId());
   EXPECT_EQ(res3->getSharesOutstanding(), pos3->getSharesOutstanding());
 }
 

--- a/cppcache/integration/test/Position.cpp
+++ b/cppcache/integration/test/Position.cpp
@@ -41,19 +41,19 @@ Position::Position(std::string id, int32_t outstandingShares) {
 
 void Position::init() {
   avg20DaysVol = 0;
-  bondRating = nullptr;
+  bondRating = "";
   convRatio = 0.0;
-  country = nullptr;
+  country = "";
   valueGain = 0.0;
   industry = 0;
   issuer = 0;
   mktValue = 0.0;
   qty = 0.0;
-  secId = nullptr;
-  secLinks = nullptr;
+  secId = "";
+  secLinks = "";
   secType = L"";
   sharesOutstanding = 0;
-  underlyer = nullptr;
+  underlyer = "";
   volatility = 0;
   pid = 0;
 }

--- a/cppcache/integration/test/Position.cpp
+++ b/cppcache/integration/test/Position.cpp
@@ -27,35 +27,26 @@ namespace DataSerializableTest {
 
 int32_t Position::cnt = 0;
 
-Position::Position() { init(); }
+Position::Position() {
+  avg20DaysVol = 0;
+  convRatio = 0.0;
+  valueGain = 0.0;
+  industry = 0;
+  issuer = 0;
+  mktValue = 0.0;
+  qty = 0.0;
+  sharesOutstanding = 0;
+  volatility = 0;
+  pid = 0;
+}
 
-Position::Position(std::string id, int32_t outstandingShares) {
-  init();
+Position::Position(std::string id, int32_t outstandingShares) : Position() {
   secId = id;
   qty = outstandingShares - (cnt % 2 == 0 ? 1000 : 100);
   mktValue = qty * 1.2345998;
   sharesOutstanding = outstandingShares;
   secType = L"a";
   pid = cnt++;
-}
-
-void Position::init() {
-  avg20DaysVol = 0;
-  bondRating = "";
-  convRatio = 0.0;
-  country = "";
-  valueGain = 0.0;
-  industry = 0;
-  issuer = 0;
-  mktValue = 0.0;
-  qty = 0.0;
-  secId = "";
-  secLinks = "";
-  secType = L"";
-  sharesOutstanding = 0;
-  underlyer = "";
-  volatility = 0;
-  pid = 0;
 }
 
 void Position::toData(apache::geode::client::DataOutput& output) const {

--- a/cppcache/integration/test/Position.cpp
+++ b/cppcache/integration/test/Position.cpp
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "Position.hpp"
+
+#include <wchar.h>
+
+#include <cwchar>
+
+#include <geode/DataInput.hpp>
+#include <geode/DataOutput.hpp>
+
+namespace DataSerializableTest {
+
+int32_t Position::cnt = 0;
+
+Position::Position() { init(); }
+
+Position::Position(const char* id, int32_t out) {
+  init();
+  secId = CacheableString::create(id);
+  qty = out - (cnt % 2 == 0 ? 1000 : 100);
+  mktValue = qty * 1.2345998;
+  sharesOutstanding = out;
+  secType = L"a";
+  pid = cnt++;
+}
+
+// This constructor is just for some internal data validation test
+Position::Position(int32_t iForExactVal) {
+  init();
+  char* id = new char[iForExactVal + 2];
+  for (int i = 0; i <= iForExactVal; i++) {
+    id[i] = 'a';
+  }
+  id[iForExactVal + 1] = '\0';
+  secId = CacheableString::create(id);
+  delete[] id;
+  qty = (iForExactVal % 2 == 0 ? 1000 : 100);
+  mktValue = qty * 2;
+  sharesOutstanding = iForExactVal;
+  secType = L"a";
+  pid = iForExactVal;
+}
+
+void Position::init() {
+  avg20DaysVol = 0;
+  bondRating = nullptr;
+  convRatio = 0.0;
+  country = nullptr;
+  delta = 0.0;
+  industry = 0;
+  issuer = 0;
+  mktValue = 0.0;
+  qty = 0.0;
+  secId = nullptr;
+  secLinks = nullptr;
+  secType = L"";
+  sharesOutstanding = 0;
+  underlyer = nullptr;
+  volatility = 0;
+  pid = 0;
+}
+
+void Position::toData(apache::geode::client::DataOutput& output) const {
+  output.writeInt(avg20DaysVol);
+  output.writeObject(bondRating);
+  output.writeDouble(convRatio);
+  output.writeObject(country);
+  output.writeDouble(delta);
+  output.writeInt(industry);
+  output.writeInt(issuer);
+  output.writeDouble(mktValue);
+  output.writeDouble(qty);
+  output.writeObject(secId);
+  output.writeObject(secLinks);
+  output.writeUTF(secType);
+  output.writeInt(sharesOutstanding);
+  output.writeObject(underlyer);
+  output.writeInt(volatility);
+  output.writeInt(pid);
+}
+
+void Position::fromData(apache::geode::client::DataInput& input) {
+  avg20DaysVol = input.readInt64();
+  bondRating = std::dynamic_pointer_cast<CacheableString>(input.readObject());
+  convRatio = input.readDouble();
+  country = std::dynamic_pointer_cast<CacheableString>(input.readObject());
+  delta = input.readDouble();
+  industry = input.readInt64();
+  issuer = input.readInt64();
+  mktValue = input.readDouble();
+  qty = input.readDouble();
+  secId = std::dynamic_pointer_cast<CacheableString>(input.readObject());
+  secLinks = std::dynamic_pointer_cast<CacheableString>(input.readObject());
+  secType = input.readUTF<wchar_t>();
+  sharesOutstanding = input.readInt32();
+  underlyer = std::dynamic_pointer_cast<CacheableString>(input.readObject());
+  volatility = input.readInt64();
+  pid = input.readInt32();
+}
+std::string Position::toString() const {
+  char buf[2048];
+  sprintf(buf,
+          "Position Object:[ secId=%s type=%ls sharesOutstanding=%d id=%d ]",
+          secId->toString().c_str(), this->secType.c_str(),
+          this->sharesOutstanding, this->pid);
+  return buf;
+}
+
+}  // namespace DataSerializableTest

--- a/cppcache/integration/test/Position.cpp
+++ b/cppcache/integration/test/Position.cpp
@@ -27,17 +27,17 @@ namespace DataSerializableTest {
 
 int32_t Position::cnt = 0;
 
-Position::Position() :
-  avg20DaysVol(0),
-  convRatio(0.0),
-  valueGain(0.0),
-  industry(0),
-  issuer(0),
-  mktValue(0.0),
-  qty(0.0),
-  sharesOutstanding(0),
-  volatility(0),
-  pid(0) {}
+Position::Position()
+    : avg20DaysVol(0),
+      convRatio(0.0),
+      valueGain(0.0),
+      industry(0),
+      issuer(0),
+      mktValue(0.0),
+      qty(0.0),
+      sharesOutstanding(0),
+      volatility(0),
+      pid(0) {}
 
 Position::Position(std::string id, int32_t outstandingShares) : Position() {
   secId = std::move(id);
@@ -60,7 +60,7 @@ void Position::toData(apache::geode::client::DataOutput& output) const {
   output.writeDouble(qty);
   output.writeString(secId);
   output.writeString(secLinks);
-  output.writeString(secType);
+  output.writeUTF(secType);
   output.writeInt(sharesOutstanding);
   output.writeString(underlyer);
   output.writeInt(volatility);
@@ -69,19 +69,19 @@ void Position::toData(apache::geode::client::DataOutput& output) const {
 
 void Position::fromData(apache::geode::client::DataInput& input) {
   avg20DaysVol = input.readInt64();
-  bondRating = std::string(input.readString());
+  bondRating = input.readString();
   convRatio = input.readDouble();
-  country = std::string(input.readString());
+  country = input.readString();
   valueGain = input.readDouble();
   industry = input.readInt64();
   issuer = input.readInt64();
   mktValue = input.readDouble();
   qty = input.readDouble();
-  secId = std::string(input.readString());
-  secLinks = std::string(input.readString());
-  secType = input.readString();
+  secId = input.readString();
+  secLinks = input.readString();
+  secType = input.readUTF();
   sharesOutstanding = input.readInt32();
-  underlyer = std::string(input.readString());
+  underlyer = input.readString();
   volatility = input.readInt64();
   pid = input.readInt32();
 }

--- a/cppcache/integration/test/Position.cpp
+++ b/cppcache/integration/test/Position.cpp
@@ -27,25 +27,24 @@ namespace DataSerializableTest {
 
 int32_t Position::cnt = 0;
 
-Position::Position() {
-  avg20DaysVol = 0;
-  convRatio = 0.0;
-  valueGain = 0.0;
-  industry = 0;
-  issuer = 0;
-  mktValue = 0.0;
-  qty = 0.0;
-  sharesOutstanding = 0;
-  volatility = 0;
-  pid = 0;
-}
+Position::Position() :
+  avg20DaysVol(0),
+  convRatio(0.0),
+  valueGain(0.0),
+  industry(0),
+  issuer(0),
+  mktValue(0.0),
+  qty(0.0),
+  sharesOutstanding(0),
+  volatility(0),
+  pid(0) {}
 
 Position::Position(std::string id, int32_t outstandingShares) : Position() {
-  secId = id;
+  secId = std::move(id);
+  secType = "a";
+  sharesOutstanding = outstandingShares;
   qty = outstandingShares - (cnt % 2 == 0 ? 1000 : 100);
   mktValue = qty * 1.2345998;
-  sharesOutstanding = outstandingShares;
-  secType = L"a";
   pid = cnt++;
 }
 
@@ -61,7 +60,7 @@ void Position::toData(apache::geode::client::DataOutput& output) const {
   output.writeDouble(qty);
   output.writeString(secId);
   output.writeString(secLinks);
-  output.writeUTF(secType);
+  output.writeString(secType);
   output.writeInt(sharesOutstanding);
   output.writeString(underlyer);
   output.writeInt(volatility);
@@ -80,7 +79,7 @@ void Position::fromData(apache::geode::client::DataInput& input) {
   qty = input.readDouble();
   secId = std::string(input.readString());
   secLinks = std::string(input.readString());
-  secType = input.readUTF<wchar_t>();
+  secType = input.readString();
   sharesOutstanding = input.readInt32();
   underlyer = std::string(input.readString());
   volatility = input.readInt64();

--- a/cppcache/integration/test/Position.cpp
+++ b/cppcache/integration/test/Position.cpp
@@ -16,74 +16,70 @@
  */
 #include "Position.hpp"
 
-#include <wchar.h>
-
-#include <cwchar>
-
 #include <geode/DataInput.hpp>
 #include <geode/DataOutput.hpp>
 
 namespace DataSerializableTest {
 
-int32_t Position::cnt = 0;
+int32_t Position::count = 0;
 
 Position::Position()
-    : avg20DaysVol(0),
-      convRatio(0.0),
-      valueGain(0.0),
-      industry(0),
-      issuer(0),
-      mktValue(0.0),
-      qty(0.0),
-      sharesOutstanding(0),
-      volatility(0),
-      pid(0) {}
+    : volumeAverageOver20Days_(0),
+      conversionRatio_(0.0),
+      valueGain_(0.0),
+      industry_(0),
+      issuer_(0),
+      marketValue_(0.0),
+      quantity_(0.0),
+      sharesOutstanding_(0),
+      volatility_(0),
+      positionId_(0) {}
 
 Position::Position(std::string id, int32_t outstandingShares) : Position() {
-  secId = std::move(id);
-  secType = "a";
-  sharesOutstanding = outstandingShares;
-  qty = outstandingShares - (cnt % 2 == 0 ? 1000 : 100);
-  mktValue = qty * 1.2345998;
-  pid = cnt++;
+  securityId_ = std::move(id);
+  securityType_ = "a";
+  sharesOutstanding_ = outstandingShares;
+  quantity_ = outstandingShares - (count % 2 == 0 ? 1000 : 100);
+  marketValue_ = quantity_ * 1.2345998;
+  positionId_ = count++;
 }
 
 void Position::toData(apache::geode::client::DataOutput& output) const {
-  output.writeInt(avg20DaysVol);
-  output.writeString(bondRating);
-  output.writeDouble(convRatio);
-  output.writeString(country);
-  output.writeDouble(valueGain);
-  output.writeInt(industry);
-  output.writeInt(issuer);
-  output.writeDouble(mktValue);
-  output.writeDouble(qty);
-  output.writeString(secId);
-  output.writeString(secLinks);
-  output.writeUTF(secType);
-  output.writeInt(sharesOutstanding);
-  output.writeString(underlyer);
-  output.writeInt(volatility);
-  output.writeInt(pid);
+  output.writeInt(volumeAverageOver20Days_);
+  output.writeString(bondRating_);
+  output.writeDouble(conversionRatio_);
+  output.writeString(country_);
+  output.writeDouble(valueGain_);
+  output.writeInt(industry_);
+  output.writeInt(issuer_);
+  output.writeDouble(marketValue_);
+  output.writeDouble(quantity_);
+  output.writeString(securityId_);
+  output.writeString(securityLinks_);
+  output.writeUTF(securityType_);
+  output.writeInt(sharesOutstanding_);
+  output.writeString(underlyingSecurity_);
+  output.writeInt(volatility_);
+  output.writeInt(positionId_);
 }
 
 void Position::fromData(apache::geode::client::DataInput& input) {
-  avg20DaysVol = input.readInt64();
-  bondRating = input.readString();
-  convRatio = input.readDouble();
-  country = input.readString();
-  valueGain = input.readDouble();
-  industry = input.readInt64();
-  issuer = input.readInt64();
-  mktValue = input.readDouble();
-  qty = input.readDouble();
-  secId = input.readString();
-  secLinks = input.readString();
-  secType = input.readUTF();
-  sharesOutstanding = input.readInt32();
-  underlyer = input.readString();
-  volatility = input.readInt64();
-  pid = input.readInt32();
+  volumeAverageOver20Days_ = input.readInt64();
+  bondRating_ = input.readString();
+  conversionRatio_ = input.readDouble();
+  country_ = input.readString();
+  valueGain_ = input.readDouble();
+  industry_ = input.readInt64();
+  issuer_ = input.readInt64();
+  marketValue_ = input.readDouble();
+  quantity_ = input.readDouble();
+  securityId_ = input.readString();
+  securityLinks_ = input.readString();
+  securityType_ = input.readUTF();
+  sharesOutstanding_ = input.readInt32();
+  underlyingSecurity_ = input.readString();
+  volatility_ = input.readInt64();
+  positionId_ = input.readInt32();
 }
 
 }  // namespace DataSerializableTest

--- a/cppcache/integration/test/Position.hpp
+++ b/cppcache/integration/test/Position.hpp
@@ -59,7 +59,7 @@ class Position : public DataSerializable {
   static int32_t cnt;
 
   Position();
-  Position(std::string id, int32_t out);
+  explicit Position(std::string id, int32_t out);
   ~Position() override = default;
   void toData(DataOutput& output) const override;
   void fromData(DataInput& input) override;

--- a/cppcache/integration/test/Position.hpp
+++ b/cppcache/integration/test/Position.hpp
@@ -49,7 +49,7 @@ class Position : public DataSerializable {
   double qty;
   std::string secId;
   std::string secLinks;
-  std::wstring secType;
+  std::string secType;
   int32_t sharesOutstanding;
   std::string underlyer;
   int64_t volatility;

--- a/cppcache/integration/test/Position.hpp
+++ b/cppcache/integration/test/Position.hpp
@@ -39,52 +39,33 @@ using apache::geode::client::DataSerializable;
 class Position : public DataSerializable {
  private:
   int64_t avg20DaysVol;
-  std::shared_ptr<CacheableString> bondRating;
+  std::string bondRating;
   double convRatio;
-  std::shared_ptr<CacheableString> country;
-  double delta;
+  std::string country;
+  double valueGain;
   int64_t industry;
   int64_t issuer;
   double mktValue;
   double qty;
-  std::shared_ptr<CacheableString> secId;
-  std::shared_ptr<CacheableString> secLinks;
-  // wchar_t* secType;
+  std::string secId;
+  std::string secLinks;
   std::wstring secType;
   int32_t sharesOutstanding;
-  std::shared_ptr<CacheableString> underlyer;
+  std::string underlyer;
   int64_t volatility;
   int32_t pid;
-
-  inline size_t getObjectSize(const std::shared_ptr<Serializable>& obj) const {
-    return (obj == nullptr ? 0 : obj->objectSize());
-  }
 
  public:
   static int32_t cnt;
 
   Position();
-  Position(const char* id, int32_t out);
-  // This constructor is just for some internal data validation test
-  explicit Position(int32_t iForExactVal);
+  Position(std::string id, int32_t out);
   ~Position() override = default;
   void toData(DataOutput& output) const override;
   void fromData(DataInput& input) override;
-  std::string toString() const override;
-
-  size_t objectSize() const override {
-    auto objectSize = sizeof(Position);
-    objectSize += getObjectSize(bondRating);
-    objectSize += getObjectSize(country);
-    objectSize += getObjectSize(secId);
-    objectSize += getObjectSize(secLinks);
-    objectSize += secType.size() * sizeof(decltype(secType)::value_type);
-    objectSize += getObjectSize(underlyer);
-    return objectSize;
-  }
 
   static void resetCounter() { cnt = 0; }
-  std::shared_ptr<CacheableString> getSecId() { return secId; }
+  std::string getSecId() { return secId; }
   int32_t getId() { return pid; }
   int32_t getSharesOutstanding() { return sharesOutstanding; }
   static std::shared_ptr<Serializable> createDeserializable() {

--- a/cppcache/integration/test/Position.hpp
+++ b/cppcache/integration/test/Position.hpp
@@ -38,25 +38,25 @@ using apache::geode::client::DataSerializable;
 
 class Position : public DataSerializable {
  private:
-  int64_t avg20DaysVol;
-  std::string bondRating;
-  double convRatio;
-  std::string country;
-  double valueGain;
-  int64_t industry;
-  int64_t issuer;
-  double mktValue;
-  double qty;
-  std::string secId;
-  std::string secLinks;
-  std::string secType;
-  int32_t sharesOutstanding;
-  std::string underlyer;
-  int64_t volatility;
-  int32_t pid;
+  int64_t volumeAverageOver20Days_;
+  std::string bondRating_;
+  double conversionRatio_;
+  std::string country_;
+  double valueGain_;
+  int64_t industry_;
+  int64_t issuer_;
+  double marketValue_;
+  double quantity_;
+  std::string securityId_;
+  std::string securityLinks_;
+  std::string securityType_;
+  int32_t sharesOutstanding_;
+  std::string underlyingSecurity_;
+  int64_t volatility_;
+  int32_t positionId_;
 
  public:
-  static int32_t cnt;
+  static int32_t count;
 
   Position();
   explicit Position(std::string id, int32_t out);
@@ -64,10 +64,10 @@ class Position : public DataSerializable {
   void toData(DataOutput& output) const override;
   void fromData(DataInput& input) override;
 
-  static void resetCounter() { cnt = 0; }
-  std::string getSecId() { return secId; }
-  int32_t getId() { return pid; }
-  int32_t getSharesOutstanding() { return sharesOutstanding; }
+  static void resetCounter() { count = 0; }
+  std::string getSecurityId() { return securityId_; }
+  int32_t getPOsitionId() { return positionId_; }
+  int32_t getSharesOutstanding() { return sharesOutstanding_; }
   static std::shared_ptr<Serializable> createDeserializable() {
     return std::make_shared<Position>();
   }

--- a/cppcache/integration/test/Position.hpp
+++ b/cppcache/integration/test/Position.hpp
@@ -71,9 +71,6 @@ class Position : public DataSerializable {
   static std::shared_ptr<Serializable> createDeserializable() {
     return std::make_shared<Position>();
   }
-
- private:
-  void init();
 };
 
 }  // namespace DataSerializableTest

--- a/cppcache/integration/test/Position.hpp
+++ b/cppcache/integration/test/Position.hpp
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef POSITION_H
+#define POSITION_H
+
+/*
+ * @brief User class for testing the put functionality for object.
+ */
+
+#include <string>
+
+#include <geode/CacheableString.hpp>
+#include <geode/DataSerializable.hpp>
+
+namespace DataSerializableTest {
+
+using apache::geode::client::CacheableString;
+using apache::geode::client::DataInput;
+using apache::geode::client::DataOutput;
+using apache::geode::client::DataSerializable;
+
+class Position : public DataSerializable {
+ private:
+  int64_t avg20DaysVol;
+  std::shared_ptr<CacheableString> bondRating;
+  double convRatio;
+  std::shared_ptr<CacheableString> country;
+  double delta;
+  int64_t industry;
+  int64_t issuer;
+  double mktValue;
+  double qty;
+  std::shared_ptr<CacheableString> secId;
+  std::shared_ptr<CacheableString> secLinks;
+  // wchar_t* secType;
+  std::wstring secType;
+  int32_t sharesOutstanding;
+  std::shared_ptr<CacheableString> underlyer;
+  int64_t volatility;
+  int32_t pid;
+
+  inline size_t getObjectSize(const std::shared_ptr<Serializable>& obj) const {
+    return (obj == nullptr ? 0 : obj->objectSize());
+  }
+
+ public:
+  static int32_t cnt;
+
+  Position();
+  Position(const char* id, int32_t out);
+  // This constructor is just for some internal data validation test
+  explicit Position(int32_t iForExactVal);
+  ~Position() override = default;
+  void toData(DataOutput& output) const override;
+  void fromData(DataInput& input) override;
+  std::string toString() const override;
+
+  size_t objectSize() const override {
+    auto objectSize = sizeof(Position);
+    objectSize += getObjectSize(bondRating);
+    objectSize += getObjectSize(country);
+    objectSize += getObjectSize(secId);
+    objectSize += getObjectSize(secLinks);
+    objectSize += secType.size() * sizeof(decltype(secType)::value_type);
+    objectSize += getObjectSize(underlyer);
+    return objectSize;
+  }
+
+  static void resetCounter() { cnt = 0; }
+  std::shared_ptr<CacheableString> getSecId() { return secId; }
+  int32_t getId() { return pid; }
+  int32_t getSharesOutstanding() { return sharesOutstanding; }
+  static std::shared_ptr<Serializable> createDeserializable() {
+    return std::make_shared<Position>();
+  }
+
+ private:
+  void init();
+};
+
+}  // namespace DataSerializableTest
+
+#endif  // POSITION_H

--- a/cppcache/integration/test/PositionKey.cpp
+++ b/cppcache/integration/test/PositionKey.cpp
@@ -22,20 +22,21 @@
 namespace DataSerializableTest {
 
 void PositionKey::toData(DataOutput& output) const {
-  output.writeInt(m_positionId);
+  output.writeInt(positionId_);
 }
 
 void PositionKey::fromData(apache::geode::client::DataInput& input) {
-  m_positionId = input.readInt64();
+  positionId_ = input.readInt64();
 }
 
 bool PositionKey::operator==(const CacheableKey& other) const {
-  return m_positionId == (reinterpret_cast<const PositionKey&>(other)).getPositionId();
+  return positionId_ ==
+         (static_cast<const PositionKey&>(other)).getPositionId();
 }
 
 int PositionKey::hashcode() const {
   int prime = 31;
-  int result = prime * static_cast<int32_t>(m_positionId);
+  int result = prime * static_cast<int32_t>(positionId_);
   return result;
 }
 

--- a/cppcache/integration/test/PositionKey.cpp
+++ b/cppcache/integration/test/PositionKey.cpp
@@ -38,9 +38,9 @@ bool PositionKey::operator==(const CacheableKey& other) const {
 }
 
 int PositionKey::hashcode() const {
-  int hash = 11;
-  hash = 31 * hash + (int)m_positionId;
-  return hash;
+  int prime = 31;
+  int result = prime * static_cast<int32_t>(m_positionId);
+  return result;
 }
 
 }  // namespace DataSerializableTest

--- a/cppcache/integration/test/PositionKey.cpp
+++ b/cppcache/integration/test/PositionKey.cpp
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "PositionKey.hpp"
+
+#include <wchar.h>
+
+#include <cwchar>
+
+#include <geode/DataInput.hpp>
+#include <geode/DataOutput.hpp>
+
+namespace DataSerializableTest {
+
+void PositionKey::toData(DataOutput& output) const {
+  output.writeInt(m_positionId);
+}
+
+void PositionKey::fromData(apache::geode::client::DataInput& input) {
+  m_positionId = input.readInt64();
+}
+
+bool PositionKey::operator==(const CacheableKey& other) const {
+  return m_positionId == ((PositionKey&)other).getPositionId();
+}
+
+int PositionKey::hashcode() const {
+  int hash = 11;
+  hash = 31 * hash + (int)m_positionId;
+  return hash;
+}
+
+}  // namespace DataSerializableTest

--- a/cppcache/integration/test/PositionKey.cpp
+++ b/cppcache/integration/test/PositionKey.cpp
@@ -30,7 +30,7 @@ void PositionKey::fromData(apache::geode::client::DataInput& input) {
 }
 
 bool PositionKey::operator==(const CacheableKey& other) const {
-  return m_positionId == ((PositionKey&)other).getPositionId();
+  return m_positionId == (reinterpret_cast<const PositionKey&>(other)).getPositionId();
 }
 
 int PositionKey::hashcode() const {

--- a/cppcache/integration/test/PositionKey.cpp
+++ b/cppcache/integration/test/PositionKey.cpp
@@ -16,10 +16,6 @@
  */
 #include "PositionKey.hpp"
 
-#include <wchar.h>
-
-#include <cwchar>
-
 #include <geode/DataInput.hpp>
 #include <geode/DataOutput.hpp>
 

--- a/cppcache/integration/test/PositionKey.hpp
+++ b/cppcache/integration/test/PositionKey.hpp
@@ -37,8 +37,8 @@ class PositionKey : public DataSerializable, public CacheableKey {
   int64_t m_positionId;
 
  public:
-  PositionKey() {}
-  PositionKey(int64_t positionId) { m_positionId = positionId; }
+  PositionKey() = default;
+  PositionKey(int64_t positionId) : m_positionId(positionId) {}
   ~PositionKey() override = default;
 
   bool operator==(const CacheableKey& other) const override;

--- a/cppcache/integration/test/PositionKey.hpp
+++ b/cppcache/integration/test/PositionKey.hpp
@@ -47,7 +47,7 @@ class PositionKey : public DataSerializable, public CacheableKey {
   void toData(DataOutput& output) const override;
   void fromData(DataInput& input) override;
 
-  int64_t getPositionId() { return m_positionId; }
+  int64_t getPositionId() const { return m_positionId; }
   static std::shared_ptr<Serializable> createDeserializable() {
     return std::make_shared<PositionKey>();
   }

--- a/cppcache/integration/test/PositionKey.hpp
+++ b/cppcache/integration/test/PositionKey.hpp
@@ -38,7 +38,7 @@ class PositionKey : public DataSerializable, public CacheableKey {
 
  public:
   PositionKey() = default;
-  PositionKey(int64_t positionId) : m_positionId(positionId) {}
+  explicit PositionKey(int64_t positionId) : m_positionId(positionId) {}
   ~PositionKey() override = default;
 
   bool operator==(const CacheableKey& other) const override;

--- a/cppcache/integration/test/PositionKey.hpp
+++ b/cppcache/integration/test/PositionKey.hpp
@@ -34,11 +34,11 @@ using apache::geode::client::DataSerializable;
 
 class PositionKey : public DataSerializable, public CacheableKey {
  private:
-  int64_t m_positionId;
+  int64_t positionId_;
 
  public:
   PositionKey() = default;
-  explicit PositionKey(int64_t positionId) : m_positionId(positionId) {}
+  explicit PositionKey(int64_t positionId) : positionId_(positionId) {}
   ~PositionKey() override = default;
 
   bool operator==(const CacheableKey& other) const override;
@@ -47,7 +47,7 @@ class PositionKey : public DataSerializable, public CacheableKey {
   void toData(DataOutput& output) const override;
   void fromData(DataInput& input) override;
 
-  int64_t getPositionId() const { return m_positionId; }
+  int64_t getPositionId() const { return positionId_; }
   static std::shared_ptr<Serializable> createDeserializable() {
     return std::make_shared<PositionKey>();
   }

--- a/cppcache/integration/test/PositionKey.hpp
+++ b/cppcache/integration/test/PositionKey.hpp
@@ -41,8 +41,8 @@ class PositionKey : public DataSerializable, public CacheableKey {
   PositionKey(int64_t positionId) { m_positionId = positionId; }
   ~PositionKey() override = default;
 
-  bool operator==(const CacheableKey& other) const;
-  int32_t hashcode() const;
+  bool operator==(const CacheableKey& other) const override;
+  int32_t hashcode() const override;
 
   void toData(DataOutput& output) const override;
   void fromData(DataInput& input) override;

--- a/cppcache/integration/test/PositionKey.hpp
+++ b/cppcache/integration/test/PositionKey.hpp
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef POSITIONKEY_H_
+#define POSITIONKEY_H_
+
+#include <string>
+
+#include <geode/CacheableString.hpp>
+#include <geode/DataSerializable.hpp>
+
+namespace DataSerializableTest {
+
+using apache::geode::client::CacheableKey;
+using apache::geode::client::DataInput;
+using apache::geode::client::DataOutput;
+using apache::geode::client::DataSerializable;
+
+class PositionKey : public DataSerializable, public CacheableKey {
+ private:
+  int64_t m_positionId;
+
+ public:
+  PositionKey() {}
+  PositionKey(int64_t positionId) { m_positionId = positionId; }
+  ~PositionKey() override = default;
+
+  bool operator==(const CacheableKey& other) const;
+  int32_t hashcode() const;
+
+  void toData(DataOutput& output) const override;
+  void fromData(DataInput& input) override;
+
+  int64_t getPositionId() { return m_positionId; }
+  static std::shared_ptr<Serializable> createDeserializable() {
+    return std::make_shared<PositionKey>();
+  }
+};
+
+}  // namespace DataSerializableTest
+
+#endif  // POSITIONKEY_H_

--- a/tests/javaobject/cli/InstantiateDataSerializable.java
+++ b/tests/javaobject/cli/InstantiateDataSerializable.java
@@ -32,15 +32,16 @@ import org.apache.geode.cache.partition.PartitionRegionHelper;
 public class InstantiateDataSerializable extends FunctionAdapter implements Declarable{
 
 public void execute(FunctionContext context) {
-  Instantiator.register(new Instantiator(javaobject.cli.Position.class, 22) {
+
+  Instantiator.register(new Instantiator(javaobject.cli.PositionKey.class, 21) {
     public DataSerializable newInstance() {
-      return new javaobject.cli.Position();
+      return new javaobject.cli.PositionKey();
     }
   });
 
-  Instantiator.register(new Instantiator(javaobject.cli.PositionKey.class, 77) {
+  Instantiator.register(new Instantiator(javaobject.cli.Position.class, 22) {
     public DataSerializable newInstance() {
-      return new javaobject.cli.PositionKey();
+      return new javaobject.cli.Position();
     }
   });
 

--- a/tests/javaobject/cli/PositionKey.java
+++ b/tests/javaobject/cli/PositionKey.java
@@ -26,7 +26,7 @@ public class PositionKey implements DataSerializable {
   private long positionId;
 
   static {
-     Instantiator.register(new Instantiator(javaobject.cli.PositionKey.class, (byte) 77) {
+     Instantiator.register(new Instantiator(javaobject.cli.PositionKey.class, (byte) 21) {
      public DataSerializable newInstance() {
         return new PositionKey();
      }

--- a/tests/javaobject/cli/PositionKey.java
+++ b/tests/javaobject/cli/PositionKey.java
@@ -26,7 +26,7 @@ public class PositionKey implements DataSerializable {
   private long positionId;
 
   static {
-     Instantiator.register(new Instantiator(javaobject.cli.PositionKey.class, (byte) 21) {
+     Instantiator.register(new Instantiator(javaobject.cli.PositionKey.class, 21) {
      public DataSerializable newInstance() {
         return new PositionKey();
      }


### PR DESCRIPTION
This adds a new C++ serialization test for using a class as a key.

Notes:
* This test leverages the new gfsh execute function support in the C++ test framework.
* A .NET serialization test for using a class as a key has been added in a previous PR.