### PR TITLE
Replaced deprecated bintray addresses.

### DIFF
--- a/dependencies/boost/CMakeLists.txt
+++ b/dependencies/boost/CMakeLists.txt
@@ -76,7 +76,7 @@ string(REPLACE "." "_" _VERSION_UNDERSCORE ${PROJECT_VERSION})
 set(EXTERN ${PROJECT_NAME}-extern)
 include(ExternalProject)
 ExternalProject_Add(${EXTERN}
-   URL "https://dl.bintray.com/boostorg/release/${PROJECT_VERSION}/source/boost_${_VERSION_UNDERSCORE}.tar.gz"
+   URL "https://boostorg.jfrog.io/artifactory/main/release/${PROJECT_VERSION}/source/boost_${_VERSION_UNDERSCORE}.tar.gz"
        "https://sourceforge.net/projects/boost/files/boost/${PROJECT_VERSION}/boost_${_VERSION_UNDERSCORE}.tar.gz/download"
    URL_HASH SHA256=${SHA256}
    UPDATE_COMMAND ""


### PR DESCRIPTION
> Bintray is “sunsetting” on the 1st of May. 
> At that time, you will be unable to download boost releases from there.
> Before that time, their service will be occasionally interrupted.
> 
> 
> We will be updating the web site before then, but the new location is:
> 
> https://boostorg.jfrog.io/artifactory/main/release/
> 
> So instead of downloading from:
> 	https://dl.bintray.com/boostorg/release/1.76.0/source/boost_1_76_0.tar.gz
> 
> You should download from:
> 	https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz
> 