### PR TITLE
GEODE-8874: Fix for transaction commit failure

### DIFF
--- a/cppcache/src/TXId.cpp
+++ b/cppcache/src/TXId.cpp
@@ -33,7 +33,6 @@ TXId::TXId() {
   // If m_transactionId has reached maximum value, then start again
   // from zero, and increment by one until first unused value is found.
   // This is done to avoid overflow of m_transactionId to negative value.
-  auto maxValueTXId = std::numeric_limits<int>::max();
   auto current = m_transactionId.load();
   decltype(current) next;
   do {

--- a/cppcache/src/TXId.hpp
+++ b/cppcache/src/TXId.hpp
@@ -45,6 +45,10 @@ class TXId : public apache::geode::client::TransactionId {
 
   int32_t getId();
 
+  // This method is only for testing and should not be used for any
+  // other purpose. See TXIdTest.cpp for more details.
+  static void setInitalTransactionIDValue(int32_t);
+
  private:
   int32_t m_TXId;
   static std::atomic<int32_t> m_transactionId;

--- a/cppcache/test/CMakeLists.txt
+++ b/cppcache/test/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(apache-geode_unittests
   StructSetTest.cpp
   TcrMessageTest.cpp
   ThreadPoolTest.cpp
+  TXIdTest.cpp
   mock/MapEntryImplMock.hpp
   statistics/HostStatSamplerTest.cpp
   util/functionalTests.cpp

--- a/cppcache/test/TXIdTest.cpp
+++ b/cppcache/test/TXIdTest.cpp
@@ -24,11 +24,11 @@ namespace geode {
 namespace client {
 
 TEST(TXIdTest, testIncrementTransactionID) {
-  auto tx = new TXId();
-  ASSERT_EQ(1, tx->getId());
+  TXId tx1;
+  ASSERT_EQ(1, tx1.getId());
 
-  tx = new TXId();
-  ASSERT_EQ(2, tx->getId());
+  TXId tx2;
+  ASSERT_EQ(2, tx2.getId());
 }
 
 TEST(TXIdTest, testIncrementTransactionIdOverMaxValue) {
@@ -36,13 +36,13 @@ TEST(TXIdTest, testIncrementTransactionIdOverMaxValue) {
   TXId::setInitalTransactionIDValue(INT32_MAX);
 
   // TransactionId is incremented by one each time TXId is created.
-  // When transactionId is incremented over the INT32_MAX value.
+  // When transactionId is incremented over the INT32_MAX value
   // then it should be reset to one.
-  auto tx = new TXId();
-  ASSERT_EQ(1, tx->getId());
+  TXId tx1;
+  ASSERT_EQ(1, tx1.getId());
 
-  tx = new TXId();
-  ASSERT_EQ(2, tx->getId());
+  TXId tx2;
+  ASSERT_EQ(2, tx2.getId());
 
   // reset value at the end of test
   TXId::setInitalTransactionIDValue(0);

--- a/cppcache/test/TXIdTest.cpp
+++ b/cppcache/test/TXIdTest.cpp
@@ -14,43 +14,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * TXId.cpp
- *
- *  Created on: 07-Feb-2011
- *      Author: ankurs
- */
 
-#include "TXId.hpp"
+#include <TXId.hpp>
+
+#include <gtest/gtest.h>
 
 namespace apache {
 namespace geode {
 namespace client {
 
-std::atomic<int32_t> TXId::m_transactionId(0);
+TEST(TXIdTest, testIncrementTransactionID) {
+  auto tx = new TXId();
+  ASSERT_EQ(1, tx->getId());
 
-TXId::TXId() {
-  // If m_transactionId has reached maximum value, then set
-  // it to zero in order to avoid overflow to negative value.
-  auto maxValueTXId = INT32_MAX;
-  m_transactionId.compare_exchange_strong(maxValueTXId, 0);
-  m_TXId = ++m_transactionId;
+  tx = new TXId();
+  ASSERT_EQ(2, tx->getId());
 }
 
-TXId& TXId::operator=(const TXId& other) {
-  m_TXId = other.m_TXId;
-  return *this;
+TEST(TXIdTest, testIncrementTransactionIdOverMaxValue) {
+  // Set inital value of transactionId to integer INT32_MAX.
+  TXId::setInitalTransactionIDValue(INT32_MAX);
+
+  // TransactionId is incremented by one each time TXId is created.
+  // When transactionId is incremented over the INT32_MAX value.
+  // then it should be reset to one.
+  auto tx = new TXId();
+  ASSERT_EQ(1, tx->getId());
+
+  tx = new TXId();
+  ASSERT_EQ(2, tx->getId());
+
+  // reset value at the end of test
+  TXId::setInitalTransactionIDValue(0);
 }
 
-// This method is only for testing and should not be used for any
-// other purpose. See TXIdTest.cpp for more details.
-void TXId::setInitalTransactionIDValue(int32_t newTransactionID) {
-  m_transactionId.exchange(newTransactionID);
-}
-
-TXId::~TXId() {}
-
-int32_t TXId::getId() { return m_TXId; }
 }  // namespace client
 }  // namespace geode
 }  // namespace apache


### PR DESCRIPTION
Issue: Transaction commit fail when m_transactionID integer overflows to
negative value, because server interprets negative value as
non-transactional message.

Fix: Client is impacted to reset transactionID to one when INT_32MAX
value is reached in order to avoid overflow.