### PR TITLE
Fix LGTM Usless Variable Assigment in C# files

### DIFF
--- a/clicache/integration-test/AttributesMutatorTestsN.cs
+++ b/clicache/integration-test/AttributesMutatorTestsN.cs
@@ -144,7 +144,7 @@ namespace Apache.Geode.Client.UnitTests
       m_reg3Writer1 = new TallyWriter<string, string>();
       var regionAttributesFactory = new RegionAttributesFactory<string, string>();
 
-      GIRegion region = CacheHelper.CreateRegion<string, string>(PeerRegionName,
+      CacheHelper.CreateRegion<string, string>(PeerRegionName,
         regionAttributesFactory.Create());
 
       SetCacheListener(PeerRegionName, m_reg3Listener1);
@@ -166,7 +166,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       var regionAttributesFactory = new RegionAttributesFactory<string, string>();
 
-      GIRegion region = CacheHelper.CreateRegion<string, string>(PeerRegionName,
+      CacheHelper.CreateRegion<string, string>(PeerRegionName,
         regionAttributesFactory.Create());
 
       CreateEntry(RegionNames[0], m_keys[1], m_vals[1]);

--- a/clicache/integration-test/BuiltinCacheableWrappersN.cs
+++ b/clicache/integration-test/BuiltinCacheableWrappersN.cs
@@ -635,7 +635,7 @@ namespace Apache.Geode.Client.UnitTests
 
     public override void InitRandomValue(int maxSize)
     {
-      int rnd = Util.Rand(int.MaxValue);
+
       //DateTime value = DateTime.Now.AddMilliseconds(rnd % 2 == 0 ? rnd : -rnd);
       DateTime value = new DateTime(CacheableHelper.ConstantDateTime);
       m_cacheableObject = value;
@@ -2241,7 +2241,7 @@ namespace Apache.Geode.Client.UnitTests
 
     public override uint GetChecksum(object cacheableObject)
     {
-      CacheableUndefined value = cacheableObject as CacheableUndefined;
+
       // TODO: [sumedh] server sends back null; check this
       //Assert.IsNotNull(value, "GetChecksum: Null object.");
 

--- a/clicache/integration-test/DistOpsStepsN.cs
+++ b/clicache/integration-test/DistOpsStepsN.cs
@@ -598,7 +598,7 @@ namespace Apache.Geode.Client.UnitTests
       foreach (UInt32 keyTypeId in registeredKeyTypeIds)
       {
         int numKeys;
-        numKeys = m_putGetTests_forFirstAppDomain.InitKeys(keyTypeId, PutGetTests.NumKeys, PutGetTests.KeySize);
+        m_putGetTests_forFirstAppDomain.InitKeys(keyTypeId, PutGetTests.NumKeys, PutGetTests.KeySize);
         numKeys = m_putGetTests_forSecondAppDomain.InitKeys(keyTypeId, PutGetTests.NumKeys, PutGetTests.KeySize);
         Type keyType = CacheableWrapperFactory.GetTypeForId(keyTypeId);
 
@@ -1281,7 +1281,7 @@ namespace Apache.Geode.Client.UnitTests
       // Try putting using Item_Set, an entry in region with key as null, should get IllegalArgumentException.
       try
       {
-        Object val = region[NullKey];//null
+        region.Get(NullKey);
         Assert.Fail("Should have got IllegalArgumentException");
       }
       catch (IllegalArgumentException)
@@ -1317,7 +1317,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        Object val = region[1];
+        region.Get(1);
         Assert.Fail("Should have got KeyNotFoundException");
       }
       catch (Apache.Geode.Client.KeyNotFoundException ex)
@@ -1330,7 +1330,7 @@ namespace Apache.Geode.Client.UnitTests
       region.Invalidate(1);
       try
       {
-        Object val = region[1];
+        region.Get(1);
         if (!isRemoteInstance)
         {
           Assert.Fail("Should have got KeyNotFoundException");
@@ -1345,7 +1345,7 @@ namespace Apache.Geode.Client.UnitTests
       //Remove an entry and then do a get on to it, should throw KeyNotFoundException.
       try
       {
-        Object val = region[1];
+        region.Get(1);
         Assert.Fail("Should have got KeyNotFoundException");
       }
       catch (Apache.Geode.Client.KeyNotFoundException ex)
@@ -1659,7 +1659,7 @@ namespace Apache.Geode.Client.UnitTests
     public virtual void Idictionary_CopyTo_Step<TKey, TValue>(IRegion<TKey, TValue> region, TypesClass type, int KeyId, int ValueId)
     {
       Util.Log("Idictionary_CopyTo_Step KeyId = {0} , valueId = {1} ", KeyId, ValueId);
-      ICollection<KeyValuePair<TKey, TValue>> IcollectionRegion = region;
+
 
       // Create an destination array of size 5 
       KeyValuePair<TKey, TValue>[] DestinationArray = new KeyValuePair<TKey, TValue>[5];
@@ -1733,7 +1733,7 @@ namespace Apache.Geode.Client.UnitTests
     public virtual void Idictionary_Array_CopyTo_Step<TKey, TValue>(IRegion<TKey, TValue> region, TypesClass type, int KeyId, int ValueId)
     {
       Util.Log("Idictionary_Array_CopyTo_Step KeyId = {0} , valueId = {1} ", KeyId, ValueId);
-      ICollection<KeyValuePair<TKey, TValue>> IcollectionRegion = region;
+
 
       // Create an destination array of size 5 
       KeyValuePair<TKey, TValue>[] DestinationArray = new KeyValuePair<TKey, TValue>[5];
@@ -1860,7 +1860,7 @@ namespace Apache.Geode.Client.UnitTests
       // Chk before doing generic Enumerator's MoveNext what is the value at Current and that exception is thrown.
       try
       {
-        Object r = RegionGenericEnumerator.Current;
+        var unused = RegionGenericEnumerator.Current;
         Assert.Fail("Should have got InvalidOperationException");
       }
       catch (InvalidOperationException ex)
@@ -1871,7 +1871,7 @@ namespace Apache.Geode.Client.UnitTests
       // Chk before doing non-generic Enumerator's MoveNext what is the value at Current and that exception is thrown.
       try
       {
-        Object r = RegionEnumerator.Current;
+        var unused = RegionEnumerator.Current;
         Assert.Fail("Should have got InvalidOperationException");
       }
       catch (InvalidOperationException ex)
@@ -1884,7 +1884,7 @@ namespace Apache.Geode.Client.UnitTests
       RegionGenericEnumerator.Reset();
       try
       {
-        Object r = RegionGenericEnumerator.Current;
+        var unused = RegionGenericEnumerator.Current;
         Assert.Fail("Should have got InvalidOperationException");
       }
       catch (InvalidOperationException ex)
@@ -1896,7 +1896,7 @@ namespace Apache.Geode.Client.UnitTests
       RegionEnumerator.Reset();
       try
       {
-        Object r = RegionEnumerator.Current;
+        var unused = RegionEnumerator.Current;
         Assert.Fail("Should have got InvalidOperationException");
       }
       catch (InvalidOperationException ex)
@@ -1964,7 +1964,7 @@ namespace Apache.Geode.Client.UnitTests
       }
 
       Assert.IsTrue(5 == RegionEntryCount, "Region entry count does not match.");
-      RegionEntryCount = 0;
+
       Util.Log("Idictionary_GetEnumerator_Step 5 complete.");
 
       // Chk after doing Generic Enumerator's MoveNext to end what is the value at Current and that exception is thrown.      
@@ -1972,7 +1972,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        Object r = RegionGenericEnumerator.Current;
+        var unused = RegionGenericEnumerator.Current;
         Assert.Fail("Should have got InvalidOperationException");
       }
       catch (InvalidOperationException ex)
@@ -1983,7 +1983,7 @@ namespace Apache.Geode.Client.UnitTests
       RegionEnumerator.MoveNext();
       try
       {
-        Object r = RegionEnumerator.Current;
+        var unused = RegionEnumerator.Current;
         Assert.Fail("Should have got InvalidOperationException");
       }
       catch (InvalidOperationException ex)
@@ -2008,7 +2008,7 @@ namespace Apache.Geode.Client.UnitTests
       // Chk before doing generic Enumerator's MoveNext what is the value at Current and that exception is thrown.
       try
       {
-        Object r = RegionGenericEnumerator.Current;
+        var unused = RegionGenericEnumerator.Current;
         Assert.Fail("Should have got InvalidOperationException");
       }
       catch (InvalidOperationException ex)
@@ -2019,7 +2019,7 @@ namespace Apache.Geode.Client.UnitTests
       // Chk before doing non-generic Enumerator's MoveNext what is the value at Current and that exception is thrown.
       try
       {
-        Object r = RegionEnumerator.Current;
+        var unused = RegionEnumerator.Current;
         Assert.Fail("Should have got InvalidOperationException");
       }
       catch (InvalidOperationException ex)
@@ -2032,7 +2032,7 @@ namespace Apache.Geode.Client.UnitTests
       RegionGenericEnumerator.Reset();
       try
       {
-        Object r = RegionGenericEnumerator.Current;
+        var unused = RegionGenericEnumerator.Current;
         Assert.Fail("Should have got InvalidOperationException");
       }
       catch (InvalidOperationException ex)
@@ -2044,7 +2044,7 @@ namespace Apache.Geode.Client.UnitTests
       RegionEnumerator.Reset();
       try
       {
-        Object r = RegionEnumerator.Current;
+        var unused = RegionEnumerator.Current;
         Assert.Fail("Should have got InvalidOperationException");
       }
       catch (InvalidOperationException ex)
@@ -2112,7 +2112,7 @@ namespace Apache.Geode.Client.UnitTests
       }
 
       Assert.IsTrue(5 == RegionEntryCount, "Region entry count does not match.");
-      RegionEntryCount = 0;
+
       Util.Log("Idictionary_Array_GetEnumerator_Step 5 complete.");
 
       // Chk after doing Generic Enumerator's MoveNext to end what is the value at Current and that exception is thrown.      
@@ -2120,7 +2120,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        Object r = RegionGenericEnumerator.Current;
+        var unused = RegionGenericEnumerator.Current;
         Assert.Fail("Should have got InvalidOperationException");
       }
       catch (InvalidOperationException ex)
@@ -2131,7 +2131,7 @@ namespace Apache.Geode.Client.UnitTests
       RegionEnumerator.MoveNext();
       try
       {
-        Object r = RegionEnumerator.Current;
+        var unused = RegionEnumerator.Current;
         Assert.Fail("Should have got InvalidOperationException");
       }
       catch (InvalidOperationException ex)
@@ -2240,7 +2240,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        bool r = region.IsReadOnly;
+        var unused = region.IsReadOnly;
       }
       catch (NotImplementedException ex)
       {
@@ -2346,7 +2346,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        bool r = region.IsReadOnly;
+        var unused = region.IsReadOnly;
       }
       catch (NotImplementedException ex)
       {

--- a/clicache/integration-test/DistributedSystemTests.cs
+++ b/clicache/integration-test/DistributedSystemTests.cs
@@ -87,8 +87,8 @@ namespace Apache.Geode.Client.UnitTests
 
           try
           {
-            Region region1 = CacheHelper.CreatePlainRegion("R1");
-            Region region2 = CacheHelper.CreatePlainRegion("R2");
+            CacheHelper.CreatePlainRegion("R1");
+            CacheHelper.CreatePlainRegion("R2");
           }
           finally
           {

--- a/clicache/integration-test/ExpirationTestsN.cs
+++ b/clicache/integration-test/ExpirationTestsN.cs
@@ -133,7 +133,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       Do1Put();
       Thread.Sleep(sleepSecs * 1000);
-      object val = m_region[m_key];
+      m_region.Get(m_key);
     }
 
     private void PutNKeysNoExpire(int numKeys, int sleepSecs)
@@ -332,7 +332,7 @@ namespace Apache.Geode.Client.UnitTests
       m_regionName = "RK4";
       SetupRegion(0, 4, 0, 7);
       PutNKeysNoExpire(1, 3);
-      object val = m_region[m_key];
+      m_region.Get(m_key);
       CheckRegion(false, 5);
       CheckRegion(true, 5);
     }

--- a/clicache/integration-test/OverflowTestsN.cs
+++ b/clicache/integration-test/OverflowTestsN.cs
@@ -536,7 +536,7 @@ namespace Apache.Geode.Client.UnitTests
         Properties<string, string> pconfig2 = attrs2.PersistenceProperties;
         Assert.IsNotNull(pconfig2, "Persistence properties should not be null for root2.");
         persistenceDir = (string)pconfig2.Find("PersistenceDirectory");
-        maxPageCount = (string)pconfig2.Find("MaxPageCount");
+        pconfig2.Find("MaxPageCount");
         maxPageCount = (string)pconfig2.Find("PageSize");
         Assert.IsNotNull(persistenceDir, "Persistence directory should not be null.");
         Assert.AreNotEqual(0, persistenceDir.Length, "Persistence directory should not be empty.");

--- a/clicache/integration-test/PutGetTestsN.cs
+++ b/clicache/integration-test/PutGetTestsN.cs
@@ -319,7 +319,7 @@ namespace Apache.Geode.Client.UnitTests
         // not really interested in results but loop through them neverthless
         Util.Log("DoRunQuery: obtained {0} results", results.Size);
         int numResults = 0;
-        foreach (object res in results)
+        foreach (object useless in results)
         {
           ++numResults;
         }
@@ -503,8 +503,8 @@ namespace Apache.Geode.Client.UnitTests
     {
       ICollection<UInt32> registeredKeyTypeIds =
         CacheableWrapperFactory.GetRegisteredKeyTypeIds();
-      ICollection<UInt32> registeredValueTypeIds =
-        CacheableWrapperFactory.GetRegisteredValueTypeIds();
+
+      CacheableWrapperFactory.GetRegisteredValueTypeIds();
 
       client1.Call(CacheableHelper.RegisterBuiltinsJavaHashCode, dtTime);
       client2.Call(CacheableHelper.RegisterBuiltinsJavaHashCode, dtTime);
@@ -514,7 +514,7 @@ namespace Apache.Geode.Client.UnitTests
         int numKeys;
         client1.Call(InitKeys, out numKeys, keyTypeId, NumKeys, KeySize);
         client2.Call(InitKeys, out numKeys, keyTypeId, NumKeys, KeySize);
-        Type keyType = CacheableWrapperFactory.GetTypeForId(keyTypeId);
+        CacheableWrapperFactory.GetTypeForId(keyTypeId);
         StartTimer();
         Util.Log("Running warmup task which verifies the puts.");
         DoHashCodePuts(client1, client2, regionName);

--- a/clicache/integration-test/RegionFailingTests.cs
+++ b/clicache/integration-test/RegionFailingTests.cs
@@ -119,8 +119,6 @@ namespace Apache.Geode.Client.UnitTests
       CacheHelper.StartJavaServerWithLocators(1, "GFECS1", 1);
       Util.Log("Cacheserver 1 started.");
 
-      var putGetTest = new PutGetTests();
-
       _client1.Call(InitializeAppDomain);
       var dtTime = DateTime.Now.Ticks;
       _client1.Call(CreateTCRegions_Pool_AD, RegionNames,

--- a/clicache/integration-test/TestCacheXmlInitializationN.cs
+++ b/clicache/integration-test/TestCacheXmlInitializationN.cs
@@ -62,7 +62,7 @@ namespace Apache.Geode.Client.UnitTests
 
             CacheHelper.InitConfig("client_pdx.xml");
 
-            var region = CacheHelper.GetRegion<object, object>("DistRegionAck");
+            CacheHelper.GetRegion<object, object>("DistRegionAck");
 
             Close();
         }

--- a/clicache/integration-test/ThinClientAppDomainQueryTests.cs
+++ b/clicache/integration-test/ThinClientAppDomainQueryTests.cs
@@ -194,7 +194,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       bool ErrorOccurred = false;
 
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
 
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
 
@@ -214,7 +214,7 @@ namespace Apache.Geode.Client.UnitTests
 
         try
         {
-          ISelectResults<object> results = query.Execute();
+          query.Execute();
 
           Util.Log("Query exception did not occur for index {0}.", qryIdx);
           ErrorOccurred = true;

--- a/clicache/integration-test/ThinClientCSTXN.cs
+++ b/clicache/integration-test/ThinClientCSTXN.cs
@@ -165,8 +165,7 @@ namespace Apache.Geode.Client.UnitTests
       else
         m_listener = null;
 
-      Region region = null;
-      region = CacheHelper.CreateTCRegion_Pool<object, object>(regionName, false, false,
+      CacheHelper.CreateTCRegion_Pool<object, object>(regionName, false, false,
         m_listener, locators, "__TESTPOOL1_", false);
 
     }
@@ -787,11 +786,11 @@ namespace Apache.Geode.Client.UnitTests
       for (int i = 0; i < 10; i++)
       {
         o_region1.Region[i] = i + 1;
-        object ret = o_region1.Region[i];
+        o_region1.Region.Get(i);
         o_region1.Region[i + 10] = i + 10;
-        ret = o_region1.Region[i + 10];
+        o_region1.Region.Get(i + 10);
         o_region1.Region[i + 20] = i + 20;
-        ret = o_region1.Region[i + 20];
+        o_region1.Region.Get(i + 20);
       }
       CacheHelper.CSTXManager.Commit();
       Util.Log("Region keys count after commit for non-pdx keys = {0} ", o_region1.Region.Keys.Count);

--- a/clicache/integration-test/ThinClientCallbackArgN.cs
+++ b/clicache/integration-test/ThinClientCallbackArgN.cs
@@ -245,8 +245,8 @@ namespace Apache.Geode.Client.UnitTests
       {
         m_listener = null;
       }
-      GIRegion region = null;
-      region = CacheHelper.CreateTCRegion_Pool<int, object>(RegionName, true, caching,
+
+      CacheHelper.CreateTCRegion_Pool<int, object>(RegionName, true, caching,
         callbackLis, locators, "__TESTPOOL1_", true);
       CacheHelper.DCache.TypeRegistry.RegisterType(Portfolio.CreateDeserializable, 8);
       CacheHelper.DCache.TypeRegistry.RegisterType(Position.CreateDeserializable, 7);

--- a/clicache/integration-test/ThinClientCqAttributesMutatorTests.cs
+++ b/clicache/integration-test/ThinClientCqAttributesMutatorTests.cs
@@ -83,9 +83,9 @@ namespace Apache.Geode.Client.UnitTests
         /*ICacheableKey*/
         TKey key = ev.getKey();
 
-        CqOperation opType = ev.getQueryOperation();
+        ev.getQueryOperation();
         //CacheableString keyS = key as CacheableString;
-        string keyS = key.ToString(); //as string;
+        key.ToString();
         Portfolio pval = val as Portfolio;
         PortfolioPdx pPdxVal = val as PortfolioPdx;
         Assert.IsTrue((pPdxVal != null) || (pval != null));
@@ -178,11 +178,11 @@ namespace Apache.Geode.Client.UnitTests
         else
           m_eventCountBefore++;
 
-        TResult val = (TResult)ev.getNewValue();
+        ev.getNewValue();
         TKey key = ev.getKey();
 
-        CqOperation opType = ev.getQueryOperation();
-        string keyS = key.ToString(); //as string;      
+        ev.getQueryOperation();
+        key.ToString();
       }
       public virtual void OnError(CqEvent<TKey, TResult> ev)
       {

--- a/clicache/integration-test/ThinClientCqPdxTest.cs
+++ b/clicache/integration-test/ThinClientCqPdxTest.cs
@@ -83,9 +83,9 @@ namespace Apache.Geode.Client.UnitTests
         /*ICacheableKey*/
         TKey key = ev.getKey();
 
-        CqOperation opType = ev.getQueryOperation();
+        ev.getQueryOperation();
         //CacheableString keyS = key as CacheableString;
-        string keyS = key.ToString(); //as string;
+        key.ToString();
         Portfolio pval = val as Portfolio;
         PortfolioPdx pPdxVal = val as PortfolioPdx;
         Assert.IsTrue((pPdxVal != null) || (pval != null));
@@ -209,11 +209,11 @@ namespace Apache.Geode.Client.UnitTests
         else
           m_eventCountBefore++;
 
-        TResult val = (TResult)ev.getNewValue();
+        ev.getNewValue();
         TKey key = ev.getKey();
 
-        CqOperation opType = ev.getQueryOperation();
-        string keyS = key.ToString(); //as string;      
+        ev.getQueryOperation();
+        key.ToString();
       }
       public virtual void OnError(CqEvent<TKey, TResult> ev)
       {

--- a/clicache/integration-test/ThinClientCqStatusTest.cs
+++ b/clicache/integration-test/ThinClientCqStatusTest.cs
@@ -83,9 +83,9 @@ namespace Apache.Geode.Client.UnitTests
         /*ICacheableKey*/
         TKey key = ev.getKey();
 
-        CqOperation opType = ev.getQueryOperation();
+        ev.getQueryOperation();
         //CacheableString keyS = key as CacheableString;
-        string keyS = key.ToString(); //as string;
+        key.ToString();
         Portfolio pval = val as Portfolio;
         PortfolioPdx pPdxVal = val as PortfolioPdx;
         Assert.IsTrue((pPdxVal != null) || (pval != null));
@@ -209,11 +209,11 @@ namespace Apache.Geode.Client.UnitTests
         else
           m_eventCountBefore++;
 
-        TResult val = (TResult)ev.getNewValue();
+        ev.getNewValue();
         TKey key = ev.getKey();
 
-        CqOperation opType = ev.getQueryOperation();
-        string keyS = key.ToString(); //as string;      
+        ev.getQueryOperation();
+        key.ToString();
       }
       public virtual void OnError(CqEvent<TKey, TResult> ev)
       {

--- a/clicache/integration-test/ThinClientCqStatusTestTwoServers.cs
+++ b/clicache/integration-test/ThinClientCqStatusTestTwoServers.cs
@@ -76,9 +76,9 @@ namespace Apache.Geode.Client.UnitTests
       /*ICacheableKey*/
       TKey key = ev.getKey();
 
-      CqOperation opType = ev.getQueryOperation();
+      ev.getQueryOperation();
       //CacheableString keyS = key as CacheableString;
-      string keyS = key.ToString(); //as string;
+      key.ToString();
       Portfolio pval = val as Portfolio;
       PortfolioPdx pPdxVal = val as PortfolioPdx;
       Assert.IsTrue((pPdxVal != null) || (pval != null));
@@ -204,11 +204,11 @@ namespace Apache.Geode.Client.UnitTests
       else
         m_eventCountBefore++;
 
-      TResult val = (TResult)ev.getNewValue();
+      ev.getNewValue();
       TKey key = ev.getKey();
 
-      CqOperation opType = ev.getQueryOperation();
-      string keyS = key.ToString(); //as string;      
+      ev.getQueryOperation();
+      key.ToString();
     }
     public virtual void OnError(CqEvent<TKey, TResult> ev)
     {

--- a/clicache/integration-test/ThinClientCqTest.cs
+++ b/clicache/integration-test/ThinClientCqTest.cs
@@ -83,9 +83,9 @@ namespace Apache.Geode.Client.UnitTests
         /*ICacheableKey*/
         TKey key = ev.getKey();
 
-        CqOperation opType = ev.getQueryOperation();
+        ev.getQueryOperation();
         //CacheableString keyS = key as CacheableString;
-        string keyS = key.ToString(); //as string;
+        key.ToString();
         Portfolio pval = val as Portfolio;
         PortfolioPdx pPdxVal = val as PortfolioPdx;
         Assert.IsTrue((pPdxVal != null) || (pval != null));
@@ -209,11 +209,11 @@ namespace Apache.Geode.Client.UnitTests
         else
           m_eventCountBefore++;
 
-        TResult val = (TResult)ev.getNewValue();
+        ev.getNewValue();
         TKey key = ev.getKey();
 
-        CqOperation opType = ev.getQueryOperation();
-        string keyS = key.ToString(); //as string;      
+        ev.getQueryOperation();
+        key.ToString();
       }
       public virtual void OnError(CqEvent<TKey, TResult> ev)
       {

--- a/clicache/integration-test/ThinClientDeltaTest.cs
+++ b/clicache/integration-test/ThinClientDeltaTest.cs
@@ -208,7 +208,7 @@ namespace Apache.Geode.Client.UnitTests
 
     public void createExpirationRegion(string name, string poolName)
     {
-      IRegion<object, object> region = CacheHelper.CreateExpirationRegion<object, object>(name,
+      CacheHelper.CreateExpirationRegion<object, object>(name,
           poolName, ExpirationAction.LocalInvalidate, TimeSpan.FromSeconds(5));
     }
 

--- a/clicache/integration-test/ThinClientDurableTestsN.cs
+++ b/clicache/integration-test/ThinClientDurableTestsN.cs
@@ -219,7 +219,7 @@ namespace Apache.Geode.Client.UnitTests
         {
           try
           {
-            int pendingEventCount = pool.PendingEventCount;
+            var unused = pool.PendingEventCount;
             Util.Log("PendingEventCount Should have got exception ");
             Assert.Fail("PendingEventCount Should have got exception");
           }

--- a/clicache/integration-test/ThinClientFunctionExecutionTestsN.cs
+++ b/clicache/integration-test/ThinClientFunctionExecutionTestsN.cs
@@ -383,7 +383,7 @@ namespace Apache.Geode.Client.UnitTests
       //TODO::enable it once the StringArray conversion is fixed.
       //test withCollector
       MyResultCollector<object> myRC = new MyResultCollector<object>();
-      rc = exc.WithArgs<ArrayList>(args1).WithCollector(myRC).Execute(getFuncIName);
+      exc.WithArgs<ArrayList>(args1).WithCollector(myRC).Execute(getFuncIName);
       //executeFunctionResult = rc.GetResult();
       Util.Log("add result count= {0}.", myRC.GetAddResultCount());
       Util.Log("get result count= {0}.", myRC.GetGetResultCount());
@@ -443,7 +443,7 @@ namespace Apache.Geode.Client.UnitTests
      
       MyResultCollector<int> myRC = new MyResultCollector<int>();
       Apache.Geode.Client.Execution<int> exc = Client.FunctionService<int>.OnServers/*OnRegion<string, string>*/(pl/*region*/);
-      Client.IResultCollector<int> rc = exc.WithArgs<int>(args1).WithCollector(myRC).Execute("SingleStrGetFunction");
+      exc.WithArgs<int>(args1).WithCollector(myRC).Execute("SingleStrGetFunction");
       
       Util.Log("add result count= {0}.", myRC.GetAddResultCount());
       Util.Log("get result count= {0}.", myRC.GetGetResultCount());
@@ -494,7 +494,7 @@ namespace Apache.Geode.Client.UnitTests
 
       MyResultCollector<string> myRC = new MyResultCollector<string>();
       Apache.Geode.Client.Execution<string> exc = Client.FunctionService<string>.OnServers/*OnRegion<string, string>*/(pl/*region*/);
-      Client.IResultCollector<string> rc = exc.WithArgs<ArrayList>(args1).WithCollector(myRC).Execute("SingleStrGetFunction");
+      exc.WithArgs<ArrayList>(args1).WithCollector(myRC).Execute("SingleStrGetFunction");
       
       Util.Log("add result count= {0}.", myRC.GetAddResultCount());
       Util.Log("get result count= {0}.", myRC.GetGetResultCount());
@@ -864,7 +864,7 @@ namespace Apache.Geode.Client.UnitTests
 
       Execution<object> exc = Client.FunctionService<object>.OnRegion<object, object>(region);
 
-      IResultCollector<object> rc = exc.WithFilter<object>(filter).Execute(putFuncName);
+      exc.WithFilter<object>(filter).Execute(putFuncName);
 
       Util.Log("Executing ExecuteFunctionOnRegion on region for execKeys for arrList arguement done.");
 
@@ -896,7 +896,7 @@ namespace Apache.Geode.Client.UnitTests
         }
         Util.Log("filter count= {0}.", filter.Length);
 
-        object args = true;
+
 
         Execution<object> exc = Client.FunctionService<object>.OnRegion<object, object>(region);
 
@@ -973,7 +973,7 @@ namespace Apache.Geode.Client.UnitTests
         }
         Util.Log("filter count= {0}.", filter.Length);
 
-        object args = true;
+
 
         Execution<object> exc = Client.FunctionService<object>.OnRegion<object, object>(region);
 
@@ -1050,7 +1050,7 @@ namespace Apache.Geode.Client.UnitTests
         }
         Util.Log("filter count= {0}.", filter.Length);
 
-        object args = true;
+
 
         Execution<object> exc = Client.FunctionService<object>.OnRegion<object, object>(region);
 
@@ -1078,7 +1078,7 @@ namespace Apache.Geode.Client.UnitTests
 
         MyResultCollector<object> myRC1 = new MyResultCollector<object>();
         rc = exc.WithFilter<object>(filter).WithCollector(myRC1).Execute(FEOnRegionPrSHOP);
-        executeFunctionResult = rc.GetResult();
+        rc.GetResult();
         Util.Log("add result count= {0}.", myRC1.GetAddResultCount());
         Util.Log("get result count= {0}.", myRC1.GetGetResultCount());
         Util.Log("end result count= {0}.", myRC1.GetEndResultCount());
@@ -1097,7 +1097,7 @@ namespace Apache.Geode.Client.UnitTests
 
         MyResultCollector<object> myRC2 = new MyResultCollector<object>();
         rc = exc.WithFilter<object>(filter).WithCollector(myRC2).Execute(FEOnRegionPrSHOP_OptimizeForWrite);
-        executeFunctionResult = rc.GetResult();
+        rc.GetResult();
         Util.Log("add result count= {0}.", myRC2.GetAddResultCount());
         Util.Log("get result count= {0}.", myRC2.GetGetResultCount());
         Util.Log("end result count= {0}.", myRC2.GetEndResultCount());
@@ -1133,7 +1133,7 @@ namespace Apache.Geode.Client.UnitTests
       // w/o filter
       MyResultCollector<object> rC = new MyResultCollector<object>();
       IResultCollector<Object> Rcollector = exe.WithCollector(rC).Execute(FEOnRegionPrSHOP);
-      FunctionResult = Rcollector.GetResult();
+      Rcollector.GetResult();
       Util.Log("add result count= {0}.", rC.GetAddResultCount());
       Util.Log("get result count= {0}.", rC.GetGetResultCount());
       Util.Log("end result count= {0}.", rC.GetEndResultCount());

--- a/clicache/integration-test/ThinClientListenerWriterN.cs
+++ b/clicache/integration-test/ThinClientListenerWriterN.cs
@@ -146,7 +146,7 @@ namespace Apache.Geode.Client.UnitTests
       Util.Log("GetOp started");
       o_region = new RegionOperation(RegionName);
       Region r = o_region.Region;
-      Object val  = r[key];
+      r.Get(key);
       Thread.Sleep(1000); // let the events reach at other end.
       Util.Log("GetOp finished");
     }

--- a/clicache/integration-test/ThinClientPdxLocalTests.cs
+++ b/clicache/integration-test/ThinClientPdxLocalTests.cs
@@ -118,10 +118,10 @@ namespace Apache.Geode.Client.UnitTests
       var p1 = new PdxTypes1();
       var x = "";
       localregion.Add(p1, x);
-      var val = localregion[p1];
+      localregion.Get(p1);
       //object val = region0[p1];
-      val = localregion[p1];
-      val = localregion[p1];
+      localregion.Get(p1);
+      var val = localregion[p1];
       Assert.IsTrue(val.Equals(x), "value should be equal");
       Assert.IsTrue(localregion.Remove(new KeyValuePair<object, object>(p1, x)),
         "Result of remove should be true, as this value null exists locally.");
@@ -140,7 +140,7 @@ namespace Apache.Geode.Client.UnitTests
       localregion.Invalidate(p1);
       try
       {
-        var retVal = localregion[p1];
+        localregion.Get(p1);
       }
       catch (Client.KeyNotFoundException)
       {
@@ -191,8 +191,6 @@ namespace Apache.Geode.Client.UnitTests
       localregion[p4] = p1;
       Assert.IsTrue(localregion.Remove(p4), "Result of remove should be true, as this value exists locally.");
       Assert.IsFalse(localregion.ContainsKey(p4), "containsKey should be false");
-
-      var p5 = new PdxTypes5();
 
       //object cval = region0[p1]; //this will only work when caching is enable else throws KeyNotFoundException
 

--- a/clicache/integration-test/ThinClientPdxTests1.cs
+++ b/clicache/integration-test/ThinClientPdxTests1.cs
@@ -106,7 +106,7 @@ namespace Apache.Geode.Client.UnitTests
 
       region0[1] = new PdxType();
 
-      var pRet = (PdxType) region0[1];
+      region0.Get(1);
       checkPdxInstanceToStringAtServer(region0);
 
       Assert.AreEqual(CacheHelper.DCache.GetPdxReadSerialized(), false,
@@ -119,7 +119,7 @@ namespace Apache.Geode.Client.UnitTests
 
       var region0 = CacheHelper.GetVerifyRegion<object, object>(m_regionNames[0]);
 
-      var pRet = (PdxType) region0[1];
+      region0.Get(1);
       checkPdxInstanceToStringAtServer(region0);
     }
 
@@ -216,7 +216,7 @@ namespace Apache.Geode.Client.UnitTests
       {
         var pf = new PortfolioPdx(1001, 10);
         region0[20] = pf;
-        var retpf = (PortfolioPdx) region0[20];
+        region0.Get(20);
         checkPdxInstanceToStringAtServer(region0);
         //Assert.AreEqual(p9, pRet9);
       }
@@ -224,7 +224,7 @@ namespace Apache.Geode.Client.UnitTests
       {
         var pf = new PortfolioPdx(1001, 10, new string[] {"one", "two", "three"});
         region0[21] = pf;
-        var retpf = (PortfolioPdx) region0[21];
+        region0.Get(21);
         checkPdxInstanceToStringAtServer(region0);
         //Assert.AreEqual(p9, pRet9);
       }
@@ -324,11 +324,11 @@ namespace Apache.Geode.Client.UnitTests
         checkPdxInstanceToStringAtServer(region0);
       }
       {
-        var retpf = (PortfolioPdx) region0[20];
+        region0.Get(20);
         checkPdxInstanceToStringAtServer(region0);
       }
       {
-        var retpf = (PortfolioPdx) region0[21];
+        region0.Get(21);
         checkPdxInstanceToStringAtServer(region0);
       }
       {
@@ -627,7 +627,7 @@ namespace Apache.Geode.Client.UnitTests
       region0[1] = 123;
 
       //Get
-      var value = (int) region0[1];
+      region0.Get(1);
       //Util.Log("JavaPutGet_LinedListType value received = " + value);
 
       //verify that listener methods have been called.
@@ -672,7 +672,7 @@ namespace Apache.Geode.Client.UnitTests
       var np = new PdxType();
       region0[1] = np;
 
-      var pRet = (PdxType) region0[1];
+      region0.Get(1);
 
       //Assert.AreEqual(np, pRet);
 
@@ -691,11 +691,9 @@ namespace Apache.Geode.Client.UnitTests
 
       var region0 = CacheHelper.GetVerifyRegion<object, object>(m_regionNames[0]);
 
-      var np = new PdxType();
+      region0.Get(1);
 
-      var pRet = (PdxType) region0[1];
-
-      var putFromjava = (PdxType) region0["putFromjava"];
+      region0.Get("putFromjava");
     }
 
     private void runJavaInterOpsWithLinkedListType()

--- a/clicache/integration-test/ThinClientPdxTests2.cs
+++ b/clicache/integration-test/ThinClientPdxTests2.cs
@@ -121,7 +121,7 @@ namespace Apache.Geode.Client.UnitTests
 
       var pt = m_pdxVesionOneAsm.GetType("PdxVersionTests.PdxTypesIgnoreUnreadFields");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
     }
 
@@ -161,7 +161,7 @@ namespace Apache.Geode.Client.UnitTests
 
       var pt = m_pdxVesionTwoAsm.GetType("PdxVersionTests.PdxTypesIgnoreUnreadFields");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
     }
 
@@ -260,8 +260,8 @@ namespace Apache.Geode.Client.UnitTests
 
       region0[1] = new PdxTypes1();
       region0[2] = new PdxType();
-      var ret = region0[1];
-      ret = region0[2];
+      region0.Get(1);
+      region0.Get(2);
       Util.Log("Put from pool-2 completed");
 
       var pdxIds = CacheHelper.DCache.GetPdxTypeRegistry().testGetNumberOfPdxIds();
@@ -807,7 +807,6 @@ namespace Apache.Geode.Client.UnitTests
       var region0 = CacheHelper.GetVerifyRegion<object, object>(m_regionNames[0]);
 
       var ret = (IPdxInstance) region0["pdxput"];
-      var dPdxType = new PdxType();
 
       var pdxInstHashcode = ret.GetHashCode();
       Util.Log("pdxinstance hash code " + pdxInstHashcode);

--- a/clicache/integration-test/ThinClientPdxTests3.cs
+++ b/clicache/integration-test/ThinClientPdxTests3.cs
@@ -114,7 +114,7 @@ namespace Apache.Geode.Client.UnitTests
 
       var pt = m_pdxVesionOneAsm.GetType("PdxVersionTests.PdxTypes3");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
     }
 
@@ -135,7 +135,7 @@ namespace Apache.Geode.Client.UnitTests
       CacheHelper.DCache.TypeRegistry.RegisterPdxType(registerPdxTypeTwo3);
       var pt = m_pdxVesionTwoAsm.GetType("PdxVersionTests.PdxTypes3");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
     }
 
@@ -970,7 +970,7 @@ namespace Apache.Geode.Client.UnitTests
       var region0 = CacheHelper.GetVerifyRegion<object, object>(m_regionNames[0]);
       for (var i = 0; i < nPdxPuts; i++)
       {
-        var ret = region0[i];
+        region0.Get(i);
       }
 
       checkLocalCache();
@@ -1046,7 +1046,7 @@ namespace Apache.Geode.Client.UnitTests
       Assert.Greater(entryFound, 8, "enteries should be in local cache");
       Assert.Greater(nBAPuts, entryFound + 10, "pdx object should have evicted");
 
-      var mem = (int) GC.GetTotalMemory(true);
+      GC.GetTotalMemory(true);
       // if(checkmem)
       //Assert.Less(mem, 200000000, "Memory should be less then 200 mb");
     }
@@ -1068,7 +1068,7 @@ namespace Apache.Geode.Client.UnitTests
       var region0 = CacheHelper.GetVerifyRegion<object, object>(m_regionNames[0]);
       for (var i = 0; i < nBAPuts; i++)
       {
-        var ret = region0[i];
+        region0.Get(i);
       }
 
       checkLocalCacheBA(true);
@@ -1361,7 +1361,7 @@ namespace Apache.Geode.Client.UnitTests
       var np = pt.InvokeMember("PdxTypes3", BindingFlags.CreateInstance, null, null, null);
       region0[1] = np;
 
-      var pRet = region0[1];
+      region0.Get(1);
     }
 
     //this has v2 object
@@ -1375,7 +1375,7 @@ namespace Apache.Geode.Client.UnitTests
       var np = pt.InvokeMember("PdxTypes3", BindingFlags.CreateInstance, null, null, null);
 
       //get v1 ojbject ..
-      var pRet = (object) region0[1];
+      region0.Get(1);
 
       //now put v2 object
       region0[2] = np;
@@ -1460,7 +1460,7 @@ namespace Apache.Geode.Client.UnitTests
       var region0 = CacheHelper.GetVerifyRegion<object, object>(m_regionNames[0]);
       try
       {
-        var ret = region0[2];
+        region0.Get(2);
         Assert.Fail("Expected exception.");
       }
       catch (Exception)

--- a/clicache/integration-test/ThinClientPdxVersionTests.cs
+++ b/clicache/integration-test/ThinClientPdxVersionTests.cs
@@ -111,7 +111,7 @@ namespace Apache.Geode.Client.UnitTests
 
       var pt = m_pdxVesionOneAsm.GetType("PdxVersionTests.PdxTypes1");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
       m_useWeakHashMap = useWeakHashmap;
     }
@@ -133,7 +133,7 @@ namespace Apache.Geode.Client.UnitTests
       CacheHelper.DCache.TypeRegistry.RegisterPdxType(registerPdxTypeTwo);
       var pt = m_pdxVesionTwoAsm.GetType("PdxVersionTests.PdxTypes1");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
       m_useWeakHashMap = useWeakHashmap;
     }
@@ -287,7 +287,7 @@ namespace Apache.Geode.Client.UnitTests
 
       var pt = m_pdxVesionOneAsm.GetType("PdxVersionTests.PdxTypes2");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
     }
 
@@ -308,7 +308,7 @@ namespace Apache.Geode.Client.UnitTests
       CacheHelper.DCache.TypeRegistry.RegisterPdxType(registerPdxTypeTwo2);
       var pt = m_pdxVesionTwoAsm.GetType("PdxVersionTests.PdxTypes2");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
     }
 
@@ -334,7 +334,7 @@ namespace Apache.Geode.Client.UnitTests
 
       var pt = m_pdxVesionOneAsm.GetType("PdxVersionTests.PdxTypes3");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
     }
 
@@ -355,7 +355,7 @@ namespace Apache.Geode.Client.UnitTests
       CacheHelper.DCache.TypeRegistry.RegisterPdxType(registerPdxTypeTwo3);
       var pt = m_pdxVesionTwoAsm.GetType("PdxVersionTests.PdxTypes3");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
     }
 
@@ -381,7 +381,7 @@ namespace Apache.Geode.Client.UnitTests
 
       var pt = m_pdxVesionOneAsm.GetType("PdxVersionTests.PdxTypesR2");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
     }
 
@@ -403,7 +403,7 @@ namespace Apache.Geode.Client.UnitTests
 
       var pt = m_pdxVesionTwoAsm.GetType("PdxVersionTests.PdxTypesR2");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
     }
 
@@ -476,7 +476,7 @@ namespace Apache.Geode.Client.UnitTests
       m_pdxVesionOneAsm = Assembly.LoadFrom("PdxVersion1Lib.dll");
 
 
-      var pt = m_pdxVesionOneAsm.GetType("PdxVersionTests.TestDiffTypePdxS");
+      m_pdxVesionOneAsm.GetType("PdxVersionTests.TestDiffTypePdxS");
 
       //object ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null, new object[] { useWeakHashmap });
       m_useWeakHashMap = useWeakHashmap;
@@ -519,7 +519,7 @@ namespace Apache.Geode.Client.UnitTests
       var isKNFE = false;
       try
       {
-        pRet = region0.GetLocalView()[key];
+        region0.GetLocalView().Get(key);
       }
       catch (Client.KeyNotFoundException)
       {
@@ -541,7 +541,7 @@ namespace Apache.Geode.Client.UnitTests
       m_pdxVesionTwoAsm = Assembly.LoadFrom("PdxVersion2Lib.dll");
 
 
-      var pt = m_pdxVesionTwoAsm.GetType("PdxVersionTests.TestDiffTypePdxS");
+      m_pdxVesionTwoAsm.GetType("PdxVersionTests.TestDiffTypePdxS");
 
       //object ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null, new object[] { useWeakHashmap });
       m_useWeakHashMap = useWeakHashmap;
@@ -621,7 +621,7 @@ namespace Apache.Geode.Client.UnitTests
       var gotexcep = false;
       try
       {
-        var r = region0.GetLocalView()[key];
+        region0.GetLocalView().Get(key);
       }
       catch (Exception)
       {
@@ -722,7 +722,7 @@ namespace Apache.Geode.Client.UnitTests
 
       var pt = m_pdxVesionOneAsm.GetType("PdxVersionTests.PdxTypesR1");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
     }
 
@@ -744,7 +744,7 @@ namespace Apache.Geode.Client.UnitTests
 
       var pt = m_pdxVesionTwoAsm.GetType("PdxVersionTests.PdxTypesR1");
 
-      var ob = pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
+      pt.InvokeMember("Reset", BindingFlags.Default | BindingFlags.InvokeMethod, null, null,
         new object[] {useWeakHashmap});
     }
 
@@ -1067,11 +1067,11 @@ namespace Apache.Geode.Client.UnitTests
       region0[1] = pRet;
 
       pt = m_pdxVesionTwoAsm.GetType("PdxVersionTests.Pdx1");
-      var pdx1 = pt.InvokeMember("Pdx1", BindingFlags.CreateInstance, null, null, null);
+      pt.InvokeMember("Pdx1", BindingFlags.CreateInstance, null, null, null);
 
       for (var i = 1000; i < 1010; i++)
       {
-        var ret = region0[i];
+        region0.Get(i);
       }
     }
 

--- a/clicache/integration-test/ThinClientPoolTestsN.cs
+++ b/clicache/integration-test/ThinClientPoolTestsN.cs
@@ -293,7 +293,7 @@ namespace Apache.Geode.Client.UnitTests
         duplicateXMLFile = Util.Rand(3432898).ToString() + "invalid_cache_pool.xml";
         CacheHelper.createDuplicateXMLFile(xmlLocation, duplicateXMLFile);
         xmlLocation = duplicateXMLFile;
-        cache = new CacheFactory()
+        new CacheFactory()
             .Set("cache-xml-file", xmlLocation)
             .Create();
         Assert.Fail("invalid_cache_pool.xml did not throw exception");
@@ -310,7 +310,7 @@ namespace Apache.Geode.Client.UnitTests
         duplicateXMLFile = Util.Rand(3432898).ToString() + "invalid_cache_pool2.xml";
         CacheHelper.createDuplicateXMLFile(xmlLocation, duplicateXMLFile);
         xmlLocation = duplicateXMLFile;
-        cache = new CacheFactory()
+        new CacheFactory()
             .Set("cache-xml-file", xmlLocation)
             .Create();
         Assert.Fail("invalid_cache_pool2.xml did not throw exception");
@@ -327,7 +327,7 @@ namespace Apache.Geode.Client.UnitTests
         duplicateXMLFile = "invalid_cache_pool3.xml";
         CacheHelper.createDuplicateXMLFile(xmlLocation, duplicateXMLFile);
         xmlLocation = duplicateXMLFile;
-        cache = new CacheFactory()
+        new CacheFactory()
             .Set("cache-xml-file", xmlLocation)
             .Create();
         Assert.Fail("invalid_cache_pool3.xml did not throw exception");
@@ -344,7 +344,7 @@ namespace Apache.Geode.Client.UnitTests
         duplicateXMLFile = Util.Rand(3432898).ToString() + "invalid_cache_pool4.xml";
         CacheHelper.createDuplicateXMLFile(xmlLocation, duplicateXMLFile);
         xmlLocation = duplicateXMLFile;
-        cache = new CacheFactory()
+        new CacheFactory()
             .Set("cache-xml-file", xmlLocation)
             .Create();
         Assert.Fail("invalid_cache_pool4.xml did not throw exception");

--- a/clicache/integration-test/ThinClientQueryTestsN.cs
+++ b/clicache/integration-test/ThinClientQueryTestsN.cs
@@ -94,7 +94,7 @@ namespace Apache.Geode.Client.UnitTests
 				var poolFail = CacheHelper.DCache.GetPoolManager().CreateFactory().Create("_TESTFAILPOOL_");
 				var qsFail = poolFail.GetQueryService();
         var qryFail = qsFail.NewQuery<object>("select distinct * from /" + QERegionName);
-        var resultsFail = qryFail.Execute();
+        qryFail.Execute();
         Assert.Fail("Since no endpoints defined, so exception expected");
       }
       catch (IllegalStateException ex)
@@ -476,7 +476,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       bool ErrorOccurred = false;
 
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
 
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
 
@@ -496,7 +496,7 @@ namespace Apache.Geode.Client.UnitTests
 
         try
         {
-          ISelectResults<object> results = query.Execute();
+          query.Execute();
 
           Util.Log("Query exception did not occur for index {0}.", qryIdx);
           ErrorOccurred = true;
@@ -522,7 +522,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       bool ErrorOccurred = false;
 
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
 
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
 
@@ -563,7 +563,7 @@ namespace Apache.Geode.Client.UnitTests
 
         try
         {
-          ISelectResults<object> results = query.Execute(paramList);
+          query.Execute(paramList);
 
           Util.Log("Query exception did not occur for index {0}.", qryIdx);
           ErrorOccurred = true;
@@ -751,7 +751,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       bool ErrorOccurred = false;
 
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
 
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
 
@@ -771,7 +771,7 @@ namespace Apache.Geode.Client.UnitTests
 
         try
         {
-          ISelectResults<object> results = query.Execute();
+          query.Execute();
 
           Util.Log("Query exception did not occur for index {0}.", qryIdx);
           ErrorOccurred = true;
@@ -797,7 +797,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       bool ErrorOccurred = false;
 
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
 
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
 
@@ -839,7 +839,7 @@ namespace Apache.Geode.Client.UnitTests
 
         try
         {
-          ISelectResults<object> results = query.Execute(paramList);
+          query.Execute(paramList);
 
           Util.Log("Query exception did not occur for index {0}.", qryIdx);
           ErrorOccurred = true;
@@ -988,7 +988,7 @@ namespace Apache.Geode.Client.UnitTests
 
     public void StepThreeQT()
     {
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
       Util.Log("query " + QueryStatics.ResultSetQueries[34].Query);
       Query<object> query = qs.NewQuery<object>(QueryStatics.ResultSetQueries[34].Query);
@@ -1009,7 +1009,7 @@ namespace Apache.Geode.Client.UnitTests
 
     public void StepFourQT()
     {
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
 
       Query<object> query = qs.NewQuery<object>(QueryStatics.ResultSetQueries[35].Query);
@@ -1029,7 +1029,7 @@ namespace Apache.Geode.Client.UnitTests
 
     public void StepFiveQT()
     {
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
 
       Query<object> query = qs.NewQuery<object>(QueryStatics.StructSetQueries[17].Query);
@@ -1050,7 +1050,7 @@ namespace Apache.Geode.Client.UnitTests
 
     public void StepSixQT()
     {
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
       Query<object> query = qs.NewQuery<object>(QueryStatics.StructSetQueries[17].Query);
 
@@ -1069,7 +1069,7 @@ namespace Apache.Geode.Client.UnitTests
 
     public void StepThreePQT()
     {
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
 
       Query<object> query = qs.NewQuery<object>(QueryStatics.StructSetParamQueries[5].Query);
@@ -1111,7 +1111,7 @@ namespace Apache.Geode.Client.UnitTests
 
     public void StepFourPQT()
     {
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
 
       Query<object> query = qs.NewQuery<object>(QueryStatics.StructSetParamQueries[5].Query);
@@ -1195,7 +1195,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        ISelectResults<object> results = region.Query<object>("");
+        region.Query<object>("");
         Assert.Fail("Expected IllegalArgumentException exception for empty predicate");
       }
       catch (IllegalArgumentException ex)
@@ -1207,7 +1207,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        ISelectResults<object> results = region.Query<object>(QueryStatics.RegionQueries[0].Query, TimeSpan.FromSeconds(2200000));
+        region.Query<object>(QueryStatics.RegionQueries[0].Query, TimeSpan.FromSeconds(2200000));
         Assert.Fail("Expected IllegalArgumentException exception for invalid timeout");
       }
       catch (IllegalArgumentException ex)
@@ -1219,7 +1219,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        ISelectResults<object> results = region.Query<object>("bad predicate");
+        region.Query<object>("bad predicate");
         Assert.Fail("Expected QueryException exception for wrong predicate");
       }
       catch (QueryException ex)
@@ -1266,7 +1266,7 @@ namespace Apache.Geode.Client.UnitTests
       Assert.IsFalse(ErrorOccurred, "One or more query validation errors occurred.");
       try
       {
-        bool existsValue = region.ExistsValue("");
+        region.ExistsValue("");
         Assert.Fail("Expected IllegalArgumentException exception for empty predicate");
       }
       catch (IllegalArgumentException ex)
@@ -1278,7 +1278,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        bool existsValue = region.ExistsValue(QueryStatics.RegionQueries[0].Query, TimeSpan.FromSeconds(2200000));
+        region.ExistsValue(QueryStatics.RegionQueries[0].Query, TimeSpan.FromSeconds(2200000));
         Assert.Fail("Expected IllegalArgumentException exception for invalid timeout");
       }
       catch (IllegalArgumentException ex)
@@ -1290,7 +1290,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        bool existsValue = region.ExistsValue("bad predicate");
+        region.ExistsValue("bad predicate");
         Assert.Fail("Expected QueryException exception for wrong predicate");
       }
       catch (QueryException ex)
@@ -1321,7 +1321,7 @@ namespace Apache.Geode.Client.UnitTests
 
         try
         {
-          Object result = region.SelectValue(qrystr.Query);
+          region.SelectValue(qrystr.Query);
 
           if (!(QueryStatics.RegionQueryRowCounts[qryIdx] == 0 ||
             QueryStatics.RegionQueryRowCounts[qryIdx] == 1))
@@ -1358,7 +1358,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        Object result = region.SelectValue("");
+        region.SelectValue("");
         Assert.Fail("Expected IllegalArgumentException exception for empty predicate");
       }
       catch (IllegalArgumentException ex)
@@ -1370,7 +1370,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        Object result = region.SelectValue(QueryStatics.RegionQueries[0].Query, TimeSpan.FromSeconds(2200000));
+        region.SelectValue(QueryStatics.RegionQueries[0].Query, TimeSpan.FromSeconds(2200000));
         Assert.Fail("Expected IllegalArgumentException exception for invalid timeout");
       }
       catch (IllegalArgumentException ex)
@@ -1381,7 +1381,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        Object result = region.SelectValue("bad predicate");
+        region.SelectValue("bad predicate");
         Assert.Fail("Expected QueryException exception for wrong predicate");
       }
       catch (QueryException ex)
@@ -1411,7 +1411,7 @@ namespace Apache.Geode.Client.UnitTests
 
         try
         {
-          ISelectResults<object> results = region.Query<object>(qrystr.Query);
+          region.Query<object>(qrystr.Query);
 
           Util.Log("Query # {0} expected exception did not occur", qryIdx);
           ErrorOccurred = true;

--- a/clicache/integration-test/ThinClientRegionQueryTests.cs
+++ b/clicache/integration-test/ThinClientRegionQueryTests.cs
@@ -197,7 +197,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        ISelectResults<object> results = region.Query<object>("");
+        region.Query<object>("");
         Assert.Fail("Expected IllegalArgumentException exception for empty predicate");
       }
       catch (IllegalArgumentException ex)
@@ -209,7 +209,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        ISelectResults<object> results = region.Query<object>(QueryStatics.RegionQueries[0].Query, TimeSpan.FromSeconds(2200000));
+        region.Query<object>(QueryStatics.RegionQueries[0].Query, TimeSpan.FromSeconds(2200000));
         Assert.Fail("Expected IllegalArgumentException exception for invalid timeout");
       }
       catch (IllegalArgumentException ex)
@@ -221,7 +221,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        ISelectResults<object> results = region.Query<object>("bad predicate");
+        region.Query<object>("bad predicate");
         Assert.Fail("Expected QueryException exception for wrong predicate");
       }
       catch (QueryException ex)
@@ -268,7 +268,7 @@ namespace Apache.Geode.Client.UnitTests
       Assert.IsFalse(ErrorOccurred, "One or more query validation errors occurred.");
       try
       {
-        bool existsValue = region.ExistsValue("");
+        region.ExistsValue("");
         Assert.Fail("Expected IllegalArgumentException exception for empty predicate");
       }
       catch (IllegalArgumentException ex)
@@ -280,7 +280,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        bool existsValue = region.ExistsValue(QueryStatics.RegionQueries[0].Query, TimeSpan.FromSeconds(2200000));
+        region.ExistsValue(QueryStatics.RegionQueries[0].Query, TimeSpan.FromSeconds(2200000));
         Assert.Fail("Expected IllegalArgumentException exception for invalid timeout");
       }
       catch (IllegalArgumentException ex)
@@ -292,7 +292,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        bool existsValue = region.ExistsValue("bad predicate");
+        region.ExistsValue("bad predicate");
         Assert.Fail("Expected QueryException exception for wrong predicate");
       }
       catch (QueryException ex)
@@ -323,7 +323,7 @@ namespace Apache.Geode.Client.UnitTests
 
         try
         {
-          Object result = region.SelectValue(qrystr.Query);
+          region.SelectValue(qrystr.Query);
 
           if (!(QueryStatics.RegionQueryRowCounts[qryIdx] == 0 ||
             QueryStatics.RegionQueryRowCounts[qryIdx] == 1))
@@ -360,7 +360,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        Object result = region.SelectValue("");
+        region.SelectValue("");
         Assert.Fail("Expected IllegalArgumentException exception for empty predicate");
       }
       catch (IllegalArgumentException ex)
@@ -372,7 +372,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        Object result = region.SelectValue(QueryStatics.RegionQueries[0].Query, TimeSpan.FromSeconds(2200000));
+        region.SelectValue(QueryStatics.RegionQueries[0].Query, TimeSpan.FromSeconds(2200000));
         Assert.Fail("Expected IllegalArgumentException exception for invalid timeout");
       }
       catch (IllegalArgumentException ex)
@@ -383,7 +383,7 @@ namespace Apache.Geode.Client.UnitTests
 
       try
       {
-        Object result = region.SelectValue("bad predicate");
+        region.SelectValue("bad predicate");
         Assert.Fail("Expected QueryException exception for wrong predicate");
       }
       catch (QueryException ex)
@@ -413,7 +413,7 @@ namespace Apache.Geode.Client.UnitTests
 
         try
         {
-          ISelectResults<object> results = region.Query<object>(qrystr.Query);
+          region.Query<object>(qrystr.Query);
 
           Util.Log("Query # {0} expected exception did not occur", qryIdx);
           ErrorOccurred = true;

--- a/clicache/integration-test/ThinClientRemoteParamQueryResultSetTests.cs
+++ b/clicache/integration-test/ThinClientRemoteParamQueryResultSetTests.cs
@@ -273,7 +273,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       bool ErrorOccurred = false;
 
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
 
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
 
@@ -314,7 +314,7 @@ namespace Apache.Geode.Client.UnitTests
 
         try
         {
-          ISelectResults<object> results = query.Execute(paramList);
+          query.Execute(paramList);
 
           Util.Log("Query exception did not occur for index {0}.", qryIdx);
           ErrorOccurred = true;

--- a/clicache/integration-test/ThinClientRemoteParamQueryStructSetTests.cs
+++ b/clicache/integration-test/ThinClientRemoteParamQueryStructSetTests.cs
@@ -239,7 +239,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       bool ErrorOccurred = false;
 
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
 
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
 
@@ -281,7 +281,7 @@ namespace Apache.Geode.Client.UnitTests
 
         try
         {
-          ISelectResults<object> results = query.Execute(paramList);
+          query.Execute(paramList);
 
           Util.Log("Query exception did not occur for index {0}.", qryIdx);
           ErrorOccurred = true;

--- a/clicache/integration-test/ThinClientRemoteQueryExclusivenessTests.cs
+++ b/clicache/integration-test/ThinClientRemoteQueryExclusivenessTests.cs
@@ -92,7 +92,7 @@ namespace Apache.Geode.Client.UnitTests
 				var poolFail = CacheHelper.DCache.GetPoolManager().CreateFactory().Create("_TESTFAILPOOL_");
 				var qsFail = poolFail.GetQueryService();
         var qryFail = qsFail.NewQuery<object>("select distinct * from /" + QERegionName);
-        var resultsFail = qryFail.Execute();
+        qryFail.Execute();
         Assert.Fail("Since no endpoints defined, so exception expected");
       }
       catch (IllegalStateException ex)

--- a/clicache/integration-test/ThinClientRemoteQueryResultSetTests.cs
+++ b/clicache/integration-test/ThinClientRemoteQueryResultSetTests.cs
@@ -262,7 +262,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       bool ErrorOccurred = false;
 
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
 
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
 
@@ -282,7 +282,7 @@ namespace Apache.Geode.Client.UnitTests
 
         try
         {
-          ISelectResults<object> results = query.Execute();
+          query.Execute();
 
           Util.Log("Query exception did not occur for index {0}.", qryIdx);
           ErrorOccurred = true;

--- a/clicache/integration-test/ThinClientRemoteQueryStructSetTests.cs
+++ b/clicache/integration-test/ThinClientRemoteQueryStructSetTests.cs
@@ -219,7 +219,7 @@ namespace Apache.Geode.Client.UnitTests
     {
       bool ErrorOccurred = false;
 
-      QueryHelper<object, object> qh = QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
+      QueryHelper<object, object>.GetHelper(CacheHelper.DCache);
 
       var qs = CacheHelper.DCache.GetPoolManager().Find("__TESTPOOL1_").GetQueryService();
 
@@ -239,7 +239,7 @@ namespace Apache.Geode.Client.UnitTests
 
         try
         {
-          ISelectResults<object> results = query.Execute();
+          query.Execute();
 
           Util.Log("Query exception did not occur for index {0}.", qryIdx);
           ErrorOccurred = true;

--- a/clicache/integration-test/ThinClientSecurityAuthzTestBaseN.cs
+++ b/clicache/integration-test/ThinClientSecurityAuthzTestBaseN.cs
@@ -327,7 +327,7 @@ namespace Apache.Geode.Client.UnitTests
               }
               for (int keyNumIndex = 0; keyNumIndex < numOps; ++keyNumIndex)
               {
-                int keyNum = indices[keyNumIndex];
+                var unused = indices[keyNumIndex];
                 string expectedVal = valPrefix + keyNumIndex;
                 if (CheckFlags(flags, OpFlags.CheckFail))
                 {
@@ -353,7 +353,6 @@ namespace Apache.Geode.Client.UnitTests
 
             case OperationCode.GetServerKeys:
               breakLoop = true;
-              ICollection<object> serverKeys = region.Keys;
               break;
 
             //TODO: Need to fix System.ArgumentOutOfRangeException: Index was out of range. Know issue with GetAll()
@@ -420,7 +419,7 @@ namespace Apache.Geode.Client.UnitTests
               }
               CqAttributesFactory<object, object> cqattrsfact = new CqAttributesFactory<object, object>();
               CqAttributes<object, object> cqattrs = cqattrsfact.Create();
-              CqQuery<object, object> cq = qs.NewCq("cq_security", "SELECT * FROM /" + region.Name, cqattrs, false);
+              qs.NewCq("cq_security", "SELECT * FROM /" + region.Name, cqattrs, false);
               qs.ExecuteCqs();
               qs.StopCqs();
               qs.CloseCqs();
@@ -447,7 +446,7 @@ namespace Apache.Geode.Client.UnitTests
                 IRegionService userCache = CacheHelper.getMultiuserCache(creds);
                 Apache.Geode.Client.Execution<object> exe = Client.FunctionService<object>.OnServer(userCache);
                 exe.Execute("securityTest");
-                exe = Client.FunctionService<object>.OnServers(userCache);
+                Client.FunctionService<object>.OnServers(userCache);
                 Client.FunctionService<object>.OnRegion<object, object>(region);
                 Client.FunctionService<object>.OnRegion<object, object>(userCache.GetRegion<object, object>(region.Name)).Execute("FireNForget");
               }
@@ -539,7 +538,7 @@ namespace Apache.Geode.Client.UnitTests
           OperationCode authOpCode = currentOp.AuthzOperationCode;
           int[] indices = currentOp.Indices;
           CredentialGenerator cGen = gen.GetCredentialGenerator();
-          Properties<string, string> javaProps = null;
+
           if (CheckFlags(opFlags, OpFlags.CheckNotAuthz) ||
             CheckFlags(opFlags, OpFlags.UseNotAuthz))
           {
@@ -557,7 +556,7 @@ namespace Apache.Geode.Client.UnitTests
           }
           if (cGen != null)
           {
-            javaProps = cGen.JavaProperties;
+            var unused = cGen.JavaProperties;
           }
           clientProps = SecurityTestUtil.ConcatProperties(
             opCredentials, extraAuthProps, extraAuthzProps);

--- a/clicache/integration-test/ThinClientSecurityAuthzTestsMUN.cs
+++ b/clicache/integration-test/ThinClientSecurityAuthzTestsMUN.cs
@@ -568,7 +568,7 @@ namespace Apache.Geode.Client.UnitTests
         Properties<string, string> createCredentials = authzGen.GetAllowedCredentials(
           new OperationCode[] { OperationCode.Put },
           new string[] { RegionName }, 1);
-        javaProps = cGen.JavaProperties;
+        var unused = cGen.JavaProperties;
         Util.Log("AllowPutsGets: For first client PUT credentials: " +
           createCredentials);
         m_client1.Call(SecurityTestUtil.CreateClientMU, RegionName,
@@ -578,7 +578,7 @@ namespace Apache.Geode.Client.UnitTests
         Properties<string, string> getCredentials = authzGen.GetAllowedCredentials(
           new OperationCode[] { OperationCode.Get },
           new string[] { RegionName }, 2);
-        javaProps = cGen.JavaProperties;
+        unused = cGen.JavaProperties;
         Util.Log("AllowPutsGets: For second client GET credentials: " +
           getCredentials);
         m_client2.Call(SecurityTestUtil.CreateClientMU, RegionName,
@@ -630,14 +630,14 @@ namespace Apache.Geode.Client.UnitTests
 
         // Check that we indeed can obtain valid credentials not allowed to do
         // gets
-        Properties<string, string> createCredentials = authzGen.GetAllowedCredentials(
+        authzGen.GetAllowedCredentials(
           new OperationCode[] { OperationCode.Put },
           new string[] { RegionName }, 1);
-        Properties<string, string> createJavaProps = cGen.JavaProperties;
-        Properties<string, string> getCredentials = authzGen.GetDisallowedCredentials(
+        var unused = cGen.JavaProperties;
+        var getCredentials = authzGen.GetDisallowedCredentials(
           new OperationCode[] { OperationCode.Get },
           new string[] { RegionName }, 2);
-        Properties<string, string> getJavaProps = cGen.JavaProperties;
+        unused = cGen.JavaProperties;
         if (getCredentials == null || getCredentials.Size == 0)
         {
           Util.Log("DisallowPutsGets: Unable to obtain valid credentials " +
@@ -657,10 +657,10 @@ namespace Apache.Geode.Client.UnitTests
         Util.Log("Cacheserver 2 started.");
 
         // Start client1 with valid CREATE credentials
-        createCredentials = authzGen.GetAllowedCredentials(
+        var createCredentials = authzGen.GetAllowedCredentials(
             new OperationCode[] { OperationCode.Put },
             new string[] { RegionName }, 1);
-        javaProps = cGen.JavaProperties;
+        unused = cGen.JavaProperties;
         Util.Log("DisallowPutsGets: For first client PUT credentials: " +
           createCredentials);
         m_client1.Call(SecurityTestUtil.CreateClientMU, RegionName,
@@ -670,7 +670,7 @@ namespace Apache.Geode.Client.UnitTests
         getCredentials = authzGen.GetDisallowedCredentials(
             new OperationCode[] { OperationCode.Get },
             new string[] { RegionName }, 2);
-        javaProps = cGen.JavaProperties;
+        unused = cGen.JavaProperties;
         Util.Log("DisallowPutsGets: For second client invalid GET " +
           "credentials: " + getCredentials);
         m_client2.Call(SecurityTestUtil.CreateClientMU, RegionName,
@@ -686,7 +686,7 @@ namespace Apache.Geode.Client.UnitTests
         getCredentials = authzGen.GetAllowedCredentials(
             new OperationCode[] { OperationCode.Get },
             new string[] { RegionName }, 5);
-        javaProps = cGen.JavaProperties;
+         unused = cGen.JavaProperties;
         Util.Log("DisallowPutsGets: For second client valid GET " +
           "credentials: " + getCredentials);
         m_client2.Call(SecurityTestUtil.CreateClientMU, RegionName,
@@ -746,7 +746,7 @@ namespace Apache.Geode.Client.UnitTests
         Properties<string, string> createCredentials = authzGen.GetAllowedCredentials(
             new OperationCode[] { OperationCode.Put },
             new string[] { RegionName }, 3);
-        javaProps = cGen.JavaProperties;
+        var unused = cGen.JavaProperties;
         Util.Log("InvalidAccessor: For first client PUT credentials: " +
           createCredentials);
         m_client1.Call(SecurityTestUtil.CreateClientMU, RegionName,
@@ -960,7 +960,7 @@ namespace Apache.Geode.Client.UnitTests
           Properties<string, string> createCredentials = authzGen.GetDisallowedCredentials(
             new OperationCode[] { OperationCode.Put },
             new string[] { RegionName }, 1);
-          javaProps = cGen.JavaProperties;
+          var unused = cGen.JavaProperties;
           Util.Log("DisallowPuts: For first client PUT credentials: " +
             createCredentials);
           m_client1.Call(SecurityTestUtil.CreateClientR0, RegionName,

--- a/clicache/integration-test/ThinClientSecurityAuthzTestsN.cs
+++ b/clicache/integration-test/ThinClientSecurityAuthzTestsN.cs
@@ -206,9 +206,9 @@ namespace Apache.Geode.Client.UnitTests
         Properties<string, string> createCredentials = authzGen.GetAllowedCredentials(
           new OperationCode[] { OperationCode.Put },
           new string[] { RegionName }, 1);
-        javaProps = cGen.JavaProperties;
+        var unused = cGen.JavaProperties;
         Util.Log("AllowPutsGets: For first client PUT credentials: " +
-          createCredentials);
+                 createCredentials);
         m_client1.Call(SecurityTestUtil.CreateClient, RegionName,
           CacheHelper.Locators, authInit, createCredentials);
 
@@ -216,7 +216,7 @@ namespace Apache.Geode.Client.UnitTests
         Properties<string, string> getCredentials = authzGen.GetAllowedCredentials(
           new OperationCode[] { OperationCode.Get },
           new string[] { RegionName }, 2);
-        javaProps = cGen.JavaProperties;
+        unused = cGen.JavaProperties;
         Util.Log("AllowPutsGets: For second client GET credentials: " +
           getCredentials);
         m_client2.Call(SecurityTestUtil.CreateClient, RegionName,
@@ -264,14 +264,14 @@ namespace Apache.Geode.Client.UnitTests
 
         // Check that we indeed can obtain valid credentials not allowed to do
         // gets
-        Properties<string, string> createCredentials = authzGen.GetAllowedCredentials(
+        authzGen.GetAllowedCredentials(
           new OperationCode[] { OperationCode.Put },
           new string[] { RegionName }, 1);
-        Properties<string, string> createJavaProps = cGen.JavaProperties;
+        var unused = cGen.JavaProperties;
         Properties<string, string> getCredentials = authzGen.GetDisallowedCredentials(
           new OperationCode[] { OperationCode.Get },
           new string[] { RegionName }, 2);
-        Properties<string, string> getJavaProps = cGen.JavaProperties;
+        unused = cGen.JavaProperties;
         if (getCredentials == null || getCredentials.Size == 0)
         {
           Util.Log("DisallowPutsGets: Unable to obtain valid credentials " +
@@ -291,10 +291,10 @@ namespace Apache.Geode.Client.UnitTests
         Util.Log("Cacheserver 2 started.");
 
         // Start client1 with valid CREATE credentials
-        createCredentials = authzGen.GetAllowedCredentials(
+        var createCredentials = authzGen.GetAllowedCredentials(
             new OperationCode[] { OperationCode.Put },
             new string[] { RegionName }, 1);
-        javaProps = cGen.JavaProperties;
+        unused = cGen.JavaProperties;
         Util.Log("DisallowPutsGets: For first client PUT credentials: " +
           createCredentials);
         m_client1.Call(SecurityTestUtil.CreateClient, RegionName,
@@ -304,7 +304,7 @@ namespace Apache.Geode.Client.UnitTests
         getCredentials = authzGen.GetDisallowedCredentials(
             new OperationCode[] { OperationCode.Get },
             new string[] { RegionName }, 2);
-        javaProps = cGen.JavaProperties;
+        unused = cGen.JavaProperties;
         Util.Log("DisallowPutsGets: For second client invalid GET " +
           "credentials: " + getCredentials);
         m_client2.Call(SecurityTestUtil.CreateClient, RegionName,
@@ -320,7 +320,7 @@ namespace Apache.Geode.Client.UnitTests
         getCredentials = authzGen.GetAllowedCredentials(
             new OperationCode[] { OperationCode.Get },
             new string[] { RegionName }, 5);
-        javaProps = cGen.JavaProperties;
+        unused = cGen.JavaProperties;
         Util.Log("DisallowPutsGets: For second client valid GET " +
           "credentials: " + getCredentials);
         m_client2.Call(SecurityTestUtil.CreateClient, RegionName,
@@ -374,7 +374,7 @@ namespace Apache.Geode.Client.UnitTests
         Properties<string, string> createCredentials = authzGen.GetAllowedCredentials(
             new OperationCode[] { OperationCode.Put },
             new string[] { RegionName }, 3);
-        javaProps = cGen.JavaProperties;
+        var unused = cGen.JavaProperties;
         Util.Log("InvalidAccessor: For first client PUT credentials: " +
           createCredentials);
         m_client1.Call(SecurityTestUtil.CreateClient, RegionName,
@@ -616,7 +616,7 @@ namespace Apache.Geode.Client.UnitTests
           Properties<string, string> createCredentials = authzGen.GetDisallowedCredentials(
             new OperationCode[] { OperationCode.Put },
             new string[] { RegionName }, 1);
-          javaProps = cGen.JavaProperties;
+          var unused = cGen.JavaProperties;
           Util.Log("DisallowPuts: For first client PUT credentials: " +
             createCredentials);
           m_client1.Call(SecurityTestUtil.CreateClientR0, RegionName,

--- a/clicache/integration-test2/AutoSerializationTests.cs
+++ b/clicache/integration-test2/AutoSerializationTests.cs
@@ -1529,7 +1529,7 @@ namespace Apache.Geode.Client.IntegrationTests
           {
             put = new UnsupportedTypes(true);
             region[i] = put;
-            var val = region[i];
+            region.Get(i);
             Console.WriteLine("Shouldn't be able to retrieve an unsupported type");
           });
 

--- a/clicache/integration-test2/CqOperationTest.cs
+++ b/clicache/integration-test2/CqOperationTest.cs
@@ -103,7 +103,7 @@ namespace Apache.Geode.Client.IntegrationTests
         {
             Debug.WriteLine("PdxCqListener::OnEvent called");
             var val = ev.getNewValue() as MyOrder;
-            TKey key = ev.getKey();
+            ev.getKey();
 
             switch (ev.getQueryOperation())
             {
@@ -142,7 +142,7 @@ namespace Apache.Geode.Client.IntegrationTests
         {
             Debug.WriteLine("CqListener::OnEvent called");
             var val = ev.getNewValue() as Position;
-            TKey key = ev.getKey();
+            ev.getKey();
 
             switch (ev.getQueryOperation())
             {
@@ -304,7 +304,7 @@ namespace Apache.Geode.Client.IntegrationTests
                 var order3 = new Position("PVTL", 101);
 
                 region.Put("order1", order1);
-                var Value = region["order1"];
+                region.Get("order1");
 
                 region.Put("order2", order2);
                 Assert.True(cqListener.CreatedEvent.WaitOne(waitInterval_), "Didn't receive expected CREATE event");

--- a/clicache/integration-test2/GfshTest.cs
+++ b/clicache/integration-test2/GfshTest.cs
@@ -91,7 +91,7 @@ namespace Apache.Geode.Client.IntegrationTests
         {
             var Gfsh = new GfshExecute(output);
 
-            var currentDir = Environment.CurrentDirectory;
+            var unused = Environment.CurrentDirectory;
 
             var server = Gfsh
                 .start()

--- a/clicache/integration-test2/QueryTest.cs
+++ b/clicache/integration-test2/QueryTest.cs
@@ -164,7 +164,7 @@ namespace Apache.Geode.Client.IntegrationTests
                 var order3 = new Position("PVTL", 101);
 
                 region.Put("order1", order1);
-                var Value = region["order1"];
+                region.Get("order1");
 
                 region.Put("order2", order2);
 


### PR DESCRIPTION
Draft cause there's a lot of them.  Also opening this pr so that lgtm can run through it.

Also if anyone is reading this, my Windows CI seems to have become sad because of

[`error MSB8036: The Windows SDK version 10.0.14393 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution"`](https://github.com/moleske/geode-native/runs/1691403365?check_suite_focus=true#step:11:270)

in building ACE.  Did something change that I missed?  Was using Visual Studio 2017, should be trying to add that SDK version in Visual Studio installer?