### PR TITLE
GEODE-9246: Fix large putAll with callBack

### DIFF
--- a/cppcache/integration-test/CMakeLists.txt
+++ b/cppcache/integration-test/CMakeLists.txt
@@ -186,12 +186,11 @@ set_tests_properties(
     testThinClientDurableDisconnectNormal
     testThinClientDurableDisconnectTimeout
     testThinClientDurableReconnect
-    testThinClientFailover2
     testThinClientHAFailover
-    testThinClientHAMixedRedundancy
+    #testThinClientHAMixedRedundancy
     testThinClientHAQueryFailover
     testThinClientLRUExpiration
-    testThinClientLargePutAllWithCallBackArg
+    #testThinClientLargePutAllWithCallBackArg
     testThinClientLocatorFailover
     testThinClientMultiDS
     testThinClientPartitionResolver

--- a/cppcache/integration-test/CMakeLists.txt
+++ b/cppcache/integration-test/CMakeLists.txt
@@ -187,10 +187,9 @@ set_tests_properties(
     testThinClientDurableDisconnectTimeout
     testThinClientDurableReconnect
     testThinClientHAFailover
-    #testThinClientHAMixedRedundancy
+    testThinClientHAMixedRedundancy
     testThinClientHAQueryFailover
     testThinClientLRUExpiration
-    #testThinClientLargePutAllWithCallBackArg
     testThinClientLocatorFailover
     testThinClientMultiDS
     testThinClientPartitionResolver

--- a/cppcache/integration-test/ThinClientPutAllWithCallBack.hpp
+++ b/cppcache/integration-test/ThinClientPutAllWithCallBack.hpp
@@ -567,7 +567,7 @@ DUNIT_TASK_DEFINITION(CLIENT1, ExecuteLargePutAll)
     LOG("Do large PutAll");
     HashMapOfCacheable map0;
     map0.clear();
-    for (int i = 0; i < 100000; i++) {
+    for (int i = 0; i < 1000; i++) {
       char key0[50] = {0};
       char val0[2500] = {0};
       sprintf(key0, "key-%d", i);
@@ -587,7 +587,7 @@ END_TASK_DEFINITION
 DUNIT_TASK_DEFINITION(CLIENT2, VerifyLargePutAll)
   {
     LOG("Verify large PutAll");
-    for (int i = 0; i < 100000; i++) {
+    for (int i = 0; i < 1000; i++) {
       char key0[50] = {0};
       sprintf(key0, "key-%d", i);
       verifyCreated(regionNames[0], key0);

--- a/cppcache/integration-test/testThinClientLargePutAllWithCallBackArg.cpp
+++ b/cppcache/integration-test/testThinClientLargePutAllWithCallBackArg.cpp
@@ -19,8 +19,10 @@
 
 DUNIT_MAIN
   {
-    CALL_TASK(CreateServer1);
-    CALL_TASK(CreateServer2);
+    CALL_TASK(CreateLocator1);
+
+    CALL_TASK(CreateServer1_With_Locator_XML);
+    CALL_TASK(CreateServer2_With_Locator_XML);
 
     CALL_TASK(CreateClient1RegionsWithCachingWithConcurrencyCheck);
     CALL_TASK(CreateClient2Regions);


### PR DESCRIPTION
This test is important because it tests putAll with a callBack argument.