### PR TITLE
Revert "GEODE-8991: Implement cached region clean up (#757)"

### DIFF
--- a/cppcache/src/ConcurrentEntriesMap.cpp
+++ b/cppcache/src/ConcurrentEntriesMap.cpp
@@ -177,8 +177,6 @@ void ConcurrentEntriesMap::getValues(
   }
 }
 
-bool ConcurrentEntriesMap::empty() const { return m_size == 0; }
-
 uint32_t ConcurrentEntriesMap::size() const { return m_size; }
 
 int ConcurrentEntriesMap::addTrackerForEntry(

--- a/cppcache/src/ConcurrentEntriesMap.hpp
+++ b/cppcache/src/ConcurrentEntriesMap.hpp
@@ -151,11 +151,6 @@ class ConcurrentEntriesMap : public EntriesMap {
       std::vector<std::shared_ptr<Cacheable>>& result) const override;
 
   /**
-   * @brief return whether there are no entries.
-   */
-  bool empty() const override;
-
-  /**
    * @brief return the number of entries in the map.
    */
   uint32_t size() const override;

--- a/cppcache/src/EntriesMap.hpp
+++ b/cppcache/src/EntriesMap.hpp
@@ -126,9 +126,6 @@ class EntriesMap {
   virtual void getValues(
       std::vector<std::shared_ptr<Cacheable>>& result) const = 0;
 
-  /** @brief return whether there are no entryies. */
-  virtual bool empty() const = 0;
-
   /** @brief return the number of entries in the map. */
   virtual uint32_t size() const = 0;
 

--- a/cppcache/src/LocalRegion.cpp
+++ b/cppcache/src/LocalRegion.cpp
@@ -17,7 +17,6 @@
 
 #include "LocalRegion.hpp"
 
-#include <regex>
 #include <vector>
 
 #include <geode/PoolManager.hpp>
@@ -30,7 +29,6 @@
 #include "EntriesMapFactory.hpp"
 #include "EntryExpiryTask.hpp"
 #include "ExpiryTaskManager.hpp"
-#include "InterestResultPolicy.hpp"
 #include "LRUEntriesMap.hpp"
 #include "RegionExpiryTask.hpp"
 #include "RegionGlobalLocks.hpp"
@@ -450,15 +448,6 @@ void LocalRegion::destroy(
                                  CacheEventFlags::NORMAL, versionTag);
   // handleReplay(err, nullptr);
   throwExceptionIfError("Region::destroy", err);
-}
-
-void LocalRegion::localDestroyNoCallbacks(
-    const std::shared_ptr<CacheableKey>& key) {
-  std::shared_ptr<VersionTag> versionTag;
-  GfErrType err = destroyNoThrow(
-      key, nullptr, -1, CacheEventFlags::LOCAL | CacheEventFlags::NOCALLBACKS,
-      versionTag);
-  throwExceptionIfError("Region::localDestroy", err);
 }
 
 void LocalRegion::localDestroy(
@@ -1764,16 +1753,12 @@ GfErrType LocalRegion::updateNoThrow(
       m_entries->removeTrackerForEntry(key);
     }
   }
-
-  if (!eventFlags.isNoCallbacks()) {
-    // invokeCacheListenerForEntryEvent method has the check that if oldValue
-    // is a CacheableToken then it sets it to nullptr; also determines if it
-    // should be AFTER_UPDATE or AFTER_CREATE depending on oldValue
-    err = invokeCacheListenerForEntryEvent(key, oldValue, value,
-                                           aCallbackArgument, eventFlags,
-                                           TAction::s_afterEventType);
-  }
-
+  // invokeCacheListenerForEntryEvent method has the check that if oldValue
+  // is a CacheableToken then it sets it to nullptr; also determines if it
+  // should be AFTER_UPDATE or AFTER_CREATE depending on oldValue
+  err =
+      invokeCacheListenerForEntryEvent(key, oldValue, value, aCallbackArgument,
+                                       eventFlags, TAction::s_afterEventType);
   return err;
 }
 
@@ -3219,49 +3204,6 @@ void LocalRegion::updateStatOpTime(Statistics* statistics, int32_t statId,
 void LocalRegion::acquireGlobals(bool) {}
 
 void LocalRegion::releaseGlobals(bool) {}
-
-void LocalRegion::clearKeysOfInterest(
-    const std::unordered_map<std::shared_ptr<CacheableKey>,
-                             InterestResultPolicy>& interest_list) {
-  if (m_entries->empty()) {
-    return;
-  }
-
-  for (const auto& kv : interest_list) {
-    localDestroyNoCallbacks(kv.first);
-  }
-}
-
-void LocalRegion::clearKeysOfInterestRegex(const std::string& pattern) {
-  if (m_entries->empty()) {
-    return;
-  }
-
-  std::regex expression{pattern};
-  for (const auto& key : keys()) {
-    if (std::regex_search(key->toString(), expression)) {
-      localDestroyNoCallbacks(key);
-    }
-  }
-}
-
-void LocalRegion::clearKeysOfInterestRegex(
-    const std::unordered_map<std::string, InterestResultPolicy>&
-        interest_list) {
-  if (m_entries->empty()) {
-    return;
-  }
-
-  for (const auto& kv : interest_list) {
-    const auto& regex = kv.first;
-    if (regex == ".*") {
-      localClear();
-      break;
-    } else {
-      clearKeysOfInterestRegex(kv.first);
-    }
-  }
-}
 
 }  // namespace client
 }  // namespace geode

--- a/cppcache/src/LocalRegion.hpp
+++ b/cppcache/src/LocalRegion.hpp
@@ -72,13 +72,12 @@ namespace client {
   } while (0)
 #endif
 
-class CreateActions;
-class DestroyActions;
-class InvalidateActions;
-class InterestResultPolicy;
 class PutActions;
 class PutActionsTx;
+class CreateActions;
+class DestroyActions;
 class RemoveActions;
+class InvalidateActions;
 class VersionedCacheableObjectPartList;
 
 typedef std::unordered_map<std::shared_ptr<CacheableKey>,
@@ -199,8 +198,6 @@ class APACHE_GEODE_EXPORT LocalRegion : public RegionInternal {
   void localDestroy(const std::shared_ptr<CacheableKey>& key,
                     const std::shared_ptr<Serializable>& aCallbackArgument =
                         nullptr) override;
-  virtual void localDestroyNoCallbacks(
-      const std::shared_ptr<CacheableKey>& key);
   bool remove(const std::shared_ptr<CacheableKey>& key,
               const std::shared_ptr<Cacheable>& value,
               const std::shared_ptr<Serializable>& aCallbackArgument =
@@ -574,14 +571,6 @@ class APACHE_GEODE_EXPORT LocalRegion : public RegionInternal {
   virtual GfErrType getNoThrow_FullObject(
       std::shared_ptr<EventId> eventId, std::shared_ptr<Cacheable>& fullObject,
       std::shared_ptr<VersionTag>& versionTag);
-
-  void clearKeysOfInterest(
-      const std::unordered_map<std::shared_ptr<CacheableKey>,
-                               InterestResultPolicy>& interest_list);
-  void clearKeysOfInterestRegex(const std::string& regex);
-  void clearKeysOfInterestRegex(
-      const std::unordered_map<std::string, InterestResultPolicy>&
-          interest_list);
 
  private:
   std::shared_ptr<Region> findSubRegion(const std::string& name);

--- a/cppcache/src/RegionInternal.cpp
+++ b/cppcache/src/RegionInternal.cpp
@@ -39,8 +39,6 @@ const CacheEventFlags CacheEventFlags::CACHE_CLOSE(
     CacheEventFlags::GF_CACHE_CLOSE);
 const CacheEventFlags CacheEventFlags::NOCACHEWRITER(
     CacheEventFlags::GF_NOCACHEWRITER);
-const CacheEventFlags CacheEventFlags::NOCALLBACKS(
-    CacheEventFlags::GF_NOCALLBACKS);
 
 RegionInternal::RegionInternal(CacheImpl* cacheImpl,
                                RegionAttributes attributes)

--- a/cppcache/src/RegionInternal.hpp
+++ b/cppcache/src/RegionInternal.hpp
@@ -45,18 +45,17 @@ namespace client {
  */
 class CacheEventFlags {
  private:
-  uint16_t m_flags;
-  static const uint16_t GF_NORMAL = 0x01;
-  static const uint16_t GF_LOCAL = 0x02;
-  static const uint16_t GF_NOTIFICATION = 0x04;
-  static const uint16_t GF_NOTIFICATION_UPDATE = 0x08;
-  static const uint16_t GF_EVICTION = 0x10;
-  static const uint16_t GF_EXPIRATION = 0x20;
-  static const uint16_t GF_CACHE_CLOSE = 0x40;
-  static const uint16_t GF_NOCACHEWRITER = 0x80;
-  static const uint16_t GF_NOCALLBACKS = 0x100;
+  uint8_t m_flags;
+  static const uint8_t GF_NORMAL = 0x01;
+  static const uint8_t GF_LOCAL = 0x02;
+  static const uint8_t GF_NOTIFICATION = 0x04;
+  static const uint8_t GF_NOTIFICATION_UPDATE = 0x08;
+  static const uint8_t GF_EVICTION = 0x10;
+  static const uint8_t GF_EXPIRATION = 0x20;
+  static const uint8_t GF_CACHE_CLOSE = 0x40;
+  static const uint8_t GF_NOCACHEWRITER = 0x80;
 
-  inline explicit CacheEventFlags(const uint16_t flags) : m_flags(flags) {}
+  inline explicit CacheEventFlags(const uint8_t flags) : m_flags(flags) {}
 
  public:
   static const CacheEventFlags NORMAL;
@@ -67,7 +66,6 @@ class CacheEventFlags {
   static const CacheEventFlags EXPIRATION;
   static const CacheEventFlags CACHE_CLOSE;
   static const CacheEventFlags NOCACHEWRITER;
-  static const CacheEventFlags NOCALLBACKS;
 
   inline CacheEventFlags(const CacheEventFlags& flags) = default;
 
@@ -86,36 +84,46 @@ class CacheEventFlags {
     return (m_flags == flags.m_flags);
   }
 
-  inline bool isNormal() const { return (m_flags & GF_NORMAL) > 0; }
+  inline bool isNormal() const {
+    return (m_flags & GF_NORMAL) > 0 ? true : false;
+  }
 
-  inline bool isLocal() const { return (m_flags & GF_LOCAL) > 0; }
+  inline bool isLocal() const {
+    return (m_flags & GF_LOCAL) > 0 ? true : false;
+  }
 
-  inline bool isNotification() const { return (m_flags & GF_NOTIFICATION) > 0; }
+  inline bool isNotification() const {
+    return (m_flags & GF_NOTIFICATION) > 0 ? true : false;
+  }
 
   inline bool isNotificationUpdate() const {
-    return (m_flags & GF_NOTIFICATION_UPDATE) > 0;
+    return (m_flags & GF_NOTIFICATION_UPDATE) > 0 ? true : false;
   }
 
-  inline bool isEviction() const { return (m_flags & GF_EVICTION) > 0; }
+  inline bool isEviction() const {
+    return (m_flags & GF_EVICTION) > 0 ? true : false;
+  }
 
-  inline bool isExpiration() const { return (m_flags & GF_EXPIRATION) > 0; }
+  inline bool isExpiration() const {
+    return (m_flags & GF_EXPIRATION) > 0 ? true : false;
+  }
 
-  inline bool isCacheClose() const { return (m_flags & GF_CACHE_CLOSE) > 0; }
+  inline bool isCacheClose() const {
+    return (m_flags & GF_CACHE_CLOSE) > 0 ? true : false;
+  }
 
   inline bool isNoCacheWriter() const {
-    return (m_flags & GF_NOCACHEWRITER) > 0;
+    return (m_flags & GF_NOCACHEWRITER) > 0 ? true : false;
   }
 
-  inline bool isNoCallbacks() const { return (m_flags & GF_NOCALLBACKS) > 0; }
-
   inline bool isEvictOrExpire() const {
-    return (m_flags & (GF_EVICTION | GF_EXPIRATION)) > 0;
+    return (m_flags & (GF_EVICTION | GF_EXPIRATION)) > 0 ? true : false;
   }
 
   // special optimized method for CacheWriter invocation condition
   inline bool invokeCacheWriter() const {
     return ((m_flags & (GF_NOTIFICATION | GF_EVICTION | GF_EXPIRATION |
-                        GF_NOCACHEWRITER | GF_NOCALLBACKS)) == 0x0);
+                        GF_NOCACHEWRITER)) == 0x0);
   }
 };
 

--- a/cppcache/src/ThinClientPoolHADM.cpp
+++ b/cppcache/src/ThinClientPoolHADM.cpp
@@ -295,13 +295,6 @@ void ThinClientPoolHADM::sendNotConMesToAllregions() {
   }
 }
 
-void ThinClientPoolHADM::clearKeysOfInterestAllRegions() {
-  std::lock_guard<decltype(m_regionsLock)> guard(m_regionsLock);
-  for (auto region : m_regions) {
-    region->clearKeysOfInterest();
-  }
-}
-
 std::shared_ptr<TcrEndpoint> ThinClientPoolHADM::createEP(
     const char* endpointName) {
   return std::make_shared<TcrPoolEndPoint>(

--- a/cppcache/src/ThinClientPoolHADM.hpp
+++ b/cppcache/src/ThinClientPoolHADM.hpp
@@ -120,7 +120,6 @@ class ThinClientPoolHADM : public ThinClientPoolDM {
   void addRegion(ThinClientRegion* theTCR);
   void removeRegion(ThinClientRegion* theTCR);
   void sendNotConMesToAllregions();
-  void clearKeysOfInterestAllRegions();
   void addDisMessToQueue(ThinClientRegion* theTCR);
 
   friend class ThinClientHARegion;

--- a/cppcache/src/ThinClientRedundancyManager.cpp
+++ b/cppcache/src/ThinClientRedundancyManager.cpp
@@ -455,7 +455,6 @@ GfErrType ThinClientRedundancyManager::maintainRedundancyLevel(
     // that we can send it back to the caller, to avoid missing out due
     // to nonfatal errors such as server not available
     if (m_poolHADM && !m_IsAllEpDisCon) {
-      m_poolHADM->clearKeysOfInterestAllRegions();
       m_poolHADM->sendNotConMesToAllregions();
       m_IsAllEpDisCon = true;
     }

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -1998,23 +1998,6 @@ GfErrType ThinClientRegion::registerStoredRegex(
   return retVal;
 }
 
-void ThinClientRegion::clearKeysOfInterest() {
-  if (!getAttributes().getCachingEnabled()) {
-    return;
-  }
-
-  clearKeysOfInterestRegex(m_interestListRegex);
-  clearKeysOfInterestRegex(m_interestListRegexForUpdatesAsInvalidates);
-  clearKeysOfInterestRegex(m_durableInterestListRegex);
-  clearKeysOfInterestRegex(m_durableInterestListRegexForUpdatesAsInvalidates);
-
-  LocalRegion::clearKeysOfInterest(m_interestList);
-  LocalRegion::clearKeysOfInterest(m_interestListForUpdatesAsInvalidates);
-  LocalRegion::clearKeysOfInterest(m_durableInterestList);
-  LocalRegion::clearKeysOfInterest(
-      m_durableInterestListForUpdatesAsInvalidates);
-}
-
 GfErrType ThinClientRegion::registerKeys(TcrEndpoint* endpoint,
                                          const TcrMessage* request,
                                          TcrMessageReply* reply) {

--- a/cppcache/src/ThinClientRegion.hpp
+++ b/cppcache/src/ThinClientRegion.hpp
@@ -191,8 +191,6 @@ class ThinClientRegion : public LocalRegion {
              const std::shared_ptr<Serializable>& callBack,
              std::shared_ptr<VersionTag> versionTag) override;
 
-  void clearKeysOfInterest();
-
  protected:
   GfErrType getNoThrow_remote(
       const std::shared_ptr<CacheableKey>& keyPtr,


### PR DESCRIPTION
- Consistent failures in legacy C++ test testThinClientHADistOps in CI

This reverts commit 33c960d6dce07a3dc04f9ed6d020ce35d2033c79.