### PR TITLE
GEODE-9056: Replace ACE_Semaphore

### DIFF
--- a/cppcache/src/CqService.hpp
+++ b/cppcache/src/CqService.hpp
@@ -34,6 +34,7 @@
 #include "ErrType.hpp"
 #include "Queue.hpp"
 #include "TcrMessage.hpp"
+#include "util/concurrent/binary_semaphore.hpp"
 #include "util/synchronized_map.hpp"
 
 namespace apache {
@@ -52,7 +53,7 @@ class TcrEndpoint;
 class CqService : public std::enable_shared_from_this<CqService> {
   ThinClientBaseDM* m_tccdm;
   statistics::StatisticsFactory* m_statisticsFactory;
-  ACE_Semaphore m_notificationSema;
+  binary_semaphore notification_semaphore_;
 
   bool m_running;
   synchronized_map<std::unordered_map<std::string, std::shared_ptr<CqQuery>>,

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -110,7 +110,7 @@ TcrConnection::TcrConnection(const TcrConnectionManager& connectionManager)
       m_hasServerQueue(NON_REDUNDANT_SERVER),
       m_queueSize(0),
       m_port(0),
-      m_chunksProcessSema(0),
+      chunks_process_semaphore_(0),
       m_isBeingUsed(false),
       m_isUsed(0),
       m_poolDM(nullptr) {}
@@ -755,7 +755,7 @@ void TcrConnection::readMessageChunked(TcrMessageReply& reply,
   reply.setTransId(responseHeader.transactionId);
 
   // Initialize the chunk processing
-  reply.startProcessChunk(m_chunksProcessSema);
+  reply.startProcessChunk(chunks_process_semaphore_);
 
   // indicate an end to chunk processing and wait for processing
   // to end even if reading the chunks fails in middle

--- a/cppcache/src/TcrConnection.hpp
+++ b/cppcache/src/TcrConnection.hpp
@@ -29,6 +29,7 @@
 
 #include "Connector.hpp"
 #include "TcrMessage.hpp"
+#include "util/concurrent/binary_semaphore.hpp"
 #include "util/synchronized_set.hpp"
 
 #define DEFAULT_TIMEOUT_RETRIES 12
@@ -355,7 +356,7 @@ class TcrConnection {
   uint16_t m_port;
 
   // semaphore to synchronize with the chunked response processing thread
-  ACE_Semaphore m_chunksProcessSema;
+  binary_semaphore chunks_process_semaphore_;
 
   std::chrono::steady_clock::time_point m_creationTime;
   std::chrono::steady_clock::time_point m_lastAccessed;

--- a/cppcache/src/TcrConnectionManager.hpp
+++ b/cppcache/src/TcrConnectionManager.hpp
@@ -89,7 +89,7 @@ class TcrConnectionManager {
 
   void addNotificationForDeletion(Task<TcrEndpoint>* notifyReceiver,
                                   TcrConnection* notifyConnection,
-                                  ACE_Semaphore& notifyCleanupSema);
+                                  binary_semaphore& notifyCleanupSema);
 
   void processMarker();
 
@@ -107,7 +107,7 @@ class TcrConnectionManager {
       TcrHADistributionManager* theHADM = nullptr,
       ThinClientRegion* region = nullptr);
 
-  inline void triggerRedundancyThread() { m_redundancySema.release(); }
+  inline void triggerRedundancyThread() { redundancy_semaphore_.release(); }
 
   inline void acquireRedundancyLock() {
     m_redundancyManager->acquireRedundancyLock();
@@ -142,7 +142,7 @@ class TcrConnectionManager {
   std::list<ThinClientBaseDM*> m_distMngrs;
   std::recursive_mutex m_distMngrsLock;
 
-  ACE_Semaphore m_failoverSema;
+  binary_semaphore failover_semaphore_;
   std::unique_ptr<Task<TcrConnectionManager>> m_failoverTask;
 
   bool removeRefToEndpoint(TcrEndpoint* ep, bool keepEndpoint = false);
@@ -152,16 +152,16 @@ class TcrConnectionManager {
   void initializeHAEndpoints(const char* endpointsStr);
   void removeHAEndpoints();
 
-  ACE_Semaphore m_cleanupSema;
+  binary_semaphore cleanup_semaphore_;
   std::unique_ptr<Task<TcrConnectionManager>> m_cleanupTask;
 
   ExpiryTaskManager::id_type m_pingTaskId;
   ExpiryTaskManager::id_type m_servermonitorTaskId;
   Queue<Task<TcrEndpoint>*> m_receiverReleaseList;
   Queue<TcrConnection*> m_connectionReleaseList;
-  Queue<ACE_Semaphore*> m_notifyCleanupSemaList;
+  Queue<binary_semaphore*> notify_cleanup_semaphore_list_;
 
-  ACE_Semaphore m_redundancySema;
+  binary_semaphore redundancy_semaphore_;
   std::unique_ptr<Task<TcrConnectionManager>> m_redundancyTask;
   std::recursive_mutex m_notificationLock;
   bool m_isDurable;

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -39,9 +39,9 @@ namespace client {
 const char* TcrEndpoint::NC_Notification = "NC Notification";
 
 TcrEndpoint::TcrEndpoint(const std::string& name, CacheImpl* cacheImpl,
-                         ACE_Semaphore& failoverSema,
-                         ACE_Semaphore& cleanupSema,
-                         ACE_Semaphore& redundancySema, ThinClientBaseDM* DM,
+                         binary_semaphore& failoverSema,
+                         binary_semaphore& cleanupSema,
+                         binary_semaphore& redundancySema, ThinClientBaseDM* DM,
                          bool isMultiUserMode)
     : m_notifyConnection(nullptr),
       m_notifyReceiver(nullptr),
@@ -53,12 +53,12 @@ TcrEndpoint::TcrEndpoint(const std::string& name, CacheImpl* cacheImpl,
       m_needToConnectInLock(false),
       m_isQueueHosted(false),
       m_uniqueId(0),
-      m_failoverSema(failoverSema),
-      m_cleanupSema(cleanupSema),
-      m_redundancySema(redundancySema),
+      failover_semaphore_(failoverSema),
+      cleanup_semaphore_(cleanupSema),
+      redundancy_semaphore_(redundancySema),
       m_baseDM(DM),
       m_name(name),
-      m_notificationCleanupSema(0),
+      notification_cleanup_semaphore_(0),
       m_numberOfTimesFailed(0),
       m_numRegions(0),
       m_pingTimeouts(0),
@@ -102,7 +102,7 @@ TcrEndpoint::~TcrEndpoint() {
   while (m_notifyCount > 0) {
     LOGDEBUG("TcrEndpoint::~TcrEndpoint(): reducing notify count at %d",
              m_notifyCount);
-    m_notificationCleanupSema.acquire();
+    notification_cleanup_semaphore_.acquire();
     m_notifyCount--;
   }
   LOGFINE("Connection to %s deleted", m_name.c_str());
@@ -1162,8 +1162,8 @@ void TcrEndpoint::setConnectionStatus(bool status) {
 }
 
 void TcrEndpoint::triggerRedundancyThread() {
-  m_failoverSema.release();
-  m_redundancySema.release();
+  failover_semaphore_.release();
+  redundancy_semaphore_.release();
 }
 
 void TcrEndpoint::closeConnection(TcrConnection*& conn) {
@@ -1197,9 +1197,9 @@ void TcrEndpoint::closeNotification() {
   m_notifyReceiver->stopNoblock();
   TcrConnectionManager& tccm = m_cacheImpl->tcrConnectionManager();
   tccm.addNotificationForDeletion(m_notifyReceiver.get(), m_notifyConnection,
-                                  m_notificationCleanupSema);
+                                  notification_cleanup_semaphore_);
   m_notifyCount++;
-  m_cleanupSema.release();
+  cleanup_semaphore_.release();
   m_isQueueHosted = false;
   LOGFINEST(
       "Added susbcription channel for deletion and "

--- a/cppcache/src/TcrEndpoint.hpp
+++ b/cppcache/src/TcrEndpoint.hpp
@@ -52,8 +52,8 @@ class TcrEndpoint : public std::enable_shared_from_this<TcrEndpoint> {
  public:
   TcrEndpoint(
       const std::string& name, CacheImpl* cacheImpl,
-      ACE_Semaphore& failoverSema, ACE_Semaphore& cleanupSema,
-      ACE_Semaphore& redundancySema, ThinClientBaseDM* dm = nullptr,
+      binary_semaphore& failoverSema, binary_semaphore& cleanupSema,
+      binary_semaphore& redundancySema, ThinClientBaseDM* dm = nullptr,
       bool isMultiUserMode = false);  // TODO: need to look for endpoint case
 
   virtual ~TcrEndpoint();
@@ -205,16 +205,16 @@ class TcrEndpoint : public std::enable_shared_from_this<TcrEndpoint> {
 
  private:
   int64_t m_uniqueId;
-  ACE_Semaphore& m_failoverSema;
-  ACE_Semaphore& m_cleanupSema;
-  ACE_Semaphore& m_redundancySema;
+  binary_semaphore& failover_semaphore_;
+  binary_semaphore& cleanup_semaphore_;
+  binary_semaphore& redundancy_semaphore_;
   ThinClientBaseDM* m_baseDM;
   std::string m_name;
   std::list<ThinClientBaseDM*> m_distMgrs;
   std::recursive_mutex m_endpointAuthenticationLock;
   std::recursive_mutex m_connectionLock;
   std::recursive_mutex m_distMgrsLock;
-  ACE_Semaphore m_notificationCleanupSema;
+  binary_semaphore notification_cleanup_semaphore_;
   synchronized_set<std::unordered_set<uint16_t>> m_ports;
   int32_t m_numberOfTimesFailed;
   int m_numRegions;

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -906,7 +906,7 @@ void TcrMessage::writeMessageLength() {
                                            // the beginning.
 }
 
-void TcrMessage::startProcessChunk(ACE_Semaphore& finalizeSema) {
+void TcrMessage::startProcessChunk(binary_semaphore& finalizeSema) {
   if (m_msgTypeRequest == TcrMessage::EXECUTECQ_MSG_TYPE ||
       m_msgTypeRequest == TcrMessage::STOPCQ_MSG_TYPE ||
       m_msgTypeRequest == TcrMessage::CLOSECQ_MSG_TYPE ||

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -182,7 +182,7 @@ class TcrMessage {
                const SerializationRegistry& serializationRegistry,
                MemberListForVersionStamp& memberListForVersionStamp);
 
-  void startProcessChunk(ACE_Semaphore& finalizeSema);
+  void startProcessChunk(binary_semaphore& finalizeSema);
   // nullptr chunk means that this is the last chunk
   void processChunk(const std::vector<uint8_t>& chunk, int32_t chunkLen,
                     uint16_t endpointmemId,

--- a/cppcache/src/TcrPoolEndPoint.cpp
+++ b/cppcache/src/TcrPoolEndPoint.cpp
@@ -26,9 +26,9 @@ namespace geode {
 namespace client {
 
 TcrPoolEndPoint::TcrPoolEndPoint(const std::string& name, CacheImpl* cache,
-                                 ACE_Semaphore& failoverSema,
-                                 ACE_Semaphore& cleanupSema,
-                                 ACE_Semaphore& redundancySema,
+                                 binary_semaphore& failoverSema,
+                                 binary_semaphore& cleanupSema,
+                                 binary_semaphore& redundancySema,
                                  ThinClientPoolDM* dm)
     : TcrEndpoint(name, cache, failoverSema, cleanupSema, redundancySema, dm),
       m_dm(dm) {}

--- a/cppcache/src/TcrPoolEndPoint.hpp
+++ b/cppcache/src/TcrPoolEndPoint.hpp
@@ -32,8 +32,8 @@ class ThinClientPoolDM;
 class TcrPoolEndPoint : public TcrEndpoint {
  public:
   TcrPoolEndPoint(const std::string& name, CacheImpl* cache,
-                  ACE_Semaphore& failoverSema, ACE_Semaphore& cleanupSema,
-                  ACE_Semaphore& redundancySema, ThinClientPoolDM* dm);
+                  binary_semaphore& failoverSema, binary_semaphore& cleanupSema,
+                  binary_semaphore& redundancySema, ThinClientPoolDM* dm);
   ThinClientPoolDM* getPoolHADM() const override;
 
   bool checkDupAndAdd(std::shared_ptr<EventId> eventid) override;

--- a/cppcache/src/ThinClientBaseDM.cpp
+++ b/cppcache/src/ThinClientBaseDM.cpp
@@ -217,13 +217,23 @@ void ThinClientBaseDM::processChunks(std::atomic<bool>& isRunning) {
   TcrChunkedContext* chunk;
   LOGFINE("Starting chunk process thread for region %s",
           (m_region ? m_region->getFullPath().c_str() : "(null)"));
+
+  std::chrono::milliseconds wait_for_chunk{100};
+  chunk = m_chunks.getFor(wait_for_chunk);
+
   while (isRunning) {
-    chunk = m_chunks.getFor(std::chrono::microseconds(100000));
     if (chunk) {
       chunk->handleChunk(false);
       _GEODE_SAFE_DELETE(chunk);
     }
+
+    chunk = m_chunks.getFor(wait_for_chunk);
   }
+
+  if (chunk) {
+    _GEODE_SAFE_DELETE(chunk);
+  }
+
   LOGFINE("Ending chunk process thread for region %s",
           (m_region ? m_region->getFullPath().c_str() : "(null)"));
 }

--- a/cppcache/src/ThinClientPoolDM.hpp
+++ b/cppcache/src/ThinClientPoolDM.hpp
@@ -47,6 +47,7 @@
 #include "ThinClientStickyManager.hpp"
 #include "ThreadPool.hpp"
 #include "UserAttributes.hpp"
+#include "util/concurrent/binary_semaphore.hpp"
 
 namespace apache {
 namespace geode {
@@ -196,9 +197,9 @@ class ThinClientPoolDM
   PoolStats* m_stats;
   bool m_sticky;
   void netDown();
-  ACE_Semaphore m_updateLocatorListSema;
-  ACE_Semaphore m_pingSema;
-  ACE_Semaphore m_cliCallbackSema;
+  binary_semaphore update_locators_semaphore_;
+  binary_semaphore ping_semaphore_;
+  binary_semaphore cli_callback_semaphore_;
   volatile bool m_isDestroyed;
   volatile bool m_destroyPending;
   volatile bool m_destroyPendingHADM;
@@ -289,7 +290,7 @@ class ThinClientPoolDM
   unsigned m_server;
 
   // Manage Connection thread
-  ACE_Semaphore m_connSema;
+  binary_semaphore conn_semaphore_;
   std::unique_ptr<Task<ThinClientPoolDM>> m_connManageTask;
   std::unique_ptr<Task<ThinClientPoolDM>> m_pingTask;
   std::unique_ptr<Task<ThinClientPoolDM>> m_updateLocatorListTask;

--- a/cppcache/src/ThinClientPoolHADM.cpp
+++ b/cppcache/src/ThinClientPoolHADM.cpp
@@ -33,7 +33,7 @@ ThinClientPoolHADM::ThinClientPoolHADM(const char* name,
                                        TcrConnectionManager& connManager)
     : ThinClientPoolDM(name, poolAttr, connManager),
       m_theTcrConnManager(connManager),
-      m_redundancySema(0),
+      redundancy_semaphore_(0),
       m_redundancyTask(nullptr),
       m_servermonitorTaskId(-1) {
   m_redundancyManager = std::unique_ptr<ThinClientRedundancyManager>(
@@ -144,19 +144,20 @@ bool ThinClientPoolHADM::postFailoverAction(TcrEndpoint*) {
 
 void ThinClientPoolHADM::redundancy(std::atomic<bool>& isRunning) {
   LOGFINE("ThinClientPoolHADM: Starting maintain redundancy thread.");
+
+  redundancy_semaphore_.acquire();
   while (isRunning) {
-    m_redundancySema.acquire();
-    if (isRunning && !m_connManager.isNetDown()) {
+    if (!m_connManager.isNetDown()) {
       m_redundancyManager->maintainRedundancyLevel();
-      while (m_redundancySema.tryacquire() != -1) {
-      }
     }
+
+    redundancy_semaphore_.acquire();
   }
   LOGFINE("ThinClientPoolHADM: Ending maintain redundancy thread.");
 }
 
 int ThinClientPoolHADM::checkRedundancy(const ACE_Time_Value&, const void*) {
-  m_redundancySema.release();
+  redundancy_semaphore_.release();
   return 0;
 }
 
@@ -188,7 +189,7 @@ void ThinClientPoolHADM::sendNotificationCloseMsgs() {
           m_servermonitorTaskId);
     }
     m_redundancyTask->stopNoblock();
-    m_redundancySema.release();
+    redundancy_semaphore_.release();
     m_redundancyTask->wait();
     m_redundancyTask = nullptr;
     m_redundancyManager->sendNotificationCloseMsgs();
@@ -309,8 +310,9 @@ void ThinClientPoolHADM::sendNotConMesToAllregions() {
 std::shared_ptr<TcrEndpoint> ThinClientPoolHADM::createEP(
     const char* endpointName) {
   return std::make_shared<TcrPoolEndPoint>(
-      endpointName, m_connManager.getCacheImpl(), m_connManager.m_failoverSema,
-      m_connManager.m_cleanupSema, m_redundancySema, this);
+      endpointName, m_connManager.getCacheImpl(),
+      m_connManager.failover_semaphore_, m_connManager.cleanup_semaphore_,
+      redundancy_semaphore_, this);
 }
 
 }  // namespace client

--- a/cppcache/src/ThinClientPoolHADM.hpp
+++ b/cppcache/src/ThinClientPoolHADM.hpp
@@ -84,7 +84,7 @@ class ThinClientPoolHADM : public ThinClientPoolDM {
 
   GfErrType sendRequestToPrimary(TcrMessage& request, TcrMessageReply& reply);
 
-  void triggerRedundancyThread() override { m_redundancySema.release(); }
+  void triggerRedundancyThread() override { redundancy_semaphore_.release(); }
 
   bool isReadyForEvent() const;
 
@@ -107,7 +107,7 @@ class ThinClientPoolHADM : public ThinClientPoolDM {
   std::unique_ptr<ThinClientRedundancyManager> m_redundancyManager;
 
   TcrConnectionManager& m_theTcrConnManager;
-  ACE_Semaphore m_redundancySema;
+  binary_semaphore redundancy_semaphore_;
   std::unique_ptr<Task<ThinClientPoolHADM>> m_redundancyTask;
 
   void redundancy(std::atomic<bool>& isRunning);

--- a/cppcache/src/ThinClientRedundancyManager.cpp
+++ b/cppcache/src/ThinClientRedundancyManager.cpp
@@ -56,6 +56,7 @@ ThinClientRedundancyManager::ThinClientRedundancyManager(
       m_locators(nullptr),
       m_servers(nullptr),
       m_periodicAckTask(nullptr),
+      periodic_ack_semaphore_(1),
       m_processEventIdMapTaskId(-1),
       m_nextAckInc(0),
       m_HAenabled(false) {}
@@ -682,7 +683,7 @@ void ThinClientRedundancyManager::close() {
           m_processEventIdMapTaskId);
     }
     m_periodicAckTask->stopNoblock();
-    m_periodicAckSema.release();
+    periodic_ack_semaphore_.release();
     m_periodicAckTask->wait();
     m_periodicAckTask = nullptr;
   }
@@ -1116,18 +1117,16 @@ void ThinClientRedundancyManager::readyForEvents() {
 
 int ThinClientRedundancyManager::processEventIdMap(const ACE_Time_Value&,
                                                    const void*) {
-  m_periodicAckSema.release();
+  periodic_ack_semaphore_.release();
   return 0;
 }
 
 void ThinClientRedundancyManager::periodicAck(std::atomic<bool>& isRunning) {
+  periodic_ack_semaphore_.acquire();
+
   while (isRunning) {
-    m_periodicAckSema.acquire();
-    if (isRunning) {
-      doPeriodicAck();
-      while (m_periodicAckSema.tryacquire() != -1) {
-      }
-    }
+    doPeriodicAck();
+    periodic_ack_semaphore_.acquire();
   }
 }
 

--- a/cppcache/src/ThinClientRedundancyManager.hpp
+++ b/cppcache/src/ThinClientRedundancyManager.hpp
@@ -34,6 +34,7 @@
 #include "ServerLocation.hpp"
 #include "Task.hpp"
 #include "TcrMessage.hpp"
+#include "util/concurrent/binary_semaphore.hpp"
 #include "util/synchronized_map.hpp"
 
 namespace apache {
@@ -136,7 +137,7 @@ class ThinClientRedundancyManager {
   inline bool isDurable();
   int processEventIdMap(const ACE_Time_Value&, const void*);
   std::unique_ptr<Task<ThinClientRedundancyManager>> m_periodicAckTask;
-  ACE_Semaphore m_periodicAckSema;
+  binary_semaphore periodic_ack_semaphore_;
   ExpiryTaskManager::id_type
       m_processEventIdMapTaskId;  // periodic check eventid map for notify ack
                                   // and/or expiry

--- a/cppcache/src/util/concurrent/binary_semaphore.cpp
+++ b/cppcache/src/util/concurrent/binary_semaphore.cpp
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "binary_semaphore.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+binary_semaphore::binary_semaphore(bool released) : released_(released) {}
+
+void binary_semaphore::release() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  released_ = true;
+  cv_.notify_one();
+}
+
+void binary_semaphore::acquire() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  cv_.wait(lock, [this]() { return released_; });
+  released_ = false;
+}
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/util/concurrent/binary_semaphore.hpp
+++ b/cppcache/src/util/concurrent/binary_semaphore.hpp
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_UTIL_CONCURRENT_BINARY_SEMAPHORE_H_
+#define GEODE_UTIL_CONCURRENT_BINARY_SEMAPHORE_H_
+
+#include <condition_variable>
+#include <mutex>
+
+namespace apache {
+namespace geode {
+namespace client {
+class binary_semaphore {
+ public:
+  explicit binary_semaphore(bool released);
+
+  void release();
+  void acquire();
+
+ protected:
+  bool released_;
+  std::mutex mutex_;
+  std::condition_variable cv_;
+};
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif /* GEODE_UTIL_CONCURRENT_BINARY_SEMAPHORE_H_ */


### PR DESCRIPTION
 - In order to progress in the task of getting rid of ACE library, a
   replacement is needed for ACE_Semaphore.
 - Currently there is no suitable Boost alternative and C++
   implementation is not in the standard until C++20. Hence STL like
   implementation was added as binary_semaphore.
 - Replaced all instances of ACE_Semaphore by binary_semaphore.
 - Fixed ill semaphore logic in several cases in which running token was
   checked twice without any specific need.