### PR TITLE
GEODE-8405: Don't ask for metadata for replicated regions

### DIFF
--- a/cppcache/src/ClientMetadataService.cpp
+++ b/cppcache/src/ClientMetadataService.cpp
@@ -121,6 +121,14 @@ void ClientMetadataService::getClientPRMetadata(const char* regionFullPath) {
     if (err == GF_NOERR &&
         reply.getMessageType() ==
             TcrMessage::RESPONSE_CLIENT_PARTITION_ATTRIBUTES) {
+      // By convention, server returns -1 bucket count to indicate replicated
+      // region
+      if (reply.getNumBuckets() == -1) {
+        LOGDEBUG(
+            "ClientMetadataService::getClientPRMetadata: region is"
+            "replicated, not partitioned - no metadata");
+        return;
+      }
       cptr = std::make_shared<ClientMetadata>(reply.getNumBuckets(),
                                               reply.getColocatedWith(), m_pool,
                                               reply.getFpaSet());


### PR DESCRIPTION
Sending GET_CLIENT_PR_METADATA to a server for a replicated region generated an EXCEPTION response message, which the native client would then ignore.  Convention in the Java client is to check for a bucket count of -1, indicating replicated region, and skip the metadata request in that case.

@gaussianrecurrence 