### PR TITLE
GEODE-9200: Clean up DisMess

### DIFF
--- a/cppcache/src/CacheImpl.cpp
+++ b/cppcache/src/CacheImpl.cpp
@@ -424,7 +424,7 @@ void CacheImpl::createRegion(std::string name,
     }
 
     regionPtr = rpImpl;
-    rpImpl->addDisMessToQueue();
+    rpImpl->addDisconnectedMessageToQueue();
     // Instantiate a PersistenceManager object if DiskPolicy is overflow
     if (regionAttributes.getDiskPolicy() == DiskPolicyType::OVERFLOWS) {
       auto pmPtr = regionAttributes.getPersistenceManager();
@@ -708,16 +708,14 @@ void CacheImpl::processMarker() {
     if (!kv.second->isDestroyed()) {
       if (const auto tcrHARegion =
               std::dynamic_pointer_cast<ThinClientHARegion>(kv.second)) {
-        auto regionMsg = new TcrMessageClientMarker(
-            new DataOutput(createDataOutput()), true);
-        tcrHARegion->receiveNotification(regionMsg);
+        tcrHARegion->receiveNotification(
+            TcrMessageClientMarker(new DataOutput(createDataOutput()), true));
         for (const auto& iter : tcrHARegion->subregions(true)) {
           if (!iter->isDestroyed()) {
             if (const auto subregion =
                     std::dynamic_pointer_cast<ThinClientHARegion>(iter)) {
-              regionMsg = new TcrMessageClientMarker(
-                  new DataOutput(createDataOutput()), true);
-              subregion->receiveNotification(regionMsg);
+              subregion->receiveNotification(TcrMessageClientMarker(
+                  new DataOutput(createDataOutput()), true));
             }
           }
         }

--- a/cppcache/src/CqService.cpp
+++ b/cppcache/src/CqService.cpp
@@ -383,10 +383,9 @@ bool CqService::isCqExists(const std::string& cqName) {
 
   return m_cqQueryMap.find(cqName) != m_cqQueryMap.end();
 }
-void CqService::receiveNotification(TcrMessage* msg) {
-  invokeCqListeners(msg->getCqs(), msg->getMessageTypeForCq(), msg->getKey(),
-                    msg->getValue(), msg->getDeltaBytes(), msg->getEventId());
-  _GEODE_SAFE_DELETE(msg);
+void CqService::receiveNotification(TcrMessage& msg) {
+  invokeCqListeners(msg.getCqs(), msg.getMessageTypeForCq(), msg.getKey(),
+                    msg.getValue(), msg.getDeltaBytes(), msg.getEventId());
   notification_semaphore_.release();
 }
 

--- a/cppcache/src/CqService.hpp
+++ b/cppcache/src/CqService.hpp
@@ -75,7 +75,7 @@ class CqService : public std::enable_shared_from_this<CqService> {
 
   ThinClientBaseDM* getDM() { return m_tccdm; }
 
-  void receiveNotification(TcrMessage* msg);
+  void receiveNotification(TcrMessage& msg);
 
   /**
    * Returns the state of the cqService.

--- a/cppcache/src/RegionInternal.hpp
+++ b/cppcache/src/RegionInternal.hpp
@@ -271,7 +271,7 @@ class RegionInternal : public Region {
   std::shared_ptr<RegionEntry> createRegionEntry(
       const std::shared_ptr<CacheableKey>& key,
       const std::shared_ptr<Cacheable>& value);
-  virtual void addDisMessToQueue() {}
+  virtual void addDisconnectedMessageToQueue() {}
 
   virtual void txDestroy(const std::shared_ptr<CacheableKey>& key,
                          const std::shared_ptr<Serializable>& callBack,

--- a/cppcache/src/RemoteQueryService.cpp
+++ b/cppcache/src/RemoteQueryService.cpp
@@ -272,7 +272,7 @@ RemoteQueryService::getCqServiceStatistics() const {
   return nullptr;
 }
 
-void RemoteQueryService::receiveNotification(TcrMessage* msg) {
+void RemoteQueryService::receiveNotification(TcrMessage& msg) {
   {
     TryReadGuard guard(m_rwLock, m_invalid);
 

--- a/cppcache/src/RemoteQueryService.hpp
+++ b/cppcache/src/RemoteQueryService.hpp
@@ -87,7 +87,7 @@ class RemoteQueryService
    * execute all cqs on the endpoint after failover
    */
   GfErrType executeAllCqs(TcrEndpoint* endpoint);
-  void receiveNotification(TcrMessage* msg);
+  void receiveNotification(TcrMessage& msg);
   void invokeCqConnectedListeners(ThinClientPoolDM* pool, bool connected);
   // For Lazy Cq Start-no use, no start
   inline void initCqService() {

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -255,7 +255,7 @@ TcrChunkedResult* TcrMessage::getChunkedResultHandler() {
   return m_chunkedResult;
 }
 
-DataInput* TcrMessage::getDelta() { return m_delta.get(); }
+DataInput* TcrMessage::getDelta() const { return m_delta.get(); }
 
 //  getDeltaBytes( ) is called *only* by CqService, returns a CacheableBytes
 //  that
@@ -270,7 +270,7 @@ std::shared_ptr<CacheableBytes> TcrMessage::getDeltaBytes() {
   return retVal;
 }
 
-bool TcrMessage::hasDelta() { return (m_delta != nullptr); }
+bool TcrMessage::hasDelta() const { return (m_delta != nullptr); }
 
 void TcrMessage::setMetaRegion(bool isMetaRegion) {
   m_isMetaRegion = isMetaRegion;
@@ -307,7 +307,9 @@ void TcrMessage::setCallBackArguement(bool aCallBackArguement) {
 void TcrMessage::setVersionTag(std::shared_ptr<VersionTag> versionTag) {
   m_versionTag = versionTag;
 }
-std::shared_ptr<VersionTag> TcrMessage::getVersionTag() { return m_versionTag; }
+std::shared_ptr<VersionTag> TcrMessage::getVersionTag() const {
+  return m_versionTag;
+}
 
 uint8_t TcrMessage::hasResult() const { return m_hasResult; }
 
@@ -317,11 +319,6 @@ std::shared_ptr<CacheableHashMap> TcrMessage::getTombstoneVersions() const {
 
 std::shared_ptr<CacheableHashSet> TcrMessage::getTombstoneKeys() const {
   return m_tombstoneKeys;
-}
-
-TcrMessage* TcrMessage::getAllEPDisMess() {
-  static auto allEPDisconnected = new TcrMessageReply(true, nullptr);
-  return allEPDisconnected;
 }
 
 void TcrMessage::writeInterestResultPolicyPart(InterestResultPolicy policy) {

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -259,7 +259,6 @@ class TcrMessage {
   std::chrono::milliseconds getTimeout() const;
   void setTimeout(std::chrono::milliseconds timeout);
 
-  static TcrMessage* getAllEPDisMess();
   bool isDurable() const;
   bool receiveValues() const;
   bool hasCqPart() const;
@@ -277,13 +276,13 @@ class TcrMessage {
   void setChunkedResultHandler(TcrChunkedResult* chunkedResult);
   TcrChunkedResult* getChunkedResultHandler();
 
-  DataInput* getDelta();
+  DataInput* getDelta() const;
   //  getDeltaBytes( ) is called *only* by CqService, returns a CacheableBytes
   //  that
   // takes ownership of delta bytes.
   std::shared_ptr<CacheableBytes> getDeltaBytes();
 
-  bool hasDelta();
+  bool hasDelta() const;
 
   void addSecurityPart(int64_t connectionId, int64_t unique_id,
                        TcrConnection* conn);
@@ -321,7 +320,7 @@ class TcrMessage {
   void setCallBackArguement(bool aCallBackArguement);
 
   void setVersionTag(std::shared_ptr<VersionTag> versionTag);
-  std::shared_ptr<VersionTag> getVersionTag();
+  std::shared_ptr<VersionTag> getVersionTag() const;
   uint8_t hasResult() const;
   std::shared_ptr<CacheableHashMap> getTombstoneVersions() const;
   std::shared_ptr<CacheableHashSet> getTombstoneKeys() const;
@@ -908,6 +907,11 @@ class TcrMessageReply : public TcrMessage {
   TcrMessageReply(bool decodeAll, ThinClientBaseDM* connectionDM);
 
   ~TcrMessageReply() override = default;
+};
+
+class TcrMessageAllEndpointsDisconnectedMarker : public TcrMessage {
+ public:
+  TcrMessageAllEndpointsDisconnectedMarker() = default;
 };
 
 /**

--- a/cppcache/src/ThinClientHARegion.cpp
+++ b/cppcache/src/ThinClientHARegion.cpp
@@ -117,15 +117,14 @@ void ThinClientHARegion::destroyDM(bool) {
   poolDM->decRegionCount();
 }
 
-void ThinClientHARegion::addDisMessToQueue() {
+void ThinClientHARegion::addDisconnectedMessageToQueue() {
   auto poolDM = std::dynamic_pointer_cast<ThinClientPoolHADM>(m_tcrdm);
-  poolDM->addDisMessToQueue(this);
+  poolDM->addDisconnectedMessageToQueue(this);
 
-  if (poolDM->m_redundancyManager->m_globalProcessedMarker &&
+  if (poolDM->redundancyManager_->m_globalProcessedMarker &&
       !m_processedMarker) {
-    TcrMessage* regionMsg = new TcrMessageClientMarker(
-        new DataOutput(m_cacheImpl->createDataOutput()), true);
-    receiveNotification(regionMsg);
+    receiveNotification(TcrMessageClientMarker(
+        new DataOutput(m_cacheImpl->createDataOutput()), true));
   }
 }
 

--- a/cppcache/src/ThinClientHARegion.hpp
+++ b/cppcache/src/ThinClientHARegion.hpp
@@ -57,7 +57,7 @@ class ThinClientHARegion : public ThinClientRegion {
   void setProcessedMarker(bool mark = true) override {
     m_processedMarker = mark;
   }
-  void addDisMessToQueue() override;
+  void addDisconnectedMessageToQueue() override;
 
  protected:
   GfErrType getNoThrow_FullObject(

--- a/cppcache/src/ThinClientPoolHADM.cpp
+++ b/cppcache/src/ThinClientPoolHADM.cpp
@@ -288,13 +288,6 @@ void ThinClientPoolHADM::removeCallbackConnection(TcrEndpoint* ep) {
   redundancyManager_->removeCallbackConnection(ep);
 }
 
-void ThinClientPoolHADM::clearKeysOfInterestAllRegions() {
-  std::lock_guard<decltype(regionsLock_)> guard(regionsLock_);
-  for (auto region : regions_) {
-    region->clearKeysOfInterest();
-  }
-}
-
 void ThinClientPoolHADM::sendNotConnectedMessageToAllregions() {
   std::lock_guard<decltype(regionsLock_)> guard(regionsLock_);
   for (auto region : regions_) {

--- a/cppcache/src/ThinClientPoolHADM.cpp
+++ b/cppcache/src/ThinClientPoolHADM.cpp
@@ -33,11 +33,11 @@ ThinClientPoolHADM::ThinClientPoolHADM(const char* name,
                                        std::shared_ptr<PoolAttributes> poolAttr,
                                        TcrConnectionManager& connManager)
     : ThinClientPoolDM(name, poolAttr, connManager),
-      m_theTcrConnManager(connManager),
+      theTcrConnManager_(connManager),
       redundancy_semaphore_(0),
-      m_redundancyTask(nullptr),
+      redundancyTask_(nullptr),
       server_monitor_task_id_(ExpiryTask::invalid()) {
-  m_redundancyManager = std::unique_ptr<ThinClientRedundancyManager>(
+  redundancyManager_ = std::unique_ptr<ThinClientRedundancyManager>(
       new ThinClientRedundancyManager(
           &connManager, poolAttr->getSubscriptionRedundancy(), this));
 }
@@ -54,10 +54,10 @@ void ThinClientPoolHADM::startBackgroundThreads() {
                     ->getDistributedSystem()
                     .getSystemProperties();
 
-  m_redundancyManager->initialize(m_attrs->getSubscriptionRedundancy());
+  redundancyManager_->initialize(m_attrs->getSubscriptionRedundancy());
   //  Call maintain redundancy level, so primary is available for notification
   //  operations.
-  GfErrType err = m_redundancyManager->maintainRedundancyLevel(true);
+  GfErrType err = redundancyManager_->maintainRedundancyLevel(true);
 
   const auto interval = props.redundancyMonitorInterval();
   auto& manager = m_connManager.getCacheImpl()->getExpiryTaskManager();
@@ -82,11 +82,11 @@ void ThinClientPoolHADM::startBackgroundThreads() {
     }
   }
 
-  m_redundancyManager->startPeriodicAck();
-  m_redundancyTask =
+  redundancyManager_->startPeriodicAck();
+  redundancyTask_ =
       std::unique_ptr<Task<ThinClientPoolHADM>>(new Task<ThinClientPoolHADM>(
           this, &ThinClientPoolHADM::redundancy, NC_Redundancy));
-  m_redundancyTask->start();
+  redundancyTask_->start();
 }
 
 GfErrType ThinClientPoolHADM::sendSyncRequest(TcrMessage& request,
@@ -121,13 +121,13 @@ GfErrType ThinClientPoolHADM::sendSyncRequestRegisterInterestEP(
 GfErrType ThinClientPoolHADM::sendSyncRequestRegisterInterest(
     TcrMessage& request, TcrMessageReply& reply, bool attemptFailover,
     ThinClientRegion* region, TcrEndpoint* endpoint) {
-  return m_redundancyManager->sendSyncRequestRegisterInterest(
+  return redundancyManager_->sendSyncRequestRegisterInterest(
       request, reply, attemptFailover, endpoint, this, region);
 }
 
 GfErrType ThinClientPoolHADM::sendSyncRequestCq(TcrMessage& request,
                                                 TcrMessageReply& reply) {
-  return m_redundancyManager->sendSyncRequestCq(request, reply, this);
+  return redundancyManager_->sendSyncRequestCq(request, reply, this);
 }
 
 bool ThinClientPoolHADM::preFailoverAction() { return true; }
@@ -143,7 +143,7 @@ void ThinClientPoolHADM::redundancy(std::atomic<bool>& isRunning) {
   redundancy_semaphore_.acquire();
   while (isRunning) {
     if (!m_connManager.isNetDown()) {
-      m_redundancyManager->maintainRedundancyLevel();
+      redundancyManager_->maintainRedundancyLevel();
     }
 
     redundancy_semaphore_.acquire();
@@ -165,7 +165,7 @@ void ThinClientPoolHADM::destroy(bool keepAlive) {
 
     sendNotificationCloseMsgs();
 
-    m_redundancyManager->close();
+    redundancyManager_->close();
 
     m_destroyPendingHADM = true;
     ThinClientPoolDM::destroy(keepAlive);
@@ -173,14 +173,14 @@ void ThinClientPoolHADM::destroy(bool keepAlive) {
 }
 
 void ThinClientPoolHADM::sendNotificationCloseMsgs() {
-  if (m_redundancyTask) {
+  if (redundancyTask_) {
     auto& manager = m_connManager.getCacheImpl()->getExpiryTaskManager();
     manager.cancel(server_monitor_task_id_);
-    m_redundancyTask->stopNoblock();
+    redundancyTask_->stopNoblock();
     redundancy_semaphore_.release();
-    m_redundancyTask->wait();
-    m_redundancyTask = nullptr;
-    m_redundancyManager->sendNotificationCloseMsgs();
+    redundancyTask_->wait();
+    redundancyTask_ = nullptr;
+    redundancyManager_->sendNotificationCloseMsgs();
   }
 }
 
@@ -188,8 +188,8 @@ GfErrType ThinClientPoolHADM::registerInterestAllRegions(
     TcrEndpoint* ep, const TcrMessage* request, TcrMessageReply* reply) {
   GfErrType err = GF_NOERR;
 
-  std::lock_guard<decltype(m_regionsLock)> guard(m_regionsLock);
-  for (const auto& region : m_regions) {
+  std::lock_guard<decltype(regionsLock_)> guard(regionsLock_);
+  for (const auto& region : regions_) {
     auto opErr = region->registerKeys(ep, request, reply);
     if (err == GF_NOERR) {
       err = opErr;
@@ -200,51 +200,52 @@ GfErrType ThinClientPoolHADM::registerInterestAllRegions(
 }
 
 bool ThinClientPoolHADM::checkDupAndAdd(std::shared_ptr<EventId> eventid) {
-  return m_redundancyManager->checkDupAndAdd(eventid);
+  return redundancyManager_->checkDupAndAdd(eventid);
 }
 
 void ThinClientPoolHADM::processMarker() {
   // also set the static bool m_processedMarker for makePrimary messages
-  m_redundancyManager->m_globalProcessedMarker = true;
+  redundancyManager_->m_globalProcessedMarker = true;
 }
 
 void ThinClientPoolHADM::acquireRedundancyLock() {
-  m_redundancyManager->acquireRedundancyLock();
+  redundancyManager_->acquireRedundancyLock();
 }
 
 void ThinClientPoolHADM::releaseRedundancyLock() {
-  m_redundancyManager->releaseRedundancyLock();
+  redundancyManager_->releaseRedundancyLock();
 }
 
 std::recursive_mutex& ThinClientPoolHADM::getRedundancyLock() {
-  return m_redundancyManager->getRedundancyLock();
+  return redundancyManager_->getRedundancyLock();
 }
 
 GfErrType ThinClientPoolHADM::sendRequestToPrimary(TcrMessage& request,
                                                    TcrMessageReply& reply) {
-  return m_redundancyManager->sendRequestToPrimary(request, reply);
+  return redundancyManager_->sendRequestToPrimary(request, reply);
 }
 
 bool ThinClientPoolHADM::isReadyForEvent() const {
-  return m_redundancyManager->isSentReadyForEvents();
+  return redundancyManager_->isSentReadyForEvents();
 }
 
 void ThinClientPoolHADM::addRegion(ThinClientRegion* theTCR) {
-  std::lock_guard<decltype(m_regionsLock)> guard(m_regionsLock);
-  m_regions.push_back(theTCR);
+  std::lock_guard<decltype(regionsLock_)> guard(regionsLock_);
+  regions_.push_back(theTCR);
 }
-void ThinClientPoolHADM::addDisMessToQueue(ThinClientRegion* theTCR) {
-  std::lock_guard<decltype(m_regionsLock)> guard(m_regionsLock);
-  if (m_redundancyManager->allEndPointDiscon()) {
-    theTCR->receiveNotification(TcrMessage::getAllEPDisMess());
+void ThinClientPoolHADM::addDisconnectedMessageToQueue(
+    ThinClientRegion* theTCR) {
+  std::lock_guard<decltype(regionsLock_)> guard(regionsLock_);
+  if (redundancyManager_->allEndPointDiscon()) {
+    theTCR->receiveNotification(TcrMessageAllEndpointsDisconnectedMarker());
   }
 }
 void ThinClientPoolHADM::removeRegion(ThinClientRegion* theTCR) {
-  std::lock_guard<decltype(m_regionsLock)> guard(m_regionsLock);
-  for (std::list<ThinClientRegion*>::iterator itr = m_regions.begin();
-       itr != m_regions.end(); itr++) {
+  std::lock_guard<decltype(regionsLock_)> guard(regionsLock_);
+  for (std::list<ThinClientRegion*>::iterator itr = regions_.begin();
+       itr != regions_.end(); itr++) {
     if (*itr == theTCR) {
-      m_regions.erase(itr);
+      regions_.erase(itr);
       return;
     }
   }
@@ -260,7 +261,7 @@ void ThinClientPoolHADM::readyForEvents() {
 
   auto&& durable = sysProp.durableClientId();
   if (!durable.empty()) {
-    m_redundancyManager->readyForEvents();
+    redundancyManager_->readyForEvents();
   }
 }
 
@@ -274,24 +275,30 @@ void ThinClientPoolHADM::netDown() {
     }
   }
 
-  m_redundancyManager->netDown();
+  redundancyManager_->netDown();
 }
 
 void ThinClientPoolHADM::pingServerLocal() {
-  auto& mutex = m_redundancyManager->getRedundancyLock();
+  auto& mutex = redundancyManager_->getRedundancyLock();
   std::lock_guard<decltype(mutex)> guard(mutex);
   ThinClientPoolDM::pingServerLocal();
 }
 
 void ThinClientPoolHADM::removeCallbackConnection(TcrEndpoint* ep) {
-  m_redundancyManager->removeCallbackConnection(ep);
+  redundancyManager_->removeCallbackConnection(ep);
 }
 
-void ThinClientPoolHADM::sendNotConMesToAllregions() {
-  std::lock_guard<decltype(m_regionsLock)> guard(m_regionsLock);
-  for (std::list<ThinClientRegion*>::iterator it = m_regions.begin();
-       it != m_regions.end(); it++) {
-    (*it)->receiveNotification(TcrMessage::getAllEPDisMess());
+void ThinClientPoolHADM::clearKeysOfInterestAllRegions() {
+  std::lock_guard<decltype(regionsLock_)> guard(regionsLock_);
+  for (auto region : regions_) {
+    region->clearKeysOfInterest();
+  }
+}
+
+void ThinClientPoolHADM::sendNotConnectedMessageToAllregions() {
+  std::lock_guard<decltype(regionsLock_)> guard(regionsLock_);
+  for (auto region : regions_) {
+    region->receiveNotification(TcrMessageAllEndpointsDisconnectedMarker());
   }
 }
 

--- a/cppcache/src/ThinClientPoolHADM.hpp
+++ b/cppcache/src/ThinClientPoolHADM.hpp
@@ -119,7 +119,6 @@ class ThinClientPoolHADM : public ThinClientPoolDM {
   std::recursive_mutex regionsLock_;
   void addRegion(ThinClientRegion* theTCR);
   void removeRegion(ThinClientRegion* theTCR);
-  void clearKeysOfInterestAllRegions();
   void sendNotConnectedMessageToAllregions();
   void addDisconnectedMessageToQueue(ThinClientRegion* theTCR);
 

--- a/cppcache/src/ThinClientPoolHADM.hpp
+++ b/cppcache/src/ThinClientPoolHADM.hpp
@@ -101,11 +101,11 @@ class ThinClientPoolHADM : public ThinClientPoolDM {
   void startBackgroundThreads() override;
 
  private:
-  std::unique_ptr<ThinClientRedundancyManager> m_redundancyManager;
+  std::unique_ptr<ThinClientRedundancyManager> redundancyManager_;
 
-  TcrConnectionManager& m_theTcrConnManager;
+  TcrConnectionManager& theTcrConnManager_;
   binary_semaphore redundancy_semaphore_;
-  std::unique_ptr<Task<ThinClientPoolHADM>> m_redundancyTask;
+  std::unique_ptr<Task<ThinClientPoolHADM>> redundancyTask_;
 
   void redundancy(std::atomic<bool>& isRunning);
 
@@ -115,12 +115,13 @@ class ThinClientPoolHADM : public ThinClientPoolDM {
 
   void removeCallbackConnection(TcrEndpoint*) override;
 
-  std::list<ThinClientRegion*> m_regions;
-  std::recursive_mutex m_regionsLock;
+  std::list<ThinClientRegion*> regions_;
+  std::recursive_mutex regionsLock_;
   void addRegion(ThinClientRegion* theTCR);
   void removeRegion(ThinClientRegion* theTCR);
-  void sendNotConMesToAllregions();
-  void addDisMessToQueue(ThinClientRegion* theTCR);
+  void clearKeysOfInterestAllRegions();
+  void sendNotConnectedMessageToAllregions();
+  void addDisconnectedMessageToQueue(ThinClientRegion* theTCR);
 
   friend class ThinClientHARegion;
   friend class TcrConnectionManager;

--- a/cppcache/src/ThinClientRedundancyManager.cpp
+++ b/cppcache/src/ThinClientRedundancyManager.cpp
@@ -455,7 +455,6 @@ GfErrType ThinClientRedundancyManager::maintainRedundancyLevel(
     // that we can send it back to the caller, to avoid missing out due
     // to nonfatal errors such as server not available
     if (m_poolHADM && !m_allEndpointsDisconnected) {
-      m_poolHADM->clearKeysOfInterestAllRegions();
       m_poolHADM->sendNotConnectedMessageToAllregions();
       m_allEndpointsDisconnected = true;
     }

--- a/cppcache/src/ThinClientRedundancyManager.hpp
+++ b/cppcache/src/ThinClientRedundancyManager.hpp
@@ -79,7 +79,7 @@ class ThinClientRedundancyManager {
   void netDown();
   void acquireRedundancyLock() { m_redundantEndpointsLock.lock(); }
   void releaseRedundancyLock() { m_redundantEndpointsLock.unlock(); }
-  bool allEndPointDiscon() { return m_IsAllEpDisCon; }
+  bool allEndPointDiscon() { return m_allEndpointsDisconnected; }
   void removeCallbackConnection(TcrEndpoint*);
 
   std::recursive_mutex& getRedundancyLock() { return m_redundantEndpointsLock; }
@@ -92,7 +92,7 @@ class ThinClientRedundancyManager {
   using time_point = clock::time_point;
 
   // for selectServers
-  volatile bool m_IsAllEpDisCon;
+  volatile bool m_allEndpointsDisconnected;
   int m_server;
   bool m_sentReadyForEvents;
   int m_redundancyLevel;

--- a/cppcache/src/ThinClientRegion.hpp
+++ b/cppcache/src/ThinClientRegion.hpp
@@ -133,7 +133,7 @@ class ThinClientRegion : public LocalRegion {
   std::vector<std::shared_ptr<CacheableString>> getInterestListRegex()
       const override;
 
-  void receiveNotification(TcrMessage* msg);
+  void receiveNotification(const TcrMessage& msg);
 
   static GfErrType handleServerException(const std::string& func,
                                          const std::string& exceptionMsg);
@@ -257,7 +257,7 @@ class ThinClientRegion : public LocalRegion {
                                    bool attemptFailover = true);
   GfErrType unregisterRegexNoThrowLocalDestroy(const std::string& regex,
                                                bool attemptFailover = true);
-  GfErrType clientNotificationHandler(TcrMessage& msg);
+  GfErrType clientNotificationHandler(const TcrMessage& msg);
 
   virtual void localInvalidateRegion_internal();
 


### PR DESCRIPTION
- Remove static endpoint disconnected message
- use dynamically allocated message for this, a la other messages
- no longer leak an instance at shutdown, no more special case code for
  this message when deleting messages.
- Remove some really unfortunate abbreviations in a couple of function and variable names.