### PR TITLE
GEODE-9147: Revert to multi-hop PUTALL in the face of missing metadata

### DIFF
--- a/cppcache/integration/test/RegionPutAllTest.cpp
+++ b/cppcache/integration/test/RegionPutAllTest.cpp
@@ -50,7 +50,10 @@ Cache createCache() {
   using apache::geode::client::CacheFactory;
 
   auto cache = CacheFactory()
-                   .set("log-level", "none")
+                   .set("log-level", "debug")
+                   .set("log-file", "RegionPutAllTest.log")
+                   .set("log-file-size-limit", "100")
+                   .set("log-disk-space-limit", "1000")
                    .set("statistic-sampling-enabled", "false")
                    .create();
 
@@ -102,4 +105,39 @@ TEST(RegionPutAllTest, putAllToPartitionedRegion) {
   }
 }
 
+//
+// verifies that putall works when not all metadata is present, i.e. not all
+// buckets exist yet on the cluster.
+//
+TEST(RegionPutAllTest, putAllAndVerifyKeysExist) {
+  Cluster cluster{LocatorCount{1}, ServerCount{3}};
+
+  cluster.start();
+
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("PARTITION")
+      .execute();
+
+  auto cache = createCache();
+  auto pool = createPool(cluster, cache);
+  auto region = setupRegion(cache, pool);
+
+  for (int i = 0; i < 50; i++) {
+    region->put(std::to_string(i), Cacheable::create(i));
+  }
+
+  HashMapOfCacheable all;
+  for (int i = 0; i < 113; i++) {
+    all.emplace(CacheableKey::create(std::to_string(i)), Cacheable::create(i));
+  }
+
+  std::this_thread::sleep_for(std::chrono::seconds(10));
+  region->putAll(all);
+  for (auto& key : all) {
+    ASSERT_TRUE(region->containsKeyOnServer(key.first));
+  }
+}
 }  // namespace

--- a/cppcache/integration/test/RegionPutAllTest.cpp
+++ b/cppcache/integration/test/RegionPutAllTest.cpp
@@ -50,10 +50,7 @@ Cache createCache() {
   using apache::geode::client::CacheFactory;
 
   auto cache = CacheFactory()
-                   .set("log-level", "debug")
-                   .set("log-file", "RegionPutAllTest.log")
-                   .set("log-file-size-limit", "100")
-                   .set("log-disk-space-limit", "1000")
+                   .set("log-level", "none")
                    .set("statistic-sampling-enabled", "false")
                    .create();
 

--- a/cppcache/src/ClientMetadataService.cpp
+++ b/cppcache/src/ClientMetadataService.cpp
@@ -358,8 +358,9 @@ ClientMetadataService::getServerToFilterMap(
       clientMetadata->getServerLocation(bucketId, isPrimary, serverLocation,
                                         version);
       if (!(serverLocation && serverLocation->isValid())) {
-        keysWhichLeft.push_back(key);
-        continue;
+        // If we're missing any metadata, give up.  This will cause us to revert
+        // to multi-hop, which is consistent with the Java client.
+        return nullptr;
       }
 
       buckets[bucketId] = serverLocation;

--- a/cppcache/src/ClientMetadataService.cpp
+++ b/cppcache/src/ClientMetadataService.cpp
@@ -194,7 +194,6 @@ std::shared_ptr<ClientMetadata> ClientMetadataService::SendClientPRMetadata(
     auto newCptr = std::make_shared<ClientMetadata>(*cptr);
     for (const auto& v : *metadata) {
       if (!v.empty()) {
-        LOGDEBUG("%s Updating bucket server locations", __FUNCTION__);
         newCptr->updateBucketServerLocations(v.at(0)->getBucketId(), v);
       }
     }
@@ -327,8 +326,6 @@ ClientMetadataService::getServerToFilterMap(
     return nullptr;
   }
 
-  LOGDEBUG("%s(%p): Getting server to filter map with %d buckets in metadata",
-           __FUNCTION__, this, clientMetadata->getTotalNumBuckets());
   auto serverToFilterMap = std::make_shared<ServerToFilterMap>();
 
   std::vector<std::shared_ptr<CacheableKey>> keysWhichLeft;

--- a/cppcache/src/ClientMetadataService.cpp
+++ b/cppcache/src/ClientMetadataService.cpp
@@ -173,16 +173,11 @@ std::shared_ptr<ClientMetadata> ClientMetadataService::SendClientPRMetadata(
       new DataOutput(m_cache->createDataOutput(m_pool)), regionPath);
   TcrMessageReply reply(true, nullptr);
   // send this message to server and get metadata from server.
-  LOGFINE("Now sending GET_CLIENT_PR_METADATA for getting from server: %s",
-          regionPath);
   std::shared_ptr<Region> region = nullptr;
   GfErrType err = m_pool->sendSyncRequest(request, reply);
-  LOGFINE("Got reply for GET_CLIENT_PR_METADATA: err=%d, type=%d", err,
-          reply.getMessageType());
   if (err == GF_NOERR &&
       reply.getMessageType() == TcrMessage::RESPONSE_CLIENT_PR_METADATA) {
     region = m_cache->getRegion(regionPath);
-    LOGDEBUG("%s region ptr=%p", __FUNCTION__, region.get());
     if (region != nullptr) {
       if (auto lregion = std::dynamic_pointer_cast<LocalRegion>(region)) {
         lregion->getRegionStats()->incMetaDataRefreshCount();
@@ -190,16 +185,13 @@ std::shared_ptr<ClientMetadata> ClientMetadataService::SendClientPRMetadata(
     }
     auto metadata = reply.getMetadata();
     if (metadata == nullptr) {
-      LOGDEBUG("%s metadata is nullptr", __FUNCTION__);
       return nullptr;
     }
     if (metadata->empty()) {
-      LOGDEBUG("%s metadata is empty", __FUNCTION__);
       delete metadata;
       return nullptr;
     }
     auto newCptr = std::make_shared<ClientMetadata>(*cptr);
-    LOGDEBUG("%s creating new metadata object", __FUNCTION__);
     for (const auto& v : *metadata) {
       if (!v.empty()) {
         LOGDEBUG("%s Updating bucket server locations", __FUNCTION__);


### PR DESCRIPTION
- This matches the behavior of the Java client
- Our current code to "tack on" values that we don't have metadata
  for will sometimes result in EventIds reaching a server out-of-order,
  causing them to be dropped and resulting in data loss.  Resorting
  to multi-hop avoids this altogether.