### PR TITLE
GEODE-9058: Remove ACE_OS references

### DIFF
--- a/cppcache/CMakeLists.txt
+++ b/cppcache/CMakeLists.txt
@@ -24,6 +24,8 @@ if (CMAKE_USE_PTHREADS_INIT)
   check_function_exists("pthread_setname_np" HAVE_pthread_setname_np)
 endif()
 
+check_function_exists(uname HAVE_uname)
+
 # Search OpenSSL
 find_package(OpenSSL COMPONENTS Crypto)
 

--- a/cppcache/integration-test/BBNamingContext.hpp
+++ b/cppcache/integration-test/BBNamingContext.hpp
@@ -44,7 +44,7 @@ class BBNamingContextClient {
   void close();
   int rebind(const char* key, const char* value, char* type = nullptr);
   void dump();
-  int resolve(const char* key, char* value, char* type = nullptr);
+  int resolve(const std::string& key, std::string& value, char* type = nullptr);
 };
 class BBNamingContextServerImpl;
 class BBNamingContextServer {

--- a/cppcache/integration-test/BuiltinCacheableWrappers.hpp
+++ b/cppcache/integration-test/BuiltinCacheableWrappers.hpp
@@ -336,10 +336,12 @@ class CacheableDateWrapper : public CacheableWrapper {
   void initRandomValue(int32_t) override {
     auto rnd = CacheableHelper::random<int32_t>(INT_MAX);
 
-    const ACE_Time_Value currentTime = ACE_OS::gettimeofday();
-    auto timeofday = currentTime.sec();
+    auto timeofday = std::chrono::time_point_cast<std::chrono::seconds>(
+                         std::chrono::system_clock::now())
+                         .time_since_epoch()
+                         .count();
     time_t epoctime =
-        static_cast<time_t>(timeofday + (rnd * (rnd % 2 == 0 ? 1 : -1)));
+        static_cast<time_t>(timeofday + (rnd * (rnd & 1 ? -1 : 1)));
 
     m_cacheableObject = CacheableDate::create(epoctime);
   }

--- a/cppcache/integration-test/CMakeLists.txt
+++ b/cppcache/integration-test/CMakeLists.txt
@@ -108,6 +108,8 @@ foreach(FILE ${SOURCES})
   target_link_libraries(${TEST}
     PRIVATE
       ACE::ACE
+      Boost::boost
+      Boost::iostreams
       test-cppcache-utils
       _WarningsAsError
       _CppCodeCoverage

--- a/cppcache/integration-test/CacheHelper.hpp
+++ b/cppcache/integration-test/CacheHelper.hpp
@@ -62,14 +62,14 @@ class CacheHelper {
   static void resetHelper();
 
   static std::string unitTestOutputFile();
-  static int getNumLocatorListUpdates(const char* s);
+  static int getNumLocatorListUpdates(const std::string& search);
 
   explicit CacheHelper(const char* member_id,
                        const std::shared_ptr<Properties>& configPtr = nullptr,
                        const bool noRootRegion = false);
 
   /** rootRegionPtr will still be null... */
-  CacheHelper(const char* member_id, const char* cachexml,
+  CacheHelper(const char* member_id, const std::string& cachexml,
               const std::shared_ptr<Properties>& configPtr = nullptr);
 
   explicit CacheHelper(const std::shared_ptr<Properties>& configPtr = nullptr,
@@ -89,7 +89,7 @@ class CacheHelper {
               const bool noRootRegion = false);
 
   CacheHelper(const bool isthinClient, const char* poolName,
-              const char* locators, const char* serverGroup,
+              const std::string& locators, const char* serverGroup,
               const std::shared_ptr<Properties>& configPtr = nullptr,
               int redundancy = 0, bool clientNotification = false,
               int subscriptionAckInterval = -1, int connections = -1,
@@ -124,23 +124,23 @@ class CacheHelper {
   std::shared_ptr<Region> getRegion(const std::string& name);
 
   std::shared_ptr<Region> createRegion(
-      const char* name, bool ack, bool caching,
+      const std::string& name, bool ack, bool caching,
       const std::shared_ptr<CacheListener>& listener,
       bool clientNotificationEnabled = false, bool scopeLocal = false,
       bool concurrencyCheckEnabled = false, int32_t tombstonetimeout = -1);
 
   std::shared_ptr<Region> createRegion(
-      const char* name, bool ack, bool caching = true,
+      const std::string& name, bool ack, bool caching = true,
       const std::chrono::seconds& ettl = std::chrono::seconds::zero(),
       const std::chrono::seconds& eit = std::chrono::seconds::zero(),
       const std::chrono::seconds& rttl = std::chrono::seconds::zero(),
       const std::chrono::seconds& rit = std::chrono::seconds::zero(),
       int lel = 0, ExpirationAction action = ExpirationAction::DESTROY,
-      const char* endpoints = nullptr, bool clientNotificationEnabled = false);
+      const std::string& endpoints = {}, bool clientNotificationEnabled = false);
 
   std::shared_ptr<Pool> createPool(
-      const std::string& poolName, const char* locators,
-      const char* serverGroup, int redundancy = 0,
+      const std::string& poolName, const std::string& locators,
+      const std::string& serverGroup, int redundancy = 0,
       bool clientNotification = false,
       std::chrono::milliseconds subscriptionAckInterval =
           std::chrono::milliseconds::zero(),
@@ -148,9 +148,9 @@ class CacheHelper {
       bool isMultiuserMode = false);
 
   // this will create pool even endpoints and locatorhost has been not defined
-  std::shared_ptr<Pool> createPool2(const char* poolName, const char* locators,
-                                    const char* serverGroup,
-                                    const char* servers = nullptr,
+  std::shared_ptr<Pool> createPool2(
+      const std::string& poolName, const std::string& locators,
+      const std::string& serverGroup, const std::string& servers = {},
                                     int redundancy = 0,
                                     bool clientNotification = false,
                                     int subscriptionAckInterval = -1,
@@ -159,12 +159,12 @@ class CacheHelper {
   void logPoolAttributes(std::shared_ptr<Pool>& pool);
 
   void createPoolWithLocators(
-      const std::string& name, const char* locators = nullptr,
+      const std::string& name, const std::string& locators = {},
       bool clientNotificationEnabled = false, int subscriptionRedundancy = -1,
       std::chrono::milliseconds subscriptionAckInterval =
           std::chrono::milliseconds::zero(),
       int connections = -1, bool isMultiuserMode = false,
-      const char* serverGroup = nullptr);
+      const std::string& serverGroup = {});
 
   std::shared_ptr<Region> createRegionAndAttachPool(
       const std::string& name, bool ack, const std::string& poolName,
@@ -185,12 +185,12 @@ class CacheHelper {
       const std::chrono::seconds& rit = std::chrono::seconds::zero(),
       int lel = 0, ExpirationAction action = ExpirationAction::DESTROY);
 
-  static void addServerLocatorEPs(const char* epList, PoolFactory& pfPtr,
+  static void addServerLocatorEPs(const std::string& epList, PoolFactory& pfPtr,
                                   bool poolLocators = true);
 
   std::shared_ptr<Region> createPooledRegion(
-      const char* name, bool ack, const char* locators = nullptr,
-      const char* poolName = "__TEST_POOL1__", bool caching = true,
+      const std::string& name, bool ack, const std::string& locators = {},
+      const std::string& poolName = "__TEST_POOL1__", bool caching = true,
       bool clientNotificationEnabled = false,
       const std::chrono::seconds& ettl = std::chrono::seconds::zero(),
       const std::chrono::seconds& eit = std::chrono::seconds::zero(),
@@ -201,8 +201,8 @@ class CacheHelper {
       ExpirationAction action = ExpirationAction::DESTROY);
 
   std::shared_ptr<Region> createPooledRegionConcurrencyCheckDisabled(
-      const char* name, bool ack, const char* locators = nullptr,
-      const char* poolName = "__TEST_POOL1__", bool caching = true,
+      const std::string& name, bool ack, const std::string& locators = {},
+      const std::string& poolName = "__TEST_POOL1__", bool caching = true,
       bool clientNotificationEnabled = false,
       bool concurrencyCheckEnabled = true,
       const std::chrono::seconds& ettl = std::chrono::seconds::zero(),
@@ -214,7 +214,7 @@ class CacheHelper {
       ExpirationAction action = ExpirationAction::DESTROY);
 
   std::shared_ptr<Region> createRegionDiscOverFlow(
-      const char* name, bool caching = true,
+      const std::string& name, bool caching = true,
       bool clientNotificationEnabled = false,
       const std::chrono::seconds& ettl = std::chrono::seconds::zero(),
       const std::chrono::seconds& eit = std::chrono::seconds::zero(),
@@ -223,8 +223,8 @@ class CacheHelper {
       int lel = 0, ExpirationAction action = ExpirationAction::DESTROY);
 
   std::shared_ptr<Region> createPooledRegionDiscOverFlow(
-      const char* name, bool ack, const char* locators = nullptr,
-      const char* poolName = "__TEST_POOL1__", bool caching = true,
+      const std::string& name, bool ack, const std::string& locators = {},
+      const std::string& poolName = "__TEST_POOL1__", bool caching = true,
       bool clientNotificationEnabled = false,
       const std::chrono::seconds& ettl = std::chrono::seconds::zero(),
       const std::chrono::seconds& eit = std::chrono::seconds::zero(),
@@ -235,8 +235,8 @@ class CacheHelper {
       ExpirationAction action = ExpirationAction::DESTROY);
 
   std::shared_ptr<Region> createPooledRegionSticky(
-      const char* name, bool ack, const char* locators = nullptr,
-      const char* poolName = "__TEST_POOL1__", bool caching = true,
+      const std::string& name, bool ack, const std::string& locators = {},
+      const std::string& poolName = "__TEST_POOL1__", bool caching = true,
       bool clientNotificationEnabled = false,
       const std::chrono::seconds& ettl = std::chrono::seconds::zero(),
       const std::chrono::seconds& eit = std::chrono::seconds::zero(),
@@ -247,8 +247,8 @@ class CacheHelper {
       ExpirationAction action = ExpirationAction::DESTROY);
 
   std::shared_ptr<Region> createPooledRegionStickySingleHop(
-      const char* name, bool ack, const char* locators = nullptr,
-      const char* poolName = "__TEST_POOL1__", bool caching = true,
+      const std::string& name, bool ack, const std::string& locators = {},
+      const std::string& poolName = "__TEST_POOL1__", bool caching = true,
       bool clientNotificationEnabled = false,
       const std::chrono::seconds& ettl = std::chrono::seconds::zero(),
       const std::chrono::seconds& eit = std::chrono::seconds::zero(),
@@ -290,13 +290,13 @@ class CacheHelper {
 
   static int staticJmxManagerPort;
 
-  static const char* getstaticLocatorHostPort1();
+  static std::string  getstaticLocatorHostPort1();
 
-  static const char* getstaticLocatorHostPort2();
+  static std::string  getstaticLocatorHostPort2();
 
-  static const char* getLocatorHostPort(int locPort);
+  static std::string  getLocatorHostPort(int locPort);
 
-  static const char* getLocatorHostPort(bool& isLocator, bool& isLocalServer,
+  static std::string  getLocatorHostPort(bool& isLocator, bool& isLocalServer,
                                         int numberOfLocators = 0);
 
   static const std::string getTcrEndpoints2(bool& isLocalServer,
@@ -306,18 +306,18 @@ class CacheHelper {
   static bool isServerCleanupCallbackRegistered;
   static void cleanupServerInstances();
 
-  static void initServer(int instance, const char* xml = nullptr,
-                         const char* locHostport = nullptr,
+  static void initServer(int instance, const std::string& xml = {},
+                         const std::string& locHostport = {},
                          const char* authParam = nullptr, bool ssl = false,
                          bool enableDelta = true, bool multiDS = false,
                          bool testServerGC = false, bool untrustedCert = false,
                          bool useSecurityManager = false);
 
-  static void createDuplicateXMLFile(std::string& originalFile, int hostport1,
-                                     int hostport2, int locport1, int locport2);
+  static std::string createDuplicateXMLFile(const std::string& source,
+                                            int hostport1, int hostport2,
+                                            int locport1, int locport2);
 
-  static void createDuplicateXMLFile(std::string& duplicateFile,
-                                     std::string& originalFile);
+  static std::string createDuplicateXMLFile(const std::string& source);
 
   static void closeServer(int instance);
 

--- a/cppcache/integration-test/LocatorHelper.hpp
+++ b/cppcache/integration-test/LocatorHelper.hpp
@@ -47,7 +47,7 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(SERVER1, CreateServer1_With_Locator)
   {
     // starting servers
-    if (isLocalServer) CacheHelper::initServer(1, nullptr, locatorsG);
+    if (isLocalServer) CacheHelper::initServer(1, {}, locatorsG);
   }
 END_TASK_DEFINITION
 
@@ -55,7 +55,7 @@ DUNIT_TASK_DEFINITION(SERVER1, CreateServer1_With_Locator_And_SSL)
   {
     // starting servers
     if (isLocalServer) {
-      CacheHelper::initServer(1, nullptr, locatorsG, nullptr, true);
+      CacheHelper::initServer(1, {}, locatorsG, nullptr, true);
     }
   }
 END_TASK_DEFINITION
@@ -64,7 +64,7 @@ DUNIT_TASK_DEFINITION(SERVER1, CreateServer2_With_Locator)
   {
     // starting servers
     if (isLocalServer) {
-      CacheHelper::initServer(2, nullptr, locatorsG);
+      CacheHelper::initServer(2, {}, locatorsG);
     }
   }
 END_TASK_DEFINITION

--- a/cppcache/integration-test/QueryHelper.hpp
+++ b/cppcache/integration-test/QueryHelper.hpp
@@ -188,10 +188,9 @@ void QueryHelper::populatePortfolioData(
       auto port = std::make_shared<Portfolio>(static_cast<int32_t>(current),
                                               objSize, nm);
 
-      char portname[100] = {0};
-      ACE_OS::sprintf(portname, "port%zd-%zd", set, current);
-
-      auto keyport = CacheableKey::create(portname);
+      std::string key =
+          "port" + std::to_string(set) + '-' + std::to_string(current);
+      auto keyport = CacheableKey::create(key);
       // printf(" QueryHelper::populatePortfolioData creating key = %s and
       // puting data \n",portname);
       rptr->put(keyport, port);
@@ -215,10 +214,9 @@ void QueryHelper::populatePositionData(std::shared_ptr<Region>& rptr,
       auto pos = std::make_shared<Position>(
           secIds[current % numSecIds], static_cast<int32_t>(current * 100));
 
-      char posname[100] = {0};
-      ACE_OS::sprintf(posname, "pos%zd-%zd", set, current);
-
-      auto keypos = CacheableKey::create(posname);
+      std::string key =
+          "pos" + std::to_string(set) + '-' + std::to_string(current);
+      auto keypos = CacheableKey::create(key);
       rptr->put(keypos, pos);
     }
   }
@@ -235,13 +233,12 @@ void QueryHelper::populatePortfolioPdxData(std::shared_ptr<Region>& rptr,
     for (size_t current = 1; current <= setSize; current++) {
       auto port = std::make_shared<PortfolioPdx>(static_cast<int32_t>(current),
                                                  objSize);
+      std::string key =
+          "port" + std::to_string(set) + '-' + std::to_string(current);
 
-      char portname[100] = {0};
-      ACE_OS::sprintf(portname, "port%zd-%zd", set, current);
-
-      auto keyport = CacheableKey::create(portname);
-
+      auto keyport = CacheableKey::create(key);
       rptr->put(keyport, port);
+
       LOGDEBUG("populatePortfolioPdxData:: Put for iteration current = %d done",
                current);
     }
@@ -261,10 +258,10 @@ void QueryHelper::populatePositionPdxData(std::shared_ptr<Region>& rptr,
       auto pos = std::make_shared<PositionPdx>(
           secIds[current % numSecIds], static_cast<int32_t>(current * 100));
 
-      char posname[100] = {0};
-      ACE_OS::sprintf(posname, "pos%zd-%zd", set, current);
+      std::string key =
+          "pos" + std::to_string(set) + '-' + std::to_string(current);
 
-      auto keypos = CacheableKey::create(posname);
+      auto keypos = CacheableKey::create(key);
       rptr->put(keypos, pos);
     }
   }

--- a/cppcache/integration-test/ThinClientCQ.hpp
+++ b/cppcache/integration-test/ThinClientCQ.hpp
@@ -28,10 +28,10 @@
 static bool isLocator = false;
 static bool isLocalServer = false;
 static int numberOfLocators = 1;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
-void createRegionForCQ(const char* name, bool ackMode,
+void createRegionForCQ(const std::string& name, bool ackMode,
                        bool clientNotificationEnabled = false,
                        int redundancyLevel = 0,
                        bool caching = true) {

--- a/cppcache/integration-test/ThinClientCallbackArg.hpp
+++ b/cppcache/integration-test/ThinClientCallbackArg.hpp
@@ -45,7 +45,7 @@ using apache::geode::client::testing::TallyWriter;
 static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 0;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 const char* poolName = "__TESTPOOL1_";
 std::shared_ptr<TallyListener> regListener;

--- a/cppcache/integration-test/ThinClientDistOps.hpp
+++ b/cppcache/integration-test/ThinClientDistOps.hpp
@@ -56,7 +56,7 @@ static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 0;
 
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 void initClient(const bool isthinClient, const bool redirectLog) {
@@ -183,12 +183,12 @@ void createRegion(const char* name, bool ackMode, const char* endpoints,
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,
@@ -197,12 +197,13 @@ void createPooledRegion(const char* name, bool ackMode, const char* locators,
   LOG("Pooled Region created.");
 }
 
-void createPooledRegionSticky(const char* name, bool ackMode,
-                              const char* locators, const char* poolname,
+void createPooledRegionSticky(const std::string& name, bool ackMode,
+                              const std::string& locators,
+                              const std::string& poolname,
                               bool clientNotificationEnabled = false,
                               bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr = getHelper()->createPooledRegionSticky(
       name, ackMode, locators, poolname, cachingEnable,
@@ -538,7 +539,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, CreatePoolForUpdateLocatorList)
     isMultiuserMode = false, int updateLocatorListInterval = 5000 )
     */
     initClient(true, true);
-    getHelper()->createPool("__TESTPOOL1_", locatorsG, nullptr, 0, false,
+    getHelper()->createPool("__TESTPOOL1_", locatorsG, {}, 0, false,
                             std::chrono::milliseconds::zero(), -1, -1, false);
     LOG("CreatePoolForUpdateLocatorList complete.");
   }
@@ -554,7 +555,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, CreatePoolForDontUpdateLocatorList)
     isMultiuserMode = false, int updateLocatorListInterval = 5000 )
     */
     initClient(true, true);
-    getHelper()->createPool("__TESTPOOL1_", locatorsG, nullptr, 0, false,
+    getHelper()->createPool("__TESTPOOL1_", locatorsG, {}, 0, false,
                             std::chrono::milliseconds::zero(), -1, -1, false);
     LOG("CreatePoolForDontUpdateLocatorList complete.");
   }

--- a/cppcache/integration-test/ThinClientDistOps2.hpp
+++ b/cppcache/integration-test/ThinClientDistOps2.hpp
@@ -53,7 +53,7 @@ static bool isLocator = false;
 static int numberOfLocators = 0;
 const char* poolName = "__TEST_POOL1__";
 
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 #include "LocatorHelper.hpp"
@@ -93,15 +93,19 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(SERVER2, CreateServer2And3_Locator)
   {
-    if (isLocalServer) CacheHelper::initServer(2, nullptr, locatorsG);
-    if (isLocalServer) CacheHelper::initServer(3, nullptr, locatorsG);
+    if (isLocalServer) {
+      CacheHelper::initServer(2, {}, locatorsG);
+    }
+    if (isLocalServer) {
+      CacheHelper::initServer(3, {}, locatorsG);
+    }
     LOG("SERVER23 started");
   }
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, CreateClient1Regions_Pooled_Locator)
   {
-    initClientWithPool(true, "__TEST_POOL1__", locatorsG, nullptr, nullptr, 0,
+    initClientWithPool(true, "__TEST_POOL1__", locatorsG, {}, nullptr, 0,
                        true);
     createPooledRegion(_regionNames[0], USE_ACK, locatorsG, poolName);
     createPooledRegion(_regionNames[1], NO_ACK, locatorsG, poolName);
@@ -111,7 +115,7 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, CreateClient2Regions_Pooled_Locator)
   {
-    initClientWithPool(true, "__TEST_POOL1__", locatorsG, nullptr, nullptr, 0,
+    initClientWithPool(true, "__TEST_POOL1__", locatorsG, {}, nullptr, 0,
                        true);
     createPooledRegion(_regionNames[0], USE_ACK, locatorsG, poolName);
     createPooledRegion(_regionNames[1], NO_ACK, locatorsG, poolName);
@@ -169,7 +173,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, Client1GetAll)
     // re-create region with caching enabled
     reg0->localDestroyRegion();
     reg0 = nullptr;
-    getHelper()->createPooledRegion(regionNames[0], USE_ACK, nullptr,
+    getHelper()->createPooledRegion(regionNames[0], USE_ACK, {},
                                     "__TEST_POOL1__", true, true);
     reg0 = getHelper()->getRegion(_regionNames[0]);
     // check for IllegalArgumentException for empty key list

--- a/cppcache/integration-test/ThinClientDurable.hpp
+++ b/cppcache/integration-test/ThinClientDurable.hpp
@@ -226,7 +226,7 @@ void feederUpdate(int value, int ignoreR2 = false) {
 
 DUNIT_TASK_DEFINITION(FEEDER, FeederInit)
   {
-    initClientWithPool(true, "__TEST_POOL1__", locatorsG, nullptr, nullptr, 0,
+    initClientWithPool(true, "__TEST_POOL1__", locatorsG, {}, nullptr, 0,
                        true);
     getHelper()->createPooledRegion(regionNames[0], USE_ACK, locatorsG,
                                     "__TEST_POOL1__", true, true);

--- a/cppcache/integration-test/ThinClientDurableConnect.hpp
+++ b/cppcache/integration-test/ThinClientDurableConnect.hpp
@@ -52,7 +52,6 @@ const char* durableId = "DurableId";
 #include "ThinClientDurableInit.hpp"
 #include "ThinClientTasks_C2S2.hpp"
 
-const char* g_Locators = locatorsG;
 
 std::string getServerEndPoint(int instance) {
   char instanceStr[16];
@@ -67,30 +66,14 @@ std::string getServerEndPoint(int instance) {
     port = CacheHelper::staticHostPort4;
   }
 
-  std::string retVal(ACE_OS::itoa(port, instanceStr, 10));
-  return retVal;
-
-  std::string allEndPts(endPointsList);
-  std::string::size_type start_idx = 0;
-  std::string::size_type end_idx = 0;
-
-  for (int i = 0; i < instance - 1; i++) {
-    start_idx = allEndPts.find(',', start_idx) + 1;
-  }
-
-  end_idx = allEndPts.find(',', start_idx);
-  if (end_idx == std::string::npos) { /* asking for last endpoint */
-    end_idx = allEndPts.size();
-  }
-
-  return (std::string(allEndPts, start_idx, end_idx - start_idx));
+  return std::to_string(port);
 }
 
 DUNIT_TASK_DEFINITION(SERVER_SET1, S1Up)
   {
     if (isLocalServer) {
       CacheHelper::initServer(1, "cacheserver_notify_subscription.xml",
-                              g_Locators);
+                              locatorsG);
     }
     LOG("SERVER 1 started");
   }
@@ -100,7 +83,7 @@ DUNIT_TASK_DEFINITION(SERVER_SET1, S2Up)
   {
     if (isLocalServer) {
       CacheHelper::initServer(2, "cacheserver_notify_subscription2.xml",
-                              g_Locators);
+                              locatorsG);
     }
     LOG("SERVER 2 started");
   }
@@ -110,7 +93,7 @@ DUNIT_TASK_DEFINITION(SERVER_SET2, S3Up)
   {
     if (isLocalServer) {
       CacheHelper::initServer(3, "cacheserver_notify_subscription3.xml",
-                              g_Locators);
+                              locatorsG);
     }
     LOG("SERVER 3 started");
   }
@@ -120,7 +103,7 @@ DUNIT_TASK_DEFINITION(SERVER_SET2, S4Up)
   {
     if (isLocalServer) {
       CacheHelper::initServer(4, "cacheserver_notify_subscription4.xml",
-                              g_Locators);
+                              locatorsG);
     }
     LOG("SERVER 4 started");
   }

--- a/cppcache/integration-test/ThinClientDurableFailover.hpp
+++ b/cppcache/integration-test/ThinClientDurableFailover.hpp
@@ -234,7 +234,7 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(FEEDER, FeederInit)
   {
-    initClientWithPool(true, "__TEST_POOL1__", locatorsG, nullptr, nullptr, 0,
+    initClientWithPool(true, "__TEST_POOL1__", locatorsG, {}, nullptr, 0,
                        true);
     getHelper()->createPooledRegion(regionNames[0], USE_ACK, locatorsG,
                                     "__TEST_POOL1__", true, true);

--- a/cppcache/integration-test/ThinClientDurableInit.hpp
+++ b/cppcache/integration-test/ThinClientDurableInit.hpp
@@ -26,7 +26,7 @@ const char* durableIds[] = {"DurableId1", "DurableId2"};
 
 static bool isLocator = false;
 static int numberOfLocators = 1;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 void initClientAndRegion(

--- a/cppcache/integration-test/ThinClientDurableInterest.hpp
+++ b/cppcache/integration-test/ThinClientDurableInterest.hpp
@@ -214,7 +214,7 @@ void feederUpdate1(int value) {
 
 DUNIT_TASK_DEFINITION(FEEDER, FeederInit)
   {
-    initClientWithPool(true, "__TEST_POOL1__", locatorsG, nullptr, nullptr, 0,
+    initClientWithPool(true, "__TEST_POOL1__", locatorsG, {}, nullptr, 0,
                        true);
     getHelper()->createPooledRegion(regionNames[0], USE_ACK, locatorsG,
                                     "__TEST_POOL1__", true, true);

--- a/cppcache/integration-test/ThinClientFailover.hpp
+++ b/cppcache/integration-test/ThinClientFailover.hpp
@@ -31,7 +31,7 @@
 
 #include "CacheHelper.hpp"
 
-namespace { // NOLINT(google-build-namespaces)
+namespace {  // NOLINT(google-build-namespaces)
 
 using apache::geode::client::CacheableKey;
 using apache::geode::client::CacheableString;
@@ -47,7 +47,7 @@ CacheHelper* cacheHelper = nullptr;
 #define SERVER2 s2p2
 static bool isLocator = false;
 // static int numberOfLocators = 0;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 void initClient(const bool isthinClient) {
@@ -127,7 +127,8 @@ void _verifyEntry(const char* name, const char* key, const char* val,
           std::dynamic_pointer_cast<CacheableString>(regPtr->get(keyPtr));
 
       ASSERT(checkPtr != nullptr, "Value Ptr should not be null.");
-      LOG("In verify loop, get returned " + checkPtr->value() + " for key " + key);
+      LOG("In verify loop, get returned " + checkPtr->value() + " for key " +
+          key);
       if (strcmp(checkPtr->value().c_str(), value) != 0) {
         testValueCnt++;
       } else {
@@ -161,12 +162,14 @@ void createRegion(const char* name, bool ackMode, const char* endpoints,
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode,
+                        const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,
@@ -175,12 +178,14 @@ void createPooledRegion(const char* name, bool ackMode, const char* locators,
   LOG("Pooled Region created.");
 }
 
-void createPooledRegionSticky(const char* name, bool ackMode,
-                              const char* locators, const char* poolname,
+void createPooledRegionSticky(const std::string& name, bool ackMode,
+                              const std::string& locators,
+                              const std::string& poolname,
                               bool clientNotificationEnabled = false,
                               bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr = getHelper()->createPooledRegionSticky(
       name, ackMode, locators, poolname, cachingEnable,

--- a/cppcache/integration-test/ThinClientFailover2.hpp
+++ b/cppcache/integration-test/ThinClientFailover2.hpp
@@ -50,7 +50,7 @@ CacheHelper* cacheHelper = nullptr;
 #define SERVER2 s2p2
 static bool isLocator = false;
 static int numberOfLocators = 0;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 #include "LocatorHelper.hpp"
 void initClient(const bool isthinClient) {
@@ -183,12 +183,12 @@ void createRegion(const char* name, bool ackMode, const char* endpoints,
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/ThinClientFailover3.hpp
+++ b/cppcache/integration-test/ThinClientFailover3.hpp
@@ -31,7 +31,7 @@
 
 #include "CacheHelper.hpp"
 
-namespace { // NOLINT(google-build-namespaces)
+namespace {  // NOLINT(google-build-namespaces)
 
 using apache::geode::client::CacheableKey;
 using apache::geode::client::CacheableString;
@@ -47,7 +47,7 @@ CacheHelper* cacheHelper = nullptr;
 #define SERVER2 s2p2
 static bool isLocator = false;
 // static int numberOfLocators = 0;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 void initClient(const bool isthinClient) {
@@ -126,7 +126,8 @@ void _verifyEntry(const char* name, const char* key, const char* val,
           std::dynamic_pointer_cast<CacheableString>(regPtr->get(keyPtr));
 
       ASSERT(checkPtr != nullptr, "Value Ptr should not be null.");
-      LOG("In verify loop, get returned " + checkPtr->value() + " for key " + key);
+      LOG("In verify loop, get returned " + checkPtr->value() + " for key " +
+          key);
       if (strcmp(checkPtr->value().c_str(), value) != 0) {
         testValueCnt++;
       } else {
@@ -149,12 +150,14 @@ void _verifyEntry(const char* name, const char* key, const char* val,
   LOG("Entry verified.");
 }
 
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode,
+                        const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,
@@ -244,7 +247,7 @@ std::vector<std::string> storeEndPoints(const std::string points) {
   size_t end = 0;
   size_t start;
   std::string delim = ",";
-  while ((start = points.find_first_not_of(delim, end)) != std::string::npos)  {
+  while ((start = points.find_first_not_of(delim, end)) != std::string::npos) {
     end = points.find(delim, start);
     if (end == std::string::npos) {
       end = points.length();

--- a/cppcache/integration-test/ThinClientFailoverInterest.hpp
+++ b/cppcache/integration-test/ThinClientFailoverInterest.hpp
@@ -46,7 +46,7 @@ CacheHelper* cacheHelper = nullptr;
 #define SERVER2 s2p2
 static bool isLocator = false;
 // static int numberOfLocators = 0;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 void initClient(const bool isthinClient) {
@@ -188,12 +188,12 @@ void createRegion(const char* name, bool ackMode, const char* endpoints,
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/ThinClientFailoverInterest2.hpp
+++ b/cppcache/integration-test/ThinClientFailoverInterest2.hpp
@@ -45,7 +45,7 @@ bool isLocalServer = false;
 #define SERVER2 s2p2
 static bool isLocator = false;
 // static int numberOfLocators = 0;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 void initClient(const bool isthinClient) {
@@ -187,12 +187,12 @@ void createRegion(const char* name, bool ackMode, const char* endpoints,
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/ThinClientFailoverInterestAllWithCache.hpp
+++ b/cppcache/integration-test/ThinClientFailoverInterestAllWithCache.hpp
@@ -47,7 +47,7 @@ volatile bool g_poolLocators = false;
 #define SERVER2 s2p2
 static bool isLocator = false;
 // static int numberOfLocators = 0;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 #include "ThinClientTasks_C2S2.hpp"
@@ -181,13 +181,13 @@ void _verifyCreated(const char* name, const char* key, int line) {
   LOG("Entry created.");
 }
 
-void createRegion(const char* name, bool ackMode, const char* endpoints,
+void createRegion(const std::string& name, bool ackMode, const std::string&,
                   bool clientNotificationEnabled = false) {
   LOG("createRegion() entered.");
-  LOGINFO("Creating region --  %s  ackMode is %d", name, ackMode);
+  LOGINFO("Creating region --  %s  ackMode is %d", name.c_str(), ackMode);
   // ack, caching
   auto regPtr = getHelper()->createRegion(name, ackMode, true, nullptr,
-                                          endpoints, clientNotificationEnabled);
+                                          clientNotificationEnabled);
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }

--- a/cppcache/integration-test/ThinClientFailoverRegex.hpp
+++ b/cppcache/integration-test/ThinClientFailoverRegex.hpp
@@ -46,7 +46,7 @@ CacheHelper* cacheHelper = nullptr;
 #define SERVER2 s2p2
 static bool isLocator = false;
 // static int numberOfLocators = 0;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 void initClient(const bool isthinClient) {
@@ -188,12 +188,13 @@ void createRegion(const char* name, bool ackMode, const char* endpoints,
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode,
+                        const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/ThinClientGatewayTest.hpp
+++ b/cppcache/integration-test/ThinClientGatewayTest.hpp
@@ -73,8 +73,8 @@ void setCacheListener(const char* regName,
   attrMutator->setCacheListener(regListener);
 }
 
-const char* locHostPort1 = nullptr;
-const char* locHostPort2 = nullptr;
+std::string locHostPort1;
+std::string locHostPort2;
 DUNIT_TASK_DEFINITION(SERVER1, StartLocator1)
   {
     CacheHelper::initLocator(1, false, true, 1,

--- a/cppcache/integration-test/ThinClientHeapLRU.hpp
+++ b/cppcache/integration-test/ThinClientHeapLRU.hpp
@@ -42,7 +42,7 @@ static bool isLocator = false;
 static bool isLocalServer = false;
 static int numberOfLocators = 0;
 const char* poolName = "__TESTPOOL1_";
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 const char* keys[] = {"Key-1", "Key-2", "Key-3", "Key-4"};

--- a/cppcache/integration-test/ThinClientHelper.hpp
+++ b/cppcache/integration-test/ThinClientHelper.hpp
@@ -22,8 +22,10 @@
 
 #include <chrono>
 
-#include <ace/OS.h>
 #include <ace/High_Res_Timer.h>
+
+#include <boost/process.hpp>
+
 #include "testUtils.hpp"
 #include "security/typedefs.hpp"
 #include "security/CredentialGenerator.hpp"
@@ -66,7 +68,7 @@ void initClient(const bool isthinClient,
 }
 
 void initClientWithPool(const bool isthinClient, const char* poolName,
-                        const char* locators, const char* serverGroup,
+                        const std::string& locators, const char* serverGroup,
                         const std::shared_ptr<Properties>& configPtr = nullptr,
                         int redundancy = 0, bool clientNotification = false,
                         int subscriptionAckInterval = -1, int connections = -1,
@@ -367,7 +369,7 @@ std::shared_ptr<Region> createOverflowRegion(const char* name, bool,
   sqLiteProps->insert("PageSize", "65536");
   sqLiteProps->insert("MaxPageCount", "1073741823");
   std::string sqlite_dir =
-      "SqLiteRegionData" + std::to_string(ACE_OS::getpid());
+      "SqLiteRegionData" + std::to_string(boost::this_process::get_id());
   sqLiteProps->insert("PersistenceDirectory", sqlite_dir.c_str());
   regionAttributesFactory.setPersistenceManager(
       "SqLiteImpl", "createSqLiteInstance", sqLiteProps);
@@ -380,7 +382,7 @@ std::shared_ptr<Region> createOverflowRegion(const char* name, bool,
   return regionPtr;
 }
 std::shared_ptr<Region> createPooledRegion(
-    const char* name, bool ackMode, const char* locators, const char* poolname,
+    const char* name, bool ackMode, const std::string& locators, const char* poolname,
     bool clientNotificationEnabled = false,
     const std::shared_ptr<CacheListener>& listener = nullptr,
     bool caching = true) {
@@ -409,7 +411,7 @@ std::shared_ptr<Pool> findPool(const char* poolName) {
   return poolPtr;
 }
 std::shared_ptr<Pool> createPool(
-    const char* poolName, const char* locators, const char* serverGroup,
+    const std::string& poolName, const std::string& locators, const std::string& serverGroup,
     int redundancy = 0, bool clientNotification = false,
     std::chrono::milliseconds subscriptionAckInterval =
         std::chrono::milliseconds::zero(),
@@ -424,7 +426,7 @@ std::shared_ptr<Pool> createPool(
   return poolPtr;
 }
 std::shared_ptr<Pool> createPoolAndDestroy(
-    const char* poolName, const char* locators, const char* serverGroup,
+    const std::string& poolName, const std::string& locators, const std::string& serverGroup,
     int redundancy = 0, bool clientNotification = false,
     std::chrono::milliseconds subscriptionAckInterval =
         std::chrono::milliseconds::zero(),
@@ -440,9 +442,9 @@ std::shared_ptr<Pool> createPoolAndDestroy(
   return poolPtr;
 }
 // this will create pool even endpoints and locatorhost has been not defined
-std::shared_ptr<Pool> createPool2(const char* poolName, const char* locators,
-                                  const char* serverGroup,
-                                  const char* servers = nullptr,
+std::shared_ptr<Pool> createPool2(const std::string& poolName, const std::string& locators,
+                                  const std::string& serverGroup,
+                                  const std::string& servers = nullptr,
                                   int redundancy = 0,
                                   bool clientNotification = false) {
   LOG("createPool2() entered.");

--- a/cppcache/integration-test/ThinClientInterest1.hpp
+++ b/cppcache/integration-test/ThinClientInterest1.hpp
@@ -30,7 +30,7 @@
 
 bool isLocalServer = true;
 static bool isLocator = false;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 DUNIT_TASK_DEFINITION(SERVER1, StartServer)

--- a/cppcache/integration-test/ThinClientInterest2.hpp
+++ b/cppcache/integration-test/ThinClientInterest2.hpp
@@ -30,7 +30,7 @@
 
 bool isLocalServer = true;
 static bool isLocator = false;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 

--- a/cppcache/integration-test/ThinClientInterest3.hpp
+++ b/cppcache/integration-test/ThinClientInterest3.hpp
@@ -36,7 +36,7 @@ using apache::geode::client::testing::TallyWriter;
 
 bool isLocalServer = true;
 static bool isLocator = false;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 std::shared_ptr<TallyListener> reg1Listener1;

--- a/cppcache/integration-test/ThinClientInterest3Cacheless.hpp
+++ b/cppcache/integration-test/ThinClientInterest3Cacheless.hpp
@@ -36,7 +36,7 @@ using apache::geode::client::testing::TallyWriter;
 
 bool isLocalServer = true;
 static bool isLocator = false;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 std::shared_ptr<TallyListener> reg1Listener1;

--- a/cppcache/integration-test/ThinClientInterestList.hpp
+++ b/cppcache/integration-test/ThinClientInterestList.hpp
@@ -44,7 +44,7 @@ bool isLocalServer = false;
 
 static bool isLocator = false;
 static int numberOfLocators = 1;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 #include "LocatorHelper.hpp"
 void initClient(const bool isthinClient) {
@@ -184,12 +184,12 @@ void _verifyCreated(const char* name, const char* key, int line) {
   LOG("Entry created.");
 }
 
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/ThinClientInterestList2.hpp
+++ b/cppcache/integration-test/ThinClientInterestList2.hpp
@@ -45,7 +45,7 @@ bool isLocalServer = false;
 
 static bool isLocator = false;
 static int numberOfLocators = 0;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 #include "LocatorHelper.hpp"
 void initClient(const bool isthinClient) {
@@ -185,11 +185,11 @@ void _verifyCreated(const char* name, const char* key, int line) {
   LOG("Entry created.");
 }
 
-void createPooledRegion(const char* name, bool ackMode, const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locatorsG, poolname,

--- a/cppcache/integration-test/ThinClientListenerInit.hpp
+++ b/cppcache/integration-test/ThinClientListenerInit.hpp
@@ -41,7 +41,7 @@ using apache::geode::client::testing::TallyWriter;
 static bool isLocator = false;
 static bool isLocalServer = true;
 static int numberOfLocators = 1;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 const char* poolName = "__TESTPOOL1_";
 std::shared_ptr<TallyListener> reg1Listener1, reg1Listener2;

--- a/cppcache/integration-test/ThinClientListenerWriter.hpp
+++ b/cppcache/integration-test/ThinClientListenerWriter.hpp
@@ -122,7 +122,7 @@ void SimpleCacheListener::afterRegionClear(const RegionEvent& event) {
 static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 0;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 const char* poolName = "__TESTPOOL1_";
 std::shared_ptr<TallyListener> regListener;
@@ -377,10 +377,9 @@ DUNIT_TASK_DEFINITION(CLIENT1, doEventOperations)
     auto subregPtr2 = exmpRegPtr->getSubregion(myRegNames[4]);
 
     for (int index = 0; index < 5; index++) {
-      char key[100] = {0};
-      char value[100] = {0};
-      ACE_OS::sprintf(key, "Key-%d", index);
-      ACE_OS::sprintf(value, "Value-%d", index);
+      std::string key = "Key-" + std::to_string(index);
+      std::string value = "Value-" + std::to_string(index);
+
       auto keyptr = CacheableKey::create(key);
       auto valuePtr = CacheableString::create(value);
       regPtr0->put(keyptr, valuePtr);

--- a/cppcache/integration-test/ThinClientLocalCacheLoader.hpp
+++ b/cppcache/integration-test/ThinClientLocalCacheLoader.hpp
@@ -98,7 +98,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SetupClient)
   {
     // Create a Geode Cache with the "client_Loader.xml" Cache XML file.
     const char* clientXmlFile = "client_Loader.xml";
-    static char* path = ACE_OS::getenv("TESTSRC");
+    static char* path = std::getenv("TESTSRC");
     std::string clientXml = path;
     clientXml += "/resources/";
     clientXml += clientXmlFile;

--- a/cppcache/integration-test/ThinClientMultipleCaches.hpp
+++ b/cppcache/integration-test/ThinClientMultipleCaches.hpp
@@ -43,7 +43,7 @@ using apache::geode::client::RegionShortcut;
 static bool isLocalServer = false;
 static bool isLocator = false;
 
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer);
 
 #include "LocatorHelper.hpp"

--- a/cppcache/integration-test/ThinClientNotification.hpp
+++ b/cppcache/integration-test/ThinClientNotification.hpp
@@ -30,7 +30,7 @@
 
 #include "CacheHelper.hpp"
 
-namespace { // NOLINT(google-build-namespaces)
+namespace {  // NOLINT(google-build-namespaces)
 
 using apache::geode::client::CacheableKey;
 using apache::geode::client::CacheableString;
@@ -124,7 +124,8 @@ void _verifyEntry(const char* name, const char* key, const char* val,
           std::dynamic_pointer_cast<CacheableString>(regPtr->get(keyPtr));
 
       ASSERT(checkPtr != nullptr, "Value Ptr should not be null.");
-      LOG("In verify loop, get returned " + checkPtr->value() + " for key " + key);
+      LOG("In verify loop, get returned " + checkPtr->value() + " for key " +
+          key);
       if (strcmp(checkPtr->value().c_str(), value) != 0) {
         testValueCnt++;
       } else {
@@ -168,12 +169,14 @@ void _verifyEntry(const char* name, const char* key, const char* val,
   LOG("Entry verified.");
 }
 
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode,
+                        const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/ThinClientPdxSerializer.hpp
+++ b/cppcache/integration-test/ThinClientPdxSerializer.hpp
@@ -51,7 +51,7 @@ bool isLocator = false;
 bool isLocalServer = false;
 
 const char* poolNames[] = {"Pool1", "Pool2", "Pool3"};
-const char* locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 bool isPoolConfig = false;  // To track if pool case is running
 
@@ -68,7 +68,7 @@ void stepOne(bool isPdxIgnoreUnreadFields = false) {
   // Create just one pool and attach all regions to that.
   initClient(true, isPdxIgnoreUnreadFields);
   isPoolConfig = true;
-  createPool(poolNames[0], locHostPort, nullptr, 0, true);
+  createPool(poolNames[0], locHostPort, {}, 0, true);
   createRegionAndAttachPool("DistRegionAck", USE_ACK, poolNames[0],
                             false /*Caching disabled*/);
   LOG("StepOne complete.");

--- a/cppcache/integration-test/ThinClientPutAll.hpp
+++ b/cppcache/integration-test/ThinClientPutAll.hpp
@@ -57,7 +57,7 @@ static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 0;
 
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 const char* poolName = "__TESTPOOL1_";
 
@@ -199,12 +199,12 @@ void createRegion(const char* name, bool ackMode, bool isCacheEnabled,
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,
@@ -214,11 +214,11 @@ void createPooledRegion(const char* name, bool ackMode, const char* locators,
 }
 
 void createPooledRegionConcurrencyCheckDisabled(
-    const char* name, bool ackMode, const char*, const char* locators,
-    const char* poolname, bool clientNotificationEnabled = false,
+    const std::string& name, bool ackMode, const std::string& locators,
+    const std::string& poolname, bool clientNotificationEnabled = false,
     bool cachingEnable = true, bool concurrencyCheckEnabled = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr = getHelper()->createPooledRegionConcurrencyCheckDisabled(
       name, ackMode, locators, poolname, cachingEnable,
@@ -365,7 +365,7 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, StepOne_Pooled_Locator_ConcurrencyCheckDisabled)
   {
     initClient(true);
-    createPooledRegionConcurrencyCheckDisabled(regionNames[0], USE_ACK, nullptr,
+    createPooledRegionConcurrencyCheckDisabled(regionNames[0], USE_ACK,
                                                locatorsG, poolName, true, true,
                                                false);
     LOG("StepOne_Pooled_Locator_ConcurrencyCheckDisabled complete.");

--- a/cppcache/integration-test/ThinClientPutAllTimeout.hpp
+++ b/cppcache/integration-test/ThinClientPutAllTimeout.hpp
@@ -40,7 +40,7 @@ using apache::geode::client::testing::TallyWriter;
 
 bool isLocalServer = true;
 static bool isLocator = false;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 

--- a/cppcache/integration-test/ThinClientPutAllWithCallBack.hpp
+++ b/cppcache/integration-test/ThinClientPutAllWithCallBack.hpp
@@ -56,7 +56,7 @@ static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 0;
 
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 const char* poolName = "__TESTPOOL1_";
 
@@ -197,12 +197,12 @@ void createRegion(const char* name, bool ackMode, bool isCacheEnabled,
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,
@@ -212,11 +212,11 @@ void createPooledRegion(const char* name, bool ackMode, const char* locators,
 }
 
 void createPooledRegionConcurrencyCheckDisabled(
-    const char* name, bool ackMode, const char* locators, const char* poolname,
+    const std::string& name, bool ackMode, const std::string& locators, const std::string& poolname,
     bool clientNotificationEnabled = false, bool cachingEnable = true,
     bool concurrencyCheckEnabled = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr = getHelper()->createPooledRegionConcurrencyCheckDisabled(
       name, ackMode, locators, poolname, cachingEnable,

--- a/cppcache/integration-test/ThinClientPutGetAll.hpp
+++ b/cppcache/integration-test/ThinClientPutGetAll.hpp
@@ -59,7 +59,7 @@ static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 0;
 
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 const char* poolName = "__TEST_POOL1__";
 
@@ -109,12 +109,12 @@ void verifyGetAllWithCallBackArg(std::shared_ptr<Region> region,
   verifyGetAll(region, values, startIndex, callBack);
 }
 
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/ThinClientRIwithlocalRegionDestroy.hpp
+++ b/cppcache/integration-test/ThinClientRIwithlocalRegionDestroy.hpp
@@ -49,7 +49,7 @@ CacheHelper* cacheHelper = nullptr;
 bool isLocalServer = false;
 
 static bool isLocator = false;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 
@@ -120,12 +120,12 @@ CacheHelper* getHelper() {
   return cacheHelper;
 }
 
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,
@@ -223,12 +223,12 @@ DUNIT_TASK_DEFINITION(CLIENT2, putOps)
     auto regPtr0 = getHelper()->getRegion(regionNames[0]);
 
     for (int index = 0; index < 5; index++) {
-      char key[100] = {0};
-      char value[100] = {0};
-      ACE_OS::sprintf(key, "Key-%d", index);
-      ACE_OS::sprintf(value, "Value-%d", index);
+      auto key = "Key-" + std::to_string(index);
+      auto value = "Value-" + std::to_string(index);
+
       auto keyptr = CacheableKey::create(key);
       auto valuePtr = CacheableString::create(value);
+
       regPtr0->put(keyptr, valuePtr);
     }
     LOG("StepFour complete.");
@@ -253,12 +253,12 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepFour)
     auto regPtr0 = getHelper()->getRegion(regionNames[0]);
 
     for (int index = 0; index < 5; index++) {
-      char key[100] = {0};
-      char value[100] = {0};
-      ACE_OS::sprintf(key, "Key-%d", index);
-      ACE_OS::sprintf(value, "Value-%d", index);
+      auto key = "Key-" + std::to_string(index);
+      auto value = "Value-" + std::to_string(index);
+
       auto keyptr = CacheableKey::create(key);
       auto valuePtr = CacheableString::create(value);
+
       regPtr0->put(keyptr, valuePtr);
     }
     LOG("StepFour complete.");
@@ -303,12 +303,12 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
     auto regPtr1 = getHelper()->getRegion(regionNames[1]);
 
     for (int index = 0; index < 5; index++) {
-      char key[100] = {0};
-      char value[100] = {0};
-      ACE_OS::sprintf(key, "Key-%d", index);
-      ACE_OS::sprintf(value, "Value-%d", index);
+      auto key = "Key-" + std::to_string(index);
+      auto value = "Value-" + std::to_string(index);
+
       auto keyptr = CacheableKey::create(key);
       auto valuePtr = CacheableString::create(value);
+
       regPtr0->put(keyptr, valuePtr);
       regPtr1->put(keyptr, valuePtr);
     }
@@ -372,12 +372,12 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepEight)
     auto subregPtr1 = regPtr2->getSubregion(regionNames[4]);
 
     for (int index = 0; index < 5; index++) {
-      char key[100] = {0};
-      char value[100] = {0};
-      ACE_OS::sprintf(key, "Key-%d", index);
-      ACE_OS::sprintf(value, "Value-%d", index);
+      auto key = "Key-" + std::to_string(index);
+      auto value = "Value-" + std::to_string(index);
+
       auto keyptr = CacheableKey::create(key);
       auto valuePtr = CacheableString::create(value);
+
       regPtr2->put(keyptr, valuePtr);
       subregPtr0->put(keyptr, valuePtr);
       subregPtr1->put(keyptr, valuePtr);
@@ -395,10 +395,9 @@ DUNIT_TASK_DEFINITION(CLIENT1, VerifySubRegionOps)
     auto subregPtr1 = regPtr2->getSubregion(regionNames[4]);
 
     for (int index = 0; index < 5; index++) {
-      char key[100] = {0};
-      char value[100] = {0};
-      ACE_OS::sprintf(key, "Key-%d", index);
-      ACE_OS::sprintf(value, "Value-%d", index);
+      auto key = "Key-" + std::to_string(index);
+      auto value = "Value-" + std::to_string(index);
+
       auto keyptr = CacheableKey::create(key);
       auto valuePtr = CacheableString::create(value);
 

--- a/cppcache/integration-test/ThinClientRegex.hpp
+++ b/cppcache/integration-test/ThinClientRegex.hpp
@@ -44,7 +44,7 @@ CacheHelper* cacheHelper = nullptr;
 bool isLocalServer = false;
 
 static bool isLocator = false;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 void initClient(const bool isthinClient) {
@@ -164,12 +164,12 @@ void _verifyEntry(const char* name, const char* key, const char* val,
   LOG("Entry verified.");
 }
 
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/ThinClientRegex2.hpp
+++ b/cppcache/integration-test/ThinClientRegex2.hpp
@@ -45,7 +45,7 @@ bool isLocalServer = false;
 
 static bool isLocator = false;
 static int numberOfLocators = 0;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 #include "LocatorHelper.hpp"
 void initClient(const bool isthinClient) {
@@ -175,12 +175,12 @@ void createRegion(const char* name, bool ackMode,
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/ThinClientRegex3.hpp
+++ b/cppcache/integration-test/ThinClientRegex3.hpp
@@ -53,7 +53,7 @@ bool isLocalServer = false;
 
 static bool isLocator = false;
 static int numberOfLocators = 0;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 #include "LocatorHelper.hpp"
 void initClient(const bool isthinClient) {
@@ -183,12 +183,12 @@ void createRegion(const char* name, bool ackMode, const char* endpoints,
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/ThinClientRemoveAll.hpp
+++ b/cppcache/integration-test/ThinClientRemoveAll.hpp
@@ -56,7 +56,7 @@ static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 0;
 
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 const char* poolName = "__TESTPOOL1_";
 
@@ -113,12 +113,12 @@ void createRegionLocal(const char* name, bool ackMode, const char*,
   LOG("Region created.");
 }
 
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/ThinClientSecurity.hpp
+++ b/cppcache/integration-test/ThinClientSecurity.hpp
@@ -33,7 +33,7 @@ using apache::geode::client::AuthenticatedView;
 static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 1;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 void setCacheListener(const std::string& regName,

--- a/cppcache/integration-test/ThinClientSecurityHelper.hpp
+++ b/cppcache/integration-test/ThinClientSecurityHelper.hpp
@@ -20,7 +20,8 @@
 #ifndef GEODE_INTEGRATION_TEST_THINCLIENTSECURITYHELPER_H_
 #define GEODE_INTEGRATION_TEST_THINCLIENTSECURITYHELPER_H_
 
-#include <ace/Process.h>
+#include <boost/process.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include "fw_dunit.hpp"
 #include "ThinClientHelper.hpp"
@@ -51,7 +52,7 @@ using apache::geode::client::testframework::security::opCodeList;
 bool isLocator = false;
 bool isLocalServer = false;
 
-const char* locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 const char* regionNamesAuth[] = {"DistRegionAck"};
@@ -59,7 +60,7 @@ std::shared_ptr<CredentialGenerator> credentialGeneratorHandler;
 
 std::string getXmlPath() {
   char xmlPath[1000] = {'\0'};
-  const char* path = ACE_OS::getenv("TESTSRC");
+  const char* path = std::getenv("TESTSRC");
   ASSERT(path != nullptr,
          "Environment variable TESTSRC for test source directory is not set.");
   strncpy(xmlPath, path, strlen(path) - strlen("cppcache"));
@@ -215,36 +216,39 @@ class putThread : public ACE_Task_Base {
     }
   }
 
-  int svc(void) override {
+  int svc() override {
     int ops = 0;
-    auto pid = ACE_OS::getpid();
+    std::string key_str;
     std::shared_ptr<CacheableKey> key;
     std::shared_ptr<CacheableString> value;
     std::vector<std::shared_ptr<CacheableKey>> keys0;
-    char buf[32];
-    char valbuf[32];
+
+    auto pid = boost::this_process::get_id();
     if (m_regInt) {
       m_reg->registerAllKeys(false, true);
     }
     if (m_waitTime != 0) {
-      ACE_OS::sleep(m_waitTime);
+      std::this_thread::sleep_for(std::chrono::seconds{m_waitTime});
     }
     while (ops++ < m_numops) {
       if (m_sameKey) {
-        sprintf(buf, "key-%d", 1);
+        key_str = "key-1";
       } else {
-        sprintf(buf, "key-%d", ops);
+        key_str = "key-" + std::to_string(ops);
       }
-      key = CacheableKey::create(buf);
+
+      key = CacheableKey::create(key_str);
       if (m_opcode == 0) {
+        std::string value_str;
+
         if (m_isCallBack) {
           auto boolptr = CacheableBoolean::create("true");
-          snprintf(valbuf, sizeof(valbuf), "client1-value%d", ops);
-          value = CacheableString::create(valbuf);
+          value_str = "client1-value" + std::to_string(ops);
+          value = CacheableString::create(value_str);
           m_reg->put(key, value, boolptr);
         } else {
-          snprintf(valbuf, sizeof(valbuf), "client2-value%d", ops);
-          value = CacheableString::create(valbuf);
+          value_str = "client2-value" + std::to_string(ops);
+          value = CacheableString::create(value_str);
           m_reg->put(key, value);
         }
       } else if (m_opcode == 1) {
@@ -265,8 +269,9 @@ class putThread : public ACE_Task_Base {
             m_reg->destroy(key);
           }
         } catch (Exception& ex) {
-          printf("%d: %" PRIu64 " exception got and exception message = %s\n",
-                 pid, hacks::aceThreadId(ACE_OS::thr_self()), ex.what());
+          auto tid = boost::lexical_cast<std::string>(std::this_thread::get_id());
+          printf("%d: %s exception got and exception message = %s\n",
+                 pid, tid.c_str(), ex.what());
         }
       }
     }

--- a/cppcache/integration-test/ThinClientTXFailover.hpp
+++ b/cppcache/integration-test/ThinClientTXFailover.hpp
@@ -32,7 +32,7 @@
 
 #include "CacheHelper.hpp"
 
-namespace { // NOLINT(google-build-namespaces)
+namespace {  // NOLINT(google-build-namespaces)
 
 using apache::geode::client::CacheableKey;
 using apache::geode::client::CacheableString;
@@ -49,7 +49,7 @@ CacheHelper* cacheHelper = nullptr;
 #define SERVER2 s2p2
 static bool isLocator = false;
 // static int numberOfLocators = 0;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 void initClient(const bool isthinClient) {
@@ -128,7 +128,8 @@ void _verifyEntry(const char* name, const char* key, const char* val,
           std::dynamic_pointer_cast<CacheableString>(regPtr->get(keyPtr));
 
       ASSERT(checkPtr != nullptr, "Value Ptr should not be null.");
-      LOG("In verify loop, get returned " + checkPtr->value() + " for key " + key);
+      LOG("In verify loop, get returned " + checkPtr->value() + " for key " +
+          key);
 
       if (strcmp(checkPtr->value().c_str(), value) != 0) {
         testValueCnt++;
@@ -163,12 +164,14 @@ void createRegion(const char* name, bool ackMode, const char* endpoints,
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode,
+                        const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,
@@ -177,12 +180,14 @@ void createPooledRegion(const char* name, bool ackMode, const char* locators,
   LOG("Pooled Region created.");
 }
 
-void createPooledRegionSticky(const char* name, bool ackMode,
-                              const char* locators, const char* poolname,
+void createPooledRegionSticky(const std::string& name, bool ackMode,
+                              const std::string& locators,
+                              const std::string& poolname,
                               bool clientNotificationEnabled = false,
                               bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr = getHelper()->createPooledRegionSticky(
       name, ackMode, locators, poolname, cachingEnable,

--- a/cppcache/integration-test/ThinClientTransactions.hpp
+++ b/cppcache/integration-test/ThinClientTransactions.hpp
@@ -58,7 +58,7 @@ static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 0;
 
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 void initClient(const bool isthinClient) {
@@ -180,12 +180,14 @@ void createRegion(const char* name, bool ackMode, const char* endpoints,
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode,
+                        const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,
@@ -194,12 +196,14 @@ void createPooledRegion(const char* name, bool ackMode, const char* locators,
   LOG("Pooled Region created.");
 }
 
-void createPooledRegionSticky(const char* name, bool ackMode,
-                              const char* locators, const char* poolname,
+void createPooledRegionSticky(const std::string& name, bool ackMode,
+                              const std::string& locators,
+                              const std::string& poolname,
                               bool clientNotificationEnabled = false,
                               bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr = getHelper()->createPooledRegionSticky(
       name, ackMode, locators, poolname, cachingEnable,
@@ -395,7 +399,7 @@ class SuspendTransactionThread : public ACE_Task_Base {
 
     if (m_sleep) {
       m_txEvent->wait();
-      ACE_OS::sleep(5);
+      std::this_thread::sleep_for(std::chrono::seconds(5));
     }
 
     m_suspendedTransaction = &txManager->suspend();
@@ -677,7 +681,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendTimeOut)
     ASSERT(txManager->exists(tid2),
            "In SuspendTimeOut - the transaction should exist");
 
-    ACE_OS::sleep(65);
+    std::this_thread::sleep_for(std::chrono::seconds(65));
     ASSERT(!txManager->tryResume(tid2),
            "In SuspendTimeOut - the transaction should NOT have been resumed");
     ASSERT(!txManager->isSuspended(tid2),
@@ -791,7 +795,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeInThread)
     SuspendTransactionThread* suspendTh =
         new SuspendTransactionThread(false, &txEvent);
     suspendTh->activate();
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     ResumeTransactionThread* resumeTh = new ResumeTransactionThread(
         suspendTh->getSuspendedTx(), false, false, &txEvent);
     resumeTh->activate();
@@ -808,7 +812,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeInThread)
     LOG(buf);
     suspendTh = new SuspendTransactionThread(false, &txEvent);
     suspendTh->activate();
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     resumeTh = new ResumeTransactionThread(suspendTh->getSuspendedTx(), true,
                                            false, &txEvent);
     resumeTh->activate();
@@ -828,7 +832,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeInThread)
     LOG(buf);
     suspendTh = new SuspendTransactionThread(true, &txEvent);
     suspendTh->activate();
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     resumeTh = new ResumeTransactionThread(suspendTh->getSuspendedTx(), false,
                                            true, &txEvent);
     resumeTh->activate();
@@ -847,7 +851,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeInThread)
     LOG(buf);
     suspendTh = new SuspendTransactionThread(true, &txEvent);
     suspendTh->activate();
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     sprintf(buf, "suspendTh->activate();");
     LOG(buf);
 

--- a/cppcache/integration-test/ThinClientTransactionsXA.hpp
+++ b/cppcache/integration-test/ThinClientTransactionsXA.hpp
@@ -59,7 +59,7 @@ static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 0;
 
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 void initClient(const bool isthinClient) {
@@ -181,12 +181,12 @@ void createRegion(const char* name, bool ackMode, const char* endpoints,
   ASSERT(regPtr != nullptr, "Failed to create region.");
   LOG("Region created.");
 }
-void createPooledRegion(const char* name, bool ackMode, const char* locators,
-                        const char* poolname,
+void createPooledRegion(const std::string& name, bool ackMode, const std::string& locators,
+                        const std::string& poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,
@@ -195,12 +195,12 @@ void createPooledRegion(const char* name, bool ackMode, const char* locators,
   LOG("Pooled Region created.");
 }
 
-void createPooledRegionSticky(const char* name, bool ackMode,
-                              const char* locators, const char* poolname,
+void createPooledRegionSticky(const std::string& name, bool ackMode,
+                              const std::string& locators, const std::string& poolname,
                               bool clientNotificationEnabled = false,
                               bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(), ackMode);
   fflush(stdout);
   auto regPtr = getHelper()->createPooledRegionSticky(
       name, ackMode, locators, poolname, cachingEnable,
@@ -396,7 +396,7 @@ class SuspendTransactionThread : public ACE_Task_Base {
 
     if (m_sleep) {
       m_txEvent->wait();
-      ACE_OS::sleep(5);
+      std::this_thread::sleep_for(std::chrono::seconds(5));
     }
 
     m_suspendedTransaction = &txManager->suspend();
@@ -687,7 +687,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendTimeOut)
     ASSERT(!regPtr0->containsKeyOnServer(keyPtr5),
            "In SuspendTimeOut - Key should not have been found in region.");
 
-    ACE_OS::sleep(65);
+    std::this_thread::sleep_for(std::chrono::seconds(65));
     ASSERT(!txManager->tryResume(tid2),
            "In SuspendTimeOut - the transaction should NOT have been resumed");
     ASSERT(!txManager->isSuspended(tid2),
@@ -798,7 +798,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeInThread)
     SuspendTransactionThread* suspendTh =
         new SuspendTransactionThread(false, &txEvent);
     suspendTh->activate();
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     ResumeTransactionThread* resumeTh = new ResumeTransactionThread(
         suspendTh->getSuspendedTx(), false, false, &txEvent);
     resumeTh->activate();
@@ -814,7 +814,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeInThread)
     LOG(buf);
     suspendTh = new SuspendTransactionThread(false, &txEvent);
     suspendTh->activate();
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     resumeTh = new ResumeTransactionThread(suspendTh->getSuspendedTx(), true,
                                            false, &txEvent);
     resumeTh->activate();
@@ -833,7 +833,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeInThread)
     LOG(buf);
     suspendTh = new SuspendTransactionThread(true, &txEvent);
     suspendTh->activate();
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     resumeTh = new ResumeTransactionThread(suspendTh->getSuspendedTx(), false,
                                            true, &txEvent);
     resumeTh->activate();
@@ -851,7 +851,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeInThread)
     LOG(buf);
     suspendTh = new SuspendTransactionThread(true, &txEvent);
     suspendTh->activate();
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     sprintf(buf, "suspendTh->activate();");
     LOG(buf);
 

--- a/cppcache/integration-test/ThinClientVersionedOps.hpp
+++ b/cppcache/integration-test/ThinClientVersionedOps.hpp
@@ -47,7 +47,7 @@ std::string gfendpoints2 = "localhost:";
 bool isLocalServer1 = false;
 
 static bool isLocator1 = false;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator1, isLocalServer1, 1);
 std::shared_ptr<CacheableString> c1v11;
 std::shared_ptr<CacheableString> c1v12;

--- a/cppcache/integration-test/fw_dunit.cpp
+++ b/cppcache/integration-test/fw_dunit.cpp
@@ -1,3 +1,4 @@
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -30,13 +31,12 @@
 #include <smrtheap.h>
 #endif
 
-#include <ace/ACE.h>
-
-#include <typeinfo>
-
 #include <string>
 #include <list>
 #include <map>
+
+#include <boost/asio.hpp>
+#include <boost/process.hpp>
 
 // SW: Switching to framework BB on linux also since it is much faster.
 #ifndef _WIN32
@@ -69,7 +69,7 @@ using apache::geode::client::testframework::BBNamingContextServer;
 #define __DUNIT_NO_MAIN__
 #include "fw_dunit.hpp"
 
-static ACE_TCHAR *g_programName = nullptr;
+static std::string g_programName;
 static uint32_t g_coordinatorPid = 0;
 
 ClientCleanup gClientCleanup;
@@ -124,12 +124,11 @@ class NamingContextImpl : virtual public NamingContext {
 #else
   ACE_Naming_Context
 #endif
+
       m_context;
 
   void millisleep(int msec) {
-    ACE_Time_Value sleepTime;
-    sleepTime.msec(msec);
-    ACE_OS::sleep(sleepTime);
+    std::this_thread::sleep_for(std::chrono::milliseconds{msec});
   }
 
   int checkResult(int result, const char *func) {
@@ -151,7 +150,7 @@ class NamingContextImpl : virtual public NamingContext {
 
   ~NamingContextImpl() noexcept override {
     m_context.close();
-    ACE_OS::unlink(ACE_OS::getenv("TESTNAME"));
+    std::remove(std::getenv("TESTNAME"));
   }
 
   /**
@@ -180,39 +179,37 @@ class NamingContextImpl : virtual public NamingContext {
    * retreive a value by key, storing the result in the users buf. If the key
    * is not found, the buf will contain the empty string "".
    */
-  void getValue(const char *key, char *buf, size_t sizeOfBuf) override {
+  std::string getValue(const std::string &key) override {
 #ifdef SOLARIS_USE_BB
-    char value[VALUE_MAX] = {0};
+    std::string value;
     char type[VALUE_MAX] = {0};
 #else
-    char *value = nullptr;
     char *type = nullptr;
+    char *value = nullptr;
 #endif
 
-    int res = -1;
-    // we should not increase attempts to avoid increasing test run times.
     int attempts = 3;
-    while ((res = m_context.resolve(key, value, type)) != 0 && attempts--) {
+    while (m_context.resolve(key.c_str(), value, type) != 0 && attempts--) {
       // we should not increase sleep to avoid increasing test run times.
       millisleep(5);
     }
 
-    if (res != 0) {
-      strncpy(buf, "", sizeOfBuf);
-      return;
+#ifndef SOLARIS_USE_BB
+    if (value == nullptr) {
+      return {};
     }
-    ACE_OS::strncpy(buf, value, sizeOfBuf);
+#endif
+
+    return value;
   }
 
   /**
    * return the value by key, as an int using the string to int conversion
    * rules of atoi.
    */
-  int getIntValue(const char *key) override {
-    char value[VALUE_MAX] = {0};
-    getValue(key, value, sizeof(value));
-    if (ACE_OS::strcmp(value, "") == 0) return 0;
-    return ACE_OS::atoi(value);
+  int getIntValue(const std::string &key) override {
+    auto val = getValue(key);
+    return val.empty() ? 0 : std::stoi(val);
   }
 
   void open() {
@@ -223,26 +220,22 @@ class NamingContextImpl : virtual public NamingContext {
     name_options->process_name(getContextName().c_str());
     name_options->namespace_dir(".");
     name_options->context(ACE_Naming_Context::PROC_LOCAL);
-    name_options->database(ACE_OS::getenv("TESTNAME"));
+    name_options->database(std::getenv("TESTNAME"));
     checkResult(m_context.open(name_options->context(), 0), "open");
 #endif
     LOGCOORDINATOR("Naming context opened.");
   }
 
   std::string getContextName() {
-    char buf[1024] = {0};
-    ACE_OS::sprintf(buf, "dunit.context.%s%d", ACE::basename(g_programName),
-                    g_coordinatorPid);
-    std::string b_str(buf);
-    return b_str;
+    return "dunit.context." +
+           boost::filesystem::path{g_programName}.filename().stem().string() +
+           std::to_string(g_coordinatorPid);
   }
 
   std::string getMutexName() {
-    char buf[1024] = {0};
-    ACE_OS::sprintf(buf, "dunit.mutex.%s%d", ACE::basename(g_programName),
-                    g_coordinatorPid);
-    std::string b_str(buf);
-    return b_str;
+    return "dunit.mutex." +
+           boost::filesystem::path{g_programName}.filename().stem().string() +
+           std::to_string(g_coordinatorPid);
   }
 
   /** print out all the entries' keys and values in the naming context. */
@@ -253,7 +246,7 @@ class NamingContextImpl : virtual public NamingContext {
     ACE_BINDING_SET set;
     if (this->m_context.list_name_entries(set, "") != 0) {
       char buf[1000] = {0};
-      ACE_OS::sprintf(buf, "There is nothing in the naming context.");
+      ::sprintf(buf, "There is nothing in the naming context.");
       LOGCOORDINATOR(buf);
     } else {
       ACE_BINDING_ITERATOR set_iterator(set);
@@ -261,8 +254,8 @@ class NamingContextImpl : virtual public NamingContext {
            set_iterator.advance()) {
         ACE_Name_Binding binding(*entry);
         char buf[1000] = {0};
-        ACE_OS::sprintf(buf, "%s => %s", binding.name_.char_rep(),
-                        binding.value_.char_rep());
+        ::sprintf(buf, "%s => %s", binding.name_.char_rep(),
+                  binding.value_.char_rep());
         LOGCOORDINATOR(buf);
       }
     }
@@ -271,7 +264,7 @@ class NamingContextImpl : virtual public NamingContext {
 
   void resetContext() {
     char buf[30] = {0};
-    sprintf(buf, "%d", ACE_OS::getpid());
+    sprintf(buf, "%d", boost::this_process::get_id());
 
     int res1 = -1;
     int attempts1 = 10;
@@ -408,9 +401,9 @@ class Dunit {
   /** call this once just inside main... */
   static void init(bool initContext = false) {
     if (initContext) {
-      ACE_OS::unlink("localnames");
-      ACE_OS::unlink("name_space_localnames");
-      ACE_OS::unlink("backing_store_localnames");
+      std::remove("localnames");
+      std::remove("name_space_localnames");
+      std::remove("backing_store_localnames");
     }
     singleton = new Dunit();
     if (initContext) {
@@ -453,27 +446,21 @@ class Dunit {
   bool getFailed() { return m_globals.getIntValue("Failure") ? true : false; }
 
   void setWorkerState(WorkerId sId, int state) {
-    char key[100] = {0};
-    ACE_OS::sprintf(key, "ReadyWorker%d", sId.getId());
-    m_globals.rebind(key, state);
+    m_globals.rebind(("ReadyWorker" + std::to_string(sId.getId())).c_str(),
+                     state);
   }
 
   int getWorkerState(WorkerId sId) {
-    char key[100] = {0};
-    ACE_OS::sprintf(key, "ReadyWorker%d", sId.getId());
-    return m_globals.getIntValue(key);
+    return m_globals.getIntValue("ReadyWorker" + std::to_string(sId.getId()));
   }
 
   void setWorkerTimeout(WorkerId sId, int seconds) {
-    char key[100] = {0};
-    ACE_OS::sprintf(key, "TimeoutWorker%d", sId.getId());
-    m_globals.rebind(key, seconds);
+    m_globals.rebind(("TimeoutWorker" + std::to_string(sId.getId())).c_str(),
+                     seconds);
   }
 
   int getWorkerTimeout(WorkerId sId) {
-    char key[100] = {0};
-    ACE_OS::sprintf(key, "TimeoutWorker%d", sId.getId());
-    return m_globals.getIntValue(key);
+    return m_globals.getIntValue("TimeoutWorker" + std::to_string(sId.getId()));
   }
 
   /** return the NamingContext for global (amongst all processes) values. */
@@ -499,7 +486,7 @@ class TestProcess : virtual public dunit::Manager {
   WorkerId m_sId;
 
  public:
-  TestProcess(const ACE_TCHAR *cmdline, uint32_t id)
+  TestProcess(const std::string &cmdline, uint32_t id)
       : Manager(cmdline), m_sId(id) {}
 
   WorkerId &getWorkerId() { return m_sId; }
@@ -524,7 +511,7 @@ class TestDriver {
   TestDriver() {
 #ifdef SOLARIS_USE_BB
     m_bbNamingContextServer = new BBNamingContextServer();
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     fprintf(stdout, "Blackboard started\n");
     fflush(stdout);
 #endif
@@ -532,29 +519,33 @@ class TestDriver {
     dunit::Dunit::init(true);
     fprintf(stdout, "Coordinator starting workers.\n");
     for (uint32_t i = 1; i < 5; i++) {
-      ACE_TCHAR cmdline[2048] = {0};
-      char *profilerCmd = ACE_OS::getenv("PROFILERCMD");
+      std::string cmdline;
+      auto profilerCmd = std::getenv("PROFILERCMD");
       if (profilerCmd != nullptr && profilerCmd[0] != '$' &&
           profilerCmd[0] != '\0') {
         // replace %d's in profilerCmd with PID and worker ID
         char cmdbuf[2048] = {0};
-        ACE_OS::sprintf(cmdbuf, profilerCmd, ACE_OS::gettimeofday().msec(),
-                        g_coordinatorPid, i);
-        ACE_OS::sprintf(cmdline, "%s %s -s%d -m%d", cmdbuf, g_programName, i,
-                        g_coordinatorPid);
+        auto now = std::chrono::time_point_cast<std::chrono::milliseconds>(
+                       std::chrono::system_clock::now())
+                       .time_since_epoch()
+                       .count();
+        ::sprintf(cmdbuf, profilerCmd, now, g_coordinatorPid, i);
+        cmdline = std::string{cmdbuf} + ' ' + g_programName + " -s" +
+                  std::to_string(i) + " -m" + std::to_string(g_coordinatorPid);
       } else {
-        ACE_OS::sprintf(cmdline, "%s -s%d -m%d", g_programName, i,
-                        g_coordinatorPid);
+        cmdline = g_programName + " -s" + std::to_string(i) + " -m" +
+                  std::to_string(g_coordinatorPid);
       }
-      fprintf(stdout, "%s\n", cmdline);
+      fprintf(stdout, "%s\n", cmdline.c_str());
       m_workers[i - 1] = new TestProcess(cmdline, i);
     }
     fflush(stdout);
     // start each of the workers...
     for (uint32_t j = 1; j < 5; j++) {
       m_workers[j - 1]->doWork();
-      ACE_OS::sleep(2);  // do not increase this to avoid precheckin runs taking
-                         // much longer.
+      std::this_thread::sleep_for(
+          std::chrono::seconds(2));  // do not increase this to avoid precheckin
+                                     // runs taking much longer.
     }
   }
 
@@ -573,7 +564,8 @@ class TestDriver {
   }
 
   int begin() {
-    fprintf(stdout, "Coordinator started with pid %d\n", ACE_OS::getpid());
+    fprintf(stdout, "Coordinator started with pid %d\n",
+            boost::this_process::get_id());
     fflush(stdout);
     waitForReady();
     // dispatch task...
@@ -608,17 +600,13 @@ class TestDriver {
     fprintf(stdout, "Waiting %d seconds for %s to finish task.\n", secs,
             sId.getIdName());
     fflush(stdout);
-    ACE_Time_Value end = ACE_OS::gettimeofday();
-    ACE_Time_Value offset(secs, 0);
-    end += offset;
+    auto end = std::chrono::steady_clock::now() + std::chrono::seconds{secs};
     while (DUNIT->getWorkerState(sId) != WORKER_STATE_TASK_COMPLETE) {
       // sleep a bit..
       if (DUNIT->getFailed()) return;
-      ACE_Time_Value sleepTime;
-      sleepTime.msec(100);
-      ACE_OS::sleep(sleepTime);
+      std::this_thread::sleep_for(std::chrono::milliseconds{100});
       checkWorkerDeath();
-      ACE_Time_Value now = ACE_OS::gettimeofday();
+      auto now = std::chrono::steady_clock::now();
       if (now >= end) {
         handleTimeout(sId);
         break;
@@ -646,18 +634,19 @@ class TestDriver {
     fprintf(stdout, "Waiting %d seconds for all workers to be ready.\n",
             TASK_TIMEOUT);
     fflush(stdout);
-    ACE_Time_Value end = ACE_OS::gettimeofday();
-    ACE_Time_Value offset(TASK_TIMEOUT, 0);
-    end += offset;
+    auto end =
+        std::chrono::steady_clock::now() + std::chrono::seconds{TASK_TIMEOUT};
     uint32_t readyCount = 0;
     while (readyCount < 4) {
       fprintf(stdout, "Ready Count: %d\n", readyCount);
       fflush(stdout);
-      if (DUNIT->getFailed()) return;
-      // sleep a bit..
-      ACE_Time_Value sleepTime(1);
-      //      sleepTime.msec( 10 );
-      ACE_OS::sleep(sleepTime);
+
+      if (DUNIT->getFailed()) {
+        return;
+      }
+
+      std::this_thread::sleep_for(std::chrono::seconds{1});
+
       readyCount = 0;
       for (uint32_t i = 1; i < 5; i++) {
         int state = DUNIT->getWorkerState(WorkerId(i));
@@ -666,7 +655,7 @@ class TestDriver {
         }
       }
       checkWorkerDeath();
-      ACE_Time_Value now = ACE_OS::gettimeofday();
+      auto now = std::chrono::steady_clock::now();
       if (now >= end) {
         handleTimeout();
         break;
@@ -679,16 +668,15 @@ class TestDriver {
     fprintf(stdout, "Waiting %d seconds for all workers to complete.\n",
             TASK_TIMEOUT);
     fflush(stdout);
-    ACE_Time_Value end = ACE_OS::gettimeofday();
-    ACE_Time_Value offset(TASK_TIMEOUT, 0);
-    end += offset;
+
     uint32_t doneCount = 0;
+    auto end =
+        std::chrono::steady_clock::now() + std::chrono::seconds{TASK_TIMEOUT};
+
     while (doneCount < 4) {
       // if ( DUNIT->getFailed() ) return;
       // sleep a bit..
-      ACE_Time_Value sleepTime;
-      sleepTime.msec(100);
-      ACE_OS::sleep(sleepTime);
+      std::this_thread::sleep_for(std::chrono::milliseconds{100});
       doneCount = 0;
       for (uint32_t i = 1; i < 5; i++) {
         int state = DUNIT->getWorkerState(WorkerId(i));
@@ -696,7 +684,7 @@ class TestDriver {
           doneCount++;
         }
       }
-      ACE_Time_Value now = ACE_OS::gettimeofday();
+      auto now = std::chrono::steady_clock::now();
       if (now >= end) {
         handleTimeout();
         break;
@@ -741,7 +729,7 @@ class TestWorker {
 
   void begin() {
     fprintf(stdout, "Worker %s started with pid %d\n", m_sId.getIdName(),
-            ACE_OS::getpid());
+            boost::this_process::get_id());
     fflush(stdout);
     WorkerId workerZero(0);
 
@@ -779,9 +767,8 @@ class TestWorker {
           }
         }
       }
-      ACE_Time_Value sleepTime;
-      sleepTime.msec(100);
-      ACE_OS::sleep(sleepTime);
+
+      std::this_thread::sleep_for(std::chrono::milliseconds{100});
     }
   }
 
@@ -796,11 +783,9 @@ WorkerId *TestWorker::procWorkerId = nullptr;
 
 void sleep(int millis) {
   if (millis == 0) {
-    ACE_OS::thr_yield();
+    std::this_thread::yield();
   } else {
-    ACE_Time_Value sleepTime;
-    sleepTime.msec(millis);
-    ACE_OS::sleep(sleepTime);
+    std::this_thread::sleep_for(std::chrono::milliseconds{millis});
   }
 }
 
@@ -809,7 +794,7 @@ void logCoordinator(std::string s, int lineno, const char * /*filename*/) {
   dunit::getTimeStr(buf, sizeof(buf));
 
   fprintf(stdout, "[TEST coordinator:pid(%d)] %s at line: %d\n",
-          ACE_OS::getpid(), s.c_str(), lineno);
+          boost::this_process::get_id(), s.c_str(), lineno);
   fflush(stdout);
 }
 
@@ -819,8 +804,8 @@ void log(std::string s, int lineno, const char * /*filename*/, int /*id*/) {
   char buf[128] = {0};
   dunit::getTimeStr(buf, sizeof(buf));
 
-  fprintf(stdout, "[TEST 0:pid(%d)] %s at line: %d\n", ACE_OS::getpid(),
-          s.c_str(), lineno);
+  fprintf(stdout, "[TEST 0:pid(%d)] %s at line: %d\n",
+          boost::this_process::get_id(), s.c_str(), lineno);
   fflush(stdout);
 }
 
@@ -833,13 +818,13 @@ void log(std::string s, int lineno, const char * /*filename*/) {
           (dunit::TestWorker::procWorkerId
                ? dunit::TestWorker::procWorkerId->getIdName()
                : "coordinator"),
-          ACE_OS::getpid(), s.c_str(), lineno);
+          boost::this_process::get_id(), s.c_str(), lineno);
   fflush(stdout);
 }
 
 void cleanup() { gClientCleanup.callClientCleanup(); }
 
-int dmain(int argc, ACE_TCHAR *argv[]) {
+int dmain(int argc, char *argv[]) {
 #ifdef USE_SMARTHEAP
   MemRegisterTask();
 #endif
@@ -847,9 +832,7 @@ int dmain(int argc, ACE_TCHAR *argv[]) {
   TimeBomb tb(&cleanup);
   // tb->arm(); // leak this on purpose.
   try {
-    g_programName = new ACE_TCHAR[2048];
-    ACE_OS::strncpy(g_programName, argv[0], 2048);
-
+    g_programName = argv[0];
     const ACE_TCHAR options[] = ACE_TEXT("s:m:");
     ACE_Get_Opt cmd_opts(argc, argv, options);
 
@@ -860,12 +843,12 @@ int dmain(int argc, ACE_TCHAR *argv[]) {
     while ((option = cmd_opts()) != EOF) {
       switch (option) {
         case 's':
-          workerId = ACE_OS::atoi(cmd_opts.opt_arg());
+          workerId = std::stoul(cmd_opts.opt_arg());
           fprintf(stdout, "Using process id: %d\n", workerId);
           fflush(stdout);
           break;
         case 'm':
-          g_coordinatorPid = ACE_OS::atoi(cmd_opts.opt_arg());
+          g_coordinatorPid = std::stoul(cmd_opts.opt_arg());
           fprintf(stdout, "Using coordinator id: %d\n", g_coordinatorPid);
           fflush(stdout);
           break;
@@ -898,7 +881,7 @@ int dmain(int argc, ACE_TCHAR *argv[]) {
     // currently this is used for giving a unique per run id to shared
     // resources.
     if (g_coordinatorPid == 0) {
-      g_coordinatorPid = ACE_OS::getpid();
+      g_coordinatorPid = boost::this_process::get_id();
     }
 
     if (workerId > 0) {
@@ -926,11 +909,14 @@ int dmain(int argc, ACE_TCHAR *argv[]) {
   } catch (apache::geode::client::testframework::FwkException &fe) {
     printf("Exception: %s\n", fe.what());
     fflush(stdout);
+  } catch (std::exception &ex) {
+    printf("Exception: system exception reached main: %s.\n", ex.what());
+    fflush(stdout);
   } catch (...) {
     printf("Exception: unhandled/unidentified exception reached main.\n");
     fflush(stdout);
-    // return 1;
   }
+
   gClientCleanup.callClientCleanup();
   return 1;
 }
@@ -945,8 +931,10 @@ namespace perf {
 TimeStamp::TimeStamp(int64_t msec) : m_msec(msec) {}
 
 TimeStamp::TimeStamp() {
-  ACE_Time_Value tmp = ACE_OS::gettimeofday();
-  m_msec = tmp.msec();
+  m_msec = std::chrono::time_point_cast<std::chrono::milliseconds>(
+               std::chrono::system_clock::now())
+               .time_since_epoch()
+               .count();
 }
 
 TimeStamp::TimeStamp(const TimeStamp &other) : m_msec(other.m_msec) {}
@@ -1078,9 +1066,11 @@ void PerfSuite::save() {
 
 /** load data saved in $ENV{'baselines'} named "<suite>_baseline.<host>" */
 void PerfSuite::compare() {
-  char hname[100] = {0};
-  ACE_OS::hostname(hname, 100);
-  std::string fname = m_suiteName + "_baseline." + hname;
+  /*
+    char hname[100] = {0};
+    ACE_OS::hostname(hname, 100);
+    std::string fname = m_suiteName + "_baseline." + hname;
+    */
 }
 
 ThreadLauncher::ThreadLauncher(int thrCount, Thread &thr)

--- a/cppcache/integration-test/fw_dunit.hpp
+++ b/cppcache/integration-test/fw_dunit.hpp
@@ -117,7 +117,6 @@ END_TASK(validate)
 
 #include <string>
 
-#include <ace/ACE.h>
 #include <signal.h>
 #include "TimeBomb.hpp"
 
@@ -318,13 +317,13 @@ class NamingContext {
    * is not found, the buf will contain the empty string "". Make sure the
    * buffer is big enough to hold whatever has have bound.
    */
-  virtual void getValue(const char* key, char* buf, size_t sizeOfBuf) = 0;
+  virtual std::string getValue(const std::string& key) = 0;
 
   /**
    * return the value by key, as an int using the string to int conversion
    * rules of atoi.
    */
-  virtual int getIntValue(const char* key) = 0;
+  virtual int getIntValue(const std::string& key) = 0;
 
   /** dump the entire context in LOG messages. */
   virtual void dump() = 0;
@@ -346,19 +345,19 @@ NamingContext* globals();
  */
 class TestException {
  public:
-  TestException(const char* msg, int lineno, const char* filename)
-      : m_message(const_cast<char*>(msg)),
+  TestException(const std::string& msg, int lineno, const std::string& filename)
+      : m_message(msg),
         m_lineno(lineno),
-        m_filename(const_cast<char*>(filename)) {}
+        m_filename(filename) {}
 
   void print() {
     fprintf(stdout, "#### TestException: %s in %s at line %d\n",
-            m_message.c_str(), m_filename, m_lineno);
+            m_message.c_str(), m_filename.c_str(), m_lineno);
     fflush(stdout);
   }
   std::string m_message;
   int m_lineno;
-  char* m_filename;
+  std::string m_filename;
 };
 
 int dmain(int argc, char* argv[]);
@@ -367,7 +366,7 @@ int dmain(int argc, char* argv[]);
 
 #ifndef __DUNIT_NO_MAIN__
 
-int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) { return dunit::dmain(argc, argv); }
+int main(int argc, char* argv[]) { return dunit::dmain(argc, argv); }
 
 #endif  // __DUNIT_NO_MAIN__
 

--- a/cppcache/integration-test/fw_helper.hpp
+++ b/cppcache/integration-test/fw_helper.hpp
@@ -125,18 +125,18 @@ void setupCRTOutput();  // disable windows popups.
 
 class TestException {
  public:
-  TestException(const char* msg, int lineno, const char* filename)
-      : m_message(const_cast<char*>(msg)),
+  TestException(const std::string& msg, int lineno, const std::string& filename)
+      : m_message(msg),
         m_lineno(lineno),
-        m_filename(const_cast<char*>(filename)) {}
+        m_filename(filename) {}
 
   void print() {
     fprintf(stdout, "--->%sTestException: %s in %s at line %d<---\n", apache::geode::client::Log::formatLogLine(apache::geode::client::LogLevel::Error).c_str(),
-            m_message.c_str(), m_filename, m_lineno);
+            m_message.c_str(), m_filename.c_str(), m_lineno);
   }
   std::string m_message;
   int m_lineno;
-  char* m_filename;
+  std::string m_filename;
 };
 
 // std::list holding names of all tests that failed.

--- a/cppcache/integration-test/locator_globals.hpp
+++ b/cppcache/integration-test/locator_globals.hpp
@@ -27,7 +27,7 @@ using apache::geode::client::CacheHelper;
 static int numberOfLocators = 1;
 bool isLocalServer = false;
 bool isLocator = false;
-const char* locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 }  // namespace

--- a/cppcache/integration-test/testCacheless.cpp
+++ b/cppcache/integration-test/testCacheless.cpp
@@ -107,7 +107,7 @@ class RegionWrapper {
 static int numberOfLocators = 1;
 bool isLocalServer = true;
 bool isLocator = true;
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 std::shared_ptr<TallyListener> listener;
 
@@ -123,7 +123,7 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(s1p1, CreateRegionNoCache)
   {
-    initClientWithPool(true, "__TEST_POOL1__", locHostPort, nullptr, nullptr, 0,
+    initClientWithPool(true, "__TEST_POOL1__", locHostPort, {}, nullptr, 0,
                        true);
     LOG("Creating region in s1p1-pusher, no-ack, no-cache, no-listener");
     getHelper()->createPooledRegion(REGIONNAME, false, locHostPort,
@@ -134,7 +134,7 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(s1p2, CreateNoCacheWListener)
   {
     LOG("Creating region in s1p2-listener, no-ack, no-cache, with-listener");
-    initClientWithPool(true, "__TEST_POOL1__", locHostPort, nullptr, nullptr, 0,
+    initClientWithPool(true, "__TEST_POOL1__", locHostPort, {}, nullptr, 0,
                        true);
     listener = std::make_shared<TallyListener>();
     getHelper()->createPooledRegion(
@@ -148,7 +148,7 @@ DUNIT_TASK_DEFINITION(s2p1, CreateRegionCacheMirror)
   {
     LOG("Creating region in s2p1-storage, no-ack, cache, no-interestlist, "
         "no-listener");
-    initClientWithPool(true, "__TEST_POOL1__", locHostPort, nullptr, nullptr, 0,
+    initClientWithPool(true, "__TEST_POOL1__", locHostPort, {}, nullptr, 0,
                        true);
     getHelper()->createPooledRegion(REGIONNAME, false, locHostPort,
                                     "__TEST_POOL1__", true, true);
@@ -159,7 +159,7 @@ DUNIT_TASK_DEFINITION(s2p2, CreateRegionCache)
   {
     LOG("Creating region in s2p2-subset, no-ack, no-mirror, cache, "
         "no-interestlist, with-listener");
-    initClientWithPool(true, "__TEST_POOL1__", locHostPort, nullptr, nullptr, 0,
+    initClientWithPool(true, "__TEST_POOL1__", locHostPort, {}, nullptr, 0,
                        true);
     listener = std::make_shared<TallyListener>();
     getHelper()->createPooledRegion(

--- a/cppcache/integration-test/testCreateAndDestroyPool.cpp
+++ b/cppcache/integration-test/testCreateAndDestroyPool.cpp
@@ -36,7 +36,7 @@ const char *poolNames[] = {"Pool1"};
 
 void stepOne() {
   initClient(true);
-  createPoolAndDestroy(poolNames[0], locatorsG, nullptr, 0, false,
+  createPoolAndDestroy(poolNames[0], locatorsG, {}, 0, false,
                        std::chrono::seconds::zero(), 1);
   LOG("StepOne complete.");
 }

--- a/cppcache/integration-test/testExpiration.cpp
+++ b/cppcache/integration-test/testExpiration.cpp
@@ -126,7 +126,7 @@ BEGIN_TEST(TEST_EXPIRATION)
 
     doNPuts(R1, 100);
 
-    ACE_OS::sleep(10);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
 
     n = getNumOfEntries(R1);
     ASSERT(n == 100, "Expected 100 entries");
@@ -145,7 +145,7 @@ BEGIN_TEST(TEST_EXPIRATION)
     LOG("Region R2 created");
     doNPuts(R2, 1);
 
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
     n = getNumOfEntries(R2);
     ASSERT(n == 1, "Expected 1 entry");
@@ -162,7 +162,7 @@ BEGIN_TEST(TEST_EXPIRATION)
     cacheImpl->createRegion("R3", attrs_3, R3);
     ASSERT(R3 != nullptr, "Expected R3 to be NON-nullptr");
 
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
     ASSERT(R3->isDestroyed() == false, "Expected R3 to be alive");
 
@@ -179,7 +179,7 @@ BEGIN_TEST(TEST_EXPIRATION)
     doNPuts(R4, 1);
     // This will be same as updating the object
 
-    ACE_OS::sleep(10);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
 
     n = getNumOfEntries(R4);
     ASSERT(n == 0, "Expected 0 entry");
@@ -198,18 +198,18 @@ BEGIN_TEST(TEST_EXPIRATION)
 
     auto key_0 = do1Put(R5);
 
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     R5->get(key_0);
-    ACE_OS::sleep(3);
+    std::this_thread::sleep_for(std::chrono::seconds(3));
 
     n = getNumOfEntries(R5);
 
     printf("n ==  %zd\n", n);
     ASSERT(n == 1, "Expected 1 entry");
 
-    // ACE_OS::sleep(3);
-    ACE_OS::sleep(6);
+    // std::this_thread::sleep_for(std::chrono::seconds(3));
+    std::this_thread::sleep_for(std::chrono::seconds(6));
     n = getNumOfEntries(R5);
 
     ASSERT(n == 0, "Expected 0 entry");
@@ -227,11 +227,11 @@ BEGIN_TEST(TEST_EXPIRATION)
 
     doNPuts(R6, 1);
 
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     doNPuts(R6, 1);
 
-    ACE_OS::sleep(7);
+    std::this_thread::sleep_for(std::chrono::seconds(7));
 
     ASSERT(R6->isDestroyed() == true, "Expected R6 to be dead");
 
@@ -247,11 +247,11 @@ BEGIN_TEST(TEST_EXPIRATION)
 
     doNPuts(R7, 1);
 
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     doNPuts(R7, 1);
 
-    ACE_OS::sleep(10);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
 
     ASSERT(R7->isDestroyed() == true, "Expected R7 to be dead");
 
@@ -267,11 +267,11 @@ BEGIN_TEST(TEST_EXPIRATION)
 
     auto key = do1Put(R8);
 
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
     R8->get(key);
 
-    ACE_OS::sleep(6);
+    std::this_thread::sleep_for(std::chrono::seconds(6));
 
     n = getNumOfEntries(R8);
     ASSERT(n == 0, "Expected 1 entries");
@@ -288,11 +288,11 @@ BEGIN_TEST(TEST_EXPIRATION)
 
     auto key_1 = do1Put(R9);
 
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
     R9->get(key_1);
 
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
     n = getNumOfEntries(R9);
     ASSERT(n == 1, "Expected 1 entries");
@@ -311,12 +311,12 @@ BEGIN_TEST(TEST_EXPIRATION)
 
     doNPuts(R10, 1);
 
-    ACE_OS::sleep(10);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
 
     n = getNumOfEntries(R10);
     ASSERT(n == 0, "Expected 0 entries");
 
-    ACE_OS::sleep(11);
+    std::this_thread::sleep_for(std::chrono::seconds(11));
 
     ASSERT(R10->isDestroyed() == true, "Expected R10 to be dead");
 
@@ -333,19 +333,19 @@ BEGIN_TEST(TEST_EXPIRATION)
 
     auto k11 = do1Put(R11);
 
-    ACE_OS::sleep(3);
+    std::this_thread::sleep_for(std::chrono::seconds(3));
 
     n = getNumOfEntries(R11);
     ASSERT(n == 1, "Expected 1 entries");
 
     R11->get(k11);
 
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
     ASSERT(R11->isDestroyed() == false,
            "Expected R11 to be alive as the get has changed the access time");
 
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
     ASSERT(R11->isDestroyed() == true, "Expected R11 to be dead");
 
@@ -361,7 +361,7 @@ BEGIN_TEST(TEST_EXPIRATION)
 
     auto key_3 = do1Put(R12);
 
-    ACE_OS::sleep(6);
+    std::this_thread::sleep_for(std::chrono::seconds(6));
 
     n = getNumOfEntries(R12);
     ASSERT(n == 0, "Expected 0 entries");
@@ -381,7 +381,7 @@ BEGIN_TEST(TEST_EXPIRATION)
 
     doNPuts(R14, 1);
 
-    ACE_OS::sleep(12);
+    std::this_thread::sleep_for(std::chrono::seconds(12));
 
     ASSERT(R14->isDestroyed() == true, "Expected R14 to be dead");
 
@@ -397,11 +397,11 @@ BEGIN_TEST(TEST_EXPIRATION)
 
     auto key_4 = do1Put(R15);
 
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     R15->destroy(key_4);
 
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
 
     ASSERT(R15->isDestroyed() == false, "Expected R15 to be alive");
 
@@ -418,12 +418,12 @@ BEGIN_TEST(TEST_EXPIRATION)
 
     doNPuts(R18, 1);
 
-    ACE_OS::sleep(4);
+    std::this_thread::sleep_for(std::chrono::seconds(4));
 
     n = getNumOfEntries(R18);
     ASSERT(n == 1, "entry idle should be useless as ttl is > 0");
 
-    ACE_OS::sleep(4);
+    std::this_thread::sleep_for(std::chrono::seconds(4));
     n = getNumOfEntries(R18);
     ASSERT(n == 0, "ttl is over so it should be 0");
 
@@ -437,16 +437,16 @@ BEGIN_TEST(TEST_EXPIRATION)
     cacheImpl->createRegion("R19x", attrs_19, R19);
     ASSERT(R19 != nullptr, "Expected R19 to be NON-nullptr");
 
-    ACE_OS::sleep(4);
+    std::this_thread::sleep_for(std::chrono::seconds(4));
 
     doNPuts(R19, 1);
 
-    ACE_OS::sleep(4);
+    std::this_thread::sleep_for(std::chrono::seconds(4));
 
     ASSERT(R19->isDestroyed() == false,
            "Expected R19 to be alive as an entry was put");
 
-    ACE_OS::sleep(4);
+    std::this_thread::sleep_for(std::chrono::seconds(4));
 
     ASSERT(R19->isDestroyed() == true, "Expected R19 to be dead");
     cache->close();

--- a/cppcache/integration-test/testFwPerf.cpp
+++ b/cppcache/integration-test/testFwPerf.cpp
@@ -30,7 +30,7 @@ class LocalPutTask : public perf::Thread {
   }
 
   void perftask() override {
-    ACE_OS::sleep(1);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     fprintf(stdout, "perffunc done.\n");
     fflush(stdout);
   }

--- a/cppcache/integration-test/testOverflowPutGetSqLite.cpp
+++ b/cppcache/integration-test/testOverflowPutGetSqLite.cpp
@@ -18,7 +18,8 @@
 #include <string>
 #include <iostream>
 
-#include <ace/OS.h>
+#include <boost/asio.hpp>
+#include <boost/process.hpp>
 
 #include <geode/RegionShortcut.hpp>
 #include <geode/RegionFactory.hpp>
@@ -351,17 +352,16 @@ void setSqLiteProperties(std::shared_ptr<Properties> &sqliteProperties,
 // creation of subregion.
 
 void createSubRegion(std::shared_ptr<Region> &regionPtr,
-                     std::shared_ptr<Region> &subRegion, const char *regionName,
+                     std::shared_ptr<Region> &subRegion,
+                     const std::string &regionName,
                      std::string pDir = sqlite_dir) {
   RegionAttributes regionAttributesPtr;
   setAttributes(regionAttributesPtr, pDir);
   subRegion = regionPtr->createSubregion(regionName, regionAttributesPtr);
   ASSERT(subRegion != nullptr, "Expected region to be NON-nullptr");
-  char fileName[512];
-  sprintf(fileName, "%s/%s/%s.db", pDir.c_str(), regionName, regionName);
-  ACE_stat fileStat;
-  ASSERT(ACE_OS::stat(fileName, &fileStat) == 0,
-         "persistence file not present");
+
+  std::string fileName = pDir + '/' + regionName + '/' + regionName + ".db";
+  ASSERT(boost::filesystem::exists(fileName), "persistence file not present");
   doNput(subRegion, 50);
   doNget(subRegion, 50);
 }
@@ -409,15 +409,12 @@ BEGIN_TEST(OverFlowTest)
       subRegion->destroyRegion();
       ASSERT(subRegion->isDestroyed(), "Expected region is not destroyed ");
       subRegion = nullptr;
-      ACE_TCHAR hname[MAXHOSTNAMELEN];
-      ACE_OS::hostname(hname, sizeof(hname) - 1);
-      char sqliteDirSubRgn[512];
-      sprintf(sqliteDirSubRgn, "%s/%s_%u/_%s_SubRegion/file_0.db",
-              sqlite_dir.c_str(), hname, ACE_OS::getpid(),
-              regionPtr->getName().c_str());
 
-      ACE_stat fileStat;
-      ASSERT(ACE_OS::stat(sqliteDirSubRgn, &fileStat) == -1,
+      std::string sqliteDirSubRgn =
+          sqlite_dir + "/" + boost::asio::ip::host_name() + '_' +
+          std::to_string(boost::this_process::get_id()) + "/_" +
+          regionPtr->getName() + "_SubRegion/file_0.db";
+      ASSERT(!boost::filesystem::exists(sqliteDirSubRgn),
              "persistence file still present");
     }
     // cache close
@@ -428,11 +425,10 @@ END_TEST(OverFlowTest)
 BEGIN_TEST(OverFlowTest_absPath)
   {
     std::shared_ptr<RegionAttributes> attrsPtr;
-    char currWDPath[512];
-    char *wdPath = ACE_OS::getcwd(currWDPath, 512);
-    ASSERT(wdPath != nullptr,
-           "Expected current Working Directory to be NON-nullptr");
-    std::string absPersistenceDir = std::string(wdPath) + "/absSqLite";
+    auto wdPath = boost::filesystem::current_path().string();
+    ASSERT(!wdPath.empty(),
+           "Expected current Working Directory to be not empty");
+    std::string absPersistenceDir = wdPath + "/absSqLite";
 
     /** Creating a cache to manage regions. */
     std::shared_ptr<Properties> sqliteProperties;
@@ -473,11 +469,9 @@ BEGIN_TEST(OverFlowTest_absPath)
       subRegion->destroyRegion();
       ASSERT(subRegion->isDestroyed(), "Expected region is not destroyed ");
       subRegion = nullptr;
-      char fileName[512];
-      sprintf(fileName, "%s/%s/%s.db", absPersistenceDir.c_str(), "SubRegion",
-              "SubRegion");
-      ACE_stat fileStat;
-      ASSERT(ACE_OS::stat(fileName, &fileStat) == -1,
+
+      std::string fileName = absPersistenceDir + "/SubRegion/SubRegion.db";
+      ASSERT(!boost::filesystem::exists(fileName),
              "persistence file still present");
     }
     // cache close
@@ -569,18 +563,16 @@ BEGIN_TEST(OverFlowTest_HeapLRU)
       setAttributes(regionAttributes);
       subRegion = regionPtr->createSubregion("SubRegion", regionAttributes);
       ASSERT(subRegion != nullptr, "Expected region to be NON-nullptr");
-      char fileName[512];
-      sprintf(fileName, "%s/%s/%s.db", sqlite_dir.c_str(), "SubRegion",
-              "SubRegion");
-      ACE_stat fileStat;
-      ASSERT(ACE_OS::stat(fileName, &fileStat) == 0,
+
+      std::string fileName = sqlite_dir + "/SubRegion/SubRegion.db";
+      ASSERT(boost::filesystem::exists(fileName),
              "persistence file not present");
       doNput(subRegion, 50);
       doNget(subRegion, 50);
       subRegion->destroyRegion();
       ASSERT(subRegion->isDestroyed(), "Expected region is not destroyed ");
       subRegion = nullptr;
-      ASSERT(ACE_OS::stat(fileName, &fileStat) == -1,
+      ASSERT(!boost::filesystem::exists(fileName),
              "persistence file still present");
     }
     // cache close

--- a/cppcache/integration-test/testPdxMetadataCheckTest.cpp
+++ b/cppcache/integration-test/testPdxMetadataCheckTest.cpp
@@ -69,7 +69,7 @@ bool isLocator = false;
 bool isLocalServer = false;
 
 const char *poolNames[] = {"Pool1", "Pool2", "Pool3"};
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 bool isPoolConfig = false;  // To track if pool case is running
 // const char * qRegionNames[] = { "Portfolios", "Positions", "Portfolios2",
@@ -89,7 +89,7 @@ void initClient1(bool isPdxIgnoreUnreadFields = false) {
   // Create just one pool and attach all regions to that.
   initClient(true, isPdxIgnoreUnreadFields);
   isPoolConfig = true;
-  createPool(poolNames[0], locHostPort, nullptr, 0, false);
+  createPool(poolNames[0], locHostPort, {}, 0, false);
   createRegionAndAttachPool("DistRegionAck", USE_ACK, poolNames[0],
                             true /*Caching enabled*/);
   LOG("StepOne complete.");
@@ -99,7 +99,7 @@ void initClient2(bool isPdxIgnoreUnreadFields = false) {
   // Create just one pool and attach all regions to that.
   initClient(true, isPdxIgnoreUnreadFields);
   isPoolConfig = true;
-  createPool(poolNames[0], locHostPort, nullptr, 0,
+  createPool(poolNames[0], locHostPort, {}, 0,
              true /*ClientNotification enabled*/);
   createRegionAndAttachPool("DistRegionAck", USE_ACK, poolNames[0],
                             true /*Caching enabled*/);

--- a/cppcache/integration-test/testRegionAccessThreadSafe.cpp
+++ b/cppcache/integration-test/testRegionAccessThreadSafe.cpp
@@ -93,7 +93,7 @@ class GetRegionThread : public ACE_Task_Base {
 static int numberOfLocators = 1;
 bool isLocalServer = true;
 bool isLocator = true;
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 GetRegionThread *getThread = nullptr;
 std::shared_ptr<Region> regionPtr;

--- a/cppcache/integration-test/testSystemProperties.cpp
+++ b/cppcache/integration-test/testSystemProperties.cpp
@@ -67,7 +67,7 @@ BEGIN_TEST(NEW_CONFIG)
   {
     // When the tests are run from the build script the environment variable
     // TESTSRC is set.
-    std::string testSource(ACE_OS::getenv("TESTSRC"));
+    std::string testSource(std::getenv("TESTSRC"));
     std::string filePath = testSource + "/resources/system.properties";
 
     // Make sure product can at least log to stdout.

--- a/cppcache/integration-test/testThinClientAfterRegionLive.cpp
+++ b/cppcache/integration-test/testThinClientAfterRegionLive.cpp
@@ -32,7 +32,7 @@ static bool isLocalServer = true;
 static int numberOfLocators = 1;
 static bool isRegionLive[4] = {false, false, false, false};
 static bool isRegionDead[4] = {false, false, false, false};
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 class DisconnectCacheListioner : public CacheListener {

--- a/cppcache/integration-test/testThinClientBigValue.cpp
+++ b/cppcache/integration-test/testThinClientBigValue.cpp
@@ -96,7 +96,7 @@ void verify(std::shared_ptr<CacheableBytes> &valuePtr, int size) {
 static int numberOfLocators = 1;
 bool isLocalServer = true;
 bool isLocator = true;
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 DUNIT_TASK(SERVER1, StartServer)

--- a/cppcache/integration-test/testThinClientCacheableStringArray.cpp
+++ b/cppcache/integration-test/testThinClientCacheableStringArray.cpp
@@ -46,7 +46,7 @@ using apache::geode::client::IllegalStateException;
 static int numberOfLocators = 1;
 bool isLocalServer = true;
 bool isLocator = true;
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 const char *_regionNames[] = {"Portfolios", "Positions"};
@@ -123,13 +123,12 @@ DUNIT_TASK(CLIENT1, StepThree)
       sprintf(buf, "results last count=%zd", count);
       LOG(buf);
     } catch (IllegalStateException &ise) {
-      char isemsg[500] = {0};
-      ACE_OS::snprintf(isemsg, 499, "IllegalStateException: %s", ise.what());
-      LOG(isemsg);
-      FAIL(isemsg);
+      std::string excpmsg = "IllegalStateException: " + std::string{ise.what()};
+
+      LOG(excpmsg);
+      FAIL(excpmsg);
     } catch (Exception &excp) {
-      char excpmsg[500] = {0};
-      ACE_OS::snprintf(excpmsg, 499, "Exception: %s", excp.what());
+      std::string excpmsg = "Exception: " + std::string{excp.what()};
       LOG(excpmsg);
       FAIL(excpmsg);
     } catch (...) {

--- a/cppcache/integration-test/testThinClientCacheablesLimits.cpp
+++ b/cppcache/integration-test/testThinClientCacheablesLimits.cpp
@@ -39,7 +39,7 @@ using apache::geode::client::OutOfMemoryException;
 static bool isLocator = false;
 static bool isLocalServer = true;
 static int numberOfLocators = 1;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 #include "LocatorHelper.hpp"
 
@@ -102,8 +102,7 @@ const char *_regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
 
 DUNIT_TASK_DEFINITION(CLIENT1, StepOne)
   {
-    initClientWithPool(true, "__TEST_POOL1__", locatorsG, nullptr, nullptr, 0,
-                       true);
+    initClientWithPool(true, "__TEST_POOL1__", locatorsG, {}, nullptr, 0, true);
     getHelper()->createPooledRegion(_regionNames[1], NO_ACK, locatorsG,
                                     "__TEST_POOL1__", false, false);
     LOG("StepOne complete.");

--- a/cppcache/integration-test/testThinClientClearRegion.cpp
+++ b/cppcache/integration-test/testThinClientClearRegion.cpp
@@ -53,7 +53,7 @@ class MyCacheListener : public CacheListener {
 static int numberOfLocators = 1;
 bool isLocalServer = true;
 bool isLocator = true;
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 DUNIT_TASK(SERVER1, StartServer)

--- a/cppcache/integration-test/testThinClientCq.cpp
+++ b/cppcache/integration-test/testThinClientCq.cpp
@@ -55,7 +55,7 @@ using apache::geode::client::QueryService;
 
 static bool m_isPdx = false;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 const char *cqNames[MAX_LISTNER] = {"MyCq_0", "MyCq_1", "MyCq_2", "MyCq_3",
                                     "MyCq_4", "MyCq_5", "MyCq_6", "MyCq_7"};
@@ -294,7 +294,7 @@ END_TASK_DEFINITION
 void createServer_group(bool locator, const char *XML) {
   LOG("Starting SERVER1...");
   if (isLocalServer) {
-    CacheHelper::initServer(1, XML, locator ? locHostPort : nullptr);
+    CacheHelper::initServer(1, XML, locator ? locHostPort : std::string{});
   }
   LOG("SERVER1 started");
 }
@@ -302,7 +302,7 @@ void createServer_group(bool locator, const char *XML) {
 void createServer_group2(bool locator, const char *XML) {
   LOG("Starting SERVER2...");
   if (isLocalServer) {
-    CacheHelper::initServer(2, XML, locator ? locHostPort : nullptr);
+    CacheHelper::initServer(2, XML, locator ? locHostPort : std::string{});
   }
   LOG("SERVER2 started");
 }
@@ -888,13 +888,15 @@ DUNIT_TASK_DEFINITION(CLIENT1, createCQ_Pool)
     char KeyStr[256] = {0};
     char valStr[256] = {0};
     for (int i = 1; i <= 5; i++) {
-      ACE_OS::snprintf(KeyStr, 256, "Key-%d ", i);
-      ACE_OS::snprintf(valStr, 256, "val-%d ", i);
-      auto keyport = CacheableKey::create(KeyStr);
-      auto valport = CacheableString::create(valStr);
+      std::string key = "Key-" + std::to_string(i);
+      std::string value = "val-" + std::to_string(i);
+
+      auto keyport = CacheableKey::create(key);
+      auto valport = CacheableString::create(value);
+
       regPtr0->put(keyport, valport);
       regPtr1->put(keyport, valport);
-      SLEEP(10 * 1000);  // sleep a while to allow server query to complete
+      SLEEP(10000);  // sleep a while to allow server query to complete
     }
     LOGINFO("putEntries complete");
 
@@ -1028,16 +1030,16 @@ DUNIT_TASK_DEFINITION(CLIENT1, putEntries)
     auto regPtr0 = getHelper()->getRegion(regionName);
     auto regPtr1 = getHelper()->getRegion(regionName1);
     std::shared_ptr<Cacheable> val = nullptr;
-    char KeyStr[256] = {0};
-    char valStr[256] = {0};
     for (int i = 1; i <= 5; i++) {
-      ACE_OS::snprintf(KeyStr, 256, "Key-%d ", i);
-      ACE_OS::snprintf(valStr, 256, "val-%d ", i);
-      auto keyport = CacheableKey::create(KeyStr);
-      auto valport = CacheableString::create(valStr);
+      std::string key = "Key-" + std::to_string(i);
+      std::string value = "val-" + std::to_string(i);
+
+      auto keyport = CacheableKey::create(key);
+      auto valport = CacheableString::create(value);
+
       regPtr0->put(keyport, valport);
       regPtr1->put(keyport, valport);
-      SLEEP(10 * 1000);  // sleep a while to allow server query to complete
+      SLEEP(10000);  // sleep a while to allow server query to complete
     }
     LOGINFO("putEntries complete");
   }
@@ -1096,15 +1098,15 @@ DUNIT_TASK_DEFINITION(CLIENT1, ProcessCQ)
 
     auto regPtr0 = getHelper()->getRegion(regionName);
     std::shared_ptr<Cacheable> val = nullptr;
-    char KeyStr[256] = {0};
-    char valStr[256] = {0};
     for (int i = 1; i <= 5; i++) {
-      ACE_OS::snprintf(KeyStr, 256, "Key-%d ", i);
-      ACE_OS::snprintf(valStr, 256, "val-%d ", i);
-      auto keyport = CacheableKey::create(KeyStr);
-      auto valport = CacheableString::create(valStr);
+      std::string key = "Key-" + std::to_string(i);
+      std::string value = "val-" + std::to_string(i);
+
+      auto keyport = CacheableKey::create(key);
+      auto valport = CacheableString::create(value);
+
       regPtr0->put(keyport, valport);
-      SLEEP(10 * 1000);  // sleep a while to allow server query to complete
+      SLEEP(10000);  // sleep a while to allow server query to complete
     }
     LOGINFO("putEntries complete");
 
@@ -1155,12 +1157,14 @@ DUNIT_TASK_DEFINITION(CLIENT1, ProcessCQ)
     myStatusCq2->clear();
 
     for (int i = 1; i <= 5; i++) {
-      ACE_OS::snprintf(KeyStr, 256, "Key-%d ", i);
-      ACE_OS::snprintf(valStr, 256, "val-%d ", i);
-      auto keyport = CacheableKey::create(KeyStr);
-      auto valport = CacheableString::create(valStr);
+      std::string key = "Key-" + std::to_string(i);
+      std::string value = "val-" + std::to_string(i);
+
+      auto keyport = CacheableKey::create(key);
+      auto valport = CacheableString::create(value);
+
       regPtr0->put(keyport, valport);
-      SLEEP(10 * 1000);  // sleep a while to allow server query to complete
+      SLEEP(10000);  // sleep a while to allow server query to complete
     }
     LOGINFO("putEntries complete again");
 

--- a/cppcache/integration-test/testThinClientCqDelta.cpp
+++ b/cppcache/integration-test/testThinClientCqDelta.cpp
@@ -106,12 +106,14 @@ void cleanProc() {
   }
 }
 
-void createPooledRegion(const char *name, bool ackMode, const char *locators,
-                        const char *poolname,
+void createPooledRegion(const std::string &name, bool ackMode,
+                        const std::string &locators,
+                        const std::string &poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/testThinClientCqDurable.cpp
+++ b/cppcache/integration-test/testThinClientCqDurable.cpp
@@ -171,7 +171,7 @@ void createServer(bool locator = false) {
   LOG("Starting SERVER1...");
   if (isLocalServer) {
     CacheHelper::initServer(1, "remotequery.xml",
-                            locator ? locatorsG : nullptr);
+                            locator ? locatorsG : std::string{});
   }
   LOG("SERVER1 started");
 }
@@ -179,7 +179,7 @@ void createServer(bool locator = false) {
 void createServer_XML() {
   LOG("Starting SERVER...");
   if (isLocalServer) {
-    CacheHelper::initServer(1, "serverDurableClient.xml", nullptr);
+    CacheHelper::initServer(1, "serverDurableClient.xml");
   }
   LOG("SERVER started");
 }

--- a/cppcache/integration-test/testThinClientCqFailover.cpp
+++ b/cppcache/integration-test/testThinClientCqFailover.cpp
@@ -227,13 +227,13 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
 
       SLEEP(15000);
     } catch (IllegalStateException &ise) {
-      char isemsg[500] = {0};
-      ACE_OS::snprintf(isemsg, 499, "IllegalStateException: %s", ise.what());
-      LOG(isemsg);
-      FAIL(isemsg);
+      std::string excpmsg = "IllegalStateException: " + std::string{ise.what()};
+
+      LOG(excpmsg);
+      FAIL(excpmsg);
     } catch (Exception &excp) {
-      char excpmsg[500] = {0};
-      ACE_OS::snprintf(excpmsg, 499, "Exception: %s", excp.what());
+      std::string excpmsg = "Exception: " + std::string{excp.what()};
+
       LOG(excpmsg);
       FAIL(excpmsg);
     } catch (...) {
@@ -287,8 +287,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepThree3)
       auto vl = cqAttr->getCqListeners();
       cqLstner = vl[0];
     } catch (Exception &excp) {
-      char excpmsg[500] = {0};
-      ACE_OS::snprintf(excpmsg, 499, "Exception: %s", excp.what());
+      std::string excpmsg = "Exception: " + std::string{excp.what()};
+
       LOG(excpmsg);
       ASSERT(false, "get listener failed");
     }
@@ -374,8 +374,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, CloseCache1)
       auto vl = cqAttr->getCqListeners();
       cqLstner = vl[0];
     } catch (Exception &excp) {
-      char excpmsg[500] = {0};
-      ACE_OS::snprintf(excpmsg, 499, "Exception: %s", excp.what());
+      std::string excpmsg = "Exception: " + std::string{excp.what()};
+
       LOG(excpmsg);
       ASSERT(false, "get listener failed");
     }

--- a/cppcache/integration-test/testThinClientCqHAFailover.cpp
+++ b/cppcache/integration-test/testThinClientCqHAFailover.cpp
@@ -249,13 +249,13 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
       //  ASSERT( count==0, "results traversal count incorrect!" );
       SLEEP(15000);
     } catch (IllegalStateException &ise) {
-      char isemsg[500] = {0};
-      ACE_OS::snprintf(isemsg, 499, "IllegalStateException: %s", ise.what());
-      LOG(isemsg);
-      FAIL(isemsg);
+      std::string excpmsg = "IllegalStateException: " + std::string{ise.what()};
+
+      LOG(excpmsg);
+      FAIL(excpmsg);
     } catch (Exception &excp) {
-      char excpmsg[500] = {0};
-      ACE_OS::snprintf(excpmsg, 499, "Exception: %s", excp.what());
+      std::string excpmsg = "Exception: " + std::string{excp.what()};
+
       LOG(excpmsg);
       FAIL(excpmsg);
     } catch (...) {
@@ -309,8 +309,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepThree3)
       auto vl = cqAttr->getCqListeners();
       cqLstner = vl[0];
     } catch (Exception &excp) {
-      char excpmsg[500] = {0};
-      ACE_OS::snprintf(excpmsg, 499, "Exception: %s", excp.what());
+      std::string excpmsg = "Exception: " + std::string{excp.what()};
+
       LOG(excpmsg);
       ASSERT(false, "get listener failed");
     }
@@ -396,8 +396,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, CloseCache1)
       auto vl = cqAttr->getCqListeners();
       cqLstner = vl[0];
     } catch (Exception &excp) {
-      char excpmsg[500] = {0};
-      ACE_OS::snprintf(excpmsg, 499, "Exception: %s", excp.what());
+      std::string excpmsg = "Exception: " + std::string{excp.what()};
+
       LOG(excpmsg);
       ASSERT(false, "get listener failed");
     }

--- a/cppcache/integration-test/testThinClientCqIR.cpp
+++ b/cppcache/integration-test/testThinClientCqIR.cpp
@@ -87,7 +87,7 @@ void createServer(bool locator = false) {
   LOG("Starting SERVER1...");
   if (isLocalServer) {
     CacheHelper::initServer(1, "remotequery.xml",
-                            locator ? locatorsG : nullptr);
+                            locator ? locatorsG : std::string{});
   }
   LOG("SERVER1 started");
 }

--- a/cppcache/integration-test/testThinClientDeltaWithNotification.cpp
+++ b/cppcache/integration-test/testThinClientDeltaWithNotification.cpp
@@ -36,7 +36,7 @@ CacheHelper *cacheHelper = nullptr;
 bool isLocalServer = false;
 
 static bool isLocator = false;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #define CLIENT1 s1p1
 #define CLIENT2 s1p2
@@ -78,12 +78,14 @@ CacheHelper *getHelper() {
   return cacheHelper;
 }
 
-void createPooledRegion(const char *name, bool ackMode, const char *locators,
-                        const char *poolname,
+void createPooledRegion(const std::string &name, bool ackMode,
+                        const std::string &locators,
+                        const std::string &poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,
@@ -101,8 +103,9 @@ void createPooledExpirationRegion(const char *name, const char *poolname) {
       0, nullptr, ExpirationAction::LOCAL_INVALIDATE);
 }
 
-void createPooledLRURegion(const char *name, bool ackMode, const char *locators,
-                           const char *poolname,
+void createPooledLRURegion(const std::string &name, bool ackMode,
+                           const std::string &locators,
+                           const std::string &poolname,
                            bool clientNotificationEnabled = false,
                            bool cachingEnable = true) {
   LOG(" createPooledLRURegion entered");

--- a/cppcache/integration-test/testThinClientDisconnectionListioner.cpp
+++ b/cppcache/integration-test/testThinClientDisconnectionListioner.cpp
@@ -28,7 +28,7 @@ static bool isLocator = false;
 static bool isLocalServer = true;
 static int numberOfLocators = 1;
 static int isDisconnected = false;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 class DisconnectCacheListioner : public CacheListener {

--- a/cppcache/integration-test/testThinClientFixedPartitionResolver.cpp
+++ b/cppcache/integration-test/testThinClientFixedPartitionResolver.cpp
@@ -183,7 +183,7 @@ auto cptr3 = std::make_shared<CustomFixedPartitionResolver3>();
 bool isLocalServer = false;
 
 static bool isLocator = false;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 std::vector<char *> storeEndPoints(const char *points) {

--- a/cppcache/integration-test/testThinClientHADistOps.cpp
+++ b/cppcache/integration-test/testThinClientHADistOps.cpp
@@ -39,7 +39,7 @@ CacheHelper *cacheHelper = nullptr;
 bool isLocalServer = false;
 
 static bool isLocator = false;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 static int clientWithRedundancy = 0;

--- a/cppcache/integration-test/testThinClientHAEventIDMap.cpp
+++ b/cppcache/integration-test/testThinClientHAEventIDMap.cpp
@@ -93,7 +93,7 @@ static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 1;
 
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 int g_redundancyLevel = 0;
 

--- a/cppcache/integration-test/testThinClientHAFailover.cpp
+++ b/cppcache/integration-test/testThinClientHAFailover.cpp
@@ -42,7 +42,7 @@ int g_redundancyLevel = 0;
 
 static bool isLocator = false;
 static int numberOfLocators = 1;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 void initClient(int redundancyLevel) {

--- a/cppcache/integration-test/testThinClientHAFailoverRegex.cpp
+++ b/cppcache/integration-test/testThinClientHAFailoverRegex.cpp
@@ -42,7 +42,7 @@ volatile int g_redundancyLevel = 0;
 
 static bool isLocator = false;
 static int numberOfLocators = 1;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 void initClient() {

--- a/cppcache/integration-test/testThinClientHAMixedRedundancy.cpp
+++ b/cppcache/integration-test/testThinClientHAMixedRedundancy.cpp
@@ -40,7 +40,7 @@ CacheHelper *cacheHelper = nullptr;
 #define SERVERS s2p2
 #define SERVER1 s2p2
 static bool isLocator = false;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 bool g_poolConfig = false;
 bool g_poolLocators = false;

--- a/cppcache/integration-test/testThinClientHAPeriodicAck.cpp
+++ b/cppcache/integration-test/testThinClientHAPeriodicAck.cpp
@@ -97,7 +97,7 @@ CacheHelper *cacheHelper = nullptr;
 static bool isLocator = false;
 static bool isLocalServer = false;
 static int numberOfLocators = 1;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 int g_redundancyLevel = 0;
 bool g_poolConfig = false;

--- a/cppcache/integration-test/testThinClientHAQueryFailover.cpp
+++ b/cppcache/integration-test/testThinClientHAQueryFailover.cpp
@@ -55,7 +55,7 @@ static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 1;
 
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 class KillServerThread : public ACE_Task_Base {
@@ -258,13 +258,13 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
 
       kst->stop();
     } catch (IllegalStateException &ise) {
-      char isemsg[500] = {0};
-      ACE_OS::snprintf(isemsg, 499, "IllegalStateException: %s", ise.what());
-      LOG(isemsg);
-      FAIL(isemsg);
+      std::string excpmsg = "IllegalStateException: " + std::string{ise.what()};
+
+      LOG(excpmsg);
+      FAIL(excpmsg);
     } catch (Exception &excp) {
-      char excpmsg[500] = {0};
-      ACE_OS::snprintf(excpmsg, 499, "Exception: %s", excp.what());
+      std::string excpmsg = "Exception: " + std::string{excp.what()};
+
       LOG(excpmsg);
       FAIL(excpmsg);
     } catch (...) {

--- a/cppcache/integration-test/testThinClientInterest1Cacheless.cpp
+++ b/cppcache/integration-test/testThinClientInterest1Cacheless.cpp
@@ -38,10 +38,12 @@ class MyListener : public CacheListener {
   inline void checkEntry(const EntryEvent &event) {
     auto keyPtr = std::dynamic_pointer_cast<CacheableString>(event.getKey());
     for (int i = 0; i < 5; i++) {
-      if (!ACE_OS::strcmp(keys[i], keyPtr->value().c_str())) {
+      if (keyPtr->value() == keys[i]) {
         auto valPtr =
             std::dynamic_pointer_cast<CacheableString>(event.getNewValue());
-        if (!ACE_OS::strcmp(vals[i], valPtr->value().c_str())) m_gotit[i] = 1;
+        if (valPtr->value() == vals[i]) {
+          m_gotit[i] = 1;
+        }
         break;
       }
     }

--- a/cppcache/integration-test/testThinClientInterestNotify.cpp
+++ b/cppcache/integration-test/testThinClientInterestNotify.cpp
@@ -261,8 +261,7 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(SERVER_AND_FEEDER, FeederUpAndFeed)
   {
-    initClientWithPool(true, "__TEST_POOL1__", locatorsG, nullptr, nullptr, 0,
-                       true);
+    initClientWithPool(true, "__TEST_POOL1__", locatorsG, {}, nullptr, 0, true);
     getHelper()->createPooledRegion(regions[0], USE_ACK, locatorsG,
                                     "__TEST_POOL1__", true, true);
     getHelper()->createPooledRegion(regions[1], USE_ACK, locatorsG,

--- a/cppcache/integration-test/testThinClientLRUExpiration.cpp
+++ b/cppcache/integration-test/testThinClientLRUExpiration.cpp
@@ -51,7 +51,7 @@ CacheHelper *cacheHelper = nullptr;
 bool isLocalServer = false;
 
 static bool isLocator = false;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 const char *regionNames[] = {"DistRegionAck1", "DistRegionAck2",
@@ -303,7 +303,7 @@ END_TASK(StepTwoCase1)
 DUNIT_TASK(CLIENT1, StepThreeCase1)
   {
     doRgnOperations(regionNames[0], 100);
-    ACE_OS::sleep(1);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     auto n = getNumOfEntries(regionNames[0]);
     ASSERT(n == 100, "Expected 100 entries");
     LOG("StepThree complete.");
@@ -320,7 +320,7 @@ END_TASK(StepFourCase1)
 DUNIT_TASK(CLIENT1, StepFiveCase1)
   {
     // wair 5 sec so all enteries gone
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     auto n = getNumOfEntries(regionNames[0]);
     ASSERT(n == 0, "Expected 0 entries");
     LOG("StepFive complete.");
@@ -328,7 +328,7 @@ DUNIT_TASK(CLIENT1, StepFiveCase1)
 END_TASK(StepFiveCase1)
 DUNIT_TASK(CLIENT2, StepSixCase1)
   {
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     // all enteris has been deleted
     // int n = getNumOfEntries(regionNames[0],true);
     auto n = getNumOfEntries(regionNames[0]);
@@ -384,10 +384,10 @@ DUNIT_TASK(CLIENT2, StepFourCase2)
 END_TASK(StepFourCase2)
 DUNIT_TASK(CLIENT1, StepFiveCase2)
   {
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     auto n = getNumOfEntries(regionNames[0]);
     ASSERT(n == 100, "Expected 100 entries");
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     // value should be invalidate as passing true
     n = getNumOfEntries(regionNames[0], true);
     ASSERT(n == 0, "Expected 0 entries");
@@ -396,7 +396,7 @@ DUNIT_TASK(CLIENT1, StepFiveCase2)
 END_TASK(StepFiveCase2)
 DUNIT_TASK(CLIENT2, StepSixCase2)
   {
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     auto n = getNumOfEntries(regionNames[0], true);
     ASSERT(n == 100, "Expected 100 entries");
     LOG("StepSixCase2 complete.");
@@ -455,7 +455,7 @@ DUNIT_TASK(CLIENT1, StepFiveCase3)
 END_TASK(StepFiveCase3)
 DUNIT_TASK(CLIENT2, StepSixCase3)
   {
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     auto n = getNumOfEntries(regionNames[0]);
     ASSERT(n == 10, "Expected 10 entries");
     n = getNumOfEntries(regionNames[0], true);
@@ -512,12 +512,12 @@ DUNIT_TASK(CLIENT2, StepFourCase4)
 END_TASK(StepFourCase4)
 DUNIT_TASK(CLIENT1, StepFiveCase4)
   {
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     auto n = getNumOfEntries(regionNames[0]);
     ASSERT(n == 5, "Expected 5 entries");
     n = getNumOfEntries(regionNames[0], true);
     ASSERT(n == 5, "Expected 5 entries");
-    ACE_OS::sleep(4);
+    std::this_thread::sleep_for(std::chrono::seconds(4));
     n = getNumOfEntries(regionNames[0]);
     ASSERT(n == 5, "Expected 5 entries");
     LOG("StepFiveCase4 "
@@ -526,7 +526,7 @@ DUNIT_TASK(CLIENT1, StepFiveCase4)
 END_TASK(StepFiveCase4)
 DUNIT_TASK(CLIENT2, StepSixCase4)
   {
-    ACE_OS::sleep(1);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     auto n = getNumOfEntries(regionNames[0]);
     ASSERT(n == 10, "Expected 10 entries");
     n = getNumOfEntries(regionNames[0], true);
@@ -596,7 +596,7 @@ DUNIT_TASK(CLIENT2, StepFourCase5)
 END_TASK(StepFourCase5)
 DUNIT_TASK(CLIENT1, StepFiveCase5)
   {
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     auto n = getNumOfEntries(regionNames[0]);
     ASSERT(n == 5,
            "Expected "
@@ -607,7 +607,7 @@ DUNIT_TASK(CLIENT1, StepFiveCase5)
            "Expected "
            "5 "
            "entries");
-    ACE_OS::sleep(4);
+    std::this_thread::sleep_for(std::chrono::seconds(4));
     n = getNumOfEntries(regionNames[0]);
     ASSERT(n == 0,
            "Expected "
@@ -620,7 +620,7 @@ DUNIT_TASK(CLIENT1, StepFiveCase5)
 END_TASK(StepFiveCase5)
 DUNIT_TASK(CLIENT2, StepSixCase5)
   {
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     auto n = getNumOfEntries(regionNames[0]);
     ASSERT(n == 5,
            "Expecte"
@@ -711,12 +711,12 @@ DUNIT_TASK(CLIENT2, StepFourCase6)
 END_TASK(StepFourCase6)
 DUNIT_TASK(CLIENT1, StepFiveCase6)
   {
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     auto n = getNumOfEntries(regionNames[0]);
     ASSERT(n == 5, "Expected 5 entries");
     n = getNumOfEntries(regionNames[0], true);
     ASSERT(n == 5, "Expected 5 entries");
-    ACE_OS::sleep(4);
+    std::this_thread::sleep_for(std::chrono::seconds(4));
     n = getNumOfEntries(regionNames[0]);
     ASSERT(n == 5, "Expected 5 entries");
     LOG("StepFiveCase6 complete.");
@@ -724,7 +724,7 @@ DUNIT_TASK(CLIENT1, StepFiveCase6)
 END_TASK(StepFiveCase6)
 DUNIT_TASK(CLIENT2, StepSixCase6)
   {
-    ACE_OS::sleep(1);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     auto n = getNumOfEntries(regionNames[0]);
     ASSERT(n == 10, "Expected 10 entries");
     n = getNumOfEntries(regionNames[0], true);
@@ -771,21 +771,21 @@ DUNIT_TASK(CLIENT2, StepFourCase7)
 END_TASK(StepFourCase7)
 DUNIT_TASK(CLIENT1, StepFiveCase7)
   {
-    ACE_OS::sleep(15);
+    std::this_thread::sleep_for(std::chrono::seconds(15));
     ValidateDestroyRegion(regionNames[0]);
     LOG("StepFiveCase7 complete.");
   }
 END_TASK(StepFiveCase7)
 DUNIT_TASK(CLIENT2, StepSixCase7)
   {
-    ACE_OS::sleep(3);
+    std::this_thread::sleep_for(std::chrono::seconds(3));
     ValidateDestroyRegion(regionNames[0]);
     LOG("StepSixCase7 complete.");
   }
 END_TASK(StepSixCase7)
 DUNIT_TASK(CLIENT1, StepOneCase8)
   {
-    ACE_OS::sleep(10);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
     // regionName, ettl, eit , rttl, rit,lel,endpoints,noOfEntry,rgnOpetation -
     // [put-0/get-5/destroy-3] ,destroyRgn - [true/false]
     // ,clientNotificationEnabled - [true/false] ,ExpirationAction
@@ -823,17 +823,17 @@ DUNIT_TASK(CLIENT2, StepFourCase8)
 END_TASK(StepFourCase8)
 DUNIT_TASK(CLIENT1, StepFiveCase8)
   {
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     auto n = getNumOfEntries(regionNames[1]);
     ASSERT(n == 10, "Expected 0 entries");
-    ACE_OS::sleep(10);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
     ValidateDestroyRegion(regionNames[1]);
     LOG("StepFiveCase8 complete.");
   }
 END_TASK(StepFiveCase8)
 DUNIT_TASK(CLIENT2, StepSixCase8)
   {
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     ValidateDestroyRegion(regionNames[1]);
     LOG("StepSixCase8 complete.");
   }
@@ -861,7 +861,7 @@ DUNIT_TASK(CLIENT2, StepTwoCase9)
 END_TASK(StepTwoCase9)
 DUNIT_TASK(CLIENT1, StepThreeCase9)
   {
-    ACE_OS::sleep(2);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     doRgnOperations(regionNames[2], 10);
     auto n = getNumOfEntries(regionNames[2]);
     ASSERT(n == 5, "Expected 5 entries");
@@ -878,17 +878,17 @@ DUNIT_TASK(CLIENT2, StepFourCase9)
 END_TASK(StepFourCase9)
 DUNIT_TASK(CLIENT1, StepFiveCase9)
   {
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     auto n = getNumOfEntries(regionNames[2]);
     ASSERT(n == 0, "Expected 0 entries");
-    ACE_OS::sleep(8);
+    std::this_thread::sleep_for(std::chrono::seconds(8));
     ValidateDestroyRegion(regionNames[2]);
     LOG("StepFiveCase9 complete.");
   }
 END_TASK(StepFiveCase9)
 DUNIT_TASK(CLIENT2, StepSixCase9)
   {
-    ACE_OS::sleep(3);
+    std::this_thread::sleep_for(std::chrono::seconds(3));
     ValidateDestroyRegion(regionNames[2]);
     LOG("StepSixCase9 complete.");
   }
@@ -932,17 +932,17 @@ DUNIT_TASK(CLIENT2, StepFourCase10)
 END_TASK(StepFourCase10)
 DUNIT_TASK(CLIENT1, StepFiveCase10)
   {
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     auto n = getNumOfEntries(regionNames[3]);
     ASSERT(n == 0, "Expected 0 entries");
-    ACE_OS::sleep(10);
+    std::this_thread::sleep_for(std::chrono::seconds(10));
     ValidateDestroyRegion(regionNames[3]);
     LOG("StepFiveCase10 complete.");
   }
 END_TASK(StepFiveCase10)
 DUNIT_TASK(CLIENT2, StepSixCase10)
   {
-    ACE_OS::sleep(3);
+    std::this_thread::sleep_for(std::chrono::seconds(3));
     ValidateDestroyRegion(regionNames[3]);
     LOG("StepSixCase10 complete.");
   }
@@ -1021,7 +1021,7 @@ DUNIT_TASK(CLIENT2, StepFourCase11)
 END_TASK(StepFourCase11)
 DUNIT_TASK(CLIENT1, StepFiveCase11)
   {
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     auto n = getNumOfEntries(regionNames[4]);
 
     ASSERT(regWriter->isWriterInvoked() == true, "Writer Should be invoked");
@@ -1058,7 +1058,7 @@ DUNIT_TASK(CLIENT2, StepSixCase11)
       so expect 5 entries instead of 0 earlier. */
     ASSERT(n == 5, "Expected 5 entries");
 
-    ACE_OS::sleep(3);
+    std::this_thread::sleep_for(std::chrono::seconds(3));
     LOG("StepSixCase11 complete.");
   }
 END_TASK(StepSixCase11)
@@ -1149,7 +1149,7 @@ DUNIT_TASK(CLIENT2, StepFourCase12)
 END_TASK(StepFourCase12)
 DUNIT_TASK(CLIENT1, StepFiveCase12)
   {
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     auto n = getNumOfEntries(regionNames[5]);
 
     ASSERT(regWriter->isWriterInvoked() == true, "Writer Should be invoked");
@@ -1168,7 +1168,7 @@ DUNIT_TASK(CLIENT1, StepFiveCase12)
 END_TASK(StepFiveCase12)
 DUNIT_TASK(CLIENT2, StepSixCase12)
   {
-    ACE_OS::sleep(3);
+    std::this_thread::sleep_for(std::chrono::seconds(3));
     auto n = getNumOfEntries(regionNames[5]);
     ASSERT(regWriter->isWriterInvoked() == false,
            "Writer Should not be invoked");
@@ -1262,7 +1262,7 @@ DUNIT_TASK(CLIENT2, StepFourCase13)
 END_TASK(StepFourCase13)
 DUNIT_TASK(CLIENT1, StepFiveCase13)
   {
-    ACE_OS::sleep(5);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     auto n = getNumOfEntries(regionNames[5]);
 
     ASSERT(regWriter->isWriterInvoked() == true, "Writer Should be invoked");
@@ -1281,7 +1281,7 @@ DUNIT_TASK(CLIENT1, StepFiveCase13)
 END_TASK(StepFiveCase13)
 DUNIT_TASK(CLIENT2, StepSixCase13)
   {
-    ACE_OS::sleep(3);
+    std::this_thread::sleep_for(std::chrono::seconds(3));
     auto n = getNumOfEntries(regionNames[5]);
     ASSERT(regWriter->isWriterInvoked() == false,
            "Writer Should not be invoked");

--- a/cppcache/integration-test/testThinClientListenerCallbackArgTest.cpp
+++ b/cppcache/integration-test/testThinClientListenerCallbackArgTest.cpp
@@ -41,7 +41,7 @@ using apache::geode::client::testing::TallyWriter;
 
 bool isLocalServer = true;
 static bool isLocator = false;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #include "LocatorHelper.hpp"
 

--- a/cppcache/integration-test/testThinClientLocator.cpp
+++ b/cppcache/integration-test/testThinClientLocator.cpp
@@ -20,7 +20,7 @@
 bool isLocalServer = false;
 bool isLocator = false;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 #define CLIENT1 s1p1
@@ -37,8 +37,12 @@ END_TASK(CreateLocator1)
 DUNIT_TASK(SERVER12, CreateServer12)
   {
     // starting servers
-    if (isLocalServer) CacheHelper::initServer(1, nullptr, locHostPort);
-    if (isLocalServer) CacheHelper::initServer(2, nullptr, locHostPort);
+    if (isLocalServer) {
+      CacheHelper::initServer(1, {}, locHostPort);
+    }
+    if (isLocalServer) {
+      CacheHelper::initServer(2, {}, locHostPort);
+    }
     LOG("Server12 started");
   }
 END_TASK(CreateServer12)

--- a/cppcache/integration-test/testThinClientLocatorFailover.cpp
+++ b/cppcache/integration-test/testThinClientLocatorFailover.cpp
@@ -22,7 +22,7 @@ using apache::geode::client::NoAvailableLocatorsException;
 bool isLocalServer = false;
 bool isLocator = false;
 
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 3);
 #define CLIENT1 s1p1
 #define CLIENT2 s1p2
@@ -41,7 +41,7 @@ END_TASK(CreateLocator_All)
 DUNIT_TASK(SERVERS, CreateServer1_All)
   {
     // starting servers
-    if (isLocalServer) CacheHelper::initServer(1, nullptr, locatorsG);
+    if (isLocalServer) CacheHelper::initServer(1, {}, locatorsG);
     LOG("Server One started");
   }
 END_TASK(CreateServer1_All)
@@ -82,7 +82,7 @@ END_TASK(ConnectC2_All)
 DUNIT_TASK(SERVERS, CreateServer2_All)
   {
     if (isLocalServer) {
-      CacheHelper::initServer(2, nullptr, locatorsG);
+      CacheHelper::initServer(2, {}, locatorsG);
       LOG("Server 2 started");
     }
   }
@@ -135,7 +135,7 @@ END_TASK(SwapLocators)
 DUNIT_TASK(SERVERS, Re_CreateServer1_All)
   {
     if (isLocalServer) {
-      CacheHelper::initServer(1, nullptr, locatorsG);
+      CacheHelper::initServer(1, {}, locatorsG);
       LOG("Server 1 started");
       SLEEP(30000);
     }
@@ -199,7 +199,7 @@ END_TASK(Re_Close1_All_All)
 DUNIT_TASK(SERVERS, StartServer2_All)
   {
     if (isLocalServer) {
-      CacheHelper::initServer(2, nullptr, nullptr);
+      CacheHelper::initServer(2);
       LOG("SERVER2 Started");
       SLEEP(30000);
     }

--- a/cppcache/integration-test/testThinClientMultiDS.cpp
+++ b/cppcache/integration-test/testThinClientMultiDS.cpp
@@ -63,9 +63,9 @@ void startServer(int instance, const char *xmlfile, const char *lochostport) {
 
 DUNIT_TASK_DEFINITION(SERVER1, CreateServer1)
   {
-    CacheHelper::initServer(1, "cacheserver_notify_subscription.xml", nullptr,
+    CacheHelper::initServer(1, "cacheserver_notify_subscription.xml", {},
                             nullptr, false, true, true);
-    CacheHelper::initServer(2, "cacheserver_notify_subscription2.xml", nullptr,
+    CacheHelper::initServer(2, "cacheserver_notify_subscription2.xml", {},
                             nullptr, false, true, true);
     LOG("SERVER1 and server2 started");
   }
@@ -73,9 +73,9 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(SERVER2, CreateServer2)
   {
-    CacheHelper::initServer(3, "cacheserver_notify_subscription3.xml", nullptr,
+    CacheHelper::initServer(3, "cacheserver_notify_subscription3.xml", {},
                             nullptr, false, true, true);
-    CacheHelper::initServer(4, "cacheserver_notify_subscription4.xml", nullptr,
+    CacheHelper::initServer(4, "cacheserver_notify_subscription4.xml", {},
                             nullptr, false, true, true);
     LOG("SERVER2 started");
   }

--- a/cppcache/integration-test/testThinClientNotificationWithDeltaWithoutcache.cpp
+++ b/cppcache/integration-test/testThinClientNotificationWithDeltaWithoutcache.cpp
@@ -81,12 +81,14 @@ CacheHelper *getHelper() {
   return cacheHelper;
 }
 
-void createPooledRegion(const char *name, bool ackMode, const char *locators,
-                        const char *poolname,
+void createPooledRegion(const std::string &name, bool ackMode,
+                        const std::string &locators,
+                        const std::string &poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/testThinClientPRPutAllFailover.cpp
+++ b/cppcache/integration-test/testThinClientPRPutAllFailover.cpp
@@ -47,7 +47,7 @@ using apache::geode::client::testing::TallyListener;
 std::shared_ptr<TallyListener> reg1Listener1;
 bool isLocalServer = false;
 static bool isLocator = false;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 void setCacheListener(const char *regName,

--- a/cppcache/integration-test/testThinClientPRSingleHopServerGroup.cpp
+++ b/cppcache/integration-test/testThinClientPRSingleHopServerGroup.cpp
@@ -51,7 +51,7 @@ using apache::geode::client::HashMapOfException;
 bool isLocalServer = false;
 
 static bool isLocator = false;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 const char *group1 = "ABC";

--- a/cppcache/integration-test/testThinClientPdxDeltaWithNotification.cpp
+++ b/cppcache/integration-test/testThinClientPdxDeltaWithNotification.cpp
@@ -35,7 +35,7 @@ CacheHelper *cacheHelper = nullptr;
 bool isLocalServer = false;
 
 static bool isLocator = false;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #define CLIENT1 s1p1
 #define CLIENT2 s1p2
@@ -78,12 +78,14 @@ CacheHelper *getHelper() {
   return cacheHelper;
 }
 
-void createPooledRegion(const char *name, bool ackMode, const char *locators,
-                        const char *poolname,
+void createPooledRegion(const std::string &name, bool ackMode,
+                        const std::string &locators,
+                        const std::string &poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,
@@ -92,7 +94,8 @@ void createPooledRegion(const char *name, bool ackMode, const char *locators,
   LOG("Pooled Region created.");
 }
 
-void createPooledExpirationRegion(const char *name, const char *poolname) {
+void createPooledExpirationRegion(const std::string &name,
+                                  const std::string &poolname) {
   LOG("createPooledExpirationRegion() entered.");
   // Entry time-to-live = 1 second.
   auto regPtr = getHelper()->createPooledRegionDiscOverFlow(
@@ -101,8 +104,9 @@ void createPooledExpirationRegion(const char *name, const char *poolname) {
       0, nullptr, ExpirationAction::LOCAL_INVALIDATE);
 }
 
-void createPooledLRURegion(const char *name, bool ackMode, const char *locators,
-                           const char *poolname,
+void createPooledLRURegion(const std::string &name, bool ackMode,
+                           const std::string &locators,
+                           const std::string &poolname,
                            bool clientNotificationEnabled = false,
                            bool cachingEnable = true) {
   LOG(" createPooledLRURegion entered");
@@ -114,10 +118,11 @@ void createPooledLRURegion(const char *name, bool ackMode, const char *locators,
   LOG(" createPooledLRURegion exited");
 }
 
-void createRegion(const char *name, bool ackMode,
+void createRegion(const std::string &name, bool ackMode,
                   bool clientNotificationEnabled = false) {
   LOG("createRegion() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   // ack, caching
   auto regPtr = getHelper()->createRegion(name, ackMode, true, nullptr,
@@ -126,7 +131,8 @@ void createRegion(const char *name, bool ackMode,
   LOG("Region created.");
 }
 
-void createLRURegion(const char *name, bool clientNotificationEnabled = false,
+void createLRURegion(const std::string &name,
+                     bool clientNotificationEnabled = false,
                      bool cachingEnable = true) {
   LOG(" createPooledLRURegion entered");
   auto regPtr = getHelper()->createRegionDiscOverFlow(
@@ -136,7 +142,7 @@ void createLRURegion(const char *name, bool clientNotificationEnabled = false,
   LOG(" createPooledLRURegion exited");
 }
 
-void createExpirationRegion(const char *name,
+void createExpirationRegion(const std::string &name,
                             bool clientNotificationEnabled = false,
                             bool cachingEnable = true) {
   LOG(" createPooledLRURegion entered");

--- a/cppcache/integration-test/testThinClientPdxEnum.cpp
+++ b/cppcache/integration-test/testThinClientPdxEnum.cpp
@@ -32,7 +32,7 @@ bool isLocalServer = false;
 #define SERVER1 s2p1
 static bool isLocator = false;
 
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 DUNIT_TASK_DEFINITION(CLIENT1, SetupClientPoolLoc)
@@ -40,7 +40,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, SetupClientPoolLoc)
     LOG("Starting Step One with Pool + Locator lists");
     initClient(true);
 
-    createPool("__TEST_POOL1__", locatorsG, nullptr, 0, true);
+    createPool("__TEST_POOL1__", locatorsG, {}, 0, true);
     createRegionAndAttachPool("DistRegionAck", USE_ACK, "__TEST_POOL1__");
 
     LOG("SetupClient complete.");

--- a/cppcache/integration-test/testThinClientPdxInstance.cpp
+++ b/cppcache/integration-test/testThinClientPdxInstance.cpp
@@ -77,7 +77,7 @@ static bool isLocator = false;
 const bool USE_ACK = true;
 const bool NO_ACK = false;
 
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 const char *regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
@@ -151,12 +151,14 @@ CacheHelper *getHelper() {
   ASSERT(cacheHelper != nullptr, "No cacheHelper initialized.");
   return cacheHelper;
 }
-void createPooledRegion(const char *name, bool ackMode, const char *locators,
-                        const char *poolname,
+void createPooledRegion(const std::string &name, bool ackMode,
+                        const std::string &locators,
+                        const std::string &poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,
@@ -1648,8 +1650,8 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstance)
     std::shared_ptr<CacheableDate> dateVal;
     wpiPtr = pIPtr->createWriter();
     time_t timeofday = 0;
-    const ACE_Time_Value currentTime = ACE_OS::gettimeofday();
-    timeofday = currentTime.sec();
+    timeofday =
+        std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     auto datePtr = CacheableDate::create(timeofday);
     wpiPtr->setField("m_dateTime", datePtr);
     rptr->put(keyport, wpiPtr);
@@ -2208,10 +2210,11 @@ DUNIT_TASK_DEFINITION(CLIENT2, modifyPdxInstanceAndCheckLocally)
 
     std::shared_ptr<CacheableDate> dateVal;
     wpiPtr = pIPtr->createWriter();
-    time_t timeofday = 0;
-    const ACE_Time_Value currentTime = ACE_OS::gettimeofday();
-    timeofday = currentTime.sec();
+
+    auto timeofday =
+        std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     auto datePtr = CacheableDate::create(timeofday);
+
     wpiPtr->setField("m_dateTime", datePtr);
     rptr->put(keyport, wpiPtr);
     newPiPtr = std::dynamic_pointer_cast<PdxInstance>(rptr->get(keyport));

--- a/cppcache/integration-test/testThinClientPdxTests.cpp
+++ b/cppcache/integration-test/testThinClientPdxTests.cpp
@@ -107,7 +107,7 @@ bool isLocator = false;
 bool isLocalServer = false;
 
 const char *poolNames[] = {"Pool1", "Pool2", "Pool3"};
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 bool isPoolConfig = false;  // To track if pool case is running
 // const char * qRegionNames[] = { "Portfolios", "Positions", "Portfolios2",

--- a/cppcache/integration-test/testThinClientPoolAttrTest.cpp
+++ b/cppcache/integration-test/testThinClientPoolAttrTest.cpp
@@ -35,7 +35,7 @@ using apache::geode::client::IllegalStateException;
 bool isLocalServer = false;
 bool isLocator = false;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 const char *poolRegNames[] = {"PoolRegion1"};
 const char *poolName = "__TEST_POOL1__";
@@ -227,9 +227,8 @@ END_TASK(StartC1)
 DUNIT_TASK(CLIENT2, StartC2)
   {
     auto props = Properties::create();
-    std::string path = "cacheserver_pool_client.xml";
-    std::string duplicateFile;
-    CacheHelper::createDuplicateXMLFile(duplicateFile, path);
+    auto duplicateFile =
+        CacheHelper::createDuplicateXMLFile("cacheserver_pool_client.xml");
 
     props->insert("cache-xml-file", duplicateFile.c_str());
 
@@ -238,10 +237,10 @@ DUNIT_TASK(CLIENT2, StartC2)
       initClient(true, props);
       LOG(" started client");
       ASSERT(getHelper()
-                     ->getCache()
-                     ->getPoolManager()
-                     .find("clientPoolMultiUser")
-                     ->getMultiuserAuthentication() == true,
+                 ->getCache()
+                 ->getPoolManager()
+                 .find("clientPoolMultiUser")
+                 ->getMultiuserAuthentication(),
              "MultiUser secure mode should be true for Pool");
     } catch (const Exception &excp) {
       LOG("Exception during client 2 XML creation");

--- a/cppcache/integration-test/testThinClientPoolExecuteFunctionThrowsException.cpp
+++ b/cppcache/integration-test/testThinClientPoolExecuteFunctionThrowsException.cpp
@@ -47,7 +47,7 @@ bool isLocalServer = false;
 bool isLocator = false;
 bool isPoolWithEndpoint = false;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 const char *poolRegNames[] = {"partition_region", "PoolRegion2"};
 
@@ -119,11 +119,15 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(SERVER, StartS12)
   {
-    const char *lhp = nullptr;
-    if (!isPoolWithEndpoint) lhp = locHostPort;
+    std::string lhp;
+    if (!isPoolWithEndpoint) {
+      lhp = locHostPort;
+    }
+
     if (isLocalServer) {
       CacheHelper::initServer(1, "func_cacheserver1_pool.xml", lhp);
     }
+
     if (isLocalServer) {
       CacheHelper::initServer(2, "func_cacheserver2_pool.xml", lhp);
     }

--- a/cppcache/integration-test/testThinClientPoolExecuteHAFunction.cpp
+++ b/cppcache/integration-test/testThinClientPoolExecuteHAFunction.cpp
@@ -36,7 +36,7 @@ bool isLocalServer = false;
 bool isLocator = false;
 bool isPoolWithEndpoint = false;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 const char *poolRegNames[] = {"partition_region", "PoolRegion2"};
 const char *poolName = "__TEST_POOL1__";
@@ -116,8 +116,11 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(SERVER, StartS12)
   {
-    const char *lhp = nullptr;
-    if (!isPoolWithEndpoint) lhp = locHostPort;
+    std::string lhp;
+    if (!isPoolWithEndpoint) {
+      lhp = locHostPort;
+    }
+
     if (isLocalServer) {
       CacheHelper::initServer(1, "func_cacheserver1_pool.xml", lhp);
     }
@@ -129,8 +132,10 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(SERVER, StartS13)
   {
-    const char *lhp = nullptr;
-    if (!isPoolWithEndpoint) lhp = locHostPort;
+    std::string lhp;
+    if (!isPoolWithEndpoint) {
+      lhp = locHostPort;
+    }
     if (isLocalServer) {
       CacheHelper::initServer(1, "func_cacheserver1_pool.xml", lhp);
     }

--- a/cppcache/integration-test/testThinClientPoolExecuteHAFunctionPrSHOP.cpp
+++ b/cppcache/integration-test/testThinClientPoolExecuteHAFunctionPrSHOP.cpp
@@ -34,7 +34,7 @@ using apache::geode::client::FunctionService;
 bool isLocalServer = false;
 bool isLocator = false;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 const char *poolRegNames[] = {"partition_region", "PoolRegion2"};
 const char *poolName = "__TEST_POOL1__";

--- a/cppcache/integration-test/testThinClientPoolLocator.cpp
+++ b/cppcache/integration-test/testThinClientPoolLocator.cpp
@@ -24,9 +24,9 @@ using apache::geode::client::NotConnectedException;
 bool isLocalServer = false;
 bool isLocator = false;
 
-const char *locHostPort1 =
+const std::string locHostPort1 =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
-const char *locHostPort2 =
+const std::string locHostPort2 =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 2);
 #define CLIENT1 s1p1
 #define CLIENT2 s1p2

--- a/cppcache/integration-test/testThinClientPoolRedundancy.cpp
+++ b/cppcache/integration-test/testThinClientPoolRedundancy.cpp
@@ -30,7 +30,7 @@
 
 bool isLocalServer = false;
 bool isLocator = false;
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 const char *poolRegNames[] = {"PoolRegion1", "PoolRegion2", "PoolRegion3"};
 const char *poolNames[] = {"Pool1", "Pool2", "Pool3"};

--- a/cppcache/integration-test/testThinClientPoolRegInterest.cpp
+++ b/cppcache/integration-test/testThinClientPoolRegInterest.cpp
@@ -28,7 +28,7 @@
 bool isLocalServer = false;
 bool isLocator = false;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 const char *poolRegNames[] = {"PoolRegion1", "PoolRegion2"};
 const char *poolName = "__TEST_POOL1__";

--- a/cppcache/integration-test/testThinClientPoolServer.cpp
+++ b/cppcache/integration-test/testThinClientPoolServer.cpp
@@ -33,7 +33,7 @@ server-group having the region.
 bool isLocalServer = false;
 bool isLocator = false;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 const char *poolRegNames[] = {"PoolRegion1", "PoolRegion2", "PoolRegion3"};
 const char *poolName = "__TEST_POOL1__";
@@ -83,7 +83,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, StartClient2)
   {
     initClient(true);
     // Create Pool with no server group
-    getHelper()->createPool(poolName, locHostPort, nullptr);
+    getHelper()->createPool(poolName, locHostPort, {});
 
     getHelper()->createRegionAndAttachPool(poolRegNames[0], USE_ACK,
                                            "__TEST_POOL1__");

--- a/cppcache/integration-test/testThinClientPutAllPRSingleHop.cpp
+++ b/cppcache/integration-test/testThinClientPutAllPRSingleHop.cpp
@@ -52,7 +52,7 @@ using apache::geode::client::HashMapOfCacheable;
 bool isLocalServer = false;
 
 static bool isLocator = false;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 DUNIT_TASK_DEFINITION(SERVER1, CreateServer1)
@@ -193,12 +193,18 @@ DUNIT_TASK_DEFINITION(CLIENT1, CheckPrSingleHopForIntKeysTask)
           valMap.emplace(keyPtr, valPtr);
         }
         LOGINFO("TEST-1");
-        ACE_Time_Value startTime = ACE_OS::gettimeofday();
+        auto startTime = std::chrono::steady_clock::now();
         dataReg->putAll(valMap);
-        ACE_Time_Value interval = ACE_OS::gettimeofday() - startTime;
+        auto interval = std::chrono::steady_clock::now() - startTime;
+        auto interval_sec =
+            std::chrono::duration_cast<std::chrono::seconds>(interval).count();
+        auto interval_usec =
+            std::chrono::duration_cast<std::chrono::microseconds>(interval)
+                .count() %
+            1000;
 
         LOGINFO("Time taken to execute putAll SH sec = %d and MSec = %d ",
-                interval.sec(), interval.usec());
+                interval_sec, interval_usec);
         bool networkhop = TestUtils::getCacheImpl(getHelper()->cachePtr)
                               ->getAndResetNetworkHopFlag();
         LOGINFO("CheckPrSingleHopForIntKeysTask2: putALL OP :: networkhop %d ",
@@ -250,12 +256,18 @@ DUNIT_TASK_DEFINITION(CLIENT1, CheckPrSingleHopRemoveAllForIntKeysTask)
           keysVector.push_back(keyPtr);
         }
         LOGINFO("TEST-1");
-        ACE_Time_Value startTime = ACE_OS::gettimeofday();
+        auto startTime = std::chrono::steady_clock::now();
         dataReg->putAll(valMap);
-        ACE_Time_Value interval = ACE_OS::gettimeofday() - startTime;
+        auto interval = std::chrono::steady_clock::now() - startTime;
+        auto interval_sec =
+            std::chrono::duration_cast<std::chrono::seconds>(interval).count();
+        auto interval_usec =
+            std::chrono::duration_cast<std::chrono::microseconds>(interval)
+                .count() %
+            1000;
 
         LOGINFO("Time taken to execute putAll SH sec = %d and MSec = %d ",
-                interval.sec(), interval.usec());
+                interval_sec, interval_usec);
         bool networkhop = TestUtils::getCacheImpl(getHelper()->cachePtr)
                               ->getAndResetNetworkHopFlag();
         LOGINFO("CheckPrSingleHopForIntKeysTask2: putALL OP :: networkhop %d ",
@@ -263,12 +275,18 @@ DUNIT_TASK_DEFINITION(CLIENT1, CheckPrSingleHopRemoveAllForIntKeysTask)
         ASSERT(networkhop == false, "PutAll : Should not cause network hop");
 
         LOGINFO("RemoveALL test");
-        startTime = ACE_OS::gettimeofday();
+        startTime = std::chrono::steady_clock::now();
         dataReg->removeAll(keysVector);
-        interval = ACE_OS::gettimeofday() - startTime;
+        interval = std::chrono::steady_clock::now() - startTime;
+        interval_sec =
+            std::chrono::duration_cast<std::chrono::seconds>(interval).count();
+        interval_usec =
+            std::chrono::duration_cast<std::chrono::microseconds>(interval)
+                .count() %
+            1000;
 
         LOGINFO("Time taken to execute removeAll SH sec = %d and MSec = %d ",
-                interval.sec(), interval.usec());
+                interval_sec, interval_usec);
         networkhop = TestUtils::getCacheImpl(getHelper()->cachePtr)
                          ->getAndResetNetworkHopFlag();
         LOGINFO(

--- a/cppcache/integration-test/testThinClientPutWithDelta.cpp
+++ b/cppcache/integration-test/testThinClientPutWithDelta.cpp
@@ -33,7 +33,7 @@ CacheHelper *cacheHelper = nullptr;
 bool isLocalServer = false;
 
 static bool isLocator = false;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 #define CLIENT1 s1p1
 #define CLIENT2 s1p2
@@ -76,12 +76,14 @@ CacheHelper *getHelper() {
   return cacheHelper;
 }
 
-void createPooledRegion(const char *name, bool ackMode, const char *locators,
-                        const char *poolname,
+void createPooledRegion(const std::string &name, bool ackMode,
+                        const std::string &locators,
+                        const std::string &poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/testThinClientRegionQueryDifferentServerConfigs.cpp
+++ b/cppcache/integration-test/testThinClientRegionQueryDifferentServerConfigs.cpp
@@ -44,7 +44,7 @@ using apache::geode::client::QueryService;
 bool isLocalServer = false;
 bool isLocator = false;
 const char *poolNames[] = {"Pool1", "Pool2", "Pool3"};
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 const char *qRegionNames[] = {"Portfolios", "Positions"};

--- a/cppcache/integration-test/testThinClientRegionQueryExclusiveness.cpp
+++ b/cppcache/integration-test/testThinClientRegionQueryExclusiveness.cpp
@@ -50,7 +50,7 @@ using testobject::Position;
 bool isLocator = false;
 bool isLocalServer = false;
 const char *poolNames[] = {"Pool1", "Pool2", "Pool3"};
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 const char *qRegionNames[] = {"Portfolios", "Positions"};
@@ -71,7 +71,7 @@ void clientOperations() {
   }
 
   std::shared_ptr<Pool> pool1 = nullptr;
-  pool1 = createPool(poolNames[0], locHostPort, nullptr, 0, true);
+  pool1 = createPool(poolNames[0], locHostPort, {}, 0, true);
   createRegionAndAttachPool(qRegionNames[0], USE_ACK, poolNames[0]);
 
   auto rptr = getHelper()->cachePtr->getRegion(qRegionNames[0]);

--- a/cppcache/integration-test/testThinClientRemoteQueryFailover.cpp
+++ b/cppcache/integration-test/testThinClientRemoteQueryFailover.cpp
@@ -81,7 +81,7 @@ bool isLocalServer = false;
 const char *qRegionNames[] = {"Portfolios", "Positions"};
 KillServerThread *kst = nullptr;
 const char *poolNames[] = {"Pool1", "Pool2", "Pool3"};
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 bool isPoolConfig = false;  // To track if pool case is running
 
@@ -139,7 +139,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, RegisterTypesAndCreatePoolAndRegion)
     }
 
     isPoolConfig = true;
-    createPool(poolNames[0], locHostPort, nullptr, 0, true);
+    createPool(poolNames[0], locHostPort, {}, 0, true);
     createRegionAndAttachPool(qRegionNames[0], USE_ACK, poolNames[0]);
 
     auto rptr = getHelper()->cachePtr->getRegion(qRegionNames[0]);
@@ -197,13 +197,13 @@ DUNIT_TASK_DEFINITION(CLIENT1, ValidateQueryExecutionAcrossServerFailure)
 
       kst->stop();
     } catch (IllegalStateException &ise) {
-      char isemsg[500] = {0};
-      ACE_OS::snprintf(isemsg, 499, "IllegalStateException: %s", ise.what());
-      LOG(isemsg);
-      FAIL(isemsg);
+      std::string excpmsg = "IllegalStateException: " + std::string{ise.what()};
+
+      LOG(excpmsg);
+      FAIL(excpmsg);
     } catch (Exception &excp) {
-      char excpmsg[500] = {0};
-      ACE_OS::snprintf(excpmsg, 499, "Exception: %s", excp.what());
+      std::string excpmsg = "Exception: " + std::string{excp.what()};
+
       LOG(excpmsg);
       FAIL(excpmsg);
     } catch (...) {

--- a/cppcache/integration-test/testThinClientRemoteQueryFailoverPdx.cpp
+++ b/cppcache/integration-test/testThinClientRemoteQueryFailoverPdx.cpp
@@ -78,7 +78,7 @@ bool isLocalServer = false;
 const char *qRegionNames[] = {"Portfolios", "Positions"};
 KillServerThread *kst = nullptr;
 const char *poolNames[] = {"Pool1", "Pool2", "Pool3"};
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 bool isPoolConfig = false;  // To track if pool case is running
 
@@ -135,7 +135,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, RegisterTypesAndCreatePoolAndRegion)
     }
 
     isPoolConfig = true;
-    createPool(poolNames[0], locHostPort, nullptr, 0, true);
+    createPool(poolNames[0], locHostPort, {}, 0, true);
     createRegionAndAttachPool(qRegionNames[0], USE_ACK, poolNames[0]);
 
     auto rptr = getHelper()->cachePtr->getRegion(qRegionNames[0]);
@@ -193,13 +193,13 @@ DUNIT_TASK_DEFINITION(CLIENT1, ValidateQueryExecutionAcrossServerFailure)
 
       kst->stop();
     } catch (IllegalStateException &ise) {
-      char isemsg[500] = {0};
-      ACE_OS::snprintf(isemsg, 499, "IllegalStateException: %s", ise.what());
-      LOG(isemsg);
-      FAIL(isemsg);
+      std::string excpmsg = "IllegalStateException: " + std::string{ise.what()};
+
+      LOG(excpmsg);
+      FAIL(excpmsg);
     } catch (Exception &excp) {
-      char excpmsg[500] = {0};
-      ACE_OS::snprintf(excpmsg, 499, "Exception: %s", excp.what());
+      std::string excpmsg = "Exception: " + std::string{excp.what()};
+
       LOG(excpmsg);
       FAIL(excpmsg);
     } catch (...) {

--- a/cppcache/integration-test/testThinClientRemoteQueryRS.cpp
+++ b/cppcache/integration-test/testThinClientRemoteQueryRS.cpp
@@ -58,7 +58,7 @@ bool isLocator = false;
 bool isLocalServer = false;
 
 const char *poolNames[] = {"Pool1", "Pool2", "Pool3"};
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 bool isPoolConfig = false;  // To track if pool case is running
 const char *qRegionNames[] = {"Portfolios", "Positions", "Portfolios2",
@@ -83,7 +83,7 @@ void stepOne() {
     // ignore exception
   }
   isPoolConfig = true;
-  createPool(poolNames[0], locHostPort, nullptr, 0, true);
+  createPool(poolNames[0], locHostPort, {}, 0, true);
   createRegionAndAttachPool(qRegionNames[0], USE_ACK, poolNames[0]);
   createRegionAndAttachPool(qRegionNames[1], USE_ACK, poolNames[0]);
   createRegionAndAttachPool(qRegionNames[2], USE_ACK, poolNames[0]);
@@ -202,9 +202,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepFour)
       auto qry = qs->newQuery(resultsetQueriesOPL[i].query());
       auto results = qry->execute();
       if (!qh->verifyRS(results, resultsetRowCountsOPL[i])) {
-        char failmsg[100] = {0};
-        ACE_OS::sprintf(failmsg, "Query verify failed for query index %d", i);
-        ASSERT(false, failmsg);
+        ASSERT(false,
+               "Query verify failed for query index " + std::to_string(i));
       }
 
       auto rsptr = std::dynamic_pointer_cast<ResultSet>(results);
@@ -303,8 +302,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepFive)
                                         ? resultsetRowCounts[i]
                                         : resultsetRowCounts[i] *
                                               qh->getPortfolioNumSets()))) {
-          char failmsg[100] = {0};
-          ACE_OS::sprintf(failmsg, "Query verify failed for query index %d", i);
+          std::string failmsg =
+              "Query verify failed for query index " + std::to_string(i);
           ASSERT(false, failmsg);
         }
 
@@ -414,8 +413,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepSix)
                                         ? resultsetRowCountsPQ[i]
                                         : resultsetRowCountsPQ[i] *
                                               qh->getPortfolioNumSets()))) {
-          char failmsg[100] = {0};
-          ACE_OS::sprintf(failmsg, "Query verify failed for query index %d", i);
+          std::string failmsg =
+              "Query verify failed for query index " + std::to_string(i);
           ASSERT(false, failmsg);
         }
 
@@ -505,10 +504,9 @@ DUNIT_TASK_DEFINITION(CLIENT1, DoQueryRSError)
 
         try {
           auto results = qry->execute();
+          std::string failmsg =
+              "Query exception didnt occur for index " + std::to_string(i);
 
-          char failmsg[100] = {0};
-          ACE_OS::sprintf(failmsg, "Query exception didnt occur for index %d",
-                          i);
           LOG(failmsg);
           FAIL(failmsg);
         } catch (apache::geode::client::QueryException &) {

--- a/cppcache/integration-test/testThinClientRemoteQueryTimeout.cpp
+++ b/cppcache/integration-test/testThinClientRemoteQueryTimeout.cpp
@@ -56,7 +56,7 @@ using apache::geode::client::TimeoutException;
 bool isLocalServer = false;
 bool isLocator = false;
 const char *poolNames[] = {"Pool1", "Pool2", "Pool3"};
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 const char *qRegionNames[] = {"Portfolios", "Positions", "Portfolios2",
@@ -83,7 +83,7 @@ void stepOne() {
     // ignore exception
   }
   isPoolConfig = true;
-  createPool(poolNames[0], locHostPort, nullptr, 0, true);
+  createPool(poolNames[0], locHostPort, {}, 0, true);
   createRegionAndAttachPool(qRegionNames[0], USE_ACK, poolNames[0]);
 
   auto regptr = getHelper()->getRegion(qRegionNames[0]);
@@ -172,9 +172,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
       results = qry->execute(std::chrono::seconds(3));
 
       LOG("EXECUTE 1 STOP");
+      std::string logmsg = "Result size is " + std::to_string(results->size());
 
-      char logmsg[50] = {0};
-      ACE_OS::sprintf(logmsg, "Result size is %zd", results->size());
       LOG(logmsg);
 
       LOG("Didnt get expected timeout exception for first execute");
@@ -216,8 +215,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepFour)
 
       LOG("EXECUTE 2 STOP");
 
-      char logmsg[50] = {0};
-      ACE_OS::sprintf(logmsg, "Result size is %zd", results->size());
+      std::string logmsg = "Result size is " + std::to_string(results->size());
       LOG(logmsg);
     } catch (Exception &excp) {
       std::string failmsg = "";
@@ -254,11 +252,9 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepFive)
       results = qry->execute(std::chrono::seconds(2));
 
       LOG("EXECUTE 3 STOP");
+      std::string logmsg = "Result size is " + std::to_string(results->size());
 
-      char logmsg[50] = {0};
-      ACE_OS::sprintf(logmsg, "Result size is %zd", results->size());
       LOG(logmsg);
-
       LOG("Didnt get expected timeout exception for third execute");
       FAIL("Didnt get expected timeout exception for third execute");
     } catch (const TimeoutException &excp) {
@@ -267,7 +263,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepFive)
       logmsg += excp.getName();
       logmsg += ": ";
       logmsg += excp.what();
-      LOG(logmsg.c_str());
+      LOG(logmsg);
     }
 
     SLEEP(40000);  // sleep to allow server query to complete
@@ -297,9 +293,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepSix)
       results = qry->execute(std::chrono::seconds(850));
 
       LOG("EXECUTE 4 STOP");
+      std::string logmsg = "Result size is " + std::to_string(results->size());
 
-      char logmsg[50] = {0};
-      ACE_OS::sprintf(logmsg, "Result size is %zd", results->size());
       LOG(logmsg);
     } catch (Exception &excp) {
       std::string failmsg = "";
@@ -345,9 +340,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepSeven)
       results = qry->execute(paramList, std::chrono::seconds(1));
 
       LOG("EXECUTE Five STOP");
+      std::string logmsg = "Result size is " + std::to_string(results->size());
 
-      char logmsg[50] = {0};
-      ACE_OS::sprintf(logmsg, "Result size is %zd", results->size());
       LOG(logmsg);
 
       LOG("Didnt get expected timeout exception for fifth execute");
@@ -398,9 +392,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepEight)
       results = qry->execute(paramList, std::chrono::seconds(850));
 
       LOG("EXECUTE 6 STOP");
+      std::string logmsg = "Result size is " + std::to_string(results->size());
 
-      char logmsg[50] = {0};
-      ACE_OS::sprintf(logmsg, "Result size is %zd", results->size());
       LOG(logmsg);
     } catch (Exception &excp) {
       std::string failmsg = "";
@@ -437,9 +430,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, verifyNegativeValueTimeout)
       results = qry->execute(std::chrono::seconds(-3));
 
       LOG("Task::verifyNegativeValueTimeout - EXECUTE 1 STOP");
+      std::string logmsg = "Result size is " + std::to_string(results->size());
 
-      char logmsg[50] = {0};
-      ACE_OS::sprintf(logmsg, "Result size is %zd", results->size());
       LOG(logmsg);
 
       LOG("Didnt get expected timeout exception for first execute");
@@ -482,9 +474,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, verifyLargeValueTimeout)
       results = qry->execute(std::chrono::seconds(2147500));
 
       LOG("Task:: verifyLargeValueTimeout - EXECUTE 1 STOP");
+      std::string logmsg = "Result size is " + std::to_string(results->size());
 
-      char logmsg[50] = {0};
-      ACE_OS::sprintf(logmsg, "Result size is %zd", results->size());
       LOG(logmsg);
 
       LOG("Didnt get expected timeout exception for first execute");

--- a/cppcache/integration-test/testThinClientRemoveOps.cpp
+++ b/cppcache/integration-test/testThinClientRemoveOps.cpp
@@ -51,7 +51,7 @@ static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 0;
 
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 void initClient(const bool isthinClient) {
@@ -188,12 +188,14 @@ void createRegion(const char *name, bool ackMode,
   LOG("Region created.");
 }
 
-void createPooledRegion(const char *name, bool ackMode, const char *locators,
-                        const char *poolname,
+void createPooledRegion(const std::string &name, bool ackMode,
+                        const std::string &locators,
+                        const std::string &poolname,
                         bool clientNotificationEnabled = false,
                         bool cachingEnable = true) {
   LOG("createRegion_Pool() entered.");
-  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name, ackMode);
+  fprintf(stdout, "Creating region --  %s  ackMode is %d\n", name.c_str(),
+          ackMode);
   fflush(stdout);
   auto regPtr =
       getHelper()->createPooledRegion(name, ackMode, locators, poolname,

--- a/cppcache/integration-test/testThinClientSecurityAuthentication.cpp
+++ b/cppcache/integration-test/testThinClientSecurityAuthentication.cpp
@@ -28,14 +28,14 @@
 
 using apache::geode::client::testframework::security::CredentialGenerator;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 const char *regionNamesAuth[] = {"DistRegionAck", "DistRegionNoAck"};
 std::shared_ptr<CredentialGenerator> credentialGeneratorHandler;
 
 std::string getXmlPath() {
   char xmlPath[1000] = {'\0'};
-  const char *path = ACE_OS::getenv("TESTSRC");
+  const char *path = std::getenv("TESTSRC");
   ASSERT(path != nullptr,
          "Environment variable TESTSRC for test source directory is not set.");
   strncpy(xmlPath, path, strlen(path) - strlen("cppcache"));

--- a/cppcache/integration-test/testThinClientSecurityAuthenticationMU.cpp
+++ b/cppcache/integration-test/testThinClientSecurityAuthenticationMU.cpp
@@ -31,14 +31,14 @@
 
 using apache::geode::client::testframework::security::CredentialGenerator;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 const char *regionNamesAuth[] = {"DistRegionAck", "DistRegionNoAck"};
 std::shared_ptr<CredentialGenerator> credentialGeneratorHandler;
 
 std::string getXmlPath() {
   char xmlPath[1000] = {'\0'};
-  const char *path = ACE_OS::getenv("TESTSRC");
+  const char *path = std::getenv("TESTSRC");
   ASSERT(path != nullptr,
          "Environment variable TESTSRC for test source directory is not set.");
   strncpy(xmlPath, path, strlen(path) - strlen("cppcache"));

--- a/cppcache/integration-test/testThinClientSecurityAuthenticationSetAuthInitialize.cpp
+++ b/cppcache/integration-test/testThinClientSecurityAuthenticationSetAuthInitialize.cpp
@@ -29,14 +29,14 @@ using apache::geode::client::AuthInitialize;
 using apache::geode::client::Cacheable;
 using apache::geode::client::testframework::security::CredentialGenerator;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 const char *regionNamesAuth[] = {"DistRegionAck", "DistRegionNoAck"};
 std::shared_ptr<CredentialGenerator> credentialGeneratorHandler;
 
 std::string getXmlPath() {
   char xmlPath[1000] = {'\0'};
-  const char *path = ACE_OS::getenv("TESTSRC");
+  const char *path = std::getenv("TESTSRC");
   ASSERT(path != NULL,
          "Environment variable TESTSRC for test source directory is not set.");
   strncpy(xmlPath, path, strlen(path) - strlen("cppcache"));
@@ -120,7 +120,7 @@ DUNIT_TASK_DEFINITION(LOCATORSERVER, CreateServer1)
         printf("Input to server cmd is -->  %s",
                cmdServerAuthenticator.c_str());
         CacheHelper::initServer(
-            1, nullptr, locHostPort,
+            1, {}, locHostPort,
             const_cast<char *>(cmdServerAuthenticator.c_str()));
         LOG("Server1 started");
       }

--- a/cppcache/integration-test/testThinClientSecurityAuthorization.cpp
+++ b/cppcache/integration-test/testThinClientSecurityAuthorization.cpp
@@ -49,13 +49,13 @@ using apache::geode::client::testframework::security::OP_UNREGISTER_INTEREST;
 using apache::geode::client::testframework::security::OP_UPDATE;
 using apache::geode::client::testframework::security::opCodeList;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 std::shared_ptr<CredentialGenerator> credentialGeneratorHandler;
 
 std::string getXmlPath() {
   char xmlPath[1000] = {'\0'};
-  const char *path = ACE_OS::getenv("TESTSRC");
+  const char *path = std::getenv("TESTSRC");
   ASSERT(path != nullptr,
          "Environment variable TESTSRC for test source directory is not set.");
   strncpy(xmlPath, path, strlen(path) - strlen("cppcache"));

--- a/cppcache/integration-test/testThinClientSecurityAuthorizationMU.cpp
+++ b/cppcache/integration-test/testThinClientSecurityAuthorizationMU.cpp
@@ -57,7 +57,7 @@ using apache::geode::client::testframework::security::OP_UNREGISTER_INTEREST;
 using apache::geode::client::testframework::security::OP_UPDATE;
 using apache::geode::client::testframework::security::opCodeList;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 std::shared_ptr<CredentialGenerator> credentialGeneratorHandler;
@@ -66,7 +66,7 @@ const char *exFuncNameSendException = "executeFunction_SendException";
 
 std::string getXmlPath() {
   char xmlPath[1000] = {'\0'};
-  const char *path = ACE_OS::getenv("TESTSRC");
+  const char *path = std::getenv("TESTSRC");
   ASSERT(path != nullptr,
          "Environment variable TESTSRC for test source directory is not set.");
   strncpy(xmlPath, path, strlen(path) - strlen("cppcache"));

--- a/cppcache/integration-test/testThinClientSecurityCQAuthorizationMU.cpp
+++ b/cppcache/integration-test/testThinClientSecurityCQAuthorizationMU.cpp
@@ -53,7 +53,7 @@ using apache::geode::client::Exception;
 using apache::geode::client::IllegalStateException;
 using apache::geode::client::QueryService;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 std::shared_ptr<CredentialGenerator> credentialGeneratorHandler;
 #define CLIENT1 s1p1
@@ -139,7 +139,7 @@ class MyCqListener : public CqListener {
 
 std::string getXmlPath() {
   char xmlPath[1000] = {'\0'};
-  const char *path = ACE_OS::getenv("TESTSRC");
+  const char *path = std::getenv("TESTSRC");
   ASSERT(path != nullptr,
          "Environment variable TESTSRC for test source directory is not set.");
   strncpy(xmlPath, path, strlen(path) - strlen("cppcache"));
@@ -188,7 +188,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, CreateServer1)
           "authenticator:authorizer:authorizerPP", getXmlPath());
       printf("string %s", cmdServerAuthenticator.c_str());
       CacheHelper::initServer(
-          1, "remotequery.xml", nullptr,
+          1, "remotequery.xml", {},
           const_cast<char *>(cmdServerAuthenticator.c_str()));
       LOG("Server1 started");
     }

--- a/cppcache/integration-test/testThinClientSecurityDurableCQAuthorizationMU.cpp
+++ b/cppcache/integration-test/testThinClientSecurityDurableCQAuthorizationMU.cpp
@@ -52,7 +52,7 @@ using apache::geode::client::IllegalStateException;
 using apache::geode::client::QueryService;
 using apache::geode::client::testframework::security::CredentialGenerator;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 std::shared_ptr<CredentialGenerator> credentialGeneratorHandler;
@@ -140,7 +140,7 @@ class MyCqListener : public CqListener {
 
 std::string getXmlPath() {
   char xmlPath[1000] = {'\0'};
-  const char *path = ACE_OS::getenv("TESTSRC");
+  const char *path = std::getenv("TESTSRC");
   ASSERT(path != nullptr,
          "Environment variable TESTSRC for test source directory is not set.");
   strncpy(xmlPath, path, strlen(path) - strlen("cppcache"));

--- a/cppcache/integration-test/testThinClientSecurityPostAuthorization.cpp
+++ b/cppcache/integration-test/testThinClientSecurityPostAuthorization.cpp
@@ -36,7 +36,7 @@ using apache::geode::client::HashMapOfCacheable;
 using apache::geode::client::HashMapOfException;
 using apache::geode::client::NotAuthorizedException;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 #define HANDLE_NO_NOT_AUTHORIZED_EXCEPTION                 \
@@ -110,17 +110,17 @@ const char *getServerSecurityParams() {
         "org.apache.geode.internal.security.FilterPostAuthorization.create "
         "log-level=fine security-log-level=finest";
 
-    char *ldapSrv = ACE_OS::getenv("LDAP_SERVER");
+    char *ldapSrv = std::getenv("LDAP_SERVER");
     serverSecurityParams += std::string(" security-ldap-server=") +
                             (ldapSrv != nullptr ? ldapSrv : "ldap");
 
-    char *ldapRoot = ACE_OS::getenv("LDAP_BASEDN");
+    char *ldapRoot = std::getenv("LDAP_BASEDN");
     serverSecurityParams +=
         std::string(" security-ldap-basedn=") +
         (ldapRoot != nullptr ? ldapRoot
                              : "ou=ldapTesting,dc=ldap,dc=apache,dc=org");
 
-    char *ldapSSL = ACE_OS::getenv("LDAP_USESSL");
+    char *ldapSSL = std::getenv("LDAP_USESSL");
     serverSecurityParams += std::string(" security-ldap-usessl=") +
                             (ldapSSL != nullptr ? ldapSSL : "false");
   }

--- a/cppcache/integration-test/testThinClientWriterException.cpp
+++ b/cppcache/integration-test/testThinClientWriterException.cpp
@@ -45,7 +45,7 @@ using apache::geode::client::testing::TallyWriter;
 std::shared_ptr<TallyListener> regListener;
 std::shared_ptr<TallyWriter> regWriter;
 
-const char *locHostPort =
+const std::string locHostPort =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, 1);
 
 const char *regionNamesAuth[] = {"DistRegionAck"};
@@ -53,7 +53,7 @@ std::shared_ptr<CredentialGenerator> credentialGeneratorHandler;
 
 std::string getXmlPath() {
   char xmlPath[1000] = {'\0'};
-  const char *path = ACE_OS::getenv("TESTSRC");
+  const char *path = std::getenv("TESTSRC");
   ASSERT(path != nullptr,
          "Environment variable TESTSRC for test source directory is not set.");
   strncpy(xmlPath, path, strlen(path) - strlen("cppcache"));

--- a/cppcache/integration-test/testTimedSemaphore.cpp
+++ b/cppcache/integration-test/testTimedSemaphore.cpp
@@ -15,8 +15,11 @@
  * limitations under the License.
  */
 
-#include "fw_helper.hpp"
+#include <iostream>
+
 #include <ace/Synch.h>
+
+#include "fw_helper.hpp"
 
 class ThreadAcquire : public ACE_Task_Base {
  public:
@@ -27,19 +30,30 @@ class ThreadAcquire : public ACE_Task_Base {
         m_status(0) {}
 
   int svc() override {
-    ACE_Time_Value start = ACE_OS::gettimeofday();
-    ACE_Time_Value interval(m_acquireSecs, 0);  // 10 seconds
-    ACE_Time_Value expireAt = start + interval;
+    auto start = std::chrono::steady_clock::now();
+    ACE_Time_Value expireAt =
+        ACE_Time_Value{time(nullptr)} + ACE_Time_Value{m_acquireSecs};
 
-    printf("Thread acquiring lock at %ld msecs.\n", start.msec());
+    std::cout << "Thread acquiring lock at "
+              << std::chrono::time_point_cast<std::chrono::milliseconds>(start)
+                     .time_since_epoch()
+                     .count()
+              << "msecs" << std::endl;
+
     if (m_sema.acquire(expireAt) == 0) {
-      interval = ACE_OS::gettimeofday() - start;
-      printf("Thread acquired lock after %ld msecs.\n", interval.msec());
+      auto interval = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - start)
+                          .count();
+      std::cout << "Thread acquired lock after " << interval << "msecs"
+                << std::endl;
       m_status = 0;
     } else {
-      interval = ACE_OS::gettimeofday() - start;
-      printf("Thread failed to acquire lock after %ld msecs.\n",
-             interval.msec());
+      auto interval = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - start)
+                          .count();
+
+      std::cout << "Thread failed to acquire lock after " << interval << "msecs"
+                << std::endl;
       m_status = -1;
     }
     return m_status;
@@ -62,7 +76,7 @@ BEGIN_TEST(CheckTimedAcquire)
     thread->activate();
 
     LOG("Sleeping for 8 secs.");
-    ACE_OS::sleep(8);
+    std::this_thread::sleep_for(std::chrono::seconds(8));
     ASSERT(thread->thr_count() == 1, "Expected thread to be running.");
     sema.release();
     SLEEP(50);  // Sleep for a few millis for the thread to end.
@@ -82,9 +96,9 @@ BEGIN_TEST(CheckTimedAcquireFail)
     thread->activate();
 
     LOG("Sleeping for 8 secs.");
-    ACE_OS::sleep(8);
+    std::this_thread::sleep_for(std::chrono::seconds(8));
     ASSERT(thread->thr_count() == 1, "Expected thread to be running.");
-    ACE_OS::sleep(3);
+    std::this_thread::sleep_for(std::chrono::seconds(3));
     ASSERT(thread->thr_count() == 0, "Expected no thread to be running.");
     ASSERT(thread->wait() == 0, "Expected successful end of thread.");
     ASSERT(thread->getStatus() == -1,
@@ -102,7 +116,7 @@ BEGIN_TEST(CheckNoWait)
     sema.release();
     thread->activate();
 
-    ACE_OS::sleep(1);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     ASSERT(thread->thr_count() == 0, "Expected no thread to be running.");
     ASSERT(thread->wait() == 0, "Expected successful end of thread.");
     ASSERT(thread->getStatus() == 0, "Expected zero exit status from thread.");
@@ -117,7 +131,7 @@ BEGIN_TEST(CheckResetAndTimedAcquire)
     ThreadAcquire *thread = new ThreadAcquire(sema, 10);
 
     sema.acquire();
-    ACE_OS::sleep(1);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     sema.release();
     sema.release();
     sema.release();
@@ -126,7 +140,7 @@ BEGIN_TEST(CheckResetAndTimedAcquire)
     thread->activate();
 
     LOG("Sleeping for 8 secs.");
-    ACE_OS::sleep(8);
+    std::this_thread::sleep_for(std::chrono::seconds(8));
     ASSERT(thread->thr_count() == 1, "Expected thread to be running.");
     sema.release();
     SLEEP(50);  // Sleep for a few millis for the thread to end.

--- a/cppcache/integration-test/testXmlCacheCreationWithOverFlow.cpp
+++ b/cppcache/integration-test/testXmlCacheCreationWithOverFlow.cpp
@@ -36,7 +36,7 @@ int testXmlCacheCreationWithOverflow() {
   const uint32_t totalSubRegionsRoot1 = 2;
   const uint32_t totalRootRegions = 2;
 
-  char *path = ACE_OS::getenv("TESTSRC");
+  char *path = std::getenv("TESTSRC");
   std::string directory(path);
 
   std::cout << "create DistributedSytem with name=XML_CACHE_CREATION_TEST"

--- a/cppcache/integration-test/testXmlCacheCreationWithPools.cpp
+++ b/cppcache/integration-test/testXmlCacheCreationWithPools.cpp
@@ -40,7 +40,7 @@ static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 1;
 const char *endPoints = nullptr;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 using std::string;
@@ -273,12 +273,11 @@ int testXmlCacheCreationWithPools() {
       << std::endl;
 
   try {
-    std::string filePath = "valid_cache_pool.xml";
-    std::string duplicateFile;
-    CacheHelper::createDuplicateXMLFile(duplicateFile, filePath);
+    auto duplicateFile =
+        CacheHelper::createDuplicateXMLFile("valid_cache_pool.xml");
     cptr = std::make_shared<Cache>(
         cacheFactory.set("cache-xml-file", duplicateFile).create());
-    if (cptr->getPdxIgnoreUnreadFields() != true) {
+    if (!cptr->getPdxIgnoreUnreadFields()) {
       std::cout << "getPdxIgnoreUnreadFields should return true." << std::endl;
       return -1;
     } else {
@@ -417,9 +416,8 @@ int testXmlCacheCreationWithPools() {
 
   try {
     std::cout << "Testing invalid pool xml 1" << std::endl;
-    std::string filePath = "invalid_cache_pool.xml";
-    std::string duplicateFile;
-    CacheHelper::createDuplicateXMLFile(duplicateFile, filePath);
+    auto duplicateFile =
+        CacheHelper::createDuplicateXMLFile("invalid_cache_pool.xml");
     Cache cache = cacheFactory.set("cache-xml-file", duplicateFile).create();
     return -1;
   } catch (Exception &ex) {
@@ -430,9 +428,8 @@ int testXmlCacheCreationWithPools() {
 
   try {
     std::cout << "Testing invalid pool xml 2" << std::endl;
-    std::string filePath = "invalid_cache_pool2.xml";
-    std::string duplicateFile;
-    CacheHelper::createDuplicateXMLFile(duplicateFile, filePath);
+    auto duplicateFile =
+        CacheHelper::createDuplicateXMLFile("invalid_cache_pool2.xml");
     Cache cache = cacheFactory.set("cache-xml-file", duplicateFile).create();
     return -1;
   } catch (Exception &ex) {
@@ -443,9 +440,8 @@ int testXmlCacheCreationWithPools() {
 
   try {
     std::cout << "Testing invalid pool xml 3" << std::endl;
-    std::string filePath = "invalid_cache_pool3.xml";
-    std::string duplicateFile;
-    CacheHelper::createDuplicateXMLFile(duplicateFile, filePath);
+    auto duplicateFile =
+        CacheHelper::createDuplicateXMLFile("invalid_cache_pool3.xml");
     Cache cache = cacheFactory.set("cache-xml-file", duplicateFile).create();
     return -1;
   } catch (Exception &ex) {
@@ -456,9 +452,8 @@ int testXmlCacheCreationWithPools() {
 
   try {
     std::cout << "Testing invalid pool xml 4" << std::endl;
-    std::string filePath = "invalid_cache_pool4.xml";
-    std::string duplicateFile;
-    CacheHelper::createDuplicateXMLFile(duplicateFile, filePath);
+    auto duplicateFile =
+        CacheHelper::createDuplicateXMLFile("invalid_cache_pool4.xml");
     Cache cache = cacheFactory.set("cache-xml-file", duplicateFile).create();
     return -1;
   } catch (Exception &ex) {

--- a/cppcache/integration-test/testXmlCacheCreationWithRefid.cpp
+++ b/cppcache/integration-test/testXmlCacheCreationWithRefid.cpp
@@ -34,7 +34,7 @@ int testXmlCacheCreationWithRefid(const char *fileName) {
   auto cacheFactory = CacheFactory();
   std::shared_ptr<Cache> cptr;
 
-  char *path = ACE_OS::getenv("TESTSRC");
+  char *path = std::getenv("TESTSRC");
   std::string directory(path);
 
   std::cout << "create DistributedSytem with name=XML_CACHE_CREATION_TEST"

--- a/cppcache/integration-test/testXmlCacheInitialization.cpp
+++ b/cppcache/integration-test/testXmlCacheInitialization.cpp
@@ -38,7 +38,7 @@ static bool isLocalServer = false;
 static bool isLocator = false;
 static int numberOfLocators = 1;
 const char *endPoints = nullptr;
-const char *locatorsG =
+const std::string locatorsG =
     CacheHelper::getLocatorHostPort(isLocator, isLocalServer, numberOfLocators);
 
 #include "LocatorHelper.hpp"
@@ -47,7 +47,7 @@ int testXmlDeclarativeCacheCreation() {
   auto cacheFactory = CacheFactory();
   std::shared_ptr<Cache> cptr;
 
-  std::string directory(ACE_OS::getenv("TESTSRC"));
+  std::string directory(std::getenv("TESTSRC"));
 
   std::cout
       << "create DistributedSytem with name=XML_DECLARATIVE_CACHE_CREATION_TEST"
@@ -122,9 +122,8 @@ int testSetCacheXmlThenGetRegion() {
       << std::endl;
 
   try {
-    std::string filePath = "valid_cache_pool.xml";
-    std::string duplicateFile;
-    CacheHelper::createDuplicateXMLFile(duplicateFile, filePath);
+    auto duplicateFile =
+        CacheHelper::createDuplicateXMLFile("valid_cache_pool.xml");
 
     cptr = std::make_shared<Cache>(
         cacheFactory.set("enable-time-statistics", "false")

--- a/cppcache/src/DistributedSystemImpl.cpp
+++ b/cppcache/src/DistributedSystemImpl.cpp
@@ -79,11 +79,8 @@ void DistributedSystemImpl::logSystemInformation() const {
   LOGCONFIG("Source revision: %s", PRODUCT_SOURCE_REVISION);
   LOGCONFIG("Source repository: %s", PRODUCT_SOURCE_REPOSITORY);
 
-  ACE_utsname u;
-  ACE_OS::uname(&u);
-  LOGCONFIG(
-      "Running on: SystemName=%s Machine=%s Host=%s Release=%s Version=%s",
-      u.sysname, u.machine, u.nodename, u.release, u.version);
+  auto sysinfo = Utils::getSystemInfo();
+  LOGCONFIG("Running on: %s", sysinfo.c_str());
   LOGCONFIG("Current directory: %s",
             boost::filesystem::current_path().string().c_str());
   LOGCONFIG("Current value of PATH: %s", Utils::getEnv("PATH").c_str());

--- a/cppcache/src/ReadWriteLock.cpp
+++ b/cppcache/src/ReadWriteLock.cpp
@@ -17,6 +17,8 @@
 
 #include "ReadWriteLock.hpp"
 
+#include <thread>
+
 namespace apache {
 namespace geode {
 namespace client {
@@ -29,7 +31,7 @@ TryReadGuard::TryReadGuard(ACE_RW_Thread_Mutex& lock,
       isAcquired_ = true;
       break;
     }
-    ACE_OS::thr_yield();
+    std::this_thread::yield();
   } while (!exitCondition);
 }
 
@@ -41,7 +43,7 @@ TryWriteGuard::TryWriteGuard(ACE_RW_Thread_Mutex& lock,
       isAcquired_ = true;
       break;
     }
-    ACE_OS::thr_yield();
+    std::this_thread::yield();
   } while (!exitCondition);
 }
 

--- a/cppcache/src/Utils.hpp
+++ b/cppcache/src/Utils.hpp
@@ -59,6 +59,8 @@ class APACHE_GEODE_EXPORT Utils {
    */
   static std::string getEnv(const char* varName);
 
+  static std::error_code getLastError();
+
 #ifdef __GNUC__
   inline static char* _gnuDemangledName(const char* typeIdName, size_t& len) {
     int status;
@@ -155,6 +157,8 @@ class APACHE_GEODE_EXPORT Utils {
                                   uint16_t& port);
 
   static std::string convertHostToCanonicalForm(const char* endpoints);
+
+  static std::string getSystemInfo();
 
   static char* copyString(const char* str);
 

--- a/cppcache/src/config.h.in
+++ b/cppcache/src/config.h.in
@@ -29,6 +29,7 @@
 #cmakedefine HAVE_pthread_setname_np
 #endif
 
+#cmakedefine HAVE_uname
 #cmakedefine HAVE_SIGSTKFLT
 #cmakedefine HAVE_ACE_Select_Reactor
 

--- a/dependencies/boost/CMakeLists.txt
+++ b/dependencies/boost/CMakeLists.txt
@@ -28,6 +28,7 @@ set(B2_FLAGS
   --prefix=<INSTALL_DIR>/$<CONFIG>
   --with-system
   --with-log
+  --with-iostreams
   --layout=system
   address-model=${BUILD_BITS}
   link=static
@@ -135,6 +136,7 @@ find_package(Threads REQUIRED)
 
 add_boost_library(system DEPENDENCIES Boost::boost)
 add_boost_library(atomic DEPENDENCIES Boost::boost)
+add_boost_library(iostreams DEPENDENCIES Boost::boost)
 add_boost_library(thread DEPENDENCIES Threads::Threads Boost::atomic Boost::boost)
 add_boost_library(filesystem DEPENDENCIES Boost::system Boost::boost)
 add_boost_library(log DEPENDENCIES Boost::thread Boost::filesystem Boost::boost)


### PR DESCRIPTION
 - All references to ACE_OS have been removed in the source and replaced
   by a suitable boost alternative, an STL alternative or in few cases,
   a custom alternative.
 - Note that most of the impacts are in the old integration tests.
 - Boost::iostream added to old integration tests.
 - IMPORTANT. There are two cases in which ACE_OS references remain:
    * ExpiryTaskManager. This reference is left there as there is
      already an ongoing PR to replace the whole implementation by
      boost::asio one. PR #678
    * DistributedSystemImpl. There is a call to uname, which I've been
      unable to find a suitable alternative. The approach on this needs
      to be discussed.