### PR TITLE
Update clang tools version in CI

### DIFF
--- a/ci/docker/clang-tools/Dockerfile
+++ b/ci/docker/clang-tools/Dockerfile
@@ -18,7 +18,7 @@ FROM ubuntu:groovy
 LABEL maintainer="Apache Geode <dev@geode.apache.org>"
 LABEL description="Minimal image for building with clang toolset."
 
-ARG CLANG_VERSION=11
+ARG CLANG_VERSION=12
 RUN apt-get update \
     && apt-get install -y \
         bash \

--- a/ci/docker/clang-tools/Dockerfile
+++ b/ci/docker/clang-tools/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:groovy
+FROM ubuntu:latest
 LABEL maintainer="Apache Geode <dev@geode.apache.org>"
 LABEL description="Minimal image for building with clang toolset."
 

--- a/ci/docker/clang-tools/Dockerfile
+++ b/ci/docker/clang-tools/Dockerfile
@@ -14,12 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:latest
+FROM ubuntu:focal
 LABEL maintainer="Apache Geode <dev@geode.apache.org>"
 LABEL description="Minimal image for building with clang toolset."
 
+ARG DEBIAN_FRONTEND=noninteractive
 ARG CLANG_VERSION=12
 RUN apt-get update \
+    && apt-get install -y \
+        curl \
+        software-properties-common \
+    && curl -s https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${CLANG_VERSION} main" \
+    && apt-get update \
     && apt-get install -y \
         bash \
         libssl-dev \
@@ -28,7 +35,6 @@ RUN apt-get update \
         doxygen \
         openjdk-8-jdk-headless \
         jq \
-        curl \
         make \
         clang-${CLANG_VERSION} \
         lld-${CLANG_VERSION} \


### PR DESCRIPTION
Homebrew formulae for MacOS  installs v12 of clang tools by default now, and once again it is not compatible with the previous version.  This installs v12 on our Docker image, so we don't have to jump through more hoops for Mac development.