### PR TITLE
Reduce parallelism in integration tests to 4

### DIFF
--- a/ci/lib/templates.lib.yml
+++ b/ci/lib/templates.lib.yml
@@ -213,7 +213,7 @@ plan:
           - #@ bash_task("upload-geode", [{"name":"instance"},{"name":"geode-latest"}], [], upload_geode_bash_task())
     - #@ build_task(config.config, build.params)
     - #@ remote_task("cpp-unit-tests", config.config, ctest_bash_task("build/cppcache/test", parallel=8), "30m", build.params)
-    - #@ remote_task("cpp-integration-tests", config.config, ctest_bash_task("build/cppcache/integration/test"), "1h", build.params)
+    - #@ remote_task("cpp-integration-tests", config.config, ctest_bash_task("build/cppcache/integration/test", parallel=4), "1h", build.params)
     - #@ remote_task("cpp-legacy-integration-tests", config.config, ctest_bash_task("build/cppcache/integration-test", timeout=500, parallel=4), "2h", build.params)
     #@ if build.with_dot_net:
     - #@ remote_task("net-unmanaged-unit-tests", config.config, ctest_bash_task("build/clicache/test", parallel=8), "10m", build.params)

--- a/cppcache/src/RegionAttributes.cpp
+++ b/cppcache/src/RegionAttributes.cpp
@@ -64,8 +64,9 @@ std::shared_ptr<CacheLoader> RegionAttributes::getCacheLoader() const {
     if (CacheXmlParser::managedCacheLoaderFn_ &&
         m_cacheLoaderFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheLoader.reset((CacheXmlParser::managedCacheLoaderFn_)(
-          m_cacheLoaderLibrary.c_str(), m_cacheLoaderFactory.c_str()));
+      m_cacheLoader.reset((
+          CacheXmlParser::managedCacheLoaderFn_)(m_cacheLoaderLibrary.c_str(),
+                                                 m_cacheLoaderFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheLoader*()>(
           m_cacheLoaderLibrary, m_cacheLoaderFactory);
@@ -80,8 +81,9 @@ std::shared_ptr<CacheWriter> RegionAttributes::getCacheWriter() const {
     if (CacheXmlParser::managedCacheWriterFn_ &&
         m_cacheWriterFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheWriter.reset((CacheXmlParser::managedCacheWriterFn_)(
-          m_cacheWriterLibrary.c_str(), m_cacheWriterFactory.c_str()));
+      m_cacheWriter.reset((
+          CacheXmlParser::managedCacheWriterFn_)(m_cacheWriterLibrary.c_str(),
+                                                 m_cacheWriterFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheWriter*()>(
           m_cacheWriterLibrary, m_cacheWriterFactory);
@@ -96,8 +98,11 @@ std::shared_ptr<CacheListener> RegionAttributes::getCacheListener() const {
     if (CacheXmlParser::managedCacheListenerFn_ &&
         m_cacheListenerFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheListener.reset((CacheXmlParser::managedCacheListenerFn_)(
-          m_cacheListenerLibrary.c_str(), m_cacheListenerFactory.c_str()));
+      m_cacheListener.reset(
+          (CacheXmlParser::managedCacheListenerFn_)(m_cacheListenerLibrary
+                                                        .c_str(),
+                                                    m_cacheListenerFactory
+                                                        .c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheListener*()>(
           m_cacheListenerLibrary, m_cacheListenerFactory);
@@ -114,9 +119,10 @@ std::shared_ptr<PartitionResolver> RegionAttributes::getPartitionResolver()
     if (CacheXmlParser::managedPartitionResolverFn_ &&
         m_partitionResolverFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_partitionResolver.reset((CacheXmlParser::managedPartitionResolverFn_)(
-          m_partitionResolverLibrary.c_str(),
-          m_partitionResolverFactory.c_str()));
+      m_partitionResolver.reset((
+          CacheXmlParser::
+              managedPartitionResolverFn_)(m_partitionResolverLibrary.c_str(),
+                                           m_partitionResolverFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<PartitionResolver*()>(
           m_partitionResolverLibrary, m_partitionResolverFactory);
@@ -132,8 +138,11 @@ std::shared_ptr<PersistenceManager> RegionAttributes::getPersistenceManager()
     if (CacheXmlParser::managedPersistenceManagerFn_ &&
         m_persistenceFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_persistenceManager.reset((CacheXmlParser::managedPersistenceManagerFn_)(
-          m_persistenceLibrary.c_str(), m_persistenceFactory.c_str()));
+      m_persistenceManager.reset(
+          (CacheXmlParser::managedPersistenceManagerFn_)(m_persistenceLibrary
+                                                             .c_str(),
+                                                         m_persistenceFactory
+                                                             .c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<PersistenceManager*()>(
           m_persistenceLibrary, m_persistenceFactory);


### PR DESCRIPTION
This seems to reduce the incidence of failure in the integration test that's causing problems with VS2019/Windows Server 2019 (CqPlusAuthInitializeTest.putInALoopWhileSubscribedAndAuthenticated).