### PR TITLE
GEODE-9193: Use local object variable for PING messages.

### DIFF
--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -510,9 +510,9 @@ void TcrEndpoint::pingServer(ThinClientPoolDM* poolDM) {
     LOGFINEST("Sending ping message to endpoint %s", m_name.c_str());
     GfErrType error;
     if (poolDM != nullptr) {
-      error = poolDM->sendRequestToEP(*pingMsg, reply, this);
+      error = poolDM->sendRequestToEP(pingMsg, reply, this);
     } else {
-      error = send(*pingMsg, reply);
+      error = send(pingMsg, reply);
     }
     LOGFINEST("Sent ping message to endpoint %s with error code %d%s",
               m_name.c_str(), error, error == GF_NOERR ? " (no error)" : "");

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -504,7 +504,8 @@ void TcrEndpoint::pingServer(ThinClientPoolDM* poolDM) {
   }
 
   if (!m_msgSent && !m_pingSent) {
-    TcrMessagePing* pingMsg = TcrMessage::getPingMessage(m_cacheImpl);
+    TcrMessagePing pingMsg(new DataOutput(m_cacheImpl->createDataOutput()),
+                           true);
     TcrMessageReply reply(true, nullptr);
     LOGFINEST("Sending ping message to endpoint %s", m_name.c_str());
     GfErrType error;

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -504,8 +504,8 @@ void TcrEndpoint::pingServer(ThinClientPoolDM* poolDM) {
   }
 
   if (!m_msgSent && !m_pingSent) {
-    TcrMessagePing pingMsg(new DataOutput(m_cacheImpl->createDataOutput()),
-                           true);
+    TcrMessagePing pingMsg(std::unique_ptr<DataOutput>(
+        new DataOutput(m_cacheImpl->createDataOutput())));
     TcrMessageReply reply(true, nullptr);
     LOGFINEST("Sending ping message to endpoint %s", m_name.c_str());
     GfErrType error;

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -2082,10 +2082,9 @@ TcrMessageReply::TcrMessageReply(bool decodeAll,
   if (connectionDM != nullptr) isSecurityOn = connectionDM->isSecurityOn();
 }
 
-TcrMessagePing::TcrMessagePing(DataOutput* dataOutput, bool decodeAll) {
+TcrMessagePing::TcrMessagePing(std::unique_ptr<DataOutput> dataOutput) {
   m_msgType = TcrMessage::PING;
-  m_decodeAll = decodeAll;
-  m_request.reset(dataOutput);
+  m_request = std::move(dataOutput);
   writeHeader(m_msgType, 0);
   writeMessageLength();
 }

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -341,12 +341,6 @@ std::shared_ptr<CacheableHashSet> TcrMessage::getTombstoneKeys() const {
   return m_tombstoneKeys;
 }
 
-TcrMessagePing* TcrMessage::getPingMessage(CacheImpl* cacheImpl) {
-  static auto pingMsg =
-      new TcrMessagePing(new DataOutput(cacheImpl->createDataOutput()), true);
-  return pingMsg;
-}
-
 TcrMessage* TcrMessage::getAllEPDisMess() {
   static auto allEPDisconnected = new TcrMessageReply(true, nullptr);
   return allEPDisconnected;

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -908,7 +908,7 @@ class TcrMessageExecuteFunction : public TcrMessage {
 
 class TcrMessagePing : public TcrMessage {
  public:
-  TcrMessagePing(std::unique_ptr<DataOutput> dataOutput);
+  explicit TcrMessagePing(std::unique_ptr<DataOutput> dataOutput);
 
   ~TcrMessagePing() override = default;
 };

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -908,7 +908,7 @@ class TcrMessageExecuteFunction : public TcrMessage {
 
 class TcrMessagePing : public TcrMessage {
  public:
-  TcrMessagePing(DataOutput* dataOutput, bool decodeAll);
+  TcrMessagePing(std::unique_ptr<DataOutput> dataOutput);
 
   ~TcrMessagePing() override = default;
 };

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -258,9 +258,6 @@ class TcrMessage {
   std::chrono::milliseconds getTimeout() const;
   void setTimeout(std::chrono::milliseconds timeout);
 
-  /* we need a static method to generate ping */
-  /* The caller should not delete the message since it is global. */
-  static TcrMessagePing* getPingMessage(CacheImpl* cacheImpl);
   static TcrMessage* getAllEPDisMess();
   /* we need a static method to generate close connection message */
   /* The caller should not delete the message since it is global. */

--- a/cppcache/test/TcrMessageTest.cpp
+++ b/cppcache/test/TcrMessageTest.cpp
@@ -548,8 +548,6 @@ TEST_F(TcrMessageTest, testConstructorGetPdxIdForEnum) {
 TEST_F(TcrMessageTest, testConstructorAddPdxEnum) {
   using apache::geode::client::TcrMessageAddPdxEnum;
 
-  std::shared_ptr<Cacheable> myPtr(CacheableString::createDeserializable());
-
   TcrMessageAddPdxEnum message(new DataOutputUnderTest(),
                                static_cast<std::shared_ptr<Cacheable>>(nullptr),
                                static_cast<ThinClientBaseDM *>(nullptr), 42);
@@ -747,9 +745,6 @@ TEST_F(TcrMessageTest, testConstructorExecuteCq) {
 TEST_F(TcrMessageTest, testConstructorWithGinormousQueryExecuteCq) {
   using apache::geode::client::TcrMessageExecuteCq;
 
-  std::shared_ptr<Cacheable> myCacheablePtr(
-      CacheableString::createDeserializable());
-
   std::ostringstream oss;
   oss << "select * from /somewhere s where s.data.id in SET(";
   // Ensure over 64KiB of query string.
@@ -781,9 +776,6 @@ TEST_F(TcrMessageTest, testConstructorWithGinormousQueryExecuteCq) {
 TEST_F(TcrMessageTest, testConstructorExecuteCqWithIr) {
   using apache::geode::client::TcrMessageExecuteCqWithIr;
 
-  std::shared_ptr<Cacheable> myCacheablePtr(
-      CacheableString::createDeserializable());
-
   TcrMessageExecuteCqWithIr testMessage(
       new DataOutputUnderTest(), "ExecuteCQWithIr", "select * from /somewhere",
       CqState::RUNNING, false, static_cast<ThinClientBaseDM *>(nullptr));
@@ -801,10 +793,8 @@ TEST_F(TcrMessageTest, testConstructorExecuteCqWithIr) {
 TEST_F(TcrMessageTest, testConstructorPing) {
   using apache::geode::client::TcrMessagePing;
 
-  std::shared_ptr<Cacheable> myCacheablePtr(
-      CacheableString::createDeserializable());
-
-  TcrMessagePing testMessage(new DataOutputUnderTest(), false);
+  TcrMessagePing testMessage(
+      std::unique_ptr<DataOutput>(new DataOutputUnderTest()));
 
   EXPECT_EQ(TcrMessage::PING, testMessage.getMessageType());
 
@@ -813,9 +803,6 @@ TEST_F(TcrMessageTest, testConstructorPing) {
 
 TEST_F(TcrMessageTest, testConstructorCloseConnection) {
   using apache::geode::client::TcrMessageCloseConnection;
-
-  std::shared_ptr<Cacheable> myCacheablePtr(
-      CacheableString::createDeserializable());
 
   TcrMessageCloseConnection testMessage(new DataOutputUnderTest(), false);
 


### PR DESCRIPTION

- Prevents a leak at shutdown, ensures object is properly destroyed.