### PR TITLE
GEODE-8845: Add missing public attribute to .NET Cacheables

### DIFF
--- a/clicache/src/CacheableHashMap.hpp
+++ b/clicache/src/CacheableHashMap.hpp
@@ -44,7 +44,7 @@ namespace Apache
       /// that can serve as a distributable object for caching. This class
       /// extends .NET generic <c>Dictionary</c> class.
       /// </summary>
-      ref class CacheableHashMap
+      public ref class CacheableHashMap
         : public IDataSerializablePrimitive
       {
       protected:

--- a/clicache/src/CacheableHashTable.hpp
+++ b/clicache/src/CacheableHashTable.hpp
@@ -38,7 +38,7 @@ namespace Apache
       /// that can serve as a distributable object for caching. This class
       /// extends .NET generic <c>Dictionary</c> class.
       /// </summary>
-      ref class CacheableHashTable
+      public ref class CacheableHashTable
         : public CacheableHashMap
       {
       public:

--- a/clicache/src/CacheableIdentityHashMap.hpp
+++ b/clicache/src/CacheableIdentityHashMap.hpp
@@ -40,7 +40,7 @@ namespace Apache
       /// <c>IdentityHashMap</c> class objects but is intentionally not
       /// intended to provide <c>java.util.IdentityHashMap</c> semantics.
       /// </summary>
-      ref class CacheableIdentityHashMap
+      public ref class CacheableIdentityHashMap
         : public CacheableHashMap
       {
       public:

--- a/clicache/src/CacheableLinkedList.hpp
+++ b/clicache/src/CacheableLinkedList.hpp
@@ -37,7 +37,7 @@ namespace Apache
       /// a distributable object for caching. This class extends .NET generic
       /// <c>List</c> class.
       /// </summary>
-      ref class CacheableLinkedList
+      public ref class CacheableLinkedList
         : public IDataSerializablePrimitive
       {
         System::Collections::Generic::LinkedList<Object^>^ m_linkedList;

--- a/clicache/src/CacheableStack.hpp
+++ b/clicache/src/CacheableStack.hpp
@@ -36,7 +36,7 @@ namespace Apache
       /// A mutable <c>ISerializable</c> vector wrapper that can serve as
       /// a distributable object for caching.
       /// </summary>
-      ref class CacheableStack
+      public ref class CacheableStack
         : public IDataSerializablePrimitive
       {
       public:

--- a/clicache/src/CacheableString.hpp
+++ b/clicache/src/CacheableString.hpp
@@ -40,7 +40,7 @@ namespace Apache
       /// An immutable string wrapper that can serve as a distributable
       /// key object for caching as well as being a string value.
       /// </summary>
-      ref class CacheableString
+      public ref class CacheableString
         :  public IDataSerializablePrimitive, public CacheableKey
       {
       public:

--- a/clicache/src/CacheableStringArray.hpp
+++ b/clicache/src/CacheableStringArray.hpp
@@ -43,7 +43,7 @@ namespace Apache
       /// An immutable wrapper for array of strings that can serve as
       /// a distributable object for caching.
       /// </summary>
-      ref class CacheableStringArray
+      public ref class CacheableStringArray
         :  public IDataSerializablePrimitive
       {
       public:

--- a/clicache/src/CacheableVector.hpp
+++ b/clicache/src/CacheableVector.hpp
@@ -42,7 +42,7 @@ namespace Apache
       /// a distributable object for caching. This class extends .NET generic
       /// <c>List</c> class.
       /// </summary>
-      ref class CacheableVector
+      public ref class CacheableVector
         : public IDataSerializablePrimitive
       {
       public:


### PR DESCRIPTION
Several of the provided .NET Cacheable types were missing the public attribute. 