### PR TITLE
GEODE-8820: Fix Windows build for latest ACE

### DIFF
--- a/dependencies/ACE/CMakeLists.txt
+++ b/dependencies/ACE/CMakeLists.txt
@@ -82,7 +82,7 @@ if (${WIN32})
   set ( _CONFIGURE_COMMAND ${_COMMAND_PREFIX}
                              ${CMAKE_COMMAND} -E env ACE_ROOT=<SOURCE_DIR> SSL_ROOT=${OPENSSL_ROOT}
 							 ${MPC} ${MPC_FLAGS} -name_modifier "*_${_TYPE}_static" -static
-							-value_template WindowsTargetPlatformVersion=${CMAKE_SYSTEM_VERSION}
+							 -value_template WindowsTargetPlatformVersion=${CMAKE_SYSTEM_VERSION}
 							 -value_template staticflags+=__ACE_INLINE__ 
 							 -value_template staticflags+=ACE_BUILD_DLL 
 							 -value_template staticflags+=ACE_AS_STATIC_LIBS 

--- a/dependencies/ACE/CMakeLists.txt
+++ b/dependencies/ACE/CMakeLists.txt
@@ -82,6 +82,7 @@ if (${WIN32})
   set ( _CONFIGURE_COMMAND ${_COMMAND_PREFIX}
                              ${CMAKE_COMMAND} -E env ACE_ROOT=<SOURCE_DIR> SSL_ROOT=${OPENSSL_ROOT}
 							 ${MPC} ${MPC_FLAGS} -name_modifier "*_${_TYPE}_static" -static
+							-value_template WindowsTargetPlatformVersion=${CMAKE_SYSTEM_VERSION}
 							 -value_template staticflags+=__ACE_INLINE__ 
 							 -value_template staticflags+=ACE_BUILD_DLL 
 							 -value_template staticflags+=ACE_AS_STATIC_LIBS 


### PR DESCRIPTION
This change allows the Windows SDK version for ACE to be specified using CMAKE_SYSTEM_VERSION, which can be set appropriately for the target machine.

Our CI uses Windows SDK version 10.0.16299.0,, so passing -DCMAKE_SYSTEM_VERSION=10.0.16299.0 to the cmake config step fixes our CI build failure on Windows. Note, this also requires a change to our CI code which generates the cmake command.