### PR TITLE
GEODE-9108: Reenable tests that fail due to no-ack region

### DIFF
--- a/cppcache/integration-test/CMakeLists.txt
+++ b/cppcache/integration-test/CMakeLists.txt
@@ -154,7 +154,7 @@ foreach(FILE ${SOURCES})
   set(ENVIRONMENT
     TESTNAME=${TEST}
     "TESTSRC=$<SHELL_PATH:${CMAKE_CURRENT_SOURCE_DIR}>"
-    TIMEBOMB=500
+    TIMEBOMB=1000
     MCAST_ADDR=0.0.0.0 # unused but framework expects
     MCAST_PORT=0       # unused but framework expects
     GFE_LOGLEVEL=config
@@ -183,24 +183,24 @@ set_tests_properties(
     testThinClientAfterRegionLive
     testThinClientCacheables
     testThinClientCq
-    testThinClientCqFailover
-    testThinClientCqHAFailover
-    testThinClientDurableConnect
+    #testThinClientCqFailover
+    #testThinClientCqHAFailover
+    #testThinClientDurableConnect
     testThinClientDurableDisconnectNormal
     testThinClientDurableDisconnectTimeout
-    testThinClientDurableFailoverClientClosedNoRedundancy
-    testThinClientDurableFailoverClientNotClosedRedundancy
-    testThinClientDurableKeepAliveFalseTimeout
-    testThinClientDurableKeepAliveTrueNormal
+    #testThinClientDurableFailoverClientClosedNoRedundancy
+    #testThinClientDurableFailoverClientNotClosedRedundancy
+    #testThinClientDurableKeepAliveFalseTimeout
+    #testThinClientDurableKeepAliveTrueNormal
     testThinClientDurableReconnect
-    testThinClientFailover
-    testThinClientFailover2
-    testThinClientFailoverInterest
-    testThinClientFailoverInterest2
-    testThinClientFailoverRegex
-    testThinClientFixedPartitionResolver
-    testThinClientHADistOps
-    testThinClientHAEventIDMap
+    #testThinClientFailover
+    #testThinClientFailover2
+    #testThinClientFailoverInterest
+    #testThinClientFailoverInterest2
+    #testThinClientFailoverRegex
+    #testThinClientFixedPartitionResolver
+    #testThinClientHADistOps
+    #testThinClientHAEventIDMap
     testThinClientHAFailover
     testThinClientHAMixedRedundancy
     testThinClientHAQueryFailover
@@ -208,26 +208,26 @@ set_tests_properties(
     testThinClientLargePutAllWithCallBackArg
     testThinClientLocatorFailover
     testThinClientMultiDS
-    testThinClientPRPutAllFailover
+    #testThinClientPRPutAllFailover
     testThinClientPartitionResolver
     testThinClientPdxDeltaWithNotification
     testThinClientPdxTests
-    testThinClientPoolRedundancy
-    testThinClientPoolServer
+    #testThinClientPoolRedundancy
+    #testThinClientPoolServer
     testThinClientPutAll
     testThinClientPutAllWithCallBackArgWithoutConcurrency
     testThinClientSecurityCQAuthorizationMU
     testThinClientTXFailover
-    testThinClientTransactionsXA
+    #testThinClientTransactionsXA
     testTimedSemaphore
     # broken
-    testFwPerf
+    #testFwPerf
     testThinClientCqDurable
     testThinClientGatewayTest
     testThinClientHAFailoverRegex
     testThinClientPoolAttrTest
     testThinClientPoolLocator
-    testThinClientRemoteQueryTimeout
+    #testThinClientRemoteQueryTimeout
     testThinClientRemoveOps
     testThinClientSecurityAuthentication
     testThinClientSecurityAuthenticationMU

--- a/cppcache/integration-test/CMakeLists.txt
+++ b/cppcache/integration-test/CMakeLists.txt
@@ -183,24 +183,9 @@ set_tests_properties(
     testThinClientAfterRegionLive
     testThinClientCacheables
     testThinClientCq
-    #testThinClientCqFailover
-    #testThinClientCqHAFailover
-    #testThinClientDurableConnect
     testThinClientDurableDisconnectNormal
     testThinClientDurableDisconnectTimeout
-    #testThinClientDurableFailoverClientClosedNoRedundancy
-    #testThinClientDurableFailoverClientNotClosedRedundancy
-    #testThinClientDurableKeepAliveFalseTimeout
-    #testThinClientDurableKeepAliveTrueNormal
     testThinClientDurableReconnect
-    #testThinClientFailover
-    #testThinClientFailover2
-    #testThinClientFailoverInterest
-    #testThinClientFailoverInterest2
-    #testThinClientFailoverRegex
-    #testThinClientFixedPartitionResolver
-    #testThinClientHADistOps
-    #testThinClientHAEventIDMap
     testThinClientHAFailover
     testThinClientHAMixedRedundancy
     testThinClientHAQueryFailover
@@ -208,26 +193,19 @@ set_tests_properties(
     testThinClientLargePutAllWithCallBackArg
     testThinClientLocatorFailover
     testThinClientMultiDS
-    #testThinClientPRPutAllFailover
     testThinClientPartitionResolver
     testThinClientPdxDeltaWithNotification
     testThinClientPdxTests
-    #testThinClientPoolRedundancy
-    #testThinClientPoolServer
     testThinClientPutAll
     testThinClientPutAllWithCallBackArgWithoutConcurrency
     testThinClientSecurityCQAuthorizationMU
     testThinClientTXFailover
-    #testThinClientTransactionsXA
     testTimedSemaphore
     # broken
-    #testFwPerf
     testThinClientCqDurable
     testThinClientGatewayTest
-    testThinClientHAFailoverRegex
     testThinClientPoolAttrTest
     testThinClientPoolLocator
-    #testThinClientRemoteQueryTimeout
     testThinClientRemoveOps
     testThinClientSecurityAuthentication
     testThinClientSecurityAuthenticationMU

--- a/cppcache/integration-test/CMakeLists.txt
+++ b/cppcache/integration-test/CMakeLists.txt
@@ -206,6 +206,7 @@ set_tests_properties(
     testThinClientGatewayTest
     testThinClientPoolAttrTest
     testThinClientPoolLocator
+    testThinClientPoolRedundancy
     testThinClientRemoveOps
     testThinClientSecurityAuthentication
     testThinClientSecurityAuthenticationMU

--- a/cppcache/integration-test/CMakeLists.txt
+++ b/cppcache/integration-test/CMakeLists.txt
@@ -186,6 +186,7 @@ set_tests_properties(
     testThinClientDurableDisconnectNormal
     testThinClientDurableDisconnectTimeout
     testThinClientDurableReconnect
+    testThinClientFailover2
     testThinClientHAFailover
     testThinClientHAMixedRedundancy
     testThinClientHAQueryFailover

--- a/cppcache/integration-test/ThinClientDurable.hpp
+++ b/cppcache/integration-test/ThinClientDurable.hpp
@@ -149,9 +149,7 @@ void setCacheListener(const char* regName,
   attrMutator->setCacheListener(monitor);
 }
 std::shared_ptr<OperMonitor> mon1C1 = nullptr;
-std::shared_ptr<OperMonitor> mon2C1 = nullptr;
 std::shared_ptr<OperMonitor> mon1C2 = nullptr;
-std::shared_ptr<OperMonitor> mon2C2 = nullptr;
 
 /* Total 10 Keys , alternate durable and non-durable */
 const char* mixKeys[] = {"Key-1", "D-Key-1", "L-Key", "LD-Key"};
@@ -163,7 +161,6 @@ const char* testRegex[] = {"D-Key-.*", "Key-.*"};
 void initClientCache(int durableIdx, int redundancy,
                      std::chrono::seconds durableTimeout,
                      std::shared_ptr<OperMonitor>& mon1,
-                     std::shared_ptr<OperMonitor>& mon2,
                      int sleepDuration = 0) {
   // Sleep before starting , Used for Timeout testing.
   if (sleepDuration) SLEEP(sleepDuration);
@@ -193,7 +190,7 @@ void initClientCache(int durableIdx, int redundancy,
   LOG("Clnt1Init complete.");
 }
 
-void feederUpdate(int value, int ignoreR2 = false) {
+void feederUpdate(int value) {
   for (int regIdx = 0; regIdx < 1; regIdx++) {
     createIntEntry(regionNames[regIdx], mixKeys[0], value);
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -231,7 +228,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, InitClient1Timeout300)
       mon1C1 = std::make_shared<OperMonitor>(durableIds[0], regionNames[0]);
     }
     initClientCache(0, 0 /* Redundancy */,
-                    std::chrono::seconds(300) /* D Timeout */, mon1C1, mon2C1);
+                    std::chrono::seconds(300) /* D Timeout */, mon1C1);
   }
 END_TASK_DEFINITION
 
@@ -241,7 +238,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, InitClient1Timeout30)
       mon1C1 = std::make_shared<OperMonitor>(durableIds[0], regionNames[0]);
     }
     initClientCache(0, 0 /* Redundancy */,
-                    std::chrono::seconds(30) /* D Timeout */, mon1C1, mon2C1);
+                    std::chrono::seconds(30) /* D Timeout */, mon1C1);
   }
 END_TASK_DEFINITION
 
@@ -251,7 +248,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, InitClient1DelayedStart)
       mon1C1 = std::make_shared<OperMonitor>(durableIds[0], regionNames[0]);
     }
     initClientCache(0, 0 /* Redundancy */,
-                    std::chrono::seconds(30) /* D Timeout */, mon1C1, mon2C1,
+                    std::chrono::seconds(30) /* D Timeout */, mon1C1,
                     35000 /* Sleep before starting */);
   }
 END_TASK_DEFINITION
@@ -262,7 +259,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, InitClient2Timeout300)
       mon1C2 = std::make_shared<OperMonitor>(durableIds[1], regionNames[0]);
     }
     initClientCache(1, 1 /* Redundancy */,
-                    std::chrono::seconds(300) /* D Timeout */, mon1C2, mon2C2);
+                    std::chrono::seconds(300) /* D Timeout */, mon1C2);
   }
 END_TASK_DEFINITION
 
@@ -273,7 +270,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, InitClient2Timeout30)
       mon1C2 = std::make_shared<OperMonitor>(durableIds[1], regionNames[0]);
     }
     initClientCache(1, 1 /* Redundancy */,
-                    std::chrono::seconds(30) /* D Timeout */, mon1C2, mon2C2);
+                    std::chrono::seconds(30) /* D Timeout */, mon1C2);
   }
 END_TASK_DEFINITION
 
@@ -383,7 +380,7 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(FEEDER, FeederUpdate2)
   {
-    feederUpdate(2, true);
+    feederUpdate(2);
     LOG("FeederUpdate2 complete.");
   }
 END_TASK_DEFINITION

--- a/cppcache/integration-test/ThinClientFailover.hpp
+++ b/cppcache/integration-test/ThinClientFailover.hpp
@@ -283,7 +283,7 @@ const char* vals[] = {"Value-1", "Value-2", "Value-3", "Value-4"};
 const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4"};
 
-const char* regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
+const char* regionName = "DistRegionAck";
 
 const bool USE_ACK = true;
 const bool NO_ACK = false;
@@ -298,8 +298,7 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, StepOne_Pooled_Locator)
   {
     initClient(true);
-    createPooledRegion(regionNames[0], USE_ACK, locatorsG, "__TEST_POOL1__");
-    createPooledRegion(regionNames[1], NO_ACK, locatorsG, "__TEST_POOL2__");
+    createPooledRegion(regionName, USE_ACK, locatorsG, "__TEST_POOL1__");
     LOG("StepOne_Pooled_Locator complete.");
   }
 END_TASK_DEFINITION
@@ -307,10 +306,8 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, StepOne_Pooled_Locator_Sticky)
   {
     initClient(true);
-    createPooledRegionSticky(regionNames[0], USE_ACK, locatorsG,
+    createPooledRegionSticky(regionName, USE_ACK, locatorsG,
                              "__TEST_POOL1__");
-    createPooledRegionSticky(regionNames[1], NO_ACK, locatorsG,
-                             "__TEST_POOL2__");
     LOG("StepOne_Pooled_Locator complete.");
   }
 END_TASK_DEFINITION
@@ -318,8 +315,7 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT2, StepTwo_Pooled_Locator)
   {
     initClient(true);
-    createPooledRegion(regionNames[0], USE_ACK, locatorsG, "__TEST_POOL1__");
-    createPooledRegion(regionNames[1], NO_ACK, locatorsG, "__TEST_POOL2__");
+    createPooledRegion(regionName, USE_ACK, locatorsG, "__TEST_POOL1__");
     LOG("StepTwo complete.");
   }
 END_TASK_DEFINITION
@@ -327,28 +323,23 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT2, StepTwo_Pooled_Locator_Sticky)
   {
     initClient(true);
-    createPooledRegionSticky(regionNames[0], USE_ACK, locatorsG,
+    createPooledRegionSticky(regionName, USE_ACK, locatorsG,
                              "__TEST_POOL1__");
-    createPooledRegionSticky(regionNames[1], NO_ACK, locatorsG,
-                             "__TEST_POOL2__");
     LOG("StepTwo complete.");
   }
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
   {
-    createEntry(regionNames[0], keys[0], vals[0]);
-    createEntry(regionNames[1], keys[2], vals[2]);
+    createEntry(regionName, keys[0], vals[0]);
     LOG("StepThree complete.");
   }
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, StepFour)
   {
-    doNetsearch(regionNames[0], keys[0], vals[0]);
-    doNetsearch(regionNames[1], keys[2], vals[2]);
-    createEntry(regionNames[0], keys[1], vals[1]);
-    createEntry(regionNames[1], keys[3], vals[3]);
+    doNetsearch(regionName, keys[0], vals[0]);
+    createEntry(regionName, keys[1], vals[1]);
     LOG("StepFour complete.");
   }
 END_TASK_DEFINITION
@@ -372,17 +363,14 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepFive)
   {
     // doNetsearch( regionNames[0], keys[1], vals[1] );
     // doNetsearch( regionNames[1], keys[3], vals[3] );
-    updateEntry(regionNames[0], keys[0], nvals[0]);
-    updateEntry(regionNames[1], keys[2], nvals[2]);
+    updateEntry(regionName, keys[0], nvals[0]);
     LOG("StepFive complete.");
   }
 END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
   {
-    doNetsearch(regionNames[0], keys[0], vals[0]);
-    doNetsearch(regionNames[1], keys[2], vals[2]);
-    updateEntry(regionNames[0], keys[1], nvals[1]);
-    updateEntry(regionNames[1], keys[3], nvals[3]);
+    doNetsearch(regionName, keys[0], vals[0]);
+    updateEntry(regionName, keys[1], nvals[1]);
     LOG("StepSix complete.");
   }
 END_TASK_DEFINITION

--- a/cppcache/integration-test/ThinClientFailover2.hpp
+++ b/cppcache/integration-test/ThinClientFailover2.hpp
@@ -335,7 +335,7 @@ const char* vals[] = {"Value-1", "Value-2", "Value-3", "Value-4", "Value-5"};
 const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4", "New Value-5"};
 
-const char* regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
+const char* regionName = "DistRegionAck";
 
 const bool USE_ACK = true;
 const bool NO_ACK = false;
@@ -353,13 +353,9 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepOne_Pool_Locator)
     char* buf = getcwd(buff, 2048);
     LOG(buf);
     initClient(true);
-    createPooledRegion(regionNames[0], USE_ACK, locatorsG, "__TEST_POOL1__",
+    createPooledRegion(regionName, USE_ACK, locatorsG, "__TEST_POOL1__",
                        true);
-    createPooledRegion(regionNames[1], NO_ACK, locatorsG, "__TEST_POOL1__",
-                       true);
-    auto regPtr = getHelper()->getRegion(regionNames[0]);
-    regPtr->registerAllKeys(false, false, false);
-    regPtr = getHelper()->getRegion(regionNames[1]);
+    auto regPtr = getHelper()->getRegion(regionName);
     regPtr->registerAllKeys(false, false, false);
     LOG("StepOne complete.");
   }
@@ -371,13 +367,9 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepTwo_Pool_Locator)
     char* buf = getcwd(buff, 2048);
     LOG(buf);
     initClient(true);
-    createPooledRegion(regionNames[0], USE_ACK, locatorsG, "__TEST_POOL1__",
+    createPooledRegion(regionName, USE_ACK, locatorsG, "__TEST_POOL1__",
                        true);
-    createPooledRegion(regionNames[1], NO_ACK, locatorsG, "__TEST_POOL1__",
-                       true);
-    auto regPtr = getHelper()->getRegion(regionNames[0]);
-    regPtr->registerAllKeys(false, false, false);
-    regPtr = getHelper()->getRegion(regionNames[1]);
+    auto regPtr = getHelper()->getRegion(regionName);
     regPtr->registerAllKeys(false, false, false);
     LOG("StepTwo complete.");
   }
@@ -385,19 +377,16 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
   {
-    createEntry(regionNames[0], keys[0], vals[0]);
-    createEntry(regionNames[1], keys[2], vals[2]);
-    createEntry(regionNames[0], keys[4], vals[4]);
+    createEntry(regionName, keys[0], vals[0]);
+    createEntry(regionName, keys[4], vals[4]);
     LOG("StepThree complete.");
   }
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, StepFour)
   {
-    doNetsearch(regionNames[0], keys[0], vals[0]);
-    doNetsearch(regionNames[1], keys[2], vals[2]);
-    createEntry(regionNames[0], keys[1], vals[1]);
-    createEntry(regionNames[1], keys[3], vals[3]);
+    doNetsearch(regionName, keys[0], vals[0]);
+    createEntry(regionName, keys[1], vals[1]);
     LOG("StepFour complete.");
   }
 END_TASK_DEFINITION
@@ -420,12 +409,9 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, StepFive)
   {
-    auto reg0 = getHelper()->getRegion(regionNames[0]);
-    auto reg1 = getHelper()->getRegion(regionNames[1]);
+    auto reg0 = getHelper()->getRegion(regionName);
     auto vec0 = reg0->serverKeys();
-    auto vec1 = reg1->serverKeys();
     ASSERT(vec0.size() == 3, "Should have 3 keys in first region.");
-    ASSERT(vec1.size() == 2, "Should have 2 keys in second region.");
 
     std::string key0, key1, key2;
     key0 = vec0[0]->toString().c_str();
@@ -441,20 +427,9 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepFive)
     ASSERT(key2 == keys[0] || key2 == keys[1] || key2 == keys[4],
            "Unexpected key in first region.");
 
-    key0 = vec1[0]->toString().c_str();
-    key1 = vec1[1]->toString().c_str();
-    ASSERT(key0 != key1, "The two keys should be different in second region.");
-    ASSERT(key0 == keys[2] || key0 == keys[3],
-           "Unexpected key in second region.");
-    ASSERT(key1 == keys[2] || key1 == keys[3],
-           "Unexpected key in second region.");
-
-    doNetsearch(regionNames[0], keys[1], vals[1]);
-    doNetsearch(regionNames[1], keys[3], vals[3]);
-    updateEntry(regionNames[0], keys[0], nvals[0]);
-    updateEntry(regionNames[1], keys[2], nvals[2]);
-    verifyEntry(regionNames[0], keys[0], nvals[0]);
-    verifyEntry(regionNames[1], keys[2], nvals[2]);
+    doNetsearch(regionName, keys[1], vals[1]);
+    updateEntry(regionName, keys[0], nvals[0]);
+    verifyEntry(regionName, keys[0], nvals[0]);
     LOG("StepFive complete.");
   }
 END_TASK_DEFINITION
@@ -466,42 +441,35 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
     // value
     // will get from server.
     // doNetsearch( regionNames[0], keys[4], vals[4] );
-    verifyEntry(regionNames[0], keys[0], nvals[0]);
-    verifyEntry(regionNames[1], keys[2], nvals[2]);
-    updateEntry(regionNames[0], keys[1], nvals[1]);
-    updateEntry(regionNames[1], keys[3], nvals[3]);
+    verifyEntry(regionName, keys[0], nvals[0]);
+    updateEntry(regionName, keys[1], nvals[1]);
     LOG("StepSix complete.");
   }
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, StepSeven)
   {
-    verifyEntry(regionNames[0], keys[1], nvals[1]);
-    verifyEntry(regionNames[1], keys[3], nvals[3]);
+    verifyEntry(regionName, keys[1], nvals[1]);
     LOG("StepSeven complete.");
   }
 END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, StepEight)
   {
-    destroyEntry(regionNames[0], keys[0]);
-    destroyEntry(regionNames[1], keys[2]);
+    destroyEntry(regionName, keys[0]);
     LOG("StepEight complete.");
   }
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, StepNine)
   {
-    verifyDestroyed(regionNames[0], keys[0]);
-    verifyDestroyed(regionNames[1], keys[2]);
-    destroyEntry(regionNames[0], keys[1]);
-    destroyEntry(regionNames[1], keys[3]);
+    verifyDestroyed(regionName, keys[0]);
+    destroyEntry(regionName, keys[1]);
     LOG("StepNine complete.");
   }
 END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, StepTen)
   {
-    verifyDestroyed(regionNames[0], keys[1]);
-    verifyDestroyed(regionNames[1], keys[3]);
+    verifyDestroyed(regionName, keys[1]);
     LOG("StepTen complete.");
   }
 END_TASK_DEFINITION

--- a/cppcache/integration-test/ThinClientFailoverInterest.hpp
+++ b/cppcache/integration-test/ThinClientFailoverInterest.hpp
@@ -290,7 +290,7 @@ const char* vals[] = {"Value-1", "Value-2", "Value-3", "Value-4"};
 const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4"};
 
-const char* regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
+const char* regionNames[] = {"DistRegionAck", "not-used"};
 
 const bool USE_ACK = true;
 const bool NO_ACK = false;
@@ -309,8 +309,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepOne_Pool_Locator)
     initClient(true);
     createPooledRegion(regionNames[0], USE_ACK, locatorsG, "__TEST_POOL1__",
                        true);
-    createPooledRegion(regionNames[1], NO_ACK, locatorsG, "__TEST_POOL1__",
-                       true);
     LOG("StepOne complete.");
   }
 END_TASK_DEFINITION
@@ -320,11 +318,8 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepTwo_Pool_Locator)
     initClient(true);
     createPooledRegion(regionNames[0], USE_ACK, locatorsG, "__TEST_POOL1__",
                        true);
-    createPooledRegion(regionNames[1], NO_ACK, locatorsG, "__TEST_POOL1__",
-                       true);
 
     auto regPtr0 = getHelper()->getRegion(regionNames[0]);
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
 
     auto keyPtr0 = CacheableKey::create(keys[0]);
     auto keyPtr2 = CacheableKey::create(keys[2]);
@@ -333,7 +328,6 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepTwo_Pool_Locator)
     keys0.push_back(keyPtr0);
     keys1.push_back(keyPtr2);
     regPtr0->registerKeys(keys0);
-    regPtr1->registerKeys(keys1);
 
     LOG("StepTwo complete.");
   }
@@ -342,7 +336,6 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
   {
     createEntry(regionNames[0], keys[0], vals[0]);
-    createEntry(regionNames[1], keys[2], vals[2]);
     LOG("StepThree complete.");
   }
 END_TASK_DEFINITION
@@ -350,9 +343,7 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT2, StepFour)
   {
     verifyCreated(regionNames[0], keys[0]);
-    verifyCreated(regionNames[1], keys[2]);
     verifyEntry(regionNames[0], keys[0], vals[0]);
-    verifyEntry(regionNames[1], keys[2], vals[2]);
     LOG("StepFour complete.");
   }
 END_TASK_DEFINITION
@@ -377,7 +368,6 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, StepFive)
   {
     updateEntry(regionNames[0], keys[0], nvals[0]);
-    updateEntry(regionNames[1], keys[2], nvals[2]);
     SLEEP(1000);
     LOG("StepFive complete.");
   }
@@ -385,7 +375,6 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
   {
     verifyEntry(regionNames[0], keys[0], nvals[0]);
-    verifyEntry(regionNames[1], keys[2], nvals[2]);
     LOG("StepSix complete.");
   }
 END_TASK_DEFINITION

--- a/cppcache/integration-test/ThinClientFailoverInterest.hpp
+++ b/cppcache/integration-test/ThinClientFailoverInterest.hpp
@@ -290,7 +290,7 @@ const char* vals[] = {"Value-1", "Value-2", "Value-3", "Value-4"};
 const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4"};
 
-const char* regionNames[] = {"DistRegionAck", "not-used"};
+const char* regionNames[] = {"DistRegionAck"};
 
 const bool USE_ACK = true;
 const bool NO_ACK = false;

--- a/cppcache/integration-test/ThinClientFailoverInterest2.hpp
+++ b/cppcache/integration-test/ThinClientFailoverInterest2.hpp
@@ -289,7 +289,7 @@ const char* vals[] = {"Value-1", "Value-2", "Value-3", "Value-4"};
 const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4"};
 
-const char* regionNames[] = {"DistRegionAck", "not-used"};
+const char* regionNames[] = {"DistRegionAck"};
 
 const bool USE_ACK = true;
 const bool NO_ACK = false;

--- a/cppcache/integration-test/ThinClientFailoverInterest2.hpp
+++ b/cppcache/integration-test/ThinClientFailoverInterest2.hpp
@@ -289,7 +289,7 @@ const char* vals[] = {"Value-1", "Value-2", "Value-3", "Value-4"};
 const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4"};
 
-const char* regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
+const char* regionNames[] = {"DistRegionAck", "not-used"};
 
 const bool USE_ACK = true;
 const bool NO_ACK = false;
@@ -308,8 +308,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepOne_Pool_Locator)
     initClient(true);
     createPooledRegion(regionNames[0], USE_ACK, locatorsG, "__TEST_POOL1__",
                        true);
-    createPooledRegion(regionNames[1], NO_ACK, locatorsG, "__TEST_POOL1__",
-                       true);
     LOG("StepOne complete.");
   }
 END_TASK_DEFINITION
@@ -320,13 +318,9 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepTwo_Pool_Locator)
     initClient(true);
     createPooledRegion(regionNames[0], USE_ACK, locatorsG, "__TEST_POOL1__",
                        true);
-    createPooledRegion(regionNames[1], NO_ACK, locatorsG, "__TEST_POOL1__",
-                       true);
 
     auto regPtr0 = getHelper()->getRegion(regionNames[0]);
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
     regPtr0->registerAllKeys();
-    regPtr1->registerAllKeys();
 
     LOG("StepTwo complete.");
   }
@@ -335,7 +329,6 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
   {
     createEntry(regionNames[0], keys[0], vals[0]);
-    createEntry(regionNames[1], keys[2], vals[2]);
     LOG("StepThree complete.");
   }
 END_TASK_DEFINITION
@@ -343,9 +336,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepFour)
   {
     // Client two should recieve all entries
     verifyCreated(regionNames[0], keys[0]);
-    verifyCreated(regionNames[1], keys[2]);
     verifyEntry(regionNames[0], keys[0], vals[0]);
-    verifyEntry(regionNames[1], keys[2], vals[2]);
     LOG("StepFour complete.");
   }
 END_TASK_DEFINITION
@@ -372,7 +363,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepFive)
   {
     // Client one update entries
     updateEntry(regionNames[0], keys[0], nvals[0]);
-    updateEntry(regionNames[1], keys[2], nvals[2]);
     SLEEP(1000);
     LOG("StepFive complete.");
   }
@@ -381,7 +371,6 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
   {
     // Client two should see updates after failover.
     verifyEntry(regionNames[0], keys[0], nvals[0]);
-    verifyEntry(regionNames[1], keys[2], nvals[2]);
     LOG("StepSix complete.");
   }
 END_TASK_DEFINITION
@@ -390,9 +379,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepSeven)
   {
     // Client two unregister all keys
     auto regPtr0 = getHelper()->getRegion(regionNames[0]);
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
     regPtr0->unregisterAllKeys();
-    regPtr1->unregisterAllKeys();
 
     LOG("StepSeven complete.");
   }
@@ -402,7 +389,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepEight)
   {
     // Client one update two entries
     updateEntry(regionNames[0], keys[0], vals[0]);
-    updateEntry(regionNames[1], keys[2], vals[2]);
     LOG("StepEight complete.");
   }
 END_TASK_DEFINITION
@@ -410,7 +396,6 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepNine)
   {
     // Client two should still have the original values
     verifyEntry(regionNames[0], keys[0], nvals[0]);
-    verifyEntry(regionNames[1], keys[2], nvals[2]);
     LOG("StepNine complete.");
   }
 END_TASK_DEFINITION

--- a/cppcache/integration-test/ThinClientFailoverRegex.hpp
+++ b/cppcache/integration-test/ThinClientFailoverRegex.hpp
@@ -292,7 +292,7 @@ const char* vals[] = {"Value-1", "Value-2", "Value-3", "Value-4"};
 const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4"};
 
-const char* regionNames[] = {"DistRegionAck", "not-used"};
+const char* regionNames[] = {"DistRegionAck"};
 
 const bool USE_ACK = true;
 const bool NO_ACK = false;
@@ -320,8 +320,6 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepTwo_Pool_Locator)
   {
     initClient(true);
     createPooledRegion(regionNames[0], USE_ACK, locatorsG, "__TEST_POOL1__",
-                       true);
-    createPooledRegion(regionNames[1], NO_ACK, locatorsG, "__TEST_POOL1__",
                        true);
 
     auto regPtr0 = getHelper()->getRegion(regionNames[0]);
@@ -357,14 +355,6 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepFour)
 
     verifyCreated(regionNames[0], keys[0]);
     verifyEntry(regionNames[0], keys[0], vals[0]);
-
-    /*
-     auto regPtr1 = getHelper()->getRegion( regionNames[1] );
-     auto keyPtr2 = CacheableKey::create(keys[2]);
-      std::vector<std::shared_ptr<CacheableKey>>  keys2;
-      keys2.push_back(keyPtr2);
-      regPtr1->unregisterKeys(keys2, nullptr);
-      */
 
     LOG("StepFour complete.");
   }

--- a/cppcache/integration-test/ThinClientFailoverRegex.hpp
+++ b/cppcache/integration-test/ThinClientFailoverRegex.hpp
@@ -292,7 +292,7 @@ const char* vals[] = {"Value-1", "Value-2", "Value-3", "Value-4"};
 const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4"};
 
-const char* regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
+const char* regionNames[] = {"DistRegionAck", "not-used"};
 
 const bool USE_ACK = true;
 const bool NO_ACK = false;
@@ -311,10 +311,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepOne_Pool_Locator)
     initClient(true);
     createPooledRegion(regionNames[0], USE_ACK, locatorsG, "__TEST_POOL1__",
                        true);
-    createPooledRegion(regionNames[1], NO_ACK, locatorsG, "__TEST_POOL1__",
-                       true);
-
-    createEntry(regionNames[1], keys[1], vals[1]);
 
     LOG("StepOne complete.");
   }
@@ -328,10 +324,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepTwo_Pool_Locator)
     createPooledRegion(regionNames[1], NO_ACK, locatorsG, "__TEST_POOL1__",
                        true);
 
-    createEntry(regionNames[1], keys[1], nvals[1]);
-
     auto regPtr0 = getHelper()->getRegion(regionNames[0]);
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
 
     /*
      auto keyPtr0 = CacheableKey::create(keys[0]);
@@ -345,7 +338,6 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepTwo_Pool_Locator)
     */
 
     regPtr0->registerRegex(regkeys[0]);
-    regPtr1->registerRegex(regkeys[2]);
 
     LOG("StepTwo complete.");
   }
@@ -354,14 +346,6 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
   {
     createEntry(regionNames[0], keys[0], vals[0]);
-    createEntry(regionNames[1], keys[2], vals[2]);
-
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
-    regPtr1->registerRegex(regkeys[1], false);
-
-    doNetsearch(
-        regionNames[1], keys[1],
-        nvals[1]);  // this should verify due to registerRegex() call before
 
     LOG("StepThree complete.");
   }
@@ -372,14 +356,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepFour)
     LOG("StepFour start.");
 
     verifyCreated(regionNames[0], keys[0]);
-    verifyCreated(regionNames[1], keys[2]);
     verifyEntry(regionNames[0], keys[0], vals[0]);
-    verifyEntry(regionNames[1], keys[2], vals[2]);
-
-    updateEntry(regionNames[1], keys[1], vals[1]);
-
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
-    regPtr1->unregisterRegex(regkeys[2]);
 
     /*
      auto regPtr1 = getHelper()->getRegion( regionNames[1] );
@@ -413,11 +390,7 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, StepFive)
   {
     updateEntry(regionNames[0], keys[0], nvals[0]);
-    updateEntry(regionNames[1], keys[2], nvals[2]);
 
-    verifyEntry(
-        regionNames[1], keys[1],
-        vals[1]);  // this should verify due to registerRegex() call before
     SLEEP(1000);
 
     LOG("StepFive complete.");
@@ -427,10 +400,6 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
   {
     LOG("StepSix start.");
     verifyEntry(regionNames[0], keys[0], nvals[0]);
-    verifyEntry(regionNames[1], keys[2],
-                vals[2]);  // this key-regex was unregistered before failover
-
-    updateEntry(regionNames[1], keys[1], nvals[1]);  // for client1 to verify
 
     LOG("StepSix complete.");
   }
@@ -441,9 +410,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepSeven)
     LOG("StepSeven start.");
 
     updateEntry(regionNames[0], keys[0], vals[0]);
-    updateEntry(regionNames[1], keys[2], vals[2]);
-
-    verifyEntry(regionNames[1], keys[1], nvals[1]);
 
     LOG("StepSeven complete.");
   }
@@ -454,9 +420,6 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepEight)
     LOG("StepEight start.");
     verifyEntry(regionNames[0], keys[0],
                 vals[0]);  // this should verify now (registered after failover)
-    verifyEntry(
-        regionNames[1], keys[2],
-        vals[2]);  // this should verify now (not registered after failover)
     LOG("StepEight complete.");
   }
 END_TASK_DEFINITION

--- a/cppcache/integration-test/ThinClientHelper.hpp
+++ b/cppcache/integration-test/ThinClientHelper.hpp
@@ -134,7 +134,7 @@ const char* vals[] = {"Value-1", "Value-2", "Value-3",
 const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4", "New Value-5", "New Value-6"};
 
-const char* regionNames[] = {"DistRegionAck", "not-used"};
+const char* regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
 
 const bool USE_ACK = true;
 const bool NO_ACK = false;

--- a/cppcache/integration-test/ThinClientHelper.hpp
+++ b/cppcache/integration-test/ThinClientHelper.hpp
@@ -134,7 +134,7 @@ const char* vals[] = {"Value-1", "Value-2", "Value-3",
 const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4", "New Value-5", "New Value-6"};
 
-const char* regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
+const char* regionNames[] = {"DistRegionAck", "not-used"};
 
 const bool USE_ACK = true;
 const bool NO_ACK = false;

--- a/cppcache/integration-test/ThinClientTransactionsXA.hpp
+++ b/cppcache/integration-test/ThinClientTransactionsXA.hpp
@@ -356,7 +356,7 @@ const char* nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4", "New Value-5", "New Value-6",
                        "New Value-7"};
 
-const char* regionNames[] = {"DistRegionAck", "DistRegionNoAck", "testregion"};
+const char* regionNames[] = {"DistRegionAck", "not-used", "not-used"};
 
 const bool USE_ACK = true;
 const bool NO_ACK = false;
@@ -390,7 +390,6 @@ class SuspendTransactionThread : public ACE_Task_Base {
     txManager->begin();
 
     createEntry(regionNames[0], keys[4], vals[4]);
-    createEntry(regionNames[1], keys[5], vals[5]);
 
     m_suspendedTransaction = &txManager->getTransactionId();
 
@@ -446,15 +445,7 @@ class ResumeTransactionThread : public ACE_Task_Base {
     auto keyPtr5 = CacheableKey::create(keys[5]);
     auto keyPtr6 = CacheableKey::create(keys[6]);
 
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
-    THREADERRORCHECK(regPtr1 != nullptr,
-                     "In ResumeTransactionThread - Region not found.");
-
     THREADERRORCHECK(!regPtr0->containsKeyOnServer(keyPtr4),
-                     "In ResumeTransactionThread - Key should not have been "
-                     "found in region.");
-
-    THREADERRORCHECK(!regPtr1->containsKeyOnServer(keyPtr5),
                      "In ResumeTransactionThread - Key should not have been "
                      "found in region.");
 
@@ -483,11 +474,6 @@ class ResumeTransactionThread : public ACE_Task_Base {
     THREADERRORCHECK(
         regPtr0->containsKeyOnServer(keyPtr4),
         "In ResumeTransactionThread - Key should have been found in region.");
-    THREADERRORCHECK(
-        regPtr1->containsKeyOnServer(keyPtr5),
-        "In ResumeTransactionThread - Key should have been found in region.");
-
-    createEntry(regionNames[1], keys[6], vals[6]);
 
     if (m_commit) {
       txManager->prepare();
@@ -495,54 +481,21 @@ class ResumeTransactionThread : public ACE_Task_Base {
       THREADERRORCHECK(
           regPtr0->containsKeyOnServer(keyPtr4),
           "In ResumeTransactionThread - Key should have been found in region.");
-      THREADERRORCHECK(
-          regPtr1->containsKeyOnServer(keyPtr5),
-          "In ResumeTransactionThread - Key should have been found in region.");
-      THREADERRORCHECK(
-          regPtr1->containsKeyOnServer(keyPtr6),
-          "In ResumeTransactionThread - Key should have been found in region.");
-
     } else {
       txManager->prepare();
       txManager->rollback();
       THREADERRORCHECK(!regPtr0->containsKeyOnServer(keyPtr4),
                        "In ResumeTransactionThread - Key should not have been "
                        "found in region.");
-      THREADERRORCHECK(!regPtr1->containsKeyOnServer(keyPtr5),
-                       "In ResumeTransactionThread - Key should not have been "
-                       "found in region.");
-      THREADERRORCHECK(!regPtr1->containsKeyOnServer(keyPtr6),
-                       "In ResumeTransactionThread - Key should not have been "
-                       "found in region.");
     }
 
     if (m_commit) {
-      regPtr1->destroy(keyPtr6);
-      regPtr1->destroy(keyPtr5);
       regPtr0->destroy(keyPtr4);
 
-      THREADERRORCHECK(!regPtr1->containsKeyOnServer(keyPtr6),
-                       "In ResumeTransactionThread - Key should not have been "
-                       "found in region.");
-      THREADERRORCHECK(!regPtr1->containsKeyOnServer(keyPtr5),
-                       "In ResumeTransactionThread - Key should not have been "
-                       "found in region.");
       THREADERRORCHECK(!regPtr0->containsKeyOnServer(keyPtr4),
                        "In ResumeTransactionThread - Key should not have been "
                        "found in region.");
     } else {
-      try {
-        regPtr1->destroy(keyPtr6);
-        FAIL("Should have got EntryNotFoundException for keyPtr6");
-      } catch (EntryNotFoundException& /*ex*/) {
-        LOG("Got expected EntryNotFoundException for keyPtr6");
-      }
-      try {
-        regPtr1->destroy(keyPtr5);
-        FAIL("Should have got EntryNotFoundException for keyPtr5");
-      } catch (EntryNotFoundException& /*ex*/) {
-        LOG("Got expected EntryNotFoundException for keyPtr5");
-      }
       try {
         regPtr0->destroy(keyPtr4);
         FAIL("Should have got EntryNotFoundException for keyPtr4");
@@ -577,22 +530,17 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeCommit)
     auto txManager = getHelper()->getCache()->getCacheTransactionManager();
     auto regPtr0 = getHelper()->getRegion(regionNames[0]);
     ASSERT(regPtr0 != nullptr, "In SuspendResumeCommit - Region not found.");
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
-    ASSERT(regPtr1 != nullptr, "In SuspendResumeCommit - Region not found.");
+
     auto keyPtr4 = CacheableKey::create(keys[4]);
     auto keyPtr5 = CacheableKey::create(keys[5]);
     auto keyPtr6 = CacheableKey::create(keys[6]);
 
     txManager->begin();
     createEntry(regionNames[0], keys[4], vals[4]);
-    createEntry(regionNames[1], keys[5], vals[5]);
     auto& m_suspendedTransaction = txManager->suspend();
 
     ASSERT(
         !regPtr0->containsKeyOnServer(keyPtr4),
-        "In SuspendResumeCommit - Key should not have been found in region.");
-    ASSERT(
-        !regPtr1->containsKeyOnServer(keyPtr5),
         "In SuspendResumeCommit - Key should not have been found in region.");
 
     ASSERT(txManager->isSuspended(m_suspendedTransaction),
@@ -608,22 +556,12 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeCommit)
         "SuspendResumeRollback: Transaction shouldnt have been resumed again");
     ASSERT(regPtr0->containsKeyOnServer(keyPtr4),
            "In SuspendResumeCommit - Key should have been found in region.");
-    ASSERT(regPtr1->containsKeyOnServer(keyPtr5),
-           "In SuspendResumeCommit - Key should have been found in region.");
-
-    createEntry(regionNames[1], keys[6], vals[6]);
 
     txManager->prepare();
     txManager->commit();
     ASSERT(regPtr0->containsKeyOnServer(keyPtr4),
            "In SuspendResumeCommit - Key should have been found in region.");
-    ASSERT(regPtr1->containsKeyOnServer(keyPtr5),
-           "In SuspendResumeCommit - Key should have been found in region.");
-    ASSERT(regPtr1->containsKeyOnServer(keyPtr6),
-           "In SuspendResumeCommit - Key should have been found in region.");
 
-    regPtr1->destroy(keyPtr6);
-    regPtr1->destroy(keyPtr5);
     regPtr0->destroy(keyPtr4);
 
     ASSERT(!txManager->isSuspended(m_suspendedTransaction),
@@ -706,19 +644,13 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeRollback)
 
     auto regPtr0 = getHelper()->getRegion(regionNames[0]);
     ASSERT(regPtr0 != nullptr, "In SuspendResumeRollback - Region not found.");
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
-    ASSERT(regPtr1 != nullptr, "In SuspendResumeRollback - Region not found.");
 
     txManager->begin();
     createEntry(regionNames[0], keys[4], vals[4]);
-    createEntry(regionNames[1], keys[5], vals[5]);
     auto& m_suspendedTransaction = txManager->suspend();
 
     ASSERT(
         !regPtr0->containsKeyOnServer(keyPtr4),
-        "In SuspendResumeRollback - Key should not have been found in region.");
-    ASSERT(
-        !regPtr1->containsKeyOnServer(keyPtr5),
         "In SuspendResumeRollback - Key should not have been found in region.");
 
     ASSERT(txManager->isSuspended(m_suspendedTransaction),
@@ -731,35 +663,13 @@ DUNIT_TASK_DEFINITION(CLIENT1, SuspendResumeRollback)
 
     ASSERT(regPtr0->containsKeyOnServer(keyPtr4),
            "In SuspendResumeRollback - Key should have been found in region.");
-    ASSERT(regPtr1->containsKeyOnServer(keyPtr5),
-           "In SuspendResumeRollback - Key should have been found in region.");
-
-    createEntry(regionNames[1], keys[6], vals[6]);
 
     txManager->prepare();
     txManager->rollback();
     ASSERT(
         !regPtr0->containsKeyOnServer(keyPtr4),
         "In SuspendResumeRollback - Key should not have been found in region.");
-    ASSERT(
-        !regPtr1->containsKeyOnServer(keyPtr5),
-        "In SuspendResumeRollback - Key should not have been found in region.");
-    ASSERT(
-        !regPtr1->containsKeyOnServer(keyPtr6),
-        "In SuspendResumeRollback - Key should not have been found in region.");
 
-    try {
-      regPtr1->destroy(keyPtr6);
-      FAIL("Should have got EntryNotFoundException for keyPtr6");
-    } catch (EntryNotFoundException& /*ex*/) {
-      LOG("Got expected EntryNotFoundException for keyPtr6");
-    }
-    try {
-      regPtr1->destroy(keyPtr5);
-      FAIL("Should have got EntryNotFoundException for keyPtr5");
-    } catch (EntryNotFoundException& /*ex*/) {
-      LOG("Got expected EntryNotFoundException for keyPtr5");
-    }
     try {
       regPtr0->destroy(keyPtr4);
       FAIL("Should have got EntryNotFoundException for keyPtr4");
@@ -904,7 +814,6 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, StepOne_Pooled_Locator)
   {
     createPooledRegion(regionNames[0], USE_ACK, locatorsG, "__TESTPOOL1_");
-    createPooledRegion(regionNames[1], NO_ACK, locatorsG, "__TESTPOOL1_");
     LOG("StepOne_Pooled complete.");
   }
 END_TASK_DEFINITION
@@ -913,7 +822,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepOne_Pooled_Locator_Sticky)
   {
     createPooledRegionSticky(regionNames[0], USE_ACK, locatorsG,
                              "__TESTPOOL1_");
-    createPooledRegionSticky(regionNames[1], NO_ACK, locatorsG, "__TESTPOOL1_");
     LOG("StepOne_Pooled_Locator_Sticky complete.");
   }
 END_TASK_DEFINITION
@@ -922,7 +830,6 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepTwo_Pooled_Locator)
   {
     initClient(true);
     createPooledRegion(regionNames[0], USE_ACK, locatorsG, "__TESTPOOL1_");
-    createPooledRegion(regionNames[1], NO_ACK, locatorsG, "__TESTPOOL1_");
     LOG("StepTwo complete.");
   }
 END_TASK_DEFINITION
@@ -932,7 +839,6 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepTwo_Pooled_Locator_Sticky)
     initClient(true);
     createPooledRegionSticky(regionNames[0], USE_ACK, locatorsG,
                              "__TESTPOOL1_");
-    createPooledRegionSticky(regionNames[1], NO_ACK, locatorsG, "__TESTPOOL1_");
     LOG("StepTwo complete.");
   }
 END_TASK_DEFINITION
@@ -942,7 +848,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
     auto txManager = getHelper()->getCache()->getCacheTransactionManager();
     txManager->begin();
     createEntry(regionNames[0], keys[0], vals[0]);
-    createEntry(regionNames[1], keys[2], vals[2]);
     txManager->prepare();
     txManager->commit();
     LOG("StepThree complete.");
@@ -952,26 +857,20 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT2, StepFour)
   {
     doNetsearch(regionNames[0], keys[0], vals[0]);
-    doNetsearch(regionNames[1], keys[2], vals[2]);
     auto txManager = getHelper()->getCache()->getCacheTransactionManager();
     txManager->begin();
     createEntry(regionNames[0], keys[1], vals[1]);
-    createEntry(regionNames[1], keys[3], vals[3]);
     txManager->prepare();
     txManager->commit();
     verifyEntry(regionNames[0], keys[1], vals[1]);
-    verifyEntry(regionNames[1], keys[3], vals[3]);
     LOG("StepFour complete.");
   }
 END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, StepFive)
   {
     auto reg0 = getHelper()->getRegion(regionNames[0]);
-    auto reg1 = getHelper()->getRegion(regionNames[1]);
     auto vec0 = reg0->serverKeys();
-    auto vec1 = reg1->serverKeys();
     ASSERT(vec0.size() == 2, "Should have 2 keys in first region.");
-    ASSERT(vec1.size() == 2, "Should have 2 keys in second region.");
     std::string key0, key1;
     key0 = vec0[0]->toString().c_str();
     key1 = vec0[1]->toString().c_str();
@@ -981,29 +880,17 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepFive)
     ASSERT(key1 == keys[0] || key1 == keys[1],
            "Unexpected key in first region.");
 
-    key0 = vec1[0]->toString().c_str();
-    key1 = vec1[1]->toString().c_str();
-    ASSERT(key0 != key1, "The two keys should be different in second region.");
-    ASSERT(key0 == keys[2] || key0 == keys[3],
-           "Unexpected key in second region.");
-    ASSERT(key1 == keys[2] || key1 == keys[3],
-           "Unexpected key in second region.");
-
     doNetsearch(regionNames[0], keys[1], vals[1]);
-    doNetsearch(regionNames[1], keys[3], vals[3]);
     updateEntry(regionNames[0], keys[0], nvals[0]);
-    updateEntry(regionNames[1], keys[2], nvals[2]);
     LOG("StepFive complete.");
   }
 END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
   {
     doNetsearch(regionNames[0], keys[0], vals[0]);
-    doNetsearch(regionNames[1], keys[2], vals[2]);
     auto txManager = getHelper()->getCache()->getCacheTransactionManager();
     txManager->begin();
     updateEntry(regionNames[0], keys[1], nvals[1]);
-    updateEntry(regionNames[1], keys[3], nvals[3]);
     txManager->prepare();
     txManager->commit();
     LOG("StepSix complete.");
@@ -1013,73 +900,21 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepSeven)
   { createEntryTwice(regionNames[0], CREATE_TWICE_KEY, CREATE_TWICE_VALUE); }
 END_TASK_DEFINITION
 
-DUNIT_TASK_DEFINITION(CLIENT1, StepEight_Pool)
-  {
-    createPooledRegion(regionNames[2], NO_ACK, locatorsG, "__TESTPOOL1_", false,
-                       false);
-    auto reg = getHelper()->getRegion(regionNames[2]);
-    LOG("REGION Created with Caching Enabled false");
-    auto keyPtr = CacheableKey::create(CREATE_TWICE_KEY);
-    auto valPtr = CacheableString::create(CREATE_TWICE_VALUE);
-    try {
-      reg->create(keyPtr, valPtr);
-      char message[200];
-      sprintf(message, "First create on Key %s ", CREATE_TWICE_KEY);
-      LOG(message);
-      reg->create(keyPtr, valPtr);
-      sprintf(message, "Second create on Key %s ", CREATE_TWICE_KEY);
-      LOG(message);
-      reg->create(keyPtr, valPtr);
-      sprintf(message, "Third create on Key %s ", CREATE_TWICE_KEY);
-      LOG(message);
-    } catch (const EntryExistsException& geodeExcp) {
-      LOG(geodeExcp.what());
-      ASSERT(false,
-             "Creating KEY Twice on a caching-enabled false region should be "
-             "allowed.");
-    }
-  }
-END_TASK_DEFINITION
-
 DUNIT_TASK_DEFINITION(CLIENT1, StepEight_Pool_Sticky)
   {
-    createPooledRegionSticky(regionNames[2], NO_ACK, locatorsG, "__TESTPOOL1_",
-                             false, false);
-    auto reg = getHelper()->getRegion(regionNames[2]);
     LOG("REGION Created with Caching Enabled false");
     auto keyPtr = CacheableKey::create(CREATE_TWICE_KEY);
     auto valPtr = CacheableString::create(CREATE_TWICE_VALUE);
 
     auto reg0 = getHelper()->getRegion(regionNames[0]);
-    auto reg1 = getHelper()->getRegion(regionNames[1]);
     reg0->localInvalidate(CacheableKey::create(keys[1]));
-    reg1->localInvalidate(CacheableKey::create(keys[3]));
     auto pool = getHelper()->getCache()->getPoolManager().find("__TESTPOOL1_");
     ASSERT(pool != nullptr, "Pool Should have been found");
     doNetsearch(regionNames[0], keys[1], nvals[1]);
-    doNetsearch(regionNames[1], keys[3], nvals[3]);
     pool->releaseThreadLocalConnection();
     updateEntry(regionNames[0], keys[0], nvals[0]);
-    updateEntry(regionNames[1], keys[2], nvals[2]);
     pool->releaseThreadLocalConnection();
-    try {
-      reg->create(keyPtr, valPtr);
-      char message[200];
-      sprintf(message, "First create on Key %s ", CREATE_TWICE_KEY);
-      LOG(message);
-      reg->create(keyPtr, valPtr);
-      sprintf(message, "Second create on Key %s ", CREATE_TWICE_KEY);
-      LOG(message);
-      reg->create(keyPtr, valPtr);
-      sprintf(message, "Third create on Key %s ", CREATE_TWICE_KEY);
-      LOG(message);
-    } catch (const EntryExistsException& geodeExcp) {
-      LOG(geodeExcp.what());
-      ASSERT(false,
-             "Creating KEY Twice on a caching-enabled false region should be "
-             "allowed.");
-    }
-  }
+}
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, CloseCache1)
@@ -1120,8 +955,6 @@ void runTransactionOps(bool isSticky = false) {
   CALL_TASK(StepSeven);
   if (isSticky) {
     CALL_TASK(StepEight_Pool_Sticky);
-  } else {
-    CALL_TASK(StepEight_Pool);
   }
 
   CALL_TASK(SuspendResumeInThread);

--- a/cppcache/integration-test/ThinClientTransactionsXA.hpp
+++ b/cppcache/integration-test/ThinClientTransactionsXA.hpp
@@ -900,23 +900,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepSeven)
   { createEntryTwice(regionNames[0], CREATE_TWICE_KEY, CREATE_TWICE_VALUE); }
 END_TASK_DEFINITION
 
-DUNIT_TASK_DEFINITION(CLIENT1, StepEight_Pool_Sticky)
-  {
-    LOG("REGION Created with Caching Enabled false");
-    auto keyPtr = CacheableKey::create(CREATE_TWICE_KEY);
-    auto valPtr = CacheableString::create(CREATE_TWICE_VALUE);
-
-    auto reg0 = getHelper()->getRegion(regionNames[0]);
-    reg0->localInvalidate(CacheableKey::create(keys[1]));
-    auto pool = getHelper()->getCache()->getPoolManager().find("__TESTPOOL1_");
-    ASSERT(pool != nullptr, "Pool Should have been found");
-    doNetsearch(regionNames[0], keys[1], nvals[1]);
-    pool->releaseThreadLocalConnection();
-    updateEntry(regionNames[0], keys[0], nvals[0]);
-    pool->releaseThreadLocalConnection();
-}
-END_TASK_DEFINITION
-
 DUNIT_TASK_DEFINITION(CLIENT1, CloseCache1)
   { cleanProc(); }
 END_TASK_DEFINITION
@@ -934,28 +917,19 @@ DUNIT_TASK_DEFINITION(SERVER1, CloseServer1)
   }
 END_TASK_DEFINITION
 
-void runTransactionOps(bool isSticky = false) {
+void runTransactionOps() {
   CALL_TASK(CreateLocator1);
   CALL_TASK(CreateServer1_With_Locator);
 
-  if (isSticky) {
-    CALL_TASK(CreateNonexistentServerRegion_Pooled_Locator_Sticky);
-    CALL_TASK(StepOne_Pooled_Locator_Sticky);
-    CALL_TASK(StepTwo_Pooled_Locator_Sticky);
-  } else {
-    CALL_TASK(CreateNonexistentServerRegion_Pooled_Locator);
-    CALL_TASK(StepOne_Pooled_Locator);
-    CALL_TASK(StepTwo_Pooled_Locator);
-  }
+  CALL_TASK(CreateNonexistentServerRegion_Pooled_Locator);
+  CALL_TASK(StepOne_Pooled_Locator);
+  CALL_TASK(StepTwo_Pooled_Locator);
 
   CALL_TASK(StepThree);
   CALL_TASK(StepFour);
   CALL_TASK(StepFive);
   CALL_TASK(StepSix);
   CALL_TASK(StepSeven);
-  if (isSticky) {
-    CALL_TASK(StepEight_Pool_Sticky);
-  }
 
   CALL_TASK(SuspendResumeInThread);
   CALL_TASK(SuspendResumeCommit);

--- a/cppcache/integration-test/resources/cacheserver.xml
+++ b/cppcache/integration-test/resources/cacheserver.xml
@@ -28,12 +28,12 @@
     <region-attributes scope="distributed-ack" data-policy="replicate"/>
   </region>
   <region name="DistRegionNoAck">
-    <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+    <region-attributes scope="distributed-ack" data-policy="replicate"/>
   </region>
   <region name="testregion">
-    <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+    <region-attributes scope="distributed-ack" data-policy="replicate"/>
   </region>
   <region name="CreateVerifyTestRegion">
-    <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+    <region-attributes scope="distributed-ack" data-policy="replicate"/>
   </region>
 </cache> 

--- a/cppcache/integration-test/resources/cacheserver2.xml
+++ b/cppcache/integration-test/resources/cacheserver2.xml
@@ -29,6 +29,6 @@
 		<region-attributes scope="distributed-ack" data-policy="replicate"/>
 	</region>
 	<region name="DistRegionNoAck">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate"/>
+		<region-attributes   scope="distributed-ack" data-policy="replicate"/>
 	</region>
 </cache> 

--- a/cppcache/integration-test/resources/cacheserver3.xml
+++ b/cppcache/integration-test/resources/cacheserver3.xml
@@ -29,6 +29,6 @@
 		<region-attributes scope="distributed-ack" data-policy="replicate"/>
 	</region>
 	<region name="DistRegionNoAck">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate"/>
+		<region-attributes   scope="distributed-ack" data-policy="replicate"/>
 	</region>
 </cache> 

--- a/cppcache/integration-test/resources/cacheserverForPdx.xml
+++ b/cppcache/integration-test/resources/cacheserverForPdx.xml
@@ -33,14 +33,14 @@
     </region-attributes>  
 	</region>
 	<region name="DistRegionNoAck">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate">
+		<region-attributes   scope="distributed-ack" data-policy="replicate">
     <cache-listener>
 				<class-name>javaobject.SimpleCacheListener</class-name>
 			</cache-listener>
     </region-attributes>  
 	</region>
 	<region name="testregion">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate">
+		<region-attributes   scope="distributed-ack" data-policy="replicate">
     <cache-listener>
 				<class-name>javaobject.SimpleCacheListener</class-name>
 			</cache-listener>

--- a/cppcache/integration-test/resources/cacheserverPdx.xml
+++ b/cppcache/integration-test/resources/cacheserverPdx.xml
@@ -33,14 +33,14 @@
     </region-attributes>
 	</region>
 	<region name="DistRegionNoAck">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate">
+		<region-attributes   scope="distributed-ack" data-policy="replicate">
     <cache-listener>
 				<class-name>javaobject.PdxCacheListener</class-name>
 			</cache-listener>
     </region-attributes>
 	</region>
 	<region name="testregion">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate">
+		<region-attributes   scope="distributed-ack" data-policy="replicate">
     <cache-listener>
 				<class-name>javaobject.PdxCacheListener</class-name>
 			</cache-listener>

--- a/cppcache/integration-test/resources/cacheserverPdx2.xml
+++ b/cppcache/integration-test/resources/cacheserverPdx2.xml
@@ -30,11 +30,11 @@
      </region-attributes>
 	</region>
 	<region name="DistRegionNoAck">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate">
+		<region-attributes   scope="distributed-ack" data-policy="replicate">
     </region-attributes>
 	</region>
 	<region name="testregion">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate">
+		<region-attributes   scope="distributed-ack" data-policy="replicate">
     </region-attributes>
 	</region>
     <function-service>

--- a/cppcache/integration-test/resources/cacheserverPdxSerializer.xml
+++ b/cppcache/integration-test/resources/cacheserverPdxSerializer.xml
@@ -29,9 +29,9 @@
 		<region-attributes scope="distributed-ack" data-policy="replicate"/>
 	</region>
 	<region name="DistRegionNoAck">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate"/>
+		<region-attributes   scope="distributed-ack" data-policy="replicate"/>
 	</region>
 	<region name="testregion">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate"/>
+		<region-attributes   scope="distributed-ack" data-policy="replicate"/>
 	</region>
 </cache> 

--- a/cppcache/integration-test/resources/cacheserver_loader.xml
+++ b/cppcache/integration-test/resources/cacheserver_loader.xml
@@ -26,7 +26,7 @@
   <region name="root">
     <region-attributes/>
     <region name="exampleRegion">
-      <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+      <region-attributes scope="distributed-ack" data-policy="replicate"/>
     </region>
   </region>
 </cache>

--- a/cppcache/integration-test/resources/cacheserver_notify_subscription.xml
+++ b/cppcache/integration-test/resources/cacheserver_notify_subscription.xml
@@ -32,9 +32,9 @@
     </region>
   </region>
   <region name="DistRegionNoAck">
-    <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+    <region-attributes scope="distributed-ack" data-policy="replicate"/>
     <region name="AuthSubregion">
-      <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+      <region-attributes scope="distributed-ack" data-policy="replicate"/>
     </region>
   </region>
   <function-service>

--- a/cppcache/integration-test/resources/cacheserver_notify_subscription2.xml
+++ b/cppcache/integration-test/resources/cacheserver_notify_subscription2.xml
@@ -32,9 +32,9 @@
     </region>
   </region>
   <region name="DistRegionNoAck">
-    <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+    <region-attributes scope="distributed-ack" data-policy="replicate"/>
     <region name="AuthSubregion">
-      <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+      <region-attributes scope="distributed-ack" data-policy="replicate"/>
     </region>
   </region>
   <function-service>

--- a/cppcache/integration-test/resources/cacheserver_notify_subscription3.xml
+++ b/cppcache/integration-test/resources/cacheserver_notify_subscription3.xml
@@ -32,9 +32,9 @@
     </region>
   </region>
   <region name="DistRegionNoAck">
-    <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+    <region-attributes scope="distributed-ack" data-policy="replicate"/>
     <region name="AuthSubregion">
-      <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+      <region-attributes scope="distributed-ack" data-policy="replicate"/>
     </region>
   </region>
 </cache> 

--- a/cppcache/integration-test/resources/cacheserver_notify_subscription4.xml
+++ b/cppcache/integration-test/resources/cacheserver_notify_subscription4.xml
@@ -32,9 +32,9 @@
     </region>
   </region>
   <region name="DistRegionNoAck">
-    <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+    <region-attributes scope="distributed-ack" data-policy="replicate"/>
     <region name="AuthSubregion">
-      <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+      <region-attributes scope="distributed-ack" data-policy="replicate"/>
     </region>
   </region>
 </cache> 

--- a/cppcache/integration-test/resources/cacheserver_notify_subscription5.xml
+++ b/cppcache/integration-test/resources/cacheserver_notify_subscription5.xml
@@ -91,7 +91,7 @@
   <region name="DistRegionNoAck">
    
   
-    <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+    <region-attributes scope="distributed-ack" data-policy="replicate"/>
      <!-- making entries -->
                     <entry>
                     <key><string>port1-1</string></key>
@@ -148,7 +148,7 @@
                     </value>
                </entry>
     <region name="AuthSubregion">
-      <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+      <region-attributes scope="distributed-ack" data-policy="replicate"/>
     </region>
   </region>
 </cache> 

--- a/cppcache/integration-test/resources/cacheserver_notify_subscriptionBug849.xml
+++ b/cppcache/integration-test/resources/cacheserver_notify_subscriptionBug849.xml
@@ -32,9 +32,9 @@
     </region>
   </region>
   <region name="DistRegionNoAck">
-    <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+    <region-attributes scope="distributed-ack" data-policy="replicate"/>
     <region name="AuthSubregion">
-      <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+      <region-attributes scope="distributed-ack" data-policy="replicate"/>
     </region>
   </region>
   <region name="ExampleRegion">

--- a/cppcache/integration-test/resources/cacheserver_notify_subscription_PutAllTimeout.xml
+++ b/cppcache/integration-test/resources/cacheserver_notify_subscription_PutAllTimeout.xml
@@ -36,9 +36,9 @@
     </region>    
   </region>
   <region name="DistRegionNoAck">
-    <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+    <region-attributes scope="distributed-ack" data-policy="replicate"/>
     <region name="AuthSubregion">
-      <region-attributes scope="distributed-no-ack" data-policy="replicate"/>
+      <region-attributes scope="distributed-ack" data-policy="replicate"/>
     </region>
   </region>
 </cache> 

--- a/cppcache/integration-test/resources/cacheserver_pdxinstance_hashcode.xml
+++ b/cppcache/integration-test/resources/cacheserver_pdxinstance_hashcode.xml
@@ -33,14 +33,14 @@
     </region-attributes>
 	</region>
 	<region name="DistRegionNoAck">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate">
+		<region-attributes   scope="distributed-ack" data-policy="replicate">
     <cache-listener>
 				<class-name>javaobject.PdxinstanceHashcodeListener</class-name>
 			</cache-listener>
     </region-attributes>
 	</region>
 	<region name="testregion">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate">
+		<region-attributes   scope="distributed-ack" data-policy="replicate">
     <cache-listener>
 				<class-name>javaobject.PdxinstanceHashcodeListener</class-name>
 			</cache-listener>

--- a/cppcache/integration-test/resources/cacheserver_remoteoql.xml
+++ b/cppcache/integration-test/resources/cacheserver_remoteoql.xml
@@ -87,6 +87,6 @@
 		<region-attributes scope="distributed-ack" data-policy="replicate"/>
 	</region>
 	<region name="DistRegionNoAck">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate"/>
+		<region-attributes   scope="distributed-ack" data-policy="replicate"/>
 	</region>
 </cache> 

--- a/cppcache/integration-test/resources/cacheserver_remoteoql2.xml
+++ b/cppcache/integration-test/resources/cacheserver_remoteoql2.xml
@@ -87,6 +87,6 @@
 		<region-attributes scope="distributed-ack" data-policy="replicate"/>
 	</region>
 	<region name="DistRegionNoAck">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate"/>
+		<region-attributes   scope="distributed-ack" data-policy="replicate"/>
 	</region>
 </cache> 

--- a/cppcache/integration-test/resources/cqqueryfailover.xml
+++ b/cppcache/integration-test/resources/cqqueryfailover.xml
@@ -103,6 +103,6 @@
 		<region-attributes scope="distributed-ack" data-policy="replicate"/>
 	</region>
 	<region name="DistRegionNoAck">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate"/>
+		<region-attributes   scope="distributed-ack" data-policy="replicate"/>
 	</region>
 </cache> 

--- a/cppcache/integration-test/resources/regionquery_diffconfig_SG.xml
+++ b/cppcache/integration-test/resources/regionquery_diffconfig_SG.xml
@@ -90,6 +90,6 @@
                </entry>
 	</region>
 	<region name="DistRegionNoAck">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate"/>
+		<region-attributes   scope="distributed-ack" data-policy="replicate"/>
 	</region>
 </cache> 

--- a/cppcache/integration-test/resources/remotequery.xml
+++ b/cppcache/integration-test/resources/remotequery.xml
@@ -106,6 +106,6 @@
 		<region-attributes scope="distributed-ack" data-policy="replicate"/>
 	</region>
 	<region name="DistRegionNoAck">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate"/>
+		<region-attributes   scope="distributed-ack" data-policy="replicate"/>
 	</region>
 </cache> 

--- a/cppcache/integration-test/resources/remotequery2.xml
+++ b/cppcache/integration-test/resources/remotequery2.xml
@@ -106,6 +106,6 @@
 		<region-attributes scope="distributed-ack" data-policy="replicate"/>
 	</region>
 	<region name="DistRegionNoAck">
-		<region-attributes   scope="distributed-no-ack" data-policy="replicate"/>
+		<region-attributes   scope="distributed-ack" data-policy="replicate"/>
 	</region>
 </cache> 

--- a/cppcache/integration-test/testThinClientHADistOps.cpp
+++ b/cppcache/integration-test/testThinClientHADistOps.cpp
@@ -358,7 +358,7 @@ const char *vals[] = {"Value-1", "Value-2", "Value-3", "Value-4"};
 const char *nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4"};
 
-const char *regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
+const char *regionName = "DistRegionAck";
 
 const bool USE_ACK = true;
 const bool NO_ACK = false;
@@ -375,17 +375,14 @@ DUNIT_TASK_DEFINITION(CLIENT1, CreateClient1PoolAndRegions)
   {
     getHelper()->createPoolWithLocators("__TESTPOOL1_", locatorsG, true, 1);
 
-    getHelper()->createRegionAndAttachPool(regionNames[0], USE_ACK,
+    getHelper()->createRegionAndAttachPool(regionName, USE_ACK,
                                            "__TESTPOOL1_", true);
-    getHelper()->createRegionAndAttachPool(regionNames[1], NO_ACK,
-                                           "__TESTPOOL1_", true);
-    /* createPooledRegion( regionNames[0], USE_ACK, locatorsG,
+    /* createPooledRegion( regionName, USE_ACK, locatorsG,
      "__TESTPOOL1_" );
      createPooledRegion( regionNames[1], NO_ACK, locatorsG, "__TESTPOOL2_"
      );*/
 
-    createEntry(regionNames[0], keys[0], vals[0]);
-    createEntry(regionNames[1], keys[2], vals[2]);
+    createEntry(regionName, keys[0], vals[0]);
 
     LOG("CreateClient1PoolAndRegions complete.");
   }
@@ -395,18 +392,15 @@ DUNIT_TASK_DEFINITION(CLIENT2, CreateClient2PoolAndRegions)
   {
     getHelper()->createPoolWithLocators("__TESTPOOL1_", locatorsG, true, 1);
 
-    getHelper()->createRegionAndAttachPool(regionNames[0], USE_ACK,
-                                           "__TESTPOOL1_", true);
-    getHelper()->createRegionAndAttachPool(regionNames[1], NO_ACK,
+    getHelper()->createRegionAndAttachPool(regionName, USE_ACK,
                                            "__TESTPOOL1_", true);
 
-    /* createPooledRegion( regionNames[0], USE_ACK,  locatorsG,
+    /* createPooledRegion( regionName, USE_ACK,  locatorsG,
      "__TESTPOOL1_" );
      createPooledRegion( regionNames[1], NO_ACK,  locatorsG, "__TESTPOOL2_"
      );*/
 
-    createEntry(regionNames[0], keys[1], vals[1]);
-    createEntry(regionNames[1], keys[3], vals[3]);
+    createEntry(regionName, keys[1], vals[1]);
 
     LOG("CreateClient2PoolAndRegions complete.");
   }
@@ -414,12 +408,9 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, RegisterClient1Keys)
   {
-    auto reg0 = getHelper()->getRegion(regionNames[0]);
-    auto reg1 = getHelper()->getRegion(regionNames[1]);
+    auto reg0 = getHelper()->getRegion(regionName);
     auto vec0 = reg0->serverKeys();
-    auto vec1 = reg1->serverKeys();
     ASSERT(vec0.size() == 2, "Should have 2 keys in first region.");
-    ASSERT(vec1.size() == 2, "Should have 2 keys in second region.");
     std::string key0, key1;
     key0 = vec0[0]->toString().c_str();
     key1 = vec0[1]->toString().c_str();
@@ -429,76 +420,54 @@ DUNIT_TASK_DEFINITION(CLIENT1, RegisterClient1Keys)
     ASSERT(key1 == keys[0] || key1 == keys[1],
            "Unexpected key in first region.");
 
-    key0 = vec1[0]->toString().c_str();
-    key1 = vec1[1]->toString().c_str();
-    ASSERT(key0 != key1, "The two keys should be different in second region.");
-    ASSERT(key0 == keys[2] || key0 == keys[3],
-           "Unexpected key in second region.");
-    ASSERT(key1 == keys[2] || key1 == keys[3],
-           "Unexpected key in second region.");
-
-    doNetsearch(regionNames[0], keys[1], vals[1]);
-    doNetsearch(regionNames[1], keys[3], vals[3]);
+    doNetsearch(regionName, keys[1], vals[1]);
 
     auto keyPtr1 = CacheableKey::create(keys[1]);
-    auto keyPtr3 = CacheableKey::create(keys[3]);
 
-    auto regPtr0 = getHelper()->getRegion(regionNames[0]);
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
+    auto regPtr0 = getHelper()->getRegion(regionName);
 
     std::vector<std::shared_ptr<CacheableKey>> keys0, keys1;
     keys0.push_back(keyPtr1);
-    keys1.push_back(keyPtr3);
     regPtr0->registerKeys(keys0);
-    regPtr1->registerKeys(keys1);
     LOG("RegisterClient1Keys complete.");
   }
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, RegisterClient2Keys)
   {
-    doNetsearch(regionNames[0], keys[0], vals[0]);
-    doNetsearch(regionNames[1], keys[2], vals[2]);
+    doNetsearch(regionName, keys[0], vals[0]);
 
     auto keyPtr0 = CacheableKey::create(keys[0]);
     auto keyPtr2 = CacheableKey::create(keys[2]);
 
-    auto regPtr0 = getHelper()->getRegion(regionNames[0]);
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
+    auto regPtr0 = getHelper()->getRegion(regionName);
 
     std::vector<std::shared_ptr<CacheableKey>> keys0, keys1;
     keys0.push_back(keyPtr0);
     keys1.push_back(keyPtr2);
     regPtr0->registerKeys(keys0);
-    regPtr1->registerKeys(keys1);
     LOG("RegisterClient2Keys complete.");
   }
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, UpdateClient1Entries)
   {
-    updateEntry(regionNames[0], keys[0], nvals[0]);
-    updateEntry(regionNames[1], keys[2], nvals[2]);
+    updateEntry(regionName, keys[0], nvals[0]);
     LOG("UpdateClient1Entries complete.");
   }
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, VerifyAndUpdateClient2Entries)
   {
-    verifyEntry(regionNames[0], keys[0], nvals[0]);
-    verifyEntry(regionNames[1], keys[2], nvals[2]);
+    verifyEntry(regionName, keys[0], nvals[0]);
 
-    updateEntry(regionNames[0], keys[1], nvals[1]);
-    updateEntry(regionNames[1], keys[3], nvals[3]);
+    updateEntry(regionName, keys[1], nvals[1]);
     LOG("VerifyAndUpdateClient2Entries complete.");
   }
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, VerifyClient1Entries)
-  {
-    verifyEntry(regionNames[0], keys[1], nvals[1]);
-    verifyEntry(regionNames[1], keys[3], nvals[3]);
-  }
+  { verifyEntry(regionName, keys[1], nvals[1]); }
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, DoAbsolutelyNothing)
@@ -507,10 +476,8 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, DestroyAllKeys)
   {
-    destroyEntry(regionNames[0], keys[0]);
-    destroyEntry(regionNames[0], keys[1]);
-    destroyEntry(regionNames[1], keys[2]);
-    destroyEntry(regionNames[1], keys[3]);
+    destroyEntry(regionName, keys[0]);
+    destroyEntry(regionName, keys[1]);
   }
 END_TASK_DEFINITION
 

--- a/cppcache/integration-test/testThinClientHADistOps.cpp
+++ b/cppcache/integration-test/testThinClientHADistOps.cpp
@@ -375,12 +375,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, CreateClient1PoolAndRegions)
   {
     getHelper()->createPoolWithLocators("__TESTPOOL1_", locatorsG, true, 1);
 
-    getHelper()->createRegionAndAttachPool(regionName, USE_ACK,
-                                           "__TESTPOOL1_", true);
-    /* createPooledRegion( regionName, USE_ACK, locatorsG,
-     "__TESTPOOL1_" );
-     createPooledRegion( regionNames[1], NO_ACK, locatorsG, "__TESTPOOL2_"
-     );*/
+    getHelper()->createRegionAndAttachPool(regionName, USE_ACK, "__TESTPOOL1_",
+                                           true);
 
     createEntry(regionName, keys[0], vals[0]);
 
@@ -392,13 +388,8 @@ DUNIT_TASK_DEFINITION(CLIENT2, CreateClient2PoolAndRegions)
   {
     getHelper()->createPoolWithLocators("__TESTPOOL1_", locatorsG, true, 1);
 
-    getHelper()->createRegionAndAttachPool(regionName, USE_ACK,
-                                           "__TESTPOOL1_", true);
-
-    /* createPooledRegion( regionName, USE_ACK,  locatorsG,
-     "__TESTPOOL1_" );
-     createPooledRegion( regionNames[1], NO_ACK,  locatorsG, "__TESTPOOL2_"
-     );*/
+    getHelper()->createRegionAndAttachPool(regionName, USE_ACK, "__TESTPOOL1_",
+                                           true);
 
     createEntry(regionName, keys[1], vals[1]);
 

--- a/cppcache/integration-test/testThinClientHAEventIDMap.cpp
+++ b/cppcache/integration-test/testThinClientHAEventIDMap.cpp
@@ -405,12 +405,11 @@ const char *vals[] = {"Value-1", "Value-2", "Value-3", "Value-4"};
 const char *nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4"};
 
-const char *regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
+const char *regionName = "DistRegionAck";
 
 const bool USE_ACK = true;
 const bool NO_ACK = false;
 std::shared_ptr<DupChecker> checker1;
-std::shared_ptr<DupChecker> checker2;
 
 void initClientAndRegion(int redundancy,
                          bool clientNotificationEnabled = true) {
@@ -418,10 +417,8 @@ void initClientAndRegion(int redundancy,
   getHelper()->createPoolWithLocators("__TESTPOOL1_", locatorsG,
                                       clientNotificationEnabled, redundancy);
 
-  getHelper()->createRegionAndAttachPool(regionNames[0], USE_ACK,
+  getHelper()->createRegionAndAttachPool(regionName, USE_ACK,
                                          "__TESTPOOL1_", true);
-  getHelper()->createRegionAndAttachPool(regionNames[1], NO_ACK, "__TESTPOOL1_",
-                                         true);
 }
 
 #include "LocatorHelper.hpp"
@@ -451,18 +448,11 @@ DUNIT_TASK_DEFINITION(CLIENT2, InitClient2)
     LOG("Initialized client with redundancy level 1.");
 
     checker1 = std::make_shared<DupChecker>();
-    checker2 = std::make_shared<DupChecker>();
 
-    setCacheListener(regionNames[0], checker1);
-    setCacheListener(regionNames[1], checker2);
+    setCacheListener(regionName, checker1);
 
     try {
-      getHelper()->getRegion(regionNames[0])->registerAllKeys();
-    } catch (...) {
-    }
-
-    try {
-      getHelper()->getRegion(regionNames[1])->registerAllKeys();
+      getHelper()->getRegion(regionName)->registerAllKeys();
     } catch (...) {
     }
 
@@ -482,21 +472,13 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT1, CreateEntries)
   {
     for (int value = 1; value <= 100; value++) {
-      createIntEntry(regionNames[0], keys[0], value);
+      createIntEntry(regionName, keys[0], value);
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      createIntEntry(regionNames[0], keys[1], value);
+      createIntEntry(regionName, keys[1], value);
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      createIntEntry(regionNames[0], keys[2], value);
+      createIntEntry(regionName, keys[2], value);
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      createIntEntry(regionNames[0], keys[3], value);
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      createIntEntry(regionNames[1], keys[0], value);
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      createIntEntry(regionNames[1], keys[1], value);
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      createIntEntry(regionNames[1], keys[2], value);
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      createIntEntry(regionNames[1], keys[3], value);
+      createIntEntry(regionName, keys[3], value);
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
   }
@@ -516,19 +498,13 @@ DUNIT_TASK_DEFINITION(CLIENT2, VerifyClient2Entries)
     // wait 30 sec for notifications to complete
     std::this_thread::sleep_for(std::chrono::seconds(30));
 
-    verifyIntEntry(regionNames[0], keys[0], 100);
-    verifyIntEntry(regionNames[0], keys[1], 100);
-    verifyIntEntry(regionNames[0], keys[2], 100);
-    verifyIntEntry(regionNames[0], keys[3], 100);
-    verifyIntEntry(regionNames[1], keys[0], 100);
-    verifyIntEntry(regionNames[1], keys[1], 100);
-    verifyIntEntry(regionNames[1], keys[2], 100);
-    verifyIntEntry(regionNames[1], keys[3], 100);
+    verifyIntEntry(regionName, keys[0], 100);
+    verifyIntEntry(regionName, keys[1], 100);
+    verifyIntEntry(regionName, keys[2], 100);
+    verifyIntEntry(regionName, keys[3], 100);
 
     LOG("Validating checker1 cachelistener");
     checker1->validate();
-    LOG("Validating checker2 cachelistener");
-    checker2->validate();
 
     LOG("VerifyClient2Entries complete.");
   }

--- a/cppcache/integration-test/testThinClientHAEventIDMap.cpp
+++ b/cppcache/integration-test/testThinClientHAEventIDMap.cpp
@@ -417,8 +417,8 @@ void initClientAndRegion(int redundancy,
   getHelper()->createPoolWithLocators("__TESTPOOL1_", locatorsG,
                                       clientNotificationEnabled, redundancy);
 
-  getHelper()->createRegionAndAttachPool(regionName, USE_ACK,
-                                         "__TESTPOOL1_", true);
+  getHelper()->createRegionAndAttachPool(regionName, USE_ACK, "__TESTPOOL1_",
+                                         true);
 }
 
 #include "LocatorHelper.hpp"

--- a/cppcache/integration-test/testThinClientHAFailoverRegex.cpp
+++ b/cppcache/integration-test/testThinClientHAFailoverRegex.cpp
@@ -285,8 +285,8 @@ void initClientAndRegion(int redundancy) {
   auto pp = Properties::create();
   getHelper()->createPoolWithLocators("__TESTPOOL1_", locatorsG, true,
                                       redundancy);
-  getHelper()->createRegionAndAttachPool(regionName, USE_ACK,
-                                         "__TESTPOOL1_", true);
+  getHelper()->createRegionAndAttachPool(regionName, USE_ACK, "__TESTPOOL1_",
+                                         true);
 }
 //#include "ThinClientDurableInit.hpp"
 #include "LocatorHelper.hpp"

--- a/cppcache/integration-test/testThinClientHAFailoverRegex.cpp
+++ b/cppcache/integration-test/testThinClientHAFailoverRegex.cpp
@@ -277,7 +277,7 @@ const char *vals[] = {"Value-1", "Value-2", "Value-3", "Value-4"};
 const char *nvals[] = {"New Value-1", "New Value-2", "New Value-3",
                        "New Value-4"};
 
-const char *regionNames[] = {"DistRegionAck", "DistRegionNoAck"};
+const char *regionName = "DistRegionAck";
 
 const bool USE_ACK = true;
 void initClientAndRegion(int redundancy) {
@@ -285,9 +285,7 @@ void initClientAndRegion(int redundancy) {
   auto pp = Properties::create();
   getHelper()->createPoolWithLocators("__TESTPOOL1_", locatorsG, true,
                                       redundancy);
-  getHelper()->createRegionAndAttachPool(regionNames[0], USE_ACK,
-                                         "__TESTPOOL1_", true);
-  getHelper()->createRegionAndAttachPool(regionNames[1], USE_ACK,
+  getHelper()->createRegionAndAttachPool(regionName, USE_ACK,
                                          "__TESTPOOL1_", true);
 }
 //#include "ThinClientDurableInit.hpp"
@@ -336,7 +334,7 @@ END_TASK_DEFINITION
 
 /*DUNIT_TASK_DEFINITION( CLIENT1, StepOne )
 {
-  createRegion( regionNames[0], USE_ACK, false );
+  createRegion( regionName, USE_ACK, false );
   createRegion( regionNames[1], NO_ACK, false );
   LOG( "StepOne complete." );
 }
@@ -344,7 +342,7 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION( CLIENT2, StepTwo )
 {
-  createRegion( regionNames[0], USE_ACK, false );
+  createRegion( regionName, USE_ACK, false );
   createRegion( regionNames[1], NO_ACK, false );
 
   LOG( "StepTwo complete." );
@@ -362,37 +360,29 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, RegisterRegexes)
   {
-    auto regPtr0 = getHelper()->getRegion(regionNames[0]);
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
+    auto regPtr0 = getHelper()->getRegion(regionName);
 
     if (g_redundancyLevel > 1) {
       regPtr0->registerRegex(testregex[0]);
-      regPtr1->registerRegex(testregex[2]);
     } else {
       regPtr0->registerRegex(testregex[0]);
-      regPtr1->registerRegex(testregex[2]);
     }
   }
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
   {
-    createEntry(regionNames[0], keys[0], vals[0]);
-    createEntry(regionNames[0], keys[1], vals[1]);
-    createEntry(regionNames[1], keys[2], vals[2]);
-    createEntry(regionNames[1], keys[3], vals[3]);
+    createEntry(regionName, keys[0], vals[0]);
+    createEntry(regionName, keys[1], vals[1]);
     LOG("StepThree complete.");
   }
 END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, StepFour)
   {
-    verifyCreated(regionNames[0], keys[0]);
-    verifyCreated(regionNames[1], keys[2]);
-    verifyEntry(regionNames[0], keys[0], vals[0]);
-    verifyEntry(regionNames[1], keys[2], vals[2]);
-    doNetsearch(regionNames[0], keys[1], vals[1]);
-    doNetsearch(regionNames[1], keys[3], vals[3]);
+    verifyCreated(regionName, keys[0]);
+    verifyEntry(regionName, keys[0], vals[0]);
+    doNetsearch(regionName, keys[1], vals[1]);
     LOG("StepFour complete.");
   }
 END_TASK_DEFINITION
@@ -409,10 +399,8 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, StepFive)
   {
-    updateEntry(regionNames[0], keys[0], nvals[0]);
-    updateEntry(regionNames[0], keys[1], nvals[1]);
-    updateEntry(regionNames[1], keys[2], nvals[2]);
-    updateEntry(regionNames[1], keys[3], nvals[3]);
+    updateEntry(regionName, keys[0], nvals[0]);
+    updateEntry(regionName, keys[1], nvals[1]);
     SLEEP(1000);
     LOG("StepFive complete.");
   }
@@ -420,12 +408,9 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
   {
-    auto reg0 = getHelper()->getRegion(regionNames[0]);
-    auto reg1 = getHelper()->getRegion(regionNames[1]);
+    auto reg0 = getHelper()->getRegion(regionName);
     auto vec0 = reg0->serverKeys();
-    auto vec1 = reg1->serverKeys();
     ASSERT(vec0.size() == 2, "Should have 2 keys in first region.");
-    ASSERT(vec1.size() == 2, "Should have 2 keys in second region.");
     std::string key0, key1;
     key0 = vec0[0]->toString().c_str();
     key1 = vec0[1]->toString().c_str();
@@ -435,18 +420,8 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
     ASSERT(key1 == keys[0] || key1 == keys[1],
            "Unexpected key in first region.");
 
-    key0 = vec1[0]->toString().c_str();
-    key1 = vec1[1]->toString().c_str();
-    ASSERT(key0 != key1, "The two keys should be different in second region.");
-    ASSERT(key0 == keys[2] || key0 == keys[3],
-           "Unexpected key in second region.");
-    ASSERT(key1 == keys[2] || key1 == keys[3],
-           "Unexpected key in second region.");
-
-    verifyEntry(regionNames[0], keys[0], nvals[0]);
-    verifyEntry(regionNames[0], keys[1], vals[1]);
-    verifyEntry(regionNames[1], keys[2], nvals[2]);
-    verifyEntry(regionNames[1], keys[3], vals[3]);
+    verifyEntry(regionName, keys[0], nvals[0]);
+    verifyEntry(regionName, keys[1], vals[1]);
     LOG("StepSix complete.");
   }
 END_TASK_DEFINITION
@@ -485,10 +460,8 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, StepSeven)
   {
-    updateEntry(regionNames[0], keys[0], vals[0]);
-    updateEntry(regionNames[0], keys[1], vals[1]);
-    updateEntry(regionNames[1], keys[2], vals[2]);
-    updateEntry(regionNames[1], keys[3], vals[3]);
+    updateEntry(regionName, keys[0], vals[0]);
+    updateEntry(regionName, keys[1], vals[1]);
     SLEEP(1000);
     LOG("StepSeven complete.");
   }
@@ -496,13 +469,8 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, StepEight)
   {
-    verifyEntry(regionNames[0], keys[0], vals[0]);
-    verifyEntry(regionNames[0], keys[1], vals[1]);
-    verifyEntry(regionNames[1], keys[2], vals[2]);
-    verifyEntry(regionNames[1], keys[3], vals[3]);
-
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
-    regPtr1->unregisterRegex(testregex[2]);
+    verifyEntry(regionName, keys[0], vals[0]);
+    verifyEntry(regionName, keys[1], vals[1]);
 
     LOG("StepEight complete.");
   }
@@ -531,10 +499,8 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, StepNine)
   {
-    updateEntry(regionNames[0], keys[0], nvals[0]);
-    updateEntry(regionNames[0], keys[1], nvals[1]);
-    updateEntry(regionNames[1], keys[2], nvals[2]);
-    updateEntry(regionNames[1], keys[3], nvals[3]);
+    updateEntry(regionName, keys[0], nvals[0]);
+    updateEntry(regionName, keys[1], nvals[1]);
     SLEEP(1000);
     LOG("StepNine complete.");
   }
@@ -542,10 +508,8 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, StepTen)
   {
-    verifyEntry(regionNames[0], keys[0], nvals[0]);
-    verifyEntry(regionNames[0], keys[1], vals[1]);
-    verifyEntry(regionNames[1], keys[2], vals[2]);
-    verifyEntry(regionNames[1], keys[3], vals[3]);
+    verifyEntry(regionName, keys[0], nvals[0]);
+    verifyEntry(regionName, keys[1], vals[1]);
     LOG("StepTen complete.");
   }
 END_TASK_DEFINITION
@@ -562,10 +526,8 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT1, StepEleven)
   {
-    updateEntry(regionNames[0], keys[0], vals[0]);
-    updateEntry(regionNames[0], keys[1], vals[1]);
-    updateEntry(regionNames[1], keys[2], vals[2]);
-    updateEntry(regionNames[1], keys[3], vals[3]);
+    updateEntry(regionName, keys[0], vals[0]);
+    updateEntry(regionName, keys[1], vals[1]);
     SLEEP(1000);
     LOG("StepEleven complete.");
   }
@@ -573,10 +535,8 @@ END_TASK_DEFINITION
 
 DUNIT_TASK_DEFINITION(CLIENT2, StepTwelve)
   {
-    verifyEntry(regionNames[0], keys[0], vals[0]);
-    verifyEntry(regionNames[0], keys[1], vals[1]);
-    verifyEntry(regionNames[1], keys[2], vals[2]);
-    verifyEntry(regionNames[1], keys[3], vals[3]);
+    verifyEntry(regionName, keys[0], vals[0]);
+    verifyEntry(regionName, keys[1], vals[1]);
     LOG("StepTwelve complete.");
   }
 END_TASK_DEFINITION

--- a/cppcache/integration-test/testThinClientLocator.cpp
+++ b/cppcache/integration-test/testThinClientLocator.cpp
@@ -53,8 +53,6 @@ DUNIT_TASK(CLIENT1, StepOne)
                        true);
     getHelper()->createPooledRegion(regionNames[0], USE_ACK, locHostPort,
                                     "__TEST_POOL1__", true, true);
-    getHelper()->createPooledRegion(regionNames[1], NO_ACK, locHostPort,
-                                    "__TEST_POOL1__", true, true);
     LOG("StepOne complete.");
   }
 END_TASK(StepOne)
@@ -64,8 +62,6 @@ DUNIT_TASK(CLIENT2, StepTwo)
                        true);
     getHelper()->createPooledRegion(regionNames[0], USE_ACK, locHostPort,
                                     "__TEST_POOL1__", true, true);
-    getHelper()->createPooledRegion(regionNames[1], NO_ACK, locHostPort,
-                                    "__TEST_POOL1__", true, true);
     LOG("StepTwo complete.");
   }
 END_TASK(StepTwo)
@@ -73,34 +69,27 @@ END_TASK(StepTwo)
 DUNIT_TASK(CLIENT1, StepThree)
   {
     createEntry(regionNames[0], keys[0], vals[0]);
-    createEntry(regionNames[1], keys[2], vals[2]);
     LOG("StepThree complete.");
   }
 END_TASK(StepThree)
 DUNIT_TASK(CLIENT2, StepFour)
   {
     doNetsearch(regionNames[0], keys[0], vals[0]);
-    doNetsearch(regionNames[1], keys[2], vals[2]);
     createEntry(regionNames[0], keys[1], vals[1]);
-    createEntry(regionNames[1], keys[3], vals[3]);
     LOG("StepFour complete.");
   }
 END_TASK(StepFour)
 DUNIT_TASK(CLIENT1, StepFive)
   {
     doNetsearch(regionNames[0], keys[1], vals[1]);
-    doNetsearch(regionNames[1], keys[3], vals[3]);
     updateEntry(regionNames[0], keys[0], nvals[0]);
-    updateEntry(regionNames[1], keys[2], nvals[2]);
     LOG("StepFive complete.");
   }
 END_TASK(StepFive)
 DUNIT_TASK(CLIENT2, StepSix)
   {
     doNetsearch(regionNames[0], keys[0], vals[0], false);
-    doNetsearch(regionNames[1], keys[2], vals[2], false);
     updateEntry(regionNames[0], keys[1], nvals[1]);
-    updateEntry(regionNames[1], keys[3], nvals[3]);
     LOG("StepSix complete.");
   }
 END_TASK(StepSix)

--- a/cppcache/integration-test/testThinClientPRPutAllFailover.cpp
+++ b/cppcache/integration-test/testThinClientPRPutAllFailover.cpp
@@ -82,8 +82,6 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepOne_Pooled_Locator_Client1)
     getHelper()->createPoolWithLocators("__TEST_POOL1__", locatorsG);
     getHelper()->createRegionAndAttachPool(regionNames[0], USE_ACK,
                                            "__TEST_POOL1__");
-    getHelper()->createRegionAndAttachPool(regionNames[1], NO_ACK,
-                                           "__TEST_POOL1__");
 
     reg1Listener1 = std::make_shared<TallyListener>();
     setCacheListener(regionNames[0], reg1Listener1);
@@ -98,8 +96,6 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepOne_Pooled_Locator_Client2)
     getHelper()->createPoolWithLocators("__TEST_POOL1__", locatorsG, true, 2);
     getHelper()->createRegionAndAttachPool(regionNames[0], USE_ACK,
                                            "__TEST_POOL1__");
-    getHelper()->createRegionAndAttachPool(regionNames[1], NO_ACK,
-                                           "__TEST_POOL1__");
 
     reg1Listener1 = std::make_shared<TallyListener>();
     setCacheListener(regionNames[0], reg1Listener1);
@@ -111,8 +107,6 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepTwo_RegisterAllKeys)
   {
     auto regPtr0 = getHelper()->getRegion(regionNames[0]);
     regPtr0->registerAllKeys();
-    auto regPtr1 = getHelper()->getRegion(regionNames[1]);
-    regPtr1->registerAllKeys();
     LOG("StepTwo_Pooled_EndPoint_RegisterAllKeys complete.");
   }
 END_TASK_DEFINITION

--- a/cppcache/integration-test/testThinClientRemoteQueryTimeout.cpp
+++ b/cppcache/integration-test/testThinClientRemoteQueryTimeout.cpp
@@ -169,7 +169,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
     try {
       LOG("EXECUTE 1 START");
 
-      results = qry->execute(std::chrono::seconds(3));
+      results = qry->execute(std::chrono::milliseconds(100));
 
       LOG("EXECUTE 1 STOP");
       std::string logmsg = "Result size is " + std::to_string(results->size());
@@ -187,7 +187,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
       LOG(logmsg.c_str());
     }
 
-    SLEEP(150000);  // sleep 2.5 min to allow server query to complete
+    // SLEEP(150000);  // sleep 2.5 min to allow server query to complete
+    SLEEP(15000);  // sleep 2.5 min to allow server query to complete
 
     LOG("StepThree complete.");
   }
@@ -249,7 +250,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepFive)
     try {
       LOG("EXECUTE 3 START");
 
-      results = qry->execute(std::chrono::seconds(2));
+      results = qry->execute(std::chrono::milliseconds(100));
 
       LOG("EXECUTE 3 STOP");
       std::string logmsg = "Result size is " + std::to_string(results->size());
@@ -290,7 +291,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepSix)
     try {
       LOG("EXECUTE 4 START");
 
-      results = qry->execute(std::chrono::seconds(850));
+      results = qry->execute(std::chrono::seconds(850000));
 
       LOG("EXECUTE 4 STOP");
       std::string logmsg = "Result size is " + std::to_string(results->size());
@@ -337,7 +338,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepSeven)
           paramList->push_back(Cacheable::create(queryparamSetSS[5][j]));
         }
       }
-      results = qry->execute(paramList, std::chrono::seconds(1));
+      results = qry->execute(paramList, std::chrono::milliseconds(2000));
 
       LOG("EXECUTE Five STOP");
       std::string logmsg = "Result size is " + std::to_string(results->size());
@@ -389,7 +390,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepEight)
         }
       }
 
-      results = qry->execute(paramList, std::chrono::seconds(850));
+      results = qry->execute(paramList, std::chrono::seconds(850000));
 
       LOG("EXECUTE 6 STOP");
       std::string logmsg = "Result size is " + std::to_string(results->size());
@@ -447,7 +448,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, verifyNegativeValueTimeout)
       LOG(logmsg.c_str());
     }
 
-    SLEEP(150000);  // sleep 2.5 min to allow server query to complete
+    // SLEEP(150000);  // sleep 2.5 min to allow server query to complete
+    SLEEP(15000);  // sleep 2.5 min to allow server query to complete
 
     LOG("StepThree complete.");
   }
@@ -491,7 +493,8 @@ DUNIT_TASK_DEFINITION(CLIENT1, verifyLargeValueTimeout)
       LOG(logmsg.c_str());
     }
 
-    SLEEP(150000);  // sleep 2.5 min to allow server query to complete
+    // SLEEP(150000);  // sleep 2.5 min to allow server query to complete
+    SLEEP(15000);  // sleep 2.5 min to allow server query to complete
 
     LOG("StepThree complete.");
   }
@@ -559,12 +562,12 @@ void UnsetPortfolioType() { CALL_TASK(UnsetPortfolioTypeToPdx); }
 DUNIT_MAIN
   {
     // Basic Old Test
-    runRemoteQueryTimeoutTest();
+    // runRemoteQueryTimeoutTest(); // not Pdx
 
-    UnsetPortfolioType();
+    UnsetPortfolioType();  // not needed, m_isPdx already false
     for (int runIdx = 1; runIdx <= 2; ++runIdx) {
       // New Test with Pool + EP
-      runRemoteQueryTimeoutTest();
+      runRemoteQueryTimeoutTest();  // Same as line 574
       setPortfolioPdxType();
     }
   }

--- a/cppcache/integration-test/testThinClientRemoteQueryTimeout.cpp
+++ b/cppcache/integration-test/testThinClientRemoteQueryTimeout.cpp
@@ -187,8 +187,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepThree)
       LOG(logmsg.c_str());
     }
 
-    // SLEEP(150000);  // sleep 2.5 min to allow server query to complete
-    SLEEP(15000);  // sleep 2.5 min to allow server query to complete
+    SLEEP(15000);
 
     LOG("StepThree complete.");
   }
@@ -291,7 +290,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepSix)
     try {
       LOG("EXECUTE 4 START");
 
-      results = qry->execute(std::chrono::seconds(850000));
+      results = qry->execute(std::chrono::seconds(850));
 
       LOG("EXECUTE 4 STOP");
       std::string logmsg = "Result size is " + std::to_string(results->size());
@@ -390,7 +389,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, StepEight)
         }
       }
 
-      results = qry->execute(paramList, std::chrono::seconds(850000));
+      results = qry->execute(paramList, std::chrono::seconds(850));
 
       LOG("EXECUTE 6 STOP");
       std::string logmsg = "Result size is " + std::to_string(results->size());
@@ -448,8 +447,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, verifyNegativeValueTimeout)
       LOG(logmsg.c_str());
     }
 
-    // SLEEP(150000);  // sleep 2.5 min to allow server query to complete
-    SLEEP(15000);  // sleep 2.5 min to allow server query to complete
+    SLEEP(15000);
 
     LOG("StepThree complete.");
   }
@@ -493,8 +491,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, verifyLargeValueTimeout)
       LOG(logmsg.c_str());
     }
 
-    // SLEEP(150000);  // sleep 2.5 min to allow server query to complete
-    SLEEP(15000);  // sleep 2.5 min to allow server query to complete
+    SLEEP(15000);
 
     LOG("StepThree complete.");
   }
@@ -561,13 +558,11 @@ void UnsetPortfolioType() { CALL_TASK(UnsetPortfolioTypeToPdx); }
 
 DUNIT_MAIN
   {
-    // Basic Old Test
-    // runRemoteQueryTimeoutTest(); // not Pdx
+    UnsetPortfolioType();
 
-    UnsetPortfolioType();  // not needed, m_isPdx already false
     for (int runIdx = 1; runIdx <= 2; ++runIdx) {
       // New Test with Pool + EP
-      runRemoteQueryTimeoutTest();  // Same as line 574
+      runRemoteQueryTimeoutTest();
       setPortfolioPdxType();
     }
   }

--- a/cppcache/integration-test/testThinClientTransactionsXA.cpp
+++ b/cppcache/integration-test/testThinClientTransactionsXA.cpp
@@ -18,8 +18,5 @@
 #include "ThinClientTransactionsXA.hpp"
 
 DUNIT_MAIN
-  {
-    runTransactionOps(false);
-    runTransactionOps(true);
-  }
+  { runTransactionOps(); }
 END_MAIN


### PR DESCRIPTION
There's 22 tests that were made to pass by simply by changing the region scope to no-ack in the server xml files. This PR reenables removes the no-ack components of the test and removes all no-ack regions from the server xml files.