### PR TITLE
GEODE-8884: Update ACE to 7.0.0

### DIFF
--- a/dependencies/ACE/CMakeLists.txt
+++ b/dependencies/ACE/CMakeLists.txt
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project( ACE VERSION 6.5.12 LANGUAGES NONE )
+project( ACE VERSION 7.0.0 LANGUAGES NONE )
 
-set( SHA256 de96c68a6262d6b9ba76b5057c02c7e6964c070b1328a63bf70259e9530a7996 )
+set( SHA256 9dfdc31664bc2faf7832e50197203fe274c661a56f17b18af2b227ddb34174be )
 
 if ("SunOS" STREQUAL ${CMAKE_SYSTEM_NAME})
   set( ACE_PLATFORM sunos5_sunc++ )


### PR DESCRIPTION
Authored-by: M. Oleske <michael@oleske.engineer>

I didn't really want to update ACE, but I really wanted to be able to [build on MacOS 11 (Big Sur)](https://github.com/moleske/geode-native/runs/1773671597?check_suite_focus=true) so 🤷‍♀️ 

Seems to work in my tests for the existing operating systems, but will let folks with fancy pipelines tell me I'm wrong