### PR TITLE
GEODE-9236: Fix testThinClientFailover2 and reenable

### DIFF
--- a/cppcache/integration-test/CMakeLists.txt
+++ b/cppcache/integration-test/CMakeLists.txt
@@ -186,7 +186,7 @@ set_tests_properties(
     testThinClientDurableDisconnectNormal
     testThinClientDurableDisconnectTimeout
     testThinClientDurableReconnect
-    testThinClientFailover2
+    #testThinClientFailover2
     testThinClientHAFailover
     testThinClientHAMixedRedundancy
     testThinClientHAQueryFailover

--- a/cppcache/integration-test/CMakeLists.txt
+++ b/cppcache/integration-test/CMakeLists.txt
@@ -186,7 +186,6 @@ set_tests_properties(
     testThinClientDurableDisconnectNormal
     testThinClientDurableDisconnectTimeout
     testThinClientDurableReconnect
-    #testThinClientFailover2
     testThinClientHAFailover
     testThinClientHAMixedRedundancy
     testThinClientHAQueryFailover

--- a/cppcache/integration-test/ThinClientFailover2.hpp
+++ b/cppcache/integration-test/ThinClientFailover2.hpp
@@ -440,8 +440,7 @@ DUNIT_TASK_DEFINITION(CLIENT2, StepSix)
     // This step get the value from region, if key is inavalidate in region,
     // value
     // will get from server.
-    // doNetsearch( regionNames[0], keys[4], vals[4] );
-    verifyEntry(regionName, keys[0], nvals[0]);
+    doNetsearch( regionName, keys[0], nvals[0] );
     updateEntry(regionName, keys[1], nvals[1]);
     LOG("StepSix complete.");
   }


### PR DESCRIPTION
This test is important because it validates CACHING_PROXY with client notifications enabled for multiple client caches.