### PR TITLE
GEODE-8900: Bump sqlite and sqlite-netfx to latest

### DIFF
--- a/dependencies/sqlite-netFx/CMakeLists.txt
+++ b/dependencies/sqlite-netFx/CMakeLists.txt
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project( sqlite-netFx VERSION 1.0.102.0 LANGUAGES NONE )
+project( sqlite-netFx VERSION 1.0.113.0 LANGUAGES NONE )
 
-set( SHA256 b980e8a151ddc685ed30652d39573381aef7b623478cba80b02d0795607638e1 )
+set( SHA256 deceee8c28c77c1edc9e3edd0a4a7805df6a4a1fb9d2df2a6b70dc0a96491560 )
 
 include(ExternalProject)
 ExternalProject_Add( ${PROJECT_NAME}

--- a/dependencies/sqlite/CMakeLists.txt
+++ b/dependencies/sqlite/CMakeLists.txt
@@ -13,15 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project( sqlite VERSION 3310100 LANGUAGES NONE )
+project( sqlite VERSION 3340100 LANGUAGES NONE )
 
-set( SHA256 f3c79bc9f4162d0b06fa9fe09ee6ccd23bb99ce310b792c5145f87fbcc30efca )
+set( SHA256 e0b1c0345fe4338b936e17da8e1bd88366cd210e576834546977f040c12a8f68 )
 
 
 set( EXTERN ${PROJECT_NAME}-extern )
 include(ExternalProject)
 ExternalProject_Add( ${EXTERN}
-  URL "https://www.sqlite.org/2020/sqlite-amalgamation-${PROJECT_VERSION}.zip"
+  URL "https://www.sqlite.org/2021/sqlite-amalgamation-${PROJECT_VERSION}.zip"
   URL_HASH SHA256=${SHA256}
   UPDATE_COMMAND ""
   CMAKE_ARGS


### PR DESCRIPTION
Since I was updating ACE, figured I should check the rest of the dependencies.  Seems good on the [operating systems that I tested on](https://github.com/moleske/geode-native/pull/34/checks).

As an aside, has anyone looked at trying to use [dependabot ](https://github.com/dependabot/dependabot-core) to create a CMake dependency updater?  I've seen a few people fork and run their own dependabot to keep dependencies up to date in a build system that dependabot didn't support.  I haven't looked too closely cause I didn't really want to muck with ruby.