### PR TITLE
GEODE-6816: Geode Native Client user guide: Fix broken API links

### DIFF
--- a/docs/geode-native-book-cpp/redirects.rb
+++ b/docs/geode-native-book-cpp/redirects.rb
@@ -15,12 +15,10 @@
 
 # Links to API Documentation #
 r301 %r{/releases/latest/javadoc/(.*)}, 'https://geode.apache.org/releases/latest/javadoc/$1'
-# preferred API redirects 12/8/2020
+r302 %r{/cppdocs/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
+r302 %r{/dotnetdocs/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
 r302 %r{/cppapiref/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
 r302 %r{/dotnetapiref/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
-# old redirects (/cppdocs, /dotnetdocs) deprecated due to recursion in geode .htaccess (delete when no longer needed)
-#r302 %r{/cppdocs/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
-#r302 %r{/dotnetdocs/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
 
 # Links to User Guides #
 rewrite '/', '/docs/geode-native/cpp/113/about-client-users-guide.html'

--- a/docs/geode-native-book-dotnet/redirects.rb
+++ b/docs/geode-native-book-dotnet/redirects.rb
@@ -15,12 +15,10 @@
 
 # Links to API Documentation #
 r301 %r{/releases/latest/javadoc/(.*)}, 'https://geode.apache.org/releases/latest/javadoc/$1'
-# preferred API redirects 12/8/2020
+r302 %r{/cppdocs/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
+r302 %r{/dotnetdocs/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
 r302 %r{/cppapiref/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
 r302 %r{/dotnetapiref/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
-# old redirects (/cppdocs, /dotnetdocs) deprecated due to recursion in geode .htaccess (delete when no longer needed)
-#r302 %r{/cppdocs/(.*)}, 'https://geode.apache.org/releases/latest/cppdocs/$1'
-#r302 %r{/dotnetdocs/(.*)}, 'https://geode.apache.org/releases/latest/dotnetdocs/$1'
 
 # Links to User Guides #
 rewrite '/', '/docs/geode-native/dotnet/113/about-client-users-guide.html'

--- a/docs/geode-native-docs-cpp/configuring/config-client-cache.html.md.erb
+++ b/docs/geode-native-docs-cpp/configuring/config-client-cache.html.md.erb
@@ -32,5 +32,5 @@ Regions are created from `Cache` instances. Regions provide the entry points to 
 instances of `Region` and `RegionEntry`.
 
 For more information specific to your client programming language, see the
-[C++ Client API](cppdocs).
+[C++ Client API](cppapiref).
 

--- a/docs/geode-native-docs-dotnet/configuring/config-client-cache.html.md.erb
+++ b/docs/geode-native-docs-dotnet/configuring/config-client-cache.html.md.erb
@@ -32,5 +32,5 @@ Regions are created from `Cache` instances. Regions provide the entry points to 
 instances of `Region` and `RegionEntry`.
 
 For more information specific to your client programming language, see the
-[.NET Client API](dotnetdocs).
+[.NET Client API](/dotnetapiref).
 


### PR DESCRIPTION
The page "Configuring the Client Cache" contains two links to the API docs, one for C++, one for .NET. The links didn't connect, now they do.