### PR TITLE
GEODE-8949: Fix broken build inconsistent-missing-override

### DIFF
--- a/cppcache/test/LoggingTest.cpp
+++ b/cppcache/test/LoggingTest.cpp
@@ -94,6 +94,8 @@ class LoggingTest : public testing::Test {
     }
   }
 
+  void SetUp() override { scrubTestLogFiles(); }
+
   void TearDown() override { scrubTestLogFiles(); }
 
  public:

--- a/cppcache/test/LoggingTest.cpp
+++ b/cppcache/test/LoggingTest.cpp
@@ -94,10 +94,6 @@ class LoggingTest : public testing::Test {
     }
   }
 
-  virtual void SetUp() {
-    // scrubTestLogFiles();
-  }
-
   void TearDown() override { scrubTestLogFiles(); }
 
  public:


### PR DESCRIPTION
Was failing to build on Mac

Authored-by: M. Oleske <michael@oleske.engineer>

PR https://github.com/apache/geode-native/pull/746 caused a failure on Mac only it seems due to `SetUp` function from gTest not using override correctly.  Since the body was commented out and `scrubTestLogFiles` is used in `TearDown`, I just deleted the function to solve the problem