### PR TITLE
GEODE-9189: Upgrades dependencies. 

### DIFF
--- a/cppcache/integration/benchmark/RegionBM.cpp
+++ b/cppcache/integration/benchmark/RegionBM.cpp
@@ -59,7 +59,7 @@ class RegionBM : public benchmark::Fixture {
   void SetUp(benchmark::State&) override {
     if (!cluster) {
       cluster = std::unique_ptr<Cluster>(
-          new Cluster(Name{name_}, LocatorCount{1}, ServerCount{1}));
+          new Cluster(::Name{name_}, LocatorCount{1}, ServerCount{1}));
       cluster->getGfsh()
           .create()
           .region()

--- a/cppcache/test/CMakeLists.txt
+++ b/cppcache/test/CMakeLists.txt
@@ -78,6 +78,12 @@ if (MSVC)
   target_compile_options(apache-geode_unittests PRIVATE "/MD$<$<CONFIG:Debug>:d>")
 endif()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(apache-geode_unittests PRIVATE
+    -Wno-used-but-marked-unused # GTest uses unused attribute incorrectly
+  )
+endif()
+
 target_link_libraries(apache-geode_unittests
   PRIVATE
     apache-geode-static

--- a/dependencies/ACE/CMakeLists.txt
+++ b/dependencies/ACE/CMakeLists.txt
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project( ACE VERSION 7.0.0 LANGUAGES NONE )
+project(ACE VERSION 7.0.1 LANGUAGES NONE)
 
-set( SHA256 9dfdc31664bc2faf7832e50197203fe274c661a56f17b18af2b227ddb34174be )
+set(SHA256 a28339750620c70cd29a8a7088a4bc6ebaf1ff7ba667498a0279ac97f0e32e01)
 
 if ("SunOS" STREQUAL ${CMAKE_SYSTEM_NAME})
   set( ACE_PLATFORM sunos5_sunc++ )

--- a/dependencies/benchmark/CMakeLists.txt
+++ b/dependencies/benchmark/CMakeLists.txt
@@ -13,22 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project( benchmark VERSION 1.5.2 LANGUAGES NONE )
+project(benchmark LANGUAGES NONE)
 
-set( SHA256 21e6e096c9a9a88076b46bd38c33660f565fa050ca427125f64c4a8bf60f336b )
-set( DEPENDS GTest::gtest )
+set(DEPENDS GTest::gtest)
 
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "SunPro")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
 endif()
 
-set( EXTERN ${PROJECT_NAME}-extern )
+set(EXTERN ${PROJECT_NAME}-extern)
 include(ExternalProject)
-ExternalProject_Add( ${EXTERN}
-  URL "https://github.com/google/benchmark/archive/v${PROJECT_VERSION}.zip"
-  URL_HASH SHA256=${SHA256}
-  UPDATE_COMMAND ""
+ExternalProject_Add(${EXTERN}
+  GIT_REPOSITORY "https://github.com/google/benchmark.git"
+  GIT_SHALLOW ON
   CMAKE_ARGS
     -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
     -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
@@ -43,8 +41,8 @@ ExternalProject_Add( ${EXTERN}
   DEPENDS ${DEPENDS}
 )
 
-ExternalProject_Get_Property( ${EXTERN} SOURCE_DIR )
-ExternalProject_Get_Property( ${EXTERN} INSTALL_DIR )
+ExternalProject_Get_Property(${EXTERN} SOURCE_DIR)
+ExternalProject_Get_Property(${EXTERN} INSTALL_DIR)
 set(INSTALL_DIR "${INSTALL_DIR}/$<CONFIG>")
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "SunPro")

--- a/dependencies/benchmark/CMakeLists.txt
+++ b/dependencies/benchmark/CMakeLists.txt
@@ -26,7 +26,8 @@ set(EXTERN ${PROJECT_NAME}-extern)
 include(ExternalProject)
 ExternalProject_Add(${EXTERN}
   GIT_REPOSITORY "https://github.com/google/benchmark.git"
-  GIT_SHALLOW ON
+  GIT_SHALLOW TRUE
+  UPDATE_DISCONNECTED TRUE
   CMAKE_ARGS
     -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
     -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}

--- a/dependencies/boost/CMakeLists.txt
+++ b/dependencies/boost/CMakeLists.txt
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project(boost VERSION 1.75.0 LANGUAGES NONE)
+project(boost VERSION 1.76.0 LANGUAGES NONE)
 
-set(SHA256 aeb26f80e80945e82ee93e5939baebdca47b9dee80a07d3144be1e1a6a66dd6a)
+set(HASH SHA256=7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca)
 
 if (WIN32)
   set(BOOTSTRAP_COMMAND ./bootstrap.bat)
@@ -78,7 +78,7 @@ include(ExternalProject)
 ExternalProject_Add(${EXTERN}
    URL "https://boostorg.jfrog.io/artifactory/main/release/${PROJECT_VERSION}/source/boost_${_VERSION_UNDERSCORE}.tar.gz"
        "https://sourceforge.net/projects/boost/files/boost/${PROJECT_VERSION}/boost_${_VERSION_UNDERSCORE}.tar.gz/download"
-   URL_HASH SHA256=${SHA256}
+   URL_HASH ${HASH}
    UPDATE_COMMAND ""
    BUILD_IN_SOURCE 1
    CONFIGURE_COMMAND ${BOOTSTRAP_COMMAND} ${BOOTSTRAP_FLAGS}

--- a/dependencies/gtest/CMakeLists.txt
+++ b/dependencies/gtest/CMakeLists.txt
@@ -18,7 +18,8 @@ project(gtest LANGUAGES NONE)
 include(ExternalProject)
 ExternalProject_Add( ${PROJECT_NAME}-extern
   GIT_REPOSITORY "https://github.com/google/googletest.git"
-  GIT_SHALLOW ON
+  GIT_SHALLOW TRUE
+  UPDATE_DISCONNECTED TRUE
   CMAKE_ARGS
     -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
     -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}

--- a/dependencies/gtest/CMakeLists.txt
+++ b/dependencies/gtest/CMakeLists.txt
@@ -13,14 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project( gtest VERSION 1.10.0 LANGUAGES NONE )
-
-set( SHA256 94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91 )
+project(gtest LANGUAGES NONE)
 
 include(ExternalProject)
 ExternalProject_Add( ${PROJECT_NAME}-extern
-  URL "https://github.com/google/googletest/archive/release-${PROJECT_VERSION}.zip"
-  URL_HASH SHA256=${SHA256}
+  GIT_REPOSITORY "https://github.com/google/googletest.git"
+  GIT_SHALLOW ON
   CMAKE_ARGS
     -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
     -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
@@ -33,7 +31,7 @@ ExternalProject_Add( ${PROJECT_NAME}-extern
     -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}
 )
 
-ExternalProject_Get_Property( ${PROJECT_NAME}-extern INSTALL_DIR )
+ExternalProject_Get_Property(${PROJECT_NAME}-extern INSTALL_DIR)
 
 if(WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 /D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING")

--- a/dependencies/sqlite/CMakeLists.txt
+++ b/dependencies/sqlite/CMakeLists.txt
@@ -13,16 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project( sqlite VERSION 3340100 LANGUAGES NONE )
+project( sqlite VERSION 3350500 LANGUAGES NONE )
 
-set( SHA256 e0b1c0345fe4338b936e17da8e1bd88366cd210e576834546977f040c12a8f68 )
+set( HASH SHA3_256=8175cba8e28c2274aa6f8305076116622a4ecb7829673b92290dc047fba9bba6 )
 
 
 set( EXTERN ${PROJECT_NAME}-extern )
 include(ExternalProject)
 ExternalProject_Add( ${EXTERN}
   URL "https://www.sqlite.org/2021/sqlite-amalgamation-${PROJECT_VERSION}.zip"
-  URL_HASH SHA256=${SHA256}
+  URL_HASH ${HASH}
   UPDATE_COMMAND ""
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE=$<CONFIG>

--- a/dependencies/xerces-c/CMakeLists.txt
+++ b/dependencies/xerces-c/CMakeLists.txt
@@ -30,7 +30,7 @@ string(APPEND CMAKE_C_FLAGS " -w")
 string(APPEND CMAKE_CXX_FLAGS " -w")
 
 ExternalProject_Add( ${PROJECT_NAME}-extern
-  URL "http://archive.apache.org/dist/xerces/c/3/sources/xerces-c-${PROJECT_VERSION}.tar.gz"
+  URL "https://www.apache.org/dyn/closer.lua/xerces/c/3/sources/xerces-c-${PROJECT_VERSION}.tar.gz?action=download"
   URL_HASH SHA256=${SHA256}
   UPDATE_COMMAND ""
   CMAKE_ARGS


### PR DESCRIPTION
Upgrades Boost to 1.76.
Upgrades ACE to 7.0.1.
Upgrades SQLite to 3.35.5
Upgrades GTest to follow head.
Upgrades Benchmark to follow head.
Fixes Xerces-C to use Apache mirrors.