### PR TITLE
GEODE-9322: Fix possible race condition on new ITs

### DIFF
--- a/cppcache/integration/test/TransactionCleaningTest.cpp
+++ b/cppcache/integration/test/TransactionCleaningTest.cpp
@@ -17,25 +17,55 @@
 
 #include <gmock/gmock.h>
 
-#include <future>
-#include <thread>
-
 #include <gtest/gtest.h>
 
 #include <geode/CacheTransactionManager.hpp>
+#include <geode/EntryEvent.hpp>
+#include <geode/RegionEvent.hpp>
 #include <geode/RegionFactory.hpp>
 #include <geode/RegionShortcut.hpp>
 
 #include "framework/Cluster.h"
+#include "gmock_actions.hpp"
+#include "mock/CacheListenerMock.hpp"
+#include "util/concurrent/binary_semaphore.hpp"
 
 namespace {
 
+using apache::geode::client::binary_semaphore;
+
+using apache::geode::client::Cache;
+using apache::geode::client::CacheFactory;
+using apache::geode::client::CacheListener;
+using apache::geode::client::CacheListenerMock;
+using apache::geode::client::Exception;
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::NiceMock;
+
+Cache createTestCache() {
+  CacheFactory cacheFactory;
+  return cacheFactory.set("log-level", "none")
+      .set("statistic-sampling-enabled", "false")
+      .create();
+}
+
+void createTestPool(Cache& cache, Cluster& cluster) {
+  auto poolFactory =
+      cache.getPoolManager().createFactory().setSubscriptionEnabled(true);
+  cluster.applyLocators(poolFactory);
+  poolFactory.create("default");
+}
+
 std::shared_ptr<apache::geode::client::Region> setupRegion(
-    apache::geode::client::Cache &cache) {
-  auto region =
-      cache.createRegionFactory(apache::geode::client::RegionShortcut::PROXY)
-          .setPoolName("default")
-          .create("region");
+    Cache& cache, const std::shared_ptr<CacheListener>& listener) {
+  auto region = cache
+                    .createRegionFactory(
+                        apache::geode::client::RegionShortcut::CACHING_PROXY)
+                    .setPoolName("default")
+                    .setCacheListener(listener)
+                    .create("region");
   return region;
 }
 
@@ -51,27 +81,34 @@ TEST(TransactionCleaningTest, txWithStoppedServer) {
       .withType("PARTITION")
       .execute();
 
-  auto cache = cluster.createCache();
-  auto region = setupRegion(cache);
+  auto cache = createTestCache();
+  createTestPool(cache, cluster);
+
+  binary_semaphore live_sem{0};
+  binary_semaphore shut_sem{1};
+  auto listener = std::make_shared<NiceMock<CacheListenerMock>>();
+  EXPECT_CALL(*listener, afterRegionLive(_))
+      .WillRepeatedly(DoAll(ReleaseSem(&live_sem), AcquireSem(&shut_sem)));
+  EXPECT_CALL(*listener, afterRegionDisconnected(_))
+      .WillRepeatedly(DoAll(ReleaseSem(&shut_sem), AcquireSem(&live_sem)));
+  auto region = setupRegion(cache, listener);
 
   cache.getCacheTransactionManager()->begin();
   region->put("one", "one");
   cache.getCacheTransactionManager()->commit();
 
   cluster.getServers()[0].stop();
+  shut_sem.acquire();
+  shut_sem.release();
 
-  try {
-    cache.getCacheTransactionManager()->begin();
-    region->put("one", "two");
-  } catch (apache::geode::client::Exception &) {
-  }
+  cache.getCacheTransactionManager()->begin();
+  EXPECT_THROW(region->put("one", "two"), Exception);
 
-  try {
-    cache.getCacheTransactionManager()->rollback();
-  } catch (apache::geode::client::Exception &) {
-  }
+  cache.getCacheTransactionManager()->rollback();
 
   cluster.getServers()[0].start();
+  live_sem.acquire();
+  live_sem.release();
 
   cache.getCacheTransactionManager()->begin();
   region->put("one", "three");


### PR DESCRIPTION
 - Solved a potential race condition in TransactionCleaningTest TS
   due to the fact that no checks were performed after starting/stopping
   the server.