### PR TITLE
GEODE-9212: Fix docker images build

### DIFF
--- a/ci/docker/clang-tools/Dockerfile
+++ b/ci/docker/clang-tools/Dockerfile
@@ -48,6 +48,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN installer=$(mktemp) \
-    && curl -o ${installer} -L $(curl -s https://api.github.com/repos/Kitware/CMake/releases/latest | jq -r '.assets[].browser_download_url | select(test("Linux-x86_64.sh"))') \
+    && curl -o ${installer} -L $(curl -s https://api.github.com/repos/Kitware/CMake/releases/latest | jq -r '.assets[].browser_download_url | select(test("linux-x86_64.sh"))') \
     && bash ${installer} --skip-license --prefix=/usr/local \
     && rm ${installer}

--- a/docker/centos-8/Dockerfile
+++ b/docker/centos-8/Dockerfile
@@ -26,7 +26,7 @@ RUN yum update -y && \
 COPY bellsoft.repo /etc/yum.repos.d/
 
 RUN yum install -y 'dnf-command(config-manager)' && \
-    yum config-manager --set-enabled PowerTools && \
+    yum config-manager --set-enabled powertools && \
     yum update -y && \
     yum install -y --setopt=tsflags=nodocs \
         git \

--- a/docker/rhel-8/Dockerfile
+++ b/docker/rhel-8/Dockerfile
@@ -24,10 +24,10 @@ RUN yum update -y && \
     yum -y clean all
 
 COPY bellsoft.repo /etc/yum.repos.d/
-COPY --from=centos:8 /etc/yum.repos.d/CentOS-PowerTools.repo /etc/yum.repos.d/
+COPY --from=centos:8 /etc/yum.repos.d/CentOS-Linux-PowerTools.repo /etc/yum.repos.d/
 COPY --from=centos:8 /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial /etc/pki/rpm-gpg/
 
-RUN yum config-manager --set-enabled PowerTools && \
+RUN yum config-manager --set-enabled powertools && \
     yum update -y && \
     yum install -y --setopt=tsflags=nodocs \
         git \


### PR DESCRIPTION
 - Due to some changes in base images and in the CMake artifact names,
   docker build is not working for the following images:
    * rhel-8
    * centos-8
    * clang-tools
 - This commit solves all build issues.