### PR TITLE
GEODE-8991: Implement cached region clean up

### DIFF
--- a/cppcache/src/ConcurrentEntriesMap.cpp
+++ b/cppcache/src/ConcurrentEntriesMap.cpp
@@ -177,6 +177,8 @@ void ConcurrentEntriesMap::getValues(
   }
 }
 
+bool ConcurrentEntriesMap::empty() const { return m_size == 0; }
+
 uint32_t ConcurrentEntriesMap::size() const { return m_size; }
 
 int ConcurrentEntriesMap::addTrackerForEntry(

--- a/cppcache/src/ConcurrentEntriesMap.hpp
+++ b/cppcache/src/ConcurrentEntriesMap.hpp
@@ -151,6 +151,11 @@ class ConcurrentEntriesMap : public EntriesMap {
       std::vector<std::shared_ptr<Cacheable>>& result) const override;
 
   /**
+   * @brief return whether there are no entries.
+   */
+  bool empty() const override;
+
+  /**
    * @brief return the number of entries in the map.
    */
   uint32_t size() const override;

--- a/cppcache/src/EntriesMap.hpp
+++ b/cppcache/src/EntriesMap.hpp
@@ -126,6 +126,9 @@ class EntriesMap {
   virtual void getValues(
       std::vector<std::shared_ptr<Cacheable>>& result) const = 0;
 
+  /** @brief return whether there are no entryies. */
+  virtual bool empty() const = 0;
+
   /** @brief return the number of entries in the map. */
   virtual uint32_t size() const = 0;
 

--- a/cppcache/src/LocalRegion.hpp
+++ b/cppcache/src/LocalRegion.hpp
@@ -72,12 +72,13 @@ namespace client {
   } while (0)
 #endif
 
-class PutActions;
-class PutActionsTx;
 class CreateActions;
 class DestroyActions;
-class RemoveActions;
 class InvalidateActions;
+class InterestResultPolicy;
+class PutActions;
+class PutActionsTx;
+class RemoveActions;
 class VersionedCacheableObjectPartList;
 
 typedef std::unordered_map<std::shared_ptr<CacheableKey>,
@@ -198,6 +199,8 @@ class APACHE_GEODE_EXPORT LocalRegion : public RegionInternal {
   void localDestroy(const std::shared_ptr<CacheableKey>& key,
                     const std::shared_ptr<Serializable>& aCallbackArgument =
                         nullptr) override;
+  virtual GfErrType localDestroyNoCallbacks(
+      const std::shared_ptr<CacheableKey>& key);
   bool remove(const std::shared_ptr<CacheableKey>& key,
               const std::shared_ptr<Cacheable>& value,
               const std::shared_ptr<Serializable>& aCallbackArgument =
@@ -571,6 +574,14 @@ class APACHE_GEODE_EXPORT LocalRegion : public RegionInternal {
   virtual GfErrType getNoThrow_FullObject(
       std::shared_ptr<EventId> eventId, std::shared_ptr<Cacheable>& fullObject,
       std::shared_ptr<VersionTag>& versionTag);
+
+  void clearKeysOfInterest(
+      const std::unordered_map<std::shared_ptr<CacheableKey>,
+                               InterestResultPolicy>& interest_list);
+  void clearKeysOfInterestRegex(const std::string& regex);
+  void clearKeysOfInterestRegex(
+      const std::unordered_map<std::string, InterestResultPolicy>&
+          interest_list);
 
  private:
   std::shared_ptr<Region> findSubRegion(const std::string& name);

--- a/cppcache/src/RegionInternal.cpp
+++ b/cppcache/src/RegionInternal.cpp
@@ -39,6 +39,8 @@ const CacheEventFlags CacheEventFlags::CACHE_CLOSE(
     CacheEventFlags::GF_CACHE_CLOSE);
 const CacheEventFlags CacheEventFlags::NOCACHEWRITER(
     CacheEventFlags::GF_NOCACHEWRITER);
+const CacheEventFlags CacheEventFlags::NOCALLBACKS(
+    CacheEventFlags::GF_NOCALLBACKS);
 
 RegionInternal::RegionInternal(CacheImpl* cacheImpl,
                                RegionAttributes attributes)

--- a/cppcache/src/RegionInternal.hpp
+++ b/cppcache/src/RegionInternal.hpp
@@ -45,17 +45,18 @@ namespace client {
  */
 class CacheEventFlags {
  private:
-  uint8_t m_flags;
-  static const uint8_t GF_NORMAL = 0x01;
-  static const uint8_t GF_LOCAL = 0x02;
-  static const uint8_t GF_NOTIFICATION = 0x04;
-  static const uint8_t GF_NOTIFICATION_UPDATE = 0x08;
-  static const uint8_t GF_EVICTION = 0x10;
-  static const uint8_t GF_EXPIRATION = 0x20;
-  static const uint8_t GF_CACHE_CLOSE = 0x40;
-  static const uint8_t GF_NOCACHEWRITER = 0x80;
+  uint16_t m_flags;
+  static const uint16_t GF_NORMAL = 0x01;
+  static const uint16_t GF_LOCAL = 0x02;
+  static const uint16_t GF_NOTIFICATION = 0x04;
+  static const uint16_t GF_NOTIFICATION_UPDATE = 0x08;
+  static const uint16_t GF_EVICTION = 0x10;
+  static const uint16_t GF_EXPIRATION = 0x20;
+  static const uint16_t GF_CACHE_CLOSE = 0x40;
+  static const uint16_t GF_NOCACHEWRITER = 0x80;
+  static const uint16_t GF_NOCALLBACKS = 0x100;
 
-  inline explicit CacheEventFlags(const uint8_t flags) : m_flags(flags) {}
+  inline explicit CacheEventFlags(const uint16_t flags) : m_flags(flags) {}
 
  public:
   static const CacheEventFlags NORMAL;
@@ -66,6 +67,7 @@ class CacheEventFlags {
   static const CacheEventFlags EXPIRATION;
   static const CacheEventFlags CACHE_CLOSE;
   static const CacheEventFlags NOCACHEWRITER;
+  static const CacheEventFlags NOCALLBACKS;
 
   inline CacheEventFlags(const CacheEventFlags& flags) = default;
 
@@ -84,46 +86,36 @@ class CacheEventFlags {
     return (m_flags == flags.m_flags);
   }
 
-  inline bool isNormal() const {
-    return (m_flags & GF_NORMAL) > 0 ? true : false;
-  }
+  inline bool isNormal() const { return (m_flags & GF_NORMAL) > 0; }
 
-  inline bool isLocal() const {
-    return (m_flags & GF_LOCAL) > 0 ? true : false;
-  }
+  inline bool isLocal() const { return (m_flags & GF_LOCAL) > 0; }
 
-  inline bool isNotification() const {
-    return (m_flags & GF_NOTIFICATION) > 0 ? true : false;
-  }
+  inline bool isNotification() const { return (m_flags & GF_NOTIFICATION) > 0; }
 
   inline bool isNotificationUpdate() const {
-    return (m_flags & GF_NOTIFICATION_UPDATE) > 0 ? true : false;
+    return (m_flags & GF_NOTIFICATION_UPDATE) > 0;
   }
 
-  inline bool isEviction() const {
-    return (m_flags & GF_EVICTION) > 0 ? true : false;
-  }
+  inline bool isEviction() const { return (m_flags & GF_EVICTION) > 0; }
 
-  inline bool isExpiration() const {
-    return (m_flags & GF_EXPIRATION) > 0 ? true : false;
-  }
+  inline bool isExpiration() const { return (m_flags & GF_EXPIRATION) > 0; }
 
-  inline bool isCacheClose() const {
-    return (m_flags & GF_CACHE_CLOSE) > 0 ? true : false;
-  }
+  inline bool isCacheClose() const { return (m_flags & GF_CACHE_CLOSE) > 0; }
 
   inline bool isNoCacheWriter() const {
-    return (m_flags & GF_NOCACHEWRITER) > 0 ? true : false;
+    return (m_flags & GF_NOCACHEWRITER) > 0;
   }
 
+  inline bool isNoCallbacks() const { return (m_flags & GF_NOCALLBACKS) > 0; }
+
   inline bool isEvictOrExpire() const {
-    return (m_flags & (GF_EVICTION | GF_EXPIRATION)) > 0 ? true : false;
+    return (m_flags & (GF_EVICTION | GF_EXPIRATION)) > 0;
   }
 
   // special optimized method for CacheWriter invocation condition
   inline bool invokeCacheWriter() const {
     return ((m_flags & (GF_NOTIFICATION | GF_EVICTION | GF_EXPIRATION |
-                        GF_NOCACHEWRITER)) == 0x0);
+                        GF_NOCACHEWRITER | GF_NOCALLBACKS)) == 0x0);
   }
 };
 

--- a/cppcache/src/ThinClientPoolHADM.cpp
+++ b/cppcache/src/ThinClientPoolHADM.cpp
@@ -295,6 +295,13 @@ void ThinClientPoolHADM::sendNotConnectedMessageToAllregions() {
   }
 }
 
+void ThinClientPoolHADM::clearKeysOfInterestAllRegions() {
+  std::lock_guard<decltype(regionsLock_)> guard(regionsLock_);
+  for (auto region : regions_) {
+    region->clearKeysOfInterest();
+  }
+}
+
 std::shared_ptr<TcrEndpoint> ThinClientPoolHADM::createEP(
     const char* endpointName) {
   return std::make_shared<TcrPoolEndPoint>(

--- a/cppcache/src/ThinClientPoolHADM.hpp
+++ b/cppcache/src/ThinClientPoolHADM.hpp
@@ -121,6 +121,7 @@ class ThinClientPoolHADM : public ThinClientPoolDM {
   void removeRegion(ThinClientRegion* theTCR);
   void sendNotConnectedMessageToAllregions();
   void addDisconnectedMessageToQueue(ThinClientRegion* theTCR);
+  void clearKeysOfInterestAllRegions();
 
   friend class ThinClientHARegion;
   friend class TcrConnectionManager;

--- a/cppcache/src/ThinClientRedundancyManager.cpp
+++ b/cppcache/src/ThinClientRedundancyManager.cpp
@@ -455,6 +455,7 @@ GfErrType ThinClientRedundancyManager::maintainRedundancyLevel(
     // that we can send it back to the caller, to avoid missing out due
     // to nonfatal errors such as server not available
     if (m_poolHADM && !m_allEndpointsDisconnected) {
+      m_poolHADM->clearKeysOfInterestAllRegions();
       m_poolHADM->sendNotConnectedMessageToAllregions();
       m_allEndpointsDisconnected = true;
     }

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -1998,6 +1998,23 @@ GfErrType ThinClientRegion::registerStoredRegex(
   return retVal;
 }
 
+void ThinClientRegion::clearKeysOfInterest() {
+  if (!getAttributes().getCachingEnabled()) {
+    return;
+  }
+
+  clearKeysOfInterestRegex(m_interestListRegex);
+  clearKeysOfInterestRegex(m_interestListRegexForUpdatesAsInvalidates);
+  clearKeysOfInterestRegex(m_durableInterestListRegex);
+  clearKeysOfInterestRegex(m_durableInterestListRegexForUpdatesAsInvalidates);
+
+  LocalRegion::clearKeysOfInterest(m_interestList);
+  LocalRegion::clearKeysOfInterest(m_interestListForUpdatesAsInvalidates);
+  LocalRegion::clearKeysOfInterest(m_durableInterestList);
+  LocalRegion::clearKeysOfInterest(
+      m_durableInterestListForUpdatesAsInvalidates);
+}
+
 GfErrType ThinClientRegion::registerKeys(TcrEndpoint* endpoint,
                                          const TcrMessage* request,
                                          TcrMessageReply* reply) {

--- a/cppcache/src/ThinClientRegion.hpp
+++ b/cppcache/src/ThinClientRegion.hpp
@@ -191,6 +191,8 @@ class ThinClientRegion : public LocalRegion {
              const std::shared_ptr<Serializable>& callBack,
              std::shared_ptr<VersionTag> versionTag) override;
 
+  void clearKeysOfInterest();
+
  protected:
   GfErrType getNoThrow_remote(
       const std::shared_ptr<CacheableKey>& keyPtr,

--- a/cppcache/src/util/concurrent/binary_semaphore.hpp
+++ b/cppcache/src/util/concurrent/binary_semaphore.hpp
@@ -23,10 +23,12 @@
 #include <condition_variable>
 #include <mutex>
 
+#include <geode/internal/geode_globals.hpp>
+
 namespace apache {
 namespace geode {
 namespace client {
-class binary_semaphore {
+class APACHE_GEODE_EXPORT binary_semaphore {
  public:
   explicit binary_semaphore(bool released);
 


### PR DESCRIPTION
 - Whenever subscription redundancy is lost cached regions are supposed
   to be cleaned up. This commit implements interest recovery to achieve
   precisely that.
 - Whenever subscription redundancy is lost all entries with interest
   registered are cleaned up.
 - Implemented an optimization for regions which have interest
   registered to all keys.
 - ITs implemented to verify the functionality.
 - Adapted RegisterAllWithConsistencyDisabled test to work with the
   modified CacheListener mock.
 - As noted for RegisterAllWithConsistencyDisabled case, a fail-safe
   have been added to avoid a rare race condition.
 - Fixed coredump when trying to clear interest registry keys for
   regions with caching disabled.
 - Fixed exception whenever cleaning up cached region which interest
   list is a set of keys and some of them were already destroyed.
 - Export binary_semaphore class to make it avaialable for ITs. In the
   future it would be nice to have a library with all of the utilities
   common to the apache-geode library and tests.
   
---

**Additional information**. After testThinClientHADistOps failing, RC was solved and test coverage was increased