### PR TITLE
GEODE-9321: Fix possible race condition on ITs

### DIFF
--- a/cppcache/integration/test/RegisterKeysTest.cpp
+++ b/cppcache/integration/test/RegisterKeysTest.cpp
@@ -16,9 +16,6 @@
 
 #include <gmock/gmock.h>
 
-#include <condition_variable>
-#include <mutex>
-
 #include <boost/thread/latch.hpp>
 
 #include <gtest/gtest.h>
@@ -33,6 +30,7 @@
 #include "framework/Cluster.h"
 #include "framework/Framework.h"
 #include "framework/Gfsh.h"
+#include "gmock_actions.hpp"
 #include "mock/CacheListenerMock.hpp"
 #include "util/concurrent/binary_semaphore.hpp"
 
@@ -53,10 +51,6 @@ using ::testing::_;
 using ::testing::DoAll;
 using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
-
-ACTION_P(ReleaseSem, sem) { sem->release(); }
-ACTION_P(AcquireSem, sem) { sem->acquire(); }
-ACTION_P(CountDownLatch, latch) { latch->count_down(); }
 
 Cache createTestCache() {
   CacheFactory cacheFactory;

--- a/cppcache/integration/test/gmock_actions.hpp
+++ b/cppcache/integration/test/gmock_actions.hpp
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GMOCK_ACTIONS_H_
+#define GMOCK_ACTIONS_H_
+
+#include <gmock/gmock.h>
+
+ACTION_P(ReleaseSem, sem) { sem->release(); }
+ACTION_P(AcquireSem, sem) { sem->acquire(); }
+ACTION_P(CountDownLatch, latch) { latch->count_down(); }
+
+#endif  // GMOCK_ACTIONS_H_


### PR DESCRIPTION
 - Solved a possible race condition in ServerDisconnectWithListener TS
   due to the fact that there was no check to verify the server was
   actually stopped.
 - Also added gmock_actions helper to avoid duplication.
 - Modified RegisterKeysTest to use gmock_actions helper.