### PR TITLE
GEODE-9213: Add Ubuntu 20.04 build docker image

### DIFF
--- a/docker/ubuntu-20.04/Dockerfile
+++ b/docker/ubuntu-20.04/Dockerfile
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:20.04
+LABEL maintainer Apache Geode <dev@geode.apache.org>
+
+USER root
+WORKDIR /
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt update && \
+    apt -yq full-upgrade && \
+    apt-get -y install \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg2 \
+        software-properties-common && \
+    apt-get -y autoremove && \
+    apt-get autoclean
+
+RUN . /etc/os-release && \
+    curl -s https://download.bell-sw.com/pki/GPG-KEY-bellsoft | apt-key add - && \
+    apt-add-repository "deb http://apt.bell-sw.com/ stable main"
+
+RUN apt update && apt -yq full-upgrade && apt-get -y install \
+        build-essential \
+        libc++-dev \
+        libc++abi-dev \
+        zlib1g-dev \
+        libssl-dev \
+        bellsoft-java11 \
+        git \
+        doxygen \
+        graphviz \
+        python3-pip \
+        clang-format-6.0 && \
+    apt-get -y autoremove && \
+    apt-get autoclean
+
+RUN pip3 install --upgrade pip && \
+    pip3 install cpp-coveralls
+
+# Get latest release of CMake ignoring pre-releases
+RUN installer=$(mktemp) \
+    && curl -o ${installer} -L $(curl -s https://api.github.com/repos/Kitware/CMake/releases \
+        | grep -P -i 'browser_download_url.*cmake-\d+\.\d+\.\d+-linux-x86_64\.sh' \
+        | head -n 1 \
+        | cut -d : -f 2,3 \
+        | tr -d '"') \
+    && bash ${installer} --skip-license --prefix=/usr/local \
+    && rm ${installer}
+
+ARG GEODE_VERSION=1.13.2
+ENV GEODE_HOME /apache-geode-${GEODE_VERSION}
+RUN curl -L -s "https://www.apache.org/dyn/closer.lua/geode/${GEODE_VERSION}/apache-geode-${GEODE_VERSION}.tgz?action=download" | tar -zxvf - --exclude javadoc
+
+CMD ["bash"]


### PR DESCRIPTION
 - Currently there is a CI pipeline for Ubuntu 20.04. However, there is
   not a build docker image for Ubuntu 20.04.
 - This commit adds a build docker image based on Ubuntu 20.04, so CI
   verification can be reproduced in a local environment.