### PR TITLE
GEODE-9179: Solve potential race conditions in UTs

### DIFF
--- a/cppcache/src/util/concurrent/binary_semaphore.cpp
+++ b/cppcache/src/util/concurrent/binary_semaphore.cpp
@@ -35,6 +35,16 @@ void binary_semaphore::acquire() {
   released_ = false;
 }
 
+bool binary_semaphore::try_acquire_for(
+    const std::chrono::milliseconds& period) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (!cv_.wait_for(lock, period, [this]() { return released_; })) {
+    return false;
+  }
+
+  released_ = false;
+  return true;
+}
 }  // namespace client
 }  // namespace geode
 }  // namespace apache

--- a/cppcache/src/util/concurrent/binary_semaphore.hpp
+++ b/cppcache/src/util/concurrent/binary_semaphore.hpp
@@ -32,6 +32,7 @@ class binary_semaphore {
 
   void release();
   void acquire();
+  bool try_acquire_for(const std::chrono::milliseconds& period);
 
  protected:
   bool released_;

--- a/cppcache/test/gmock_extensions.h
+++ b/cppcache/test/gmock_extensions.h
@@ -22,6 +22,6 @@
 
 #include <gmock/gmock.h>
 
-ACTION_P(CvNotifyOne, cv) { cv->notify_one(); }
+ACTION_P(ReleaseSem, sem) { sem->release(); }
 
 #endif  // GEODE_GMOCK_EXTENSIONS_H_


### PR DESCRIPTION
 - Solved a potential race condition in ExpiryTaskTest UTs TS.
   condition_variable was replaced by a binary_semaphore.
 - Implemented try_acquire_for binary_semaphore operation.