### PR TITLE
Remove log line fixed in GEODE-8994

### DIFF
--- a/cppcache/src/EventId.cpp
+++ b/cppcache/src/EventId.cpp
@@ -63,11 +63,7 @@ class EventIdTSS {
   int64_t sequenceId_;
 };
 
-EventIdTSS::EventIdTSS() : threadId_(ThreadIdCounter::next()), sequenceId_(0) {
-  LOGDEBUG("EventIdTSS::EventIdTSS(%p): threadId_=%" PRId64
-           ", sequenceId_=%" PRId64,
-           this, threadId_, sequenceId_);
-}
+EventIdTSS::EventIdTSS() : threadId_(ThreadIdCounter::next()), sequenceId_(0) {}
 
 void EventId::toData(DataOutput& output) const {
   //  This method is always expected to write out nonstatic distributed


### PR DESCRIPTION
- One of our integration tests has started failing on Ubuntu after making this
  change, just attempting to determine if log line is the cause.