### PR TITLE
GEODE-8836: Fix incorrect schema location for cli tests

### DIFF
--- a/clicache/acceptance-test/cache.xml
+++ b/clicache/acceptance-test/cache.xml
@@ -19,7 +19,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 
   <pool name="default">

--- a/clicache/integration-test/cache.xml
+++ b/clicache/integration-test/cache.xml
@@ -21,7 +21,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 </client-cache>
 

--- a/clicache/integration-test/cache_redundancy.xml
+++ b/clicache/integration-test/cache_redundancy.xml
@@ -23,7 +23,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0"
     redundancy-level="1"
     endpoints="localhost:HOST_PORT1,localhost:HOST_PORT2" >

--- a/clicache/integration-test/client_Loader.xml
+++ b/clicache/integration-test/client_Loader.xml
@@ -23,7 +23,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 
 <region name = "root" >

--- a/clicache/integration-test/client_generics_plugins.xml
+++ b/clicache/integration-test/client_generics_plugins.xml
@@ -21,7 +21,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0"
     redundancy-level="1" >
 

--- a/clicache/integration-test/client_pdx.xml
+++ b/clicache/integration-test/client_pdx.xml
@@ -22,7 +22,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0"
      >
 

--- a/clicache/integration-test/client_pool.xml
+++ b/clicache/integration-test/client_pool.xml
@@ -22,7 +22,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0"
     redundancy-level="1" >
 

--- a/clicache/integration-test/invalid_cache1.xml
+++ b/clicache/integration-test/invalid_cache1.xml
@@ -24,7 +24,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 
   <region>

--- a/clicache/integration-test/invalid_cache2.xml
+++ b/clicache/integration-test/invalid_cache2.xml
@@ -24,7 +24,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
   <root-region name = "root1" >
      <region-attributes scope="local" caching-enabled="true" lru-entries-limit = "35">

--- a/clicache/integration-test/invalid_cache3.xml
+++ b/clicache/integration-test/invalid_cache3.xml
@@ -23,7 +23,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 
   <root-region name = "root1" >

--- a/clicache/integration-test/invalid_cache_pool.xml
+++ b/clicache/integration-test/invalid_cache_pool.xml
@@ -23,7 +23,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 
  <root-region name = "Root1" >

--- a/clicache/integration-test/invalid_cache_pool2.xml
+++ b/clicache/integration-test/invalid_cache_pool2.xml
@@ -23,7 +23,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 
 

--- a/clicache/integration-test/invalid_cache_pool3.xml
+++ b/clicache/integration-test/invalid_cache_pool3.xml
@@ -23,7 +23,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0"
    endpoints="must_fail_with_pool:12345">
 

--- a/clicache/integration-test/invalid_cache_pool4.xml
+++ b/clicache/integration-test/invalid_cache_pool4.xml
@@ -23,7 +23,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 
  <root-region name = "Root1" >

--- a/clicache/integration-test/invalid_overflowAttr1.xml
+++ b/clicache/integration-test/invalid_overflowAttr1.xml
@@ -24,7 +24,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
   <root-region name = "Root1" >
      <region-attributes scope="local" caching-enabled="true" initial-capacity="25" load-factor="0.32" concurrency-level="10" lru-entries-limit = "35" disk-policy="overflows">

--- a/clicache/integration-test/invalid_overflowAttr2.xml
+++ b/clicache/integration-test/invalid_overflowAttr2.xml
@@ -24,7 +24,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
  <root-region name = "root1" >
      <region-attributes scope="local" caching-enabled="true" lru-entries-limit = "35" disk-policy="overflows">

--- a/clicache/integration-test/invalid_overflowAttr3.xml
+++ b/clicache/integration-test/invalid_overflowAttr3.xml
@@ -24,7 +24,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
   <root-region name = "root1" >
     <region-attributes scope="local" caching-enabled="true" initial-capacity="25" load-factor="0.32" concurrency-level="10" lru-entries-limit = "35" disk-policy="overflows">

--- a/clicache/integration-test/valid_cache.xml
+++ b/clicache/integration-test/valid_cache.xml
@@ -23,7 +23,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 
  <root-region name = "Root1" >

--- a/clicache/integration-test/valid_cache_refid.xml
+++ b/clicache/integration-test/valid_cache_refid.xml
@@ -23,7 +23,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 
  <root-region name = "Root1" >

--- a/clicache/integration-test/valid_cache_region_refid.xml
+++ b/clicache/integration-test/valid_cache_region_refid.xml
@@ -23,7 +23,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 
  <root-region name = "Root1" >

--- a/clicache/integration-test/valid_declarative_cache_creation.xml
+++ b/clicache/integration-test/valid_declarative_cache_creation.xml
@@ -23,7 +23,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 <!-- xml with region-attribute having only child elements no attributes. refer to Ticket #775  -->
   <root-region name= "Root1">

--- a/clicache/integration-test/valid_lruExpiration.xml
+++ b/clicache/integration-test/valid_lruExpiration.xml
@@ -23,7 +23,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 
 <root-region name = "R1" >

--- a/clicache/integration-test/valid_overflowAttr.xml
+++ b/clicache/integration-test/valid_overflowAttr.xml
@@ -23,7 +23,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 
  <root-region name = "Root1" >

--- a/clicache/integration-test2/cache.xml
+++ b/clicache/integration-test2/cache.xml
@@ -19,7 +19,7 @@
     xmlns="http://geode.apache.org/schema/cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://geode.apache.org/schema/cache
-                        http://geode.apache.org/schema/cache/cpp-cache-1.0.xsd"
+                        http://geode.apache.org/schema/cpp-cache/cpp-cache-1.0.xsd"
     version="9.0">
 
   <pool name="default">


### PR DESCRIPTION
The xml configuration files for the clicache tests were using the old url for schemaLocation.