### PR TITLE
GEODE-8968: Fix toDataMutable coredump

### DIFF
--- a/cppcache/include/geode/ExceptionTypes.hpp
+++ b/cppcache/include/geode/ExceptionTypes.hpp
@@ -850,6 +850,18 @@ class APACHE_GEODE_EXPORT SslException : public Exception {
   }
 };
 
+/**
+ *@brief Thrown when an unknown pdx type is found.
+ **/
+class APACHE_GEODE_EXPORT UnknownPdxTypeException : public Exception {
+ public:
+  using Exception::Exception;
+  ~UnknownPdxTypeException() noexcept override {}
+  std::string getName() const override {
+    return "apache::geode::client::UnknownPdxTypeException";
+  }
+};
+
 }  // namespace client
 }  // namespace geode
 }  // namespace apache

--- a/cppcache/integration/test/mock/CacheListenerMock.hpp
+++ b/cppcache/integration/test/mock/CacheListenerMock.hpp
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GEODE_CACHELISTENERMOCK_HPP_
+#define GEODE_CACHELISTENERMOCK_HPP_
+
+#include <gmock/gmock.h>
+
+#include <geode/CacheListener.hpp>
+
+namespace apache {
+namespace geode {
+namespace client {
+class CacheListenerMock : public CacheListener {
+ public:
+  MOCK_METHOD1(afterDestroy,
+               void(const EntryEvent& event));
+  MOCK_METHOD1(afterCreate, void(const EntryEvent&));
+  MOCK_METHOD1(afterRegionLive,
+               void(const RegionEvent&));
+  MOCK_METHOD1(afterRegionDisconnected, void(Region&));
+};
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+
+#endif  // GEODE_CACHELISTENERMOCK_HPP_

--- a/cppcache/src/PdxHelper.hpp
+++ b/cppcache/src/PdxHelper.hpp
@@ -48,6 +48,10 @@ class PdxHelper {
 
   virtual ~PdxHelper();
 
+  static void serializePdxWithRetries(
+      DataOutput& output, const std::shared_ptr<PdxSerializable>& pdxObject,
+      int maxRetries = 1);
+
   static void serializePdx(DataOutput& output,
                            const std::shared_ptr<PdxSerializable>& pdxObject);
 

--- a/cppcache/src/PdxInstanceFactory.cpp
+++ b/cppcache/src/PdxInstanceFactory.cpp
@@ -52,7 +52,7 @@ std::shared_ptr<PdxInstance> PdxInstanceFactory::create() {
 
   // Forces registration of PdxType
   auto dataOutput = m_cacheImpl.createDataOutput();
-  PdxHelper::serializePdx(dataOutput, pi);
+  PdxHelper::serializePdxWithRetries(dataOutput, pi);
 
   return std::move(pi);
 }

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -1417,6 +1417,11 @@ void PdxInstanceImpl::toData(PdxWriter& writer) const {
 
 void PdxInstanceImpl::toDataMutable(PdxWriter& writer) {
   auto pt = getPdxType();
+  if (pt == nullptr) {
+    m_typeId = 0;
+    throw UnknownPdxTypeException("Unknown pdx type while serializing");
+  }
+
   std::vector<std::shared_ptr<PdxFieldType>>* pdxFieldList =
       pt->getPdxFieldTypes();
   int position = 0;  // ignore typeid and length
@@ -1483,12 +1488,8 @@ const std::string& PdxInstanceImpl::getClassName() const {
 }
 
 void PdxInstanceImpl::setPdxId(int32_t typeId) {
-  if (m_typeId == 0) {
-    m_typeId = typeId;
-    m_pdxType = nullptr;
-  } else {
-    throw IllegalStateException("PdxInstance's typeId is already set.");
-  }
+  m_pdxType->setTypeId(typeId);
+  m_typeId = typeId;
 }
 
 std::vector<std::shared_ptr<PdxFieldType>>

--- a/cppcache/src/SerializationRegistry.cpp
+++ b/cppcache/src/SerializationRegistry.cpp
@@ -594,7 +594,7 @@ void TheTypeMap::unbindPdxSerializable(const std::string& objFullName) {
 void PdxTypeHandler::serialize(
     const std::shared_ptr<PdxSerializable>& pdxSerializable,
     DataOutput& dataOutput) const {
-  PdxHelper::serializePdx(dataOutput, pdxSerializable);
+  PdxHelper::serializePdxWithRetries(dataOutput, pdxSerializable);
 }
 
 std::shared_ptr<PdxSerializable> PdxTypeHandler::deserialize(


### PR DESCRIPTION
 - In those scenarios in which Pdx serialization occurs while
   PdxTypeRegistry is being cleaned up, it happened that NC crashed
   because it couldn't find the PdxType.
 - This commit adds retries to Pdx serialization, and in case retries
   are exhausted, UnknownPdxTypeException is thrown, so it can be
   handled by the user.
 - Implemented IT to verify this behaviour.