### PR TITLE
GEODE-8207: Enforce no unknown pragma on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_options(_WarningsAsError INTERFACE
     /WX
 	/wd4996
-	/wd4068 # TODO fix
 	)
 
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ignore:4099")


### PR DESCRIPTION
Since https://github.com/apache/geode-native/pull/608 got rid of this warning on clang, we can get rid of it on windows.  Though let me know if I really should make a new jira instead of reusing the old one