### PR TITLE
GEODE-9323: Remove ACE from tests/cpp projects

### DIFF
--- a/cppcache/src/ExpiryTask.hpp
+++ b/cppcache/src/ExpiryTask.hpp
@@ -74,7 +74,7 @@ class ExpiryTask : public std::enable_shared_from_this<ExpiryTask> {
   /**
    * Returns an ID which represents an invalid task
    */
-  static constexpr id_t invalid() { return std::numeric_limits<id_t>::max(); }
+  static constexpr id_t invalid() { return (std::numeric_limits<id_t>::max)(); }
 
  protected:
   using timer_t = boost::asio::steady_timer;

--- a/cppcache/src/SerializationRegistry.cpp
+++ b/cppcache/src/SerializationRegistry.cpp
@@ -17,8 +17,7 @@
 
 #include "SerializationRegistry.hpp"
 
-#include <functional>
-#include <mutex>
+#include <limits>
 
 #include <geode/CacheableBuiltins.hpp>
 #include <geode/CacheableDate.hpp>
@@ -138,6 +137,148 @@ void TheTypeMap::setup() {
   bindDataSerializableFixedId(EnumInfo::createDeserializable);
   bindDataSerializableFixedId(DiskStoreId::createDeserializable);
   bindDataSerializableFixedId(GatewaySenderEventCallbackArgument::create);
+}
+
+void SerializationRegistry::serialize(const std::shared_ptr<Serializable>& obj,
+                                      DataOutput& output, bool isDelta) const {
+  if (obj == nullptr) {
+    output.write(static_cast<int8_t>(DSCode::NullObj));
+  } else if (auto&& pdxSerializable =
+                 std::dynamic_pointer_cast<PdxSerializable>(obj)) {
+    serialize(pdxSerializable, output);
+  } else if (const auto&& dataSerializableFixedId =
+                 std::dynamic_pointer_cast<DataSerializableFixedId>(obj)) {
+    serialize(dataSerializableFixedId, output);
+  } else if (const auto&& dataSerializablePrimitive =
+                 std::dynamic_pointer_cast<DataSerializablePrimitive>(obj)) {
+    serialize(dataSerializablePrimitive, output);
+  } else if (const auto&& dataSerializable =
+                 std::dynamic_pointer_cast<DataSerializable>(obj)) {
+    dataSerializableHandler_->serialize(dataSerializable, output, isDelta);
+  } else if (const auto&& dataSerializableInternal =
+                 std::dynamic_pointer_cast<DataSerializableInternal>(obj)) {
+    serialize(dataSerializableInternal, output);
+  } else {
+    throw UnsupportedOperationException(
+        "SerializationRegistry::serialize: Serialization type not "
+        "implemented.");
+  }
+}
+
+void SerializationRegistry::setPdxTypeHandler(PdxTypeHandler* handler) {
+  pdxTypeHandler_ = std::unique_ptr<PdxTypeHandler>(handler);
+}
+void SerializationRegistry::setDataSerializableHandler(
+    DataSerializableHandler* handler) {
+  dataSerializableHandler_ = std::unique_ptr<DataSerializableHandler>(handler);
+}
+
+TypeFactoryMethod SerializationRegistry::getDataSerializableCreationMethod(
+    int32_t objectId) {
+  TypeFactoryMethod createType;
+  theTypeMap_.findDataSerializable(objectId, createType);
+  return createType;
+}
+
+int32_t SerializationRegistry::getIdForDataSerializableType(
+    std::type_index objectType) const {
+  auto&& typeIterator = theTypeMap_.typeToClassId_.find(objectType);
+  return typeIterator->second;
+}
+
+DSCode SerializationRegistry::getSerializableDataDsCode(int32_t classId) {
+  if (classId <= std::numeric_limits<int8_t>::max() &&
+      classId >= std::numeric_limits<int8_t>::min()) {
+    return DSCode::CacheableUserData;
+  } else if (classId <= std::numeric_limits<int16_t>::max() &&
+             classId >= std::numeric_limits<int16_t>::min()) {
+    return DSCode::CacheableUserData2;
+  } else {
+    return DSCode::CacheableUserData4;
+  }
+}
+
+void SerializationRegistry::serializeWithoutHeader(
+    const std::shared_ptr<Serializable>& obj, DataOutput& output) const {
+  if (const auto&& pdxSerializable =
+          std::dynamic_pointer_cast<PdxSerializable>(obj)) {
+    serializeWithoutHeader(pdxSerializable, output);
+  } else if (const auto&& dataSerializableFixedId =
+                 std::dynamic_pointer_cast<DataSerializableFixedId>(obj)) {
+    serializeWithoutHeader(dataSerializableFixedId, output);
+  } else if (const auto&& dataSerializablePrimitive =
+                 std::dynamic_pointer_cast<DataSerializablePrimitive>(obj)) {
+    serializeWithoutHeader(dataSerializablePrimitive, output);
+  } else if (const auto&& dataSerializable =
+                 std::dynamic_pointer_cast<DataSerializable>(obj)) {
+    serializeWithoutHeader(dataSerializable, output);
+  } else if (const auto&& dataSerializableInternal =
+                 std::dynamic_pointer_cast<DataSerializableInternal>(obj)) {
+    serializeWithoutHeader(dataSerializableInternal, output);
+  } else {
+    throw UnsupportedOperationException(
+        "SerializationRegistry::serializeWithoutHeader: Serialization type "
+        "not implemented.");
+  }
+}
+
+void SerializationRegistry::serialize(
+    const std::shared_ptr<DataSerializableFixedId>& obj,
+    DataOutput& output) const {
+  auto id = static_cast<int32_t>(obj->getDSFID());
+  if (id <= std::numeric_limits<int8_t>::max() &&
+      id >= std::numeric_limits<int8_t>::min()) {
+    output.write(static_cast<int8_t>(DSCode::FixedIDByte));
+    output.write(static_cast<int8_t>(id));
+  } else if (id <= std::numeric_limits<int16_t>::max() &&
+             id >= std::numeric_limits<int16_t>::min()) {
+    output.write(static_cast<int8_t>(DSCode::FixedIDShort));
+    output.writeInt(static_cast<int16_t>(id));
+  } else {
+    output.write(static_cast<int8_t>(DSCode::FixedIDInt));
+    output.writeInt(static_cast<int32_t>(id));
+  }
+
+  serializeWithoutHeader(obj, output);
+}
+
+void SerializationRegistry::serializeWithoutHeader(
+    const std::shared_ptr<DataSerializableFixedId>& obj,
+    DataOutput& output) const {
+  obj->toData(output);
+}
+
+void SerializationRegistry::serialize(
+    const std::shared_ptr<DataSerializablePrimitive>& obj,
+    DataOutput& output) const {
+  auto id = obj->getDsCode();
+  output.write(static_cast<int8_t>(id));
+
+  serializeWithoutHeader(obj, output);
+}
+
+void SerializationRegistry::serializeWithoutHeader(
+    const std::shared_ptr<DataSerializablePrimitive>& obj,
+    DataOutput& output) const {
+  obj->toData(output);
+}
+
+void SerializationRegistry::serialize(
+    const std::shared_ptr<PdxSerializable>& obj, DataOutput& output) const {
+  output.write(static_cast<int8_t>(DSCode::PDX));
+  serializeWithoutHeader(obj, output);
+}
+
+void SerializationRegistry::serialize(
+    const std::shared_ptr<DataSerializableInternal>& obj,
+    DataOutput& output) const {
+  serializeWithoutHeader(obj, output);
+}
+
+void SerializationRegistry::serializeWithoutHeader(
+    const std::shared_ptr<DataSerializableInternal>& obj,
+    DataOutput& output) const {
+  obj->toData(output);
 }
 
 /** This starts at reading the typeid.. assumes the length has been read. */
@@ -428,6 +569,7 @@ int32_t SerializationRegistry::GetEnumValue(
 
   return static_cast<ThinClientPoolDM*>(pool.get())->GetEnumValue(enumInfo);
 }
+
 std::shared_ptr<Serializable> SerializationRegistry::GetEnum(
     std::shared_ptr<Pool> pool, int32_t val) const {
   if (pool == nullptr) {

--- a/cppcache/src/SerializationRegistry.hpp
+++ b/cppcache/src/SerializationRegistry.hpp
@@ -174,55 +174,11 @@ class APACHE_GEODE_EXPORT SerializationRegistry {
    * then write whatever the object's toData requires. The length at the
    * front is backfilled after the serialization.
    */
-  inline void serialize(const std::shared_ptr<Serializable>& obj,
-                        DataOutput& output, bool isDelta = false) const {
-    if (obj == nullptr) {
-      output.write(static_cast<int8_t>(DSCode::NullObj));
-    } else if (auto&& pdxSerializable =
-                   std::dynamic_pointer_cast<PdxSerializable>(obj)) {
-      serialize(pdxSerializable, output);
-    } else if (const auto&& dataSerializableFixedId =
-                   std::dynamic_pointer_cast<DataSerializableFixedId>(obj)) {
-      serialize(dataSerializableFixedId, output);
-    } else if (const auto&& dataSerializablePrimitive =
-                   std::dynamic_pointer_cast<DataSerializablePrimitive>(obj)) {
-      serialize(dataSerializablePrimitive, output);
-    } else if (const auto&& dataSerializable =
-                   std::dynamic_pointer_cast<DataSerializable>(obj)) {
-      dataSerializableHandler_->serialize(dataSerializable, output, isDelta);
-    } else if (const auto&& dataSerializableInternal =
-                   std::dynamic_pointer_cast<DataSerializableInternal>(obj)) {
-      serialize(dataSerializableInternal, output);
-    } else {
-      throw UnsupportedOperationException(
-          "SerializationRegistry::serialize: Serialization type not "
-          "implemented.");
-    }
-  }
+  void serialize(const std::shared_ptr<Serializable>& obj, DataOutput& output,
+                 bool isDelta = false) const;
 
-  inline void serializeWithoutHeader(const std::shared_ptr<Serializable>& obj,
-                                     DataOutput& output) const {
-    if (const auto&& pdxSerializable =
-            std::dynamic_pointer_cast<PdxSerializable>(obj)) {
-      serializeWithoutHeader(pdxSerializable, output);
-    } else if (const auto&& dataSerializableFixedId =
-                   std::dynamic_pointer_cast<DataSerializableFixedId>(obj)) {
-      serializeWithoutHeader(dataSerializableFixedId, output);
-    } else if (const auto&& dataSerializablePrimitive =
-                   std::dynamic_pointer_cast<DataSerializablePrimitive>(obj)) {
-      serializeWithoutHeader(dataSerializablePrimitive, output);
-    } else if (const auto&& dataSerializable =
-                   std::dynamic_pointer_cast<DataSerializable>(obj)) {
-      serializeWithoutHeader(dataSerializable, output);
-    } else if (const auto&& dataSerializableInternal =
-                   std::dynamic_pointer_cast<DataSerializableInternal>(obj)) {
-      serializeWithoutHeader(dataSerializableInternal, output);
-    } else {
-      throw UnsupportedOperationException(
-          "SerializationRegistry::serializeWithoutHeader: Serialization type "
-          "not implemented.");
-    }
-  }
+  void serializeWithoutHeader(const std::shared_ptr<Serializable>& obj,
+                              DataOutput& output) const;
 
   /**
    * Read the length, typeid, and run the objs fromData. Returns the New
@@ -265,110 +221,55 @@ class APACHE_GEODE_EXPORT SerializationRegistry {
   std::shared_ptr<PdxSerializable> getPdxSerializableType(
       const std::string& className) const;
 
-  void setPdxTypeHandler(PdxTypeHandler* handler) {
-    this->pdxTypeHandler_ = std::unique_ptr<PdxTypeHandler>(handler);
-  }
-  void setDataSerializableHandler(DataSerializableHandler* handler) {
-    this->dataSerializableHandler_ =
-        std::unique_ptr<DataSerializableHandler>(handler);
-  }
+  void setPdxTypeHandler(PdxTypeHandler* handler);
 
-  TypeFactoryMethod getDataSerializableCreationMethod(int32_t objectId) {
-    TypeFactoryMethod createType;
-    theTypeMap_.findDataSerializable(objectId, createType);
-    return createType;
-  }
+  void setDataSerializableHandler(DataSerializableHandler* handler);
 
-  int32_t getIdForDataSerializableType(std::type_index objectType) const {
-    auto&& typeIterator = theTypeMap_.typeToClassId_.find(objectType);
-    auto&& id = typeIterator->second;
-    return id;
-  }
+  TypeFactoryMethod getDataSerializableCreationMethod(int32_t objectId);
+
+  int32_t getIdForDataSerializableType(std::type_index objectType) const;
+
+  static DSCode getSerializableDataDsCode(int32_t classId);
+
+ private:
+  std::shared_ptr<Serializable> deserializeDataSerializableFixedId(
+      DataInput& input, DSCode dsCode) const;
+
+  void serialize(const std::shared_ptr<DataSerializableFixedId>& obj,
+                 DataOutput& output) const;
+
+  void serializeWithoutHeader(
+      const std::shared_ptr<DataSerializableFixedId>& obj,
+      DataOutput& output) const;
+
+  void serialize(const std::shared_ptr<DataSerializablePrimitive>& obj,
+                 DataOutput& output) const;
+
+  void serializeWithoutHeader(
+      const std::shared_ptr<DataSerializablePrimitive>& obj,
+      DataOutput& output) const;
+
+  void serialize(const std::shared_ptr<PdxSerializable>& obj,
+                 DataOutput& output) const;
+
+  void serializeWithoutHeader(const std::shared_ptr<PdxSerializable>& obj,
+                              DataOutput& output) const;
+
+  void serialize(const std::shared_ptr<DataSerializableInternal>& obj,
+                 DataOutput& output) const;
+
+  void serializeWithoutHeader(
+      const std::shared_ptr<DataSerializableInternal>& obj,
+      DataOutput& output) const;
+
+  void deserialize(DataInput& input,
+                   const std::shared_ptr<Serializable>& obj) const;
 
  private:
   std::unique_ptr<PdxTypeHandler> pdxTypeHandler_;
   std::shared_ptr<PdxSerializer> pdxSerializer_;
   std::unique_ptr<DataSerializableHandler> dataSerializableHandler_;
   TheTypeMap theTypeMap_;
-
-  std::shared_ptr<Serializable> deserializeDataSerializableFixedId(
-      DataInput& input, DSCode dsCode) const;
-
-  inline void serialize(const std::shared_ptr<DataSerializableFixedId>& obj,
-                        DataOutput& output) const {
-    auto id = static_cast<int32_t>(obj->getDSFID());
-    if (id <= std::numeric_limits<int8_t>::max() &&
-        id >= std::numeric_limits<int8_t>::min()) {
-      output.write(static_cast<int8_t>(DSCode::FixedIDByte));
-      output.write(static_cast<int8_t>(id));
-    } else if (id <= std::numeric_limits<int16_t>::max() &&
-               id >= std::numeric_limits<int16_t>::min()) {
-      output.write(static_cast<int8_t>(DSCode::FixedIDShort));
-      output.writeInt(static_cast<int16_t>(id));
-    } else {
-      output.write(static_cast<int8_t>(DSCode::FixedIDInt));
-      output.writeInt(static_cast<int32_t>(id));
-    }
-
-    serializeWithoutHeader(obj, output);
-  }
-
-  inline void serializeWithoutHeader(
-      const std::shared_ptr<DataSerializableFixedId>& obj,
-      DataOutput& output) const {
-    obj->toData(output);
-  }
-
-  inline void serialize(const std::shared_ptr<DataSerializablePrimitive>& obj,
-                        DataOutput& output) const {
-    auto id = obj->getDsCode();
-    output.write(static_cast<int8_t>(id));
-
-    serializeWithoutHeader(obj, output);
-  }
-
-  inline void serializeWithoutHeader(
-      const std::shared_ptr<DataSerializablePrimitive>& obj,
-      DataOutput& output) const {
-    obj->toData(output);
-  }
-
-  inline void serialize(const std::shared_ptr<PdxSerializable>& obj,
-                        DataOutput& output) const {
-    output.write(static_cast<int8_t>(DSCode::PDX));
-    serializeWithoutHeader(obj, output);
-  }
-
-  void serializeWithoutHeader(const std::shared_ptr<PdxSerializable>& obj,
-                              DataOutput& output) const;
-
-  inline void serialize(const std::shared_ptr<DataSerializableInternal>& obj,
-                        DataOutput& output) const {
-    serializeWithoutHeader(obj, output);
-  }
-
-  inline void serializeWithoutHeader(
-      const std::shared_ptr<DataSerializableInternal>& obj,
-      DataOutput& output) const {
-    obj->toData(output);
-  }
-
- public:
-  static inline DSCode getSerializableDataDsCode(int32_t classId) {
-    if (classId <= std::numeric_limits<int8_t>::max() &&
-        classId >= std::numeric_limits<int8_t>::min()) {
-      return DSCode::CacheableUserData;
-    } else if (classId <= std::numeric_limits<int16_t>::max() &&
-               classId >= std::numeric_limits<int16_t>::min()) {
-      return DSCode::CacheableUserData2;
-    } else {
-      return DSCode::CacheableUserData4;
-    }
-  }
-
- private:
-  void deserialize(DataInput& input,
-                   const std::shared_ptr<Serializable>& obj) const;
 };
 
 }  // namespace client

--- a/tests/cpp/fwklib/CMakeLists.txt
+++ b/tests/cpp/fwklib/CMakeLists.txt
@@ -42,7 +42,6 @@ target_link_libraries(framework
   PUBLIC
     apache-geode
   PRIVATE
-    ACE::ACE
     Boost::boost
     internal
     _WarningsAsError

--- a/tests/cpp/security/CMakeLists.txt
+++ b/tests/cpp/security/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(security
     OpenSSL::Crypto
     OpenSSL::SSL
   PRIVATE
-    ACE::ACE
     Boost::boost
     Boost::log
     _WarningsAsError

--- a/tests/cpp/security/CredentialGenerator.cpp
+++ b/tests/cpp/security/CredentialGenerator.cpp
@@ -37,6 +37,7 @@
 #include "LdapUserCredentialGenerator.hpp"
 #include "NoopCredentialGenerator.hpp"
 #include "PkcsCredentialGenerator.hpp"
+#include "Utils.hpp"
 
 namespace apache {
 namespace geode {
@@ -93,6 +94,15 @@ void CredentialGenerator::getAuthInit(std::shared_ptr<Properties>& prop) {
     prop->insert("security-client-auth-library",
                  getClientAuthInitLoaderLibrary().c_str());
   }
+}
+
+std::string CredentialGenerator::getPublickeyfile() {
+  auto path = Utils::getEnv("TESTSRC");
+  if (path.empty()) {
+    path = Utils::getEnv("BUILDDIR") + "/framework/data";
+  }
+
+  return path + "/keystore/publickeyfile";
 }
 
 std::string CredentialGenerator::getServerCmdParams(std::string securityParams,

--- a/tests/cpp/security/CredentialGenerator.hpp
+++ b/tests/cpp/security/CredentialGenerator.hpp
@@ -34,8 +34,6 @@
 
 #include <map>
 
-#include <ace/OS.h>
-
 #include <geode/Properties.hpp>
 
 #include "typedefs.hpp"
@@ -136,13 +134,7 @@ class CredentialGenerator {
 
   void getAuthInit(std::shared_ptr<Properties>& prop);
 
-  std::string getPublickeyfile() {
-    auto path =
-        ACE_OS::getenv("TESTSRC")
-            ? std::string(ACE_OS::getenv("TESTSRC"))
-            : std::string(ACE_OS::getenv("BUILDDIR")) + "/framework/data";
-    return path + "/keystore/publickeyfile";
-  }
+  std::string getPublickeyfile();
 
   std::string getServerCmdParams(std::string securityParams,
                                  std::string workingDir = "",

--- a/tests/cpp/security/DummyCredentialGenerator.cpp
+++ b/tests/cpp/security/DummyCredentialGenerator.cpp
@@ -31,6 +31,8 @@
 
 #include <boost/log/trivial.hpp>
 
+#include "Utils.hpp"
+
 namespace apache {
 namespace geode {
 namespace client {
@@ -39,25 +41,17 @@ namespace security {
 
 std::string DummyCredentialGenerator::getInitArgs(std::string workingDir,
                                                   bool userMode) {
-  std::string additionalArgs;
-  char* buildDir = ACE_OS::getenv("BUILDDIR");
-  if (buildDir && workingDir.length() == 0) {
-    workingDir = std::string(buildDir);
-    workingDir += std::string("/framework/xml/Security/");
+  auto buildDir = Utils::getEnv("BUILDDIR");
+  if (!buildDir.empty() && workingDir.empty()) {
+    workingDir = buildDir + "/framework/xml/Security/";
   }
 
   BOOST_LOG_TRIVIAL(info) << "Inside dummy Credentials usermode is "
                           << userMode;
 
-  if (userMode) {
-    additionalArgs = std::string(" --J=-Dgemfire.security-authz-xml-uri=") +
-                     std::string(workingDir) + std::string("authz-dummyMU.xml");
-  } else {
-    additionalArgs = std::string(" --J=-Dgemfire.security-authz-xml-uri=") +
-                     std::string(workingDir) + std::string("authz-dummy.xml");
-  }
-
-  return additionalArgs;
+  std::string result = " --J=-Dgemfire.security-authz-xml-uri=" + workingDir;
+  result += (userMode ? "authz-dummyMU.xml" : "authz-dummy.xml");
+  return result;
 }
 
 void DummyCredentialGenerator::getValidCredentials(

--- a/tests/cpp/security/DummyCredentialGenerator2.cpp
+++ b/tests/cpp/security/DummyCredentialGenerator2.cpp
@@ -31,11 +31,25 @@
 
 #include <boost/log/trivial.hpp>
 
+#include "Utils.hpp"
+
 namespace apache {
 namespace geode {
 namespace client {
 namespace testframework {
 namespace security {
+
+std::string DummyCredentialGenerator2::getInitArgs(std::string workingDir,
+                                                   bool userMode) {
+  auto buildDir = Utils::getEnv("BUILDDIR");
+  if (!buildDir.empty() && workingDir.empty()) {
+    workingDir = buildDir + "/framework/xml/Security/";
+  }
+
+  auto result = " --J=-Dgemfire.security-authz-xml-uri=" + workingDir;
+  result += (userMode ? "authz-dummyMU.xml" : "authz-dummy.xml");
+  return result;
+}
 
 void DummyCredentialGenerator2::getInvalidCredentials(
     std::shared_ptr<Properties>& p) {

--- a/tests/cpp/security/DummyCredentialGenerator2.hpp
+++ b/tests/cpp/security/DummyCredentialGenerator2.hpp
@@ -33,24 +33,7 @@ class DummyCredentialGenerator2 : public CredentialGenerator {
  public:
   DummyCredentialGenerator2() : CredentialGenerator(ID_DUMMY2, "DUMMY2") {}
 
-  std::string getInitArgs(std::string workingDir, bool userMode) override {
-    std::string additionalArgs;
-    char* buildDir = ACE_OS::getenv("BUILDDIR");
-    if (buildDir && workingDir.length() == 0) {
-      workingDir = std::string(buildDir);
-      workingDir += std::string("/framework/xml/Security/");
-    }
-    if (userMode) {
-      additionalArgs = std::string(" --J=-Dgemfire.security-authz-xml-uri=") +
-                       std::string(workingDir) +
-                       std::string("authz-dummyMU.xml");
-    } else {
-      additionalArgs = std::string(" --J=-Dgemfire.security-authz-xml-uri=") +
-                       std::string(workingDir) + std::string("authz-dummy.xml");
-    }
-
-    return additionalArgs;
-  }
+  std::string getInitArgs(std::string workingDir, bool userMode) override;
 
   std::string getClientAuthInitLoaderFactory() override {
     return "createUserPasswordAuthInitInstance";

--- a/tests/cpp/security/DummyCredentialGenerator3.cpp
+++ b/tests/cpp/security/DummyCredentialGenerator3.cpp
@@ -31,11 +31,25 @@
 
 #include <boost/log/trivial.hpp>
 
+#include "Utils.hpp"
+
 namespace apache {
 namespace geode {
 namespace client {
 namespace testframework {
 namespace security {
+std::string DummyCredentialGenerator3::getInitArgs(std::string workingDir,
+                                                   bool userMode) {
+  auto buildDir = Utils::getEnv("BUILDDIR");
+  if (!buildDir.empty() && workingDir.empty()) {
+    workingDir = buildDir + "/framework/xml/Security/";
+  }
+
+  auto result = " --J=-Dgemfire.security-authz-xml-uri=" + workingDir;
+  result += (userMode ? "authz-dummyMU.xml" : "authz-dummy.xml");
+  return result;
+}
+
 void DummyCredentialGenerator3::getValidCredentials(
     std::shared_ptr<Properties>& p) {
   p->insert("security-username", "user1");

--- a/tests/cpp/security/DummyCredentialGenerator3.hpp
+++ b/tests/cpp/security/DummyCredentialGenerator3.hpp
@@ -33,24 +33,7 @@ class DummyCredentialGenerator3 : public CredentialGenerator {
  public:
   DummyCredentialGenerator3() : CredentialGenerator(ID_DUMMY3, "DUMMY3") {}
 
-  std::string getInitArgs(std::string workingDir, bool userMode) override {
-    std::string additionalArgs;
-    char* buildDir = ACE_OS::getenv("BUILDDIR");
-    if (buildDir && workingDir.length() == 0) {
-      workingDir = std::string(buildDir);
-      workingDir += std::string("/framework/xml/Security/");
-    }
-    if (userMode) {
-      additionalArgs = std::string(" --J=-Dgemfire.security-authz-xml-uri=") +
-                       std::string(workingDir) +
-                       std::string("authz-dummyMU.xml");
-    } else {
-      additionalArgs = std::string(" --J=-Dgemfire.security-authz-xml-uri=") +
-                       std::string(workingDir) + std::string("authz-dummy.xml");
-    }
-
-    return additionalArgs;
-  }
+  std::string getInitArgs(std::string workingDir, bool userMode) override;
 
   std::string getClientAuthInitLoaderFactory() override {
     return "createUserPasswordAuthInitInstance";

--- a/tests/cpp/security/LdapUserCredentialGenerator.cpp
+++ b/tests/cpp/security/LdapUserCredentialGenerator.cpp
@@ -31,11 +31,41 @@
 
 #include <boost/log/trivial.hpp>
 
+#include "Utils.hpp"
+
 namespace apache {
 namespace geode {
 namespace client {
 namespace testframework {
 namespace security {
+
+std::string LdapUserCredentialGenerator::getInitArgs(std::string workingDir,
+                                                     bool) {
+  auto buildDir = Utils::getEnv("BUILDDIR");
+  if (!buildDir.empty() && workingDir.empty()) {
+    workingDir = buildDir + "/framework/xml/Security/";
+  }
+
+  std::string result =
+      " --J=-Dgemfire.security-authz-xml-uri=" + workingDir + "authz-ldap.xml";
+
+  auto ldapSrv = Utils::getEnv("LDAP_SERVER");
+  result += " --J=-Dgemfire.security-ldap-server=" +
+            (ldapSrv.empty() ? "ldap" : ldapSrv);
+
+  auto ldapRoot = Utils::getEnv("LDAP_BASEDN");
+  result += " --J=\\\"-Dgemfire.security-ldap-basedn=";
+  result +=
+      ldapRoot.empty() ? "ou=ldapTesting,dc=ldap,dc=apache,dc=org" : ldapRoot;
+  result += "\\\"";
+
+  auto ldapSSL = Utils::getEnv("LDAP_USESSL");
+  result += " --J=-Dgemfire.security-ldap-usessl=";
+  result += (ldapSSL.empty() ? "false" : ldapSSL);
+
+  return result;
+}
+
 void LdapUserCredentialGenerator::getValidCredentials(
     std::shared_ptr<Properties>& p) {
   p->insert("security-username", "geode1");

--- a/tests/cpp/security/LdapUserCredentialGenerator.hpp
+++ b/tests/cpp/security/LdapUserCredentialGenerator.hpp
@@ -20,8 +20,6 @@
  * limitations under the License.
  */
 
-#include <ace/ACE.h>
-#include <ace/OS.h>
 
 #include "CredentialGenerator.hpp"
 #include "XmlAuthzCredentialGenerator.hpp"
@@ -36,34 +34,7 @@ class LdapUserCredentialGenerator : public CredentialGenerator {
  public:
   LdapUserCredentialGenerator() : CredentialGenerator(ID_LDAP, "LDAP") {}
 
-  std::string getInitArgs(std::string workingDir, bool) override {
-    std::string additionalArgs;
-    char* buildDir = ACE_OS::getenv("BUILDDIR");
-    if (buildDir != nullptr && workingDir.length() == 0) {
-      workingDir = std::string(buildDir);
-      workingDir += std::string("/framework/xml/Security/");
-    }
-
-    additionalArgs = std::string(" --J=-Dgemfire.security-authz-xml-uri=") +
-                     std::string(workingDir) + std::string("authz-ldap.xml");
-
-    char* ldapSrv = ACE_OS::getenv("LDAP_SERVER");
-    additionalArgs += std::string(" --J=-Dgemfire.security-ldap-server=") +
-                      (ldapSrv != nullptr ? ldapSrv : "ldap");
-
-    char* ldapRoot = ACE_OS::getenv("LDAP_BASEDN");
-    additionalArgs +=
-        std::string(" --J=\\\"-Dgemfire.security-ldap-basedn=") +
-        (ldapRoot != nullptr ? ldapRoot
-                             : "ou=ldapTesting,dc=ldap,dc=apache,dc=org") +
-        "\\\"";
-
-    char* ldapSSL = ACE_OS::getenv("LDAP_USESSL");
-    additionalArgs += std::string(" --J=-Dgemfire.security-ldap-usessl=") +
-                      (ldapSSL != nullptr ? ldapSSL : "false");
-
-    return additionalArgs;
-  }
+  std::string getInitArgs(std::string workingDir, bool) override;
 
   std::string getClientAuthInitLoaderFactory() override {
     return "createUserPasswordAuthInitInstance";

--- a/tests/cpp/security/NoopCredentialGenerator.hpp
+++ b/tests/cpp/security/NoopCredentialGenerator.hpp
@@ -32,16 +32,8 @@ class NoopCredentialGenerator : public CredentialGenerator {
  public:
   NoopCredentialGenerator() : CredentialGenerator(ID_NOOP, "NOOP") {}
 
-  std::string getInitArgs(std::string workingDir, bool) override {
-    std::string additionalArgs;
-    char* buildDir = ACE_OS::getenv("BUILDDIR");
-    if (buildDir && workingDir.length() == 0) {
-      workingDir = std::string(buildDir);
-      workingDir += std::string("/framework/xml/Security/");
-    }
-    additionalArgs = " ";
-
-    return additionalArgs;
+  std::string getInitArgs(std::string, bool) override {
+    return " ";
   }
 
   std::string getClientAuthInitLoaderFactory() override {

--- a/tests/cpp/security/PkcsCredentialGenerator.hpp
+++ b/tests/cpp/security/PkcsCredentialGenerator.hpp
@@ -30,9 +30,6 @@ const char KEYSTORE_FILE_PATH[] = "security-keystorepath";
 const char KEYSTORE_ALIAS[] = "security-alias";
 const char KEYSTORE_PASSWORD[] = "security-keystorepass";
 
-#include <ace/ACE.h>
-#include <ace/OS.h>
-
 namespace apache {
 namespace geode {
 namespace client {
@@ -69,21 +66,10 @@ class PKCSCredentialGenerator : public CredentialGenerator {
   }
 
   void insertKeyStorePath(std::shared_ptr<Properties>& p,
-                          const std::string& username) {
-    auto path =
-        ACE_OS::getenv("TESTSRC")
-            ? std::string(ACE_OS::getenv("TESTSRC"))
-            : std::string(ACE_OS::getenv("BUILDDIR")) + "/framework/data";
-    p->insert(KEYSTORE_FILE_PATH, path + "/keystore/" + username + ".keystore");
-  }
+                          const std::string& username);
 
   void setPKCSProperties(std::shared_ptr<Properties>& p,
-                         const std::string& username) {
-    p->insert(SECURITY_USERNAME, "geode");
-    p->insert(KEYSTORE_ALIAS, username);
-    p->insert(KEYSTORE_PASSWORD, "geode");
-    insertKeyStorePath(p, username);
-  }
+                         const std::string& username);
 
   void getValidCredentials(std::shared_ptr<Properties>& p) override;
 

--- a/tests/cpp/testobject/DeltaTestImpl.cpp
+++ b/tests/cpp/testobject/DeltaTestImpl.cpp
@@ -81,10 +81,7 @@ void DeltaTestImpl::toData(DataOutput& output) const {
 }
 
 void DeltaTestImpl::toDelta(DataOutput& output) const {
-  {
-    std::lock_guard<decltype(mutex_)> guard{mutex_};
-    toDeltaCounter++;
-  }
+  ++toDeltaCounter;
 
   output.write(deltaBits);
   if ((deltaBits & INT_MASK) == INT_MASK) {
@@ -105,11 +102,7 @@ void DeltaTestImpl::toDelta(DataOutput& output) const {
 }
 
 void DeltaTestImpl::fromDelta(DataInput& input) {
-  {
-    std::lock_guard<decltype(mutex_)> guard{mutex_};
-    fromDeltaCounter++;
-  }
-
+  ++fromDeltaCounter;
   deltaBits = input.read();
 
   if ((deltaBits & INT_MASK) == INT_MASK) {

--- a/tests/cpp/testobject/DeltaTestImpl.hpp
+++ b/tests/cpp/testobject/DeltaTestImpl.hpp
@@ -20,12 +20,7 @@
 #ifndef GEODE_TESTOBJECT_DELTATESTIMPL_H_
 #define GEODE_TESTOBJECT_DELTATESTIMPL_H_
 
-#include <mutex>
-
-#include <ace/ACE.h>
-#include <ace/Condition_T.h>
-#include <ace/OS.h>
-#include <ace/Task.h>
+#include <atomic>
 
 #include <geode/DataSerializable.hpp>
 #include <geode/Delta.hpp>
@@ -60,9 +55,8 @@ class TESTOBJECT_EXPORT DeltaTestImpl : public DataSerializable, public Delta {
 
   bool m_hasDelta;
   uint8_t deltaBits;
-  mutable int64_t toDeltaCounter;
-  int64_t fromDeltaCounter;
-  mutable std::recursive_mutex mutex_;
+  mutable std::atomic<int64_t> toDeltaCounter;
+  std::atomic<int64_t> fromDeltaCounter;
 
  public:
   DeltaTestImpl();


### PR DESCRIPTION
 - Removed all ACE references from tests/cpp projects.
 - In order to sort out incomplete types errors as a consecuence
   of the changes above, inlined code from SerializationRegistry was
   moved to the cpp file.