### PR TITLE
GEODE-8973: Fix calls dup on exception handling

### DIFF
--- a/cppcache/src/util/exception.hpp
+++ b/cppcache/src/util/exception.hpp
@@ -32,12 +32,11 @@ namespace client {
 
 extern void GfErrTypeThrowException(const char* str, GfErrType err);
 
-#define throwExceptionIfError(str, err)  \
-  do {                                   \
-    if (err != GF_NOERR) {               \
-      GfErrTypeThrowException(str, err); \
-    }                                    \
-  } while (0)
+inline void throwExceptionIfError(const char* str, GfErrType err) {
+  if (err != GF_NOERR) {
+    GfErrTypeThrowException(str, err);
+  }
+}
 
 }  // namespace client
 }  // namespace geode


### PR DESCRIPTION
 - Whenever calling throwExceptionIfError macro it can happen that calls
   are duplicated. Hence the macro has been replaced by a inlined
   function.