### PR TITLE
GEODE-9008: associate tid with connection when parsing message about

### DIFF
--- a/tools/gnmsg/gnmsg.py
+++ b/tools/gnmsg/gnmsg.py
@@ -20,6 +20,7 @@ import sys
 import threading
 import traceback
 
+
 from modified_utf8 import utf8m_to_utf8s
 from numeric_conversion import to_hex_digit
 import command_line

--- a/tools/gnmsg/gnmsg.py
+++ b/tools/gnmsg/gnmsg.py
@@ -64,6 +64,7 @@ def scan_file(filename, dump_handshake, dump_messages, thread_id):
     separator = ""
     client_decoder = ClientMessageDecoder(output_queue)
     server_decoder = ServerMessageDecoder(output_queue)
+    print("[")
     with open(filename, "rb") as f:
         for line in f:
             linestr = line.decode("utf-8")
@@ -97,6 +98,8 @@ def scan_file(filename, dump_handshake, dump_messages, thread_id):
                     separator = ","
         except queue.Empty:
             break
+
+    print("]")
 
 
 if __name__ == "__main__":

--- a/tools/gnmsg/protocol_state.py
+++ b/tools/gnmsg/protocol_state.py
@@ -23,7 +23,10 @@ class ProtocolState:
         self.last_client_message_ = {}
 
     def get_last_client_message(self, thread_id):
-        return self.last_client_message_[thread_id]
+        result = ""
+        if thread_id in self.last_client_message_.keys():
+            result = self.last_client_message_[thread_id]
+        return result
 
     def set_last_client_message(self, thread_id, client_message):
         self.last_client_message_[thread_id] = client_message

--- a/tools/gnmsg/server_message_decoder.py
+++ b/tools/gnmsg/server_message_decoder.py
@@ -108,6 +108,7 @@ class ServerMessageDecoder(DecoderBase):
             parts.append(tid)
             parts.append(connection)
             parts.append(bytes)
+            self.threads_connections_[tid] = connection
             result = True
 
         return result
@@ -204,9 +205,12 @@ class ServerMessageDecoder(DecoderBase):
         )
         match = expression.search(line)
         if match:
+            tid = match.group(2)
+            connection = match.group(3)
+            self.threads_connections_[tid] = connection
             parts.append(parser.parse(match.group(1)))
-            parts.append(match.group(2))
-            parts.append(match.group(3))
+            parts.append(tid)
+            parts.append(connection)
             parts.append(match.group(4))
             parts.append(match.group(5))
             result = True
@@ -234,9 +238,12 @@ class ServerMessageDecoder(DecoderBase):
         )
         match = expression.search(line)
         if match:
+            tid = match.group(2)
+            connection = match.group(3)
+            self.threads_connections_[tid] = connection
             parts.append(parser.parse(match.group(1)))
-            parts.append(match.group(2))
-            parts.append(match.group(3))
+            parts.append(tid)
+            parts.append(connection)
             parts.append(match.group(4))
             parts.append(match.group(5))
             result = True
@@ -380,7 +387,7 @@ class ServerMessageDecoder(DecoderBase):
             size = 0
             tid = parts[1]
             (flags, size) = read_number_from_hex_string(parts[4], 2, len(parts[4]) - 2)
-            self.chunk_decoder.add_chunk_header(parts[2], flags)
+            self.chunk_decoder.add_chunk_header(parts[3], flags)
         elif self.get_chunk_bytes(line, parts):
             tid = parts[1]
             self.chunk_decoder.add_chunk(parts[3])


### PR DESCRIPTION
"receiving header"
- This association wasn't happening if the connection on this thread
  hadn't already sent a message.  When that happened, we'd drop the
  trace with the message body and mess up the state machine.