### PR TITLE
GEODE-DIDN'TMAKEASTORYYET: Allow ipv6 test to be run

### DIFF
--- a/ci/base/base.yml
+++ b/ci/base/base.yml
@@ -96,4 +96,11 @@ builds:
     image_family: build-ubuntu-20-04
     source_image_family: ubuntu-2004-lts
 
+  - _: #@ template.replace(new_build("ubuntu-20.04-ipv6"))
+    image_family: build-ubuntu-20-04
+    source_image_family: ubuntu-2004-lts
+    #@yaml/map-key-override
+    params:
+      CMAKE_CONFIGURE_FLAGS: "-DWITH_IPV6=ON"
+
 configs: [ ]

--- a/cppcache/integration/test/BasicIPv6Test.cpp
+++ b/cppcache/integration/test/BasicIPv6Test.cpp
@@ -32,6 +32,8 @@
 #include <geode/RegionShortcut.hpp>
 #include <geode/Struct.hpp>
 
+#include "config.h"
+
 namespace {
 
 using apache::geode::client::Cache;
@@ -53,7 +55,11 @@ std::shared_ptr<Region> setupRegion(Cache& cache) {
  * Example test using 2 servers and waiting for async tasks to synchronize using
  * furtures.
  */
+#ifdef WITH_IPV6
+TEST(BasicIPv6Test, queryResultForRange) {
+#else
 TEST(BasicIPv6Test, DISABLED_queryResultForRange) {
+#endif
   Cluster cluster{LocatorCount{1}, ServerCount{1}, UseIpv6(true)};
   cluster.start();
   cluster.getGfsh()

--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -116,6 +116,10 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/func_cacheserver2_pool.xml
   ${CMAKE_CURRENT_BINARY_DIR}/func_cacheserver2_pool.xml COPYONLY)
 
+list(APPEND CONFIGURE_IN_FILES ${COMMON_SOURCE_DIR}/config.h.in)
+list(APPEND CONFIGURE_OUT_FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+configure_file(${COMMON_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+
 set_target_properties(cpp-integration-test PROPERTIES
   CXX_VISIBILITY_PRESET hidden
   VISIBILITY_INLINES_HIDDEN ON

--- a/cppcache/integration/test/config.h.in
+++ b/cppcache/integration/test/config.h.in
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#cmakedefine WITH_IPV6

--- a/cppcache/test/CMakeLists.txt
+++ b/cppcache/test/CMakeLists.txt
@@ -16,6 +16,10 @@
 cmake_minimum_required( VERSION 3.10 )
 project(apache-geode_unittests LANGUAGES CXX)
 
+if( NOT WITH_IPV6 )
+  set(ENABLE_QUEUECONNECTIONREQUESTTEST QueueConnectionRequestTest.cpp)
+endif()
+
 add_executable(apache-geode_unittests
   AutoDeleteTest.cpp
   ByteArray.cpp
@@ -46,7 +50,7 @@ add_executable(apache-geode_unittests
   LRUQueueTest.cpp
   PdxInstanceImplTest.cpp
   PdxTypeTest.cpp
-  QueueConnectionRequestTest.cpp
+  ${ENABLE_QUEUECONNECTIONREQUESTTEST}
   RegionAttributesFactoryTest.cpp
   SerializableCreateTests.cpp
   StringPrefixPartitionResolverTest.cpp


### PR DESCRIPTION
- Add ifdef for enable/disable ipv6 test
- Disable unit test when ipv6 is on
- Add CI job to use WITH_IPV6=ON

Authored-by: M. Oleske <michael@oleske.engineer>

I'd like to be able to run the BasicIPv6Test in my pipeline I keep for geode native.  The recent changes to get a concourse ci marked the BasicIPv6Test as disabled.  The test works fine when setting the WITH_IPV6 variable.  This change enables the test when the flag is set and disables when not.  When testing, I noticed all tests work with ipv6 except for the unit test QueueConnectionRequestTest, so went ahead and did a similar enable/disable.  I don't know if I went the best way about doing this so wanted some feedback/collaboration since I feel weird enabling/disabling tests.

I also added a change to ci/base/base.yml so that the pipeline could run the tests with ipv6.  It only works on linux at the moment, so I chose ubuntu.  I think it is valuable to run, but don't know if it should block releases.  I haven't tested the concourse change, I would need help on that