### PR TITLE
GEODE-8469: Add -Wno-missing-variable-dclarations to specific targets instead of _WarningsAsError

### DIFF
--- a/cppcache/integration-test/BBNamingContext.cpp
+++ b/cppcache/integration-test/BBNamingContext.cpp
@@ -62,7 +62,7 @@ static int getRandomNum() {
   return (ACE_OS::rand() % 49999) + 14000;
 }
 
-int G_BBPORT = getRandomNum();
+static int G_BBPORT = getRandomNum();
 
 class BBNamingContextClientImpl {
   FwkBBClient *m_bbc;

--- a/cppcache/integration-test/CMakeLists.txt
+++ b/cppcache/integration-test/CMakeLists.txt
@@ -99,17 +99,16 @@ foreach(FILE ${SOURCES})
   set(TESTS ${TESTS} ${TEST})
   add_dependencies(integration-tests ${TEST})
   add_executable(${TEST} ${FILE})
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(${TEST} PUBLIC
+      -Wno-missing-variable-declarations
+    )
+  endif()
   set_target_properties(${TEST} PROPERTIES
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN ON
     FOLDER cpp/test/integration/legacy
   )
-
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  target_compile_options(_WarningsAsError INTERFACE
-          -Wno-missing-variable-declarations
-          )
-endif()
 
   target_link_libraries(${TEST}
     PRIVATE

--- a/cppcache/integration-test/fw_dunit.cpp
+++ b/cppcache/integration-test/fw_dunit.cpp
@@ -30,8 +30,6 @@
 #include <smrtheap.h>
 #endif
 
-#include "TimeBomb.hpp"
-
 #include <ace/ACE.h>
 
 #include <typeinfo>
@@ -71,8 +69,8 @@ using apache::geode::client::testframework::BBNamingContextServer;
 #define __DUNIT_NO_MAIN__
 #include "fw_dunit.hpp"
 
-ACE_TCHAR *g_programName = nullptr;
-uint32_t g_coordinatorPid = 0;
+static ACE_TCHAR *g_programName = nullptr;
+static uint32_t g_coordinatorPid = 0;
 
 ClientCleanup gClientCleanup;
 

--- a/cppcache/integration-test/fw_dunit.hpp
+++ b/cppcache/integration-test/fw_dunit.hpp
@@ -119,7 +119,7 @@ END_TASK(validate)
 
 #include <ace/ACE.h>
 #include <signal.h>
-
+#include "TimeBomb.hpp"
 #define ASSERT(x, y)                                   \
   do {                                                 \
   if (!(x)) {                                          \
@@ -255,7 +255,7 @@ END_TASK(validate)
 #define s1p2 2
 #define s2p1 3
 #define s2p2 4
-
+extern ClientCleanup gClientCleanup;
 namespace dunit {
 
 void logCoordinator(std::string s, int lineno, const char* filename);


### PR DESCRIPTION
- old behavior allowed other parts of the code to treat this as a
warning and not an error
- fix up BBNamingContext and fw_dunit just to make it easier in ignoring
this in old integration test files

Authored-by: M. Oleske <michael@oleske.engineer>

Using old GEODE-8469 JIRA since this is fixing a mistake in that, but feel free to tell me to make a new one