### PR TITLE
Geode 8892 loosen log file name rules

### DIFF
--- a/cppcache/test/LoggingTest.cpp
+++ b/cppcache/test/LoggingTest.cpp
@@ -238,6 +238,11 @@ TEST_F(LoggingTest, logInit) {
       apache::geode::client::LogLevel::Config, "LoggingTest.log"));
   apache::geode::client::Log::close();
 
+  // Init with legal filename with () and space
+  ASSERT_NO_THROW(apache::geode::client::Log::init(
+      apache::geode::client::LogLevel::Config, "LoggingTest (1).log"));
+  apache::geode::client::Log::close();
+
   // Init with invalid filename
   ASSERT_THROW(apache::geode::client::Log::init(
                    apache::geode::client::LogLevel::Config, "#?$?%.log"),

--- a/cppcache/test/LoggingTest.cpp
+++ b/cppcache/test/LoggingTest.cpp
@@ -238,9 +238,9 @@ TEST_F(LoggingTest, logInit) {
       apache::geode::client::LogLevel::Config, "LoggingTest.log"));
   apache::geode::client::Log::close();
 
-  // Init with legal filename with () and space
+  // Init with legal filename with (), #, and space
   ASSERT_NO_THROW(apache::geode::client::Log::init(
-      apache::geode::client::LogLevel::Config, "LoggingTest (1).log"));
+      apache::geode::client::LogLevel::Config, "LoggingTest (#).log"));
   apache::geode::client::Log::close();
 
   // Init with invalid filename


### PR DESCRIPTION
Instead of using `boost::filesystem::portable_file_name` to police log file names, try/catch boost and std exceptions when creating log file and report an error via IllegalArgumentException.

@mreddington @dihardman @davebarnes97 @karensmolermiller 