### PR TITLE
GEODE-9358: Initial revision of C bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,7 @@ if(ipo_supported)
 endif()
 
 include(CheckLinkerFlag)
-check_linker_flag(CXX -Wl,--exclude-libs,ALL has_linker_exclude_libs)
+check_linker_flag(CXX -Wl --exclude-libs ALL has_linker_exclude_libs)
 
 include(CheckCXXSymbolExists)
 check_cxx_symbol_exists("PRId8" "cinttypes" HAVE_STDC_FORMAT_MACROS)
@@ -207,7 +207,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "SunPro")
     -errwarn=%all
   )
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl -z defs")
   target_compile_options(_WarningsAsError INTERFACE
     -Werror
     -Wall

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,7 @@ if(ipo_supported)
 endif()
 
 include(CheckLinkerFlag)
-check_linker_flag(CXX -Wl --exclude-libs ALL has_linker_exclude_libs)
+check_linker_flag(CXX -Wl,--exclude-libs,ALL has_linker_exclude_libs)
 
 include(CheckCXXSymbolExists)
 check_cxx_symbol_exists("PRId8" "cinttypes" HAVE_STDC_FORMAT_MACROS)
@@ -207,7 +207,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "SunPro")
     -errwarn=%all
   )
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl -z defs")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
   target_compile_options(_WarningsAsError INTERFACE
     -Werror
     -Wall

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,6 +380,7 @@ if (${BUILD_CLI})
   add_subdirectory(templates/security/csharp)
 endif()
 add_subdirectory(tests)
+add_subdirectory(c_bindings)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/xsds/ DESTINATION xsds)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/defaultSystem/ DESTINATION defaultSystem)

--- a/c_bindings/CMakeLists.txt
+++ b/c_bindings/CMakeLists.txt
@@ -25,16 +25,6 @@ add_library(${PROJECT_NAME} SHARED "src/auth_initialize.cpp"
 "src/pool/manager.cpp"
 "src/region/factory.cpp")
 
-# add_library(${PROJECT_NAME} SHARED "src/auth_initialize.cpp"
-# "src/cache.cpp"
-# "src/client.cpp"
-# "src/pool.cpp"
-# "src/region.cpp"
-# "src/cache/factory.cpp"
-# "src/pool/factory.cpp"
-# "src/pool/manager.cpp"
-# "src/region/factory.cpp")
-
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE apache-geode-static)
@@ -56,7 +46,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     LINK_FLAGS "-exported_symbols_list \"${CMAKE_CURRENT_SOURCE_DIR}/symbols\"")
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set_target_properties(${PROJECT_NAME} PROPERTIES
-    LINK_FLAGS "--version-script \"${CMAKE_CURRENT_SOURCE_DIR}/symbols.version\"")
+    LINK_FLAGS "-Wl,--version-script=\"${CMAKE_CURRENT_SOURCE_DIR}/symbols.version\"")
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/c_bindings/CMakeLists.txt
+++ b/c_bindings/CMakeLists.txt
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project(apache-geode-c)
+
+add_library(${PROJECT_NAME} SHARED "src/auth_initialize.cpp"
+"src/cache.cpp"
+"src/client.cpp"
+"src/pool.cpp"
+"src/region.cpp"
+"src/cache/factory.cpp"
+"src/pool/factory.cpp"
+"src/pool/manager.cpp"
+"src/region/factory.cpp")
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE apache-geode-static)
+
+target_include_directories(${PROJECT_NAME} PRIVATE $<TARGET_PROPERTY:apache-geode-static,SOURCE_DIR>/../src)
+
+include(GenerateExportHeader)
+
+generate_export_header(${PROJECT_NAME}
+  BASE_NAME APACHE_GEODE_C
+  EXPORT_FILE_NAME apache-geode-c_export.h
+  CUSTOM_CONTENT_FROM_VARIABLE EXPORT_HEADER_CUSTOM_CONTENT
+)
+
+include_directories("include" "src" $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set_target_properties(${PROJECT_NAME} PROPERTIES
+    LINK_FLAGS "-Wl,-exported_symbols_list,\"${CMAKE_CURRENT_SOURCE_DIR}/symbols\"")
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  set_target_properties(${PROJECT_NAME} PROPERTIES
+    LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/symbols.version\"")
+endif()
+
+install(TARGETS ${PROJECT_NAME}
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)
+
+install(DIRECTORY "include/geode/" DESTINATION "c/include/geode")
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/apache-geode-c_export.h DESTINATION c/include/geode/internal)
+
+add_subdirectory(integration)

--- a/c_bindings/CMakeLists.txt
+++ b/c_bindings/CMakeLists.txt
@@ -59,3 +59,5 @@ install(DIRECTORY "include/geode/" DESTINATION "c/include/geode")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/apache-geode-c_export.h DESTINATION c/include/geode/internal)
 
 add_subdirectory(integration)
+
+add_clangformat(apache-geode-c)

--- a/c_bindings/CMakeLists.txt
+++ b/c_bindings/CMakeLists.txt
@@ -25,7 +25,17 @@ add_library(${PROJECT_NAME} SHARED "src/auth_initialize.cpp"
 "src/pool/manager.cpp"
 "src/region/factory.cpp")
 
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+# add_library(${PROJECT_NAME} SHARED "src/auth_initialize.cpp"
+# "src/cache.cpp"
+# "src/client.cpp"
+# "src/pool.cpp"
+# "src/region.cpp"
+# "src/cache/factory.cpp"
+# "src/pool/factory.cpp"
+# "src/pool/manager.cpp"
+# "src/region/factory.cpp")
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE apache-geode-static)
 

--- a/c_bindings/CMakeLists.txt
+++ b/c_bindings/CMakeLists.txt
@@ -43,10 +43,10 @@ include_directories("include" "src" $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set_target_properties(${PROJECT_NAME} PROPERTIES
-    LINK_FLAGS "-Wl,-exported_symbols_list,\"${CMAKE_CURRENT_SOURCE_DIR}/symbols\"")
+    LINK_FLAGS "-exported_symbols_list \"${CMAKE_CURRENT_SOURCE_DIR}/symbols\"")
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set_target_properties(${PROJECT_NAME} PROPERTIES
-    LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/symbols.version\"")
+    LINK_FLAGS "--version-script \"${CMAKE_CURRENT_SOURCE_DIR}/symbols.version\"")
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/c_bindings/include/geode/auth_initialize.h
+++ b/c_bindings/include/geode/auth_initialize.h
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef APACHE_GEODE_C_AUTH_INITIALIZE_H
+#define APACHE_GEODE_C_AUTH_INITIALIZE_H
+
+#include "geode/internal/geode_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+struct apache_geode_properties_s;
+typedef struct apache_geode_properties_s apache_geode_properties_t;
+
+void APACHE_GEODE_C_EXPORT apache_geode_AuthInitialize_AddProperty(
+    apache_geode_properties_t* properties, const char* key, const char* value);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // APACHE_GEODE_C_AUTH_INITIALIZE_H

--- a/c_bindings/include/geode/cache.h
+++ b/c_bindings/include/geode/cache.h
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef APACHE_GEODE_C_CACHE_H
+#define APACHE_GEODE_C_CACHE_H
+
+#include "geode/internal/geode_base.h"
+
+#ifdef __cplusplus
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+struct apache_geode_cache_s;
+typedef struct apache_geode_cache_s apache_geode_cache_t;
+
+struct apache_geode_pool_manager_s;
+typedef struct apache_geode_pool_manager_s apache_geode_pool_manager_t;
+
+struct apache_geode_region_factory_s;
+typedef struct apache_geode_region_factory_s apache_geode_region_factory_t;
+
+APACHE_GEODE_C_EXPORT void apache_geode_DestroyCache(apache_geode_cache_t* cache);
+
+APACHE_GEODE_C_EXPORT bool apache_geode_Cache_GetPdxIgnoreUnreadFields(
+    apache_geode_cache_t* cache);
+
+APACHE_GEODE_C_EXPORT bool apache_geode_Cache_GetPdxReadSerialized(
+    apache_geode_cache_t* cache);
+
+APACHE_GEODE_C_EXPORT apache_geode_pool_manager_t*
+apache_geode_Cache_GetPoolManager(apache_geode_cache_t* cache);
+
+#ifdef __cplusplus
+APACHE_GEODE_C_EXPORT apache_geode_region_factory_t*
+apache_geode_Cache_CreateRegionFactory(apache_geode_cache_t* cache,
+                                       std::int32_t regionType);
+#else
+APACHE_GEODE_C_EXPORT apache_geode_region_factory_t*
+apache_geode_Cache_CreateRegionFactory(apache_geode_cache_t* cache,
+                                       int32_t regionType);
+#endif
+
+APACHE_GEODE_C_EXPORT const char* apache_geode_Cache_GetName(
+    apache_geode_cache_t* cache);
+
+APACHE_GEODE_C_EXPORT void apache_geode_Cache_Close(apache_geode_cache_t* cache,
+                                                  bool keepalive);
+
+APACHE_GEODE_C_EXPORT bool apache_geode_Cache_IsClosed(
+    apache_geode_cache_t* cache);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // APACHE_GEODE_C_CACHE_H

--- a/c_bindings/include/geode/cache/factory.h
+++ b/c_bindings/include/geode/cache/factory.h
@@ -43,7 +43,7 @@ struct apache_geode_properties_s;
 typedef struct apache_geode_properties_s apache_geode_properties_t;
 
 APACHE_GEODE_C_EXPORT apache_geode_cache_factory_t*
-apache_geode_CreateCacheFactory(apache_geode_client_t *);
+apache_geode_CreateCacheFactory();
 
 APACHE_GEODE_C_EXPORT apache_geode_cache_t* apache_geode_CacheFactory_CreateCache(
     apache_geode_cache_factory_t* factory);

--- a/c_bindings/include/geode/cache/factory.h
+++ b/c_bindings/include/geode/cache/factory.h
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef APACHE_GEODE_C_CACHE_FACTORY_H
+#define APACHE_GEODE_C_CACHE_FACTORY_H
+
+#include "geode/internal/geode_base.h"
+
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+struct apache_geode_client_s;
+typedef struct apache_geode_client_s apache_geode_client_t;
+
+struct apache_geode_cache_factory_s;
+typedef struct apache_geode_cache_factory_s apache_geode_cache_factory_t;
+
+struct apache_geode_cache_s;
+typedef struct apache_geode_cache_s apache_geode_cache_t;
+
+struct apache_geode_properties_s;
+typedef struct apache_geode_properties_s apache_geode_properties_t;
+
+APACHE_GEODE_C_EXPORT apache_geode_cache_factory_t*
+apache_geode_CreateCacheFactory(apache_geode_client_t *);
+
+APACHE_GEODE_C_EXPORT apache_geode_cache_t* apache_geode_CacheFactory_CreateCache(
+    apache_geode_cache_factory_t* factory);
+
+APACHE_GEODE_C_EXPORT const char* apache_geode_CacheFactory_GetVersion(
+    apache_geode_cache_factory_t* factory);
+
+APACHE_GEODE_C_EXPORT const char* apache_geode_CacheFactory_GetProductDescription(
+    apache_geode_cache_factory_t* factory);
+
+APACHE_GEODE_C_EXPORT void apache_geode_CacheFactory_SetPdxIgnoreUnreadFields(
+    apache_geode_cache_factory_t* factory, bool pdxIgnoreUnreadFields);
+
+APACHE_GEODE_C_EXPORT void apache_geode_CacheFactory_SetAuthInitialize(
+    apache_geode_cache_factory_t* factory,
+    void (*getCredentials)(apache_geode_properties_t*), void (*close)());
+
+APACHE_GEODE_C_EXPORT void apache_geode_CacheFactory_SetPdxReadSerialized(
+    apache_geode_cache_factory_t* factory, bool pdxReadSerialized);
+
+APACHE_GEODE_C_EXPORT void apache_geode_CacheFactory_SetProperty(
+    apache_geode_cache_factory_t* factory, const char* key, const char* value);
+
+APACHE_GEODE_C_EXPORT void apache_geode_DestroyCacheFactory(
+    apache_geode_cache_factory_t* factory);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // APACHE_GEODE_C_CACHE_FACTORY_H

--- a/c_bindings/include/geode/client.h
+++ b/c_bindings/include/geode/client.h
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef APACHE_GEODE_C_CLIENT_H
+#define APACHE_GEODE_C_CLIENT_H
+
+#include "geode/internal/geode_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+struct apache_geode_client_s;
+typedef struct apache_geode_client_s apache_geode_client_t;
+
+APACHE_GEODE_C_EXPORT apache_geode_client_t* apache_geode_ClientInitialize();
+
+APACHE_GEODE_C_EXPORT int apache_geode_ClientUninitialize(
+    apache_geode_client_t* client);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // APACHE_GEODE_C_CLIENT_H

--- a/c_bindings/include/geode/internal/geode_base.h
+++ b/c_bindings/include/geode/internal/geode_base.h
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef APACHE_GEODE_C_INTERNAL_GEODE_BASE_H
+#define APACHE_GEODE_C_INTERNAL_GEODE_BASE_H
+
+#include "apache-geode-c_export.h"
+
+#endif  // APACHE_GEODE_C_INTERNAL_GEODE_BASE_H

--- a/c_bindings/include/geode/pool.h
+++ b/c_bindings/include/geode/pool.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef APACHE_GEODE_C_POOL_H
+#define APACHE_GEODE_C_POOL_H
+
+#include "geode/internal/geode_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+struct apache_geode_pool_s;
+typedef struct apache_geode_pool_s apache_geode_pool_t;
+
+APACHE_GEODE_C_EXPORT void apache_geode_DestroyPool(apache_geode_pool_t* pool);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // APACHE_GEODE_C_POOL_H

--- a/c_bindings/include/geode/pool/factory.h
+++ b/c_bindings/include/geode/pool/factory.h
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef APACHE_GEODE_C_POOL_FACTORY_H
+#define APACHE_GEODE_C_POOL_FACTORY_H
+
+#include "geode/internal/geode_base.h"
+
+#ifdef __cplusplus
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+struct apache_geode_pool_factory_s;
+typedef struct apache_geode_pool_factory_s apache_geode_pool_factory_t;
+
+struct apache_geode_pool_s;
+typedef struct apache_geode_pool_s apache_geode_pool_t;
+
+APACHE_GEODE_C_EXPORT apache_geode_pool_t* apache_geode_PoolFactory_CreatePool(
+    apache_geode_pool_factory_t* poolFactory, const char* name);
+
+#ifdef __cplusplus
+APACHE_GEODE_C_EXPORT void apache_geode_PoolFactory_AddLocator(
+    apache_geode_pool_factory_t* poolFactory, const char* hostname,
+    const std::uint16_t port);
+#else
+APACHE_GEODE_C_EXPORT void apache_geode_PoolFactory_AddLocator(
+    apache_geode_pool_factory_t* poolFactory, const char* hostname,
+    const uint16_t port);
+#endif
+
+APACHE_GEODE_C_EXPORT void apache_geode_DestroyPoolFactory(
+    apache_geode_pool_factory_t* poolFactory);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // APACHE_GEODE_C_POOL_FACTORY_H

--- a/c_bindings/include/geode/pool/manager.h
+++ b/c_bindings/include/geode/pool/manager.h
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef APACHE_GEODE_C_POOL_MANAGER_H
+#define APACHE_GEODE_C_POOL_MANAGER_H
+
+#include "geode/internal/geode_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+struct apache_geode_pool_manager_s;
+typedef struct apache_geode_pool_manager_s apache_geode_pool_manager_t;
+
+struct apache_geode_pool_factory_s;
+typedef struct apache_geode_pool_factory_s apache_geode_pool_factory_t;
+
+APACHE_GEODE_C_EXPORT apache_geode_pool_factory_t*
+apache_geode_PoolManager_CreateFactory(
+    apache_geode_pool_manager_t* poolManager);
+
+APACHE_GEODE_C_EXPORT void apache_geode_DestroyPoolManager(
+    apache_geode_pool_manager_t* poolManager);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // APACHE_GEODE_C_POOL_MANAGER_H

--- a/c_bindings/include/geode/region.h
+++ b/c_bindings/include/geode/region.h
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef APACHE_GEODE_C_REGION_H
+#define APACHE_GEODE_C_REGION_H
+
+#include "geode/internal/geode_base.h"
+
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+struct apache_geode_region_s;
+typedef struct apache_geode_region_s apache_geode_region_t;
+
+APACHE_GEODE_C_EXPORT void apache_geode_DestroyRegion(
+    apache_geode_region_t* region);
+
+APACHE_GEODE_C_EXPORT void apache_geode_Region_PutString(
+    apache_geode_region_t* region, const char* key, const char* value);
+
+APACHE_GEODE_C_EXPORT void apache_geode_Region_PutByteArray(
+    apache_geode_region_t* region, const char* key, const char* value, size_t size);
+
+APACHE_GEODE_C_EXPORT const char* apache_geode_Region_GetString(
+    apache_geode_region_t* region, const char* key);
+
+APACHE_GEODE_C_EXPORT void apache_geode_Region_GetByteArray(
+    apache_geode_region_t* region, const char* key, char** value, size_t* size);
+
+APACHE_GEODE_C_EXPORT void apache_geode_Region_Remove(
+    apache_geode_region_t* region, const char* key);
+
+APACHE_GEODE_C_EXPORT bool apache_geode_Region_ContainsValueForKey(
+    apache_geode_region_t* region, const char* key);
+    
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // APACHE_GEODE_C_REGION_H

--- a/c_bindings/include/geode/region/factory.h
+++ b/c_bindings/include/geode/region/factory.h
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef APACHE_GEODE_C_REGION_FACTORY_H
+#define APACHE_GEODE_C_REGION_FACTORY_H
+
+#include "geode/internal/geode_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+struct apache_geode_cache_s;
+typedef struct apache_geode_cache_s apache_geode_cache_t;
+
+struct apache_geode_region_factory_s;
+typedef struct apache_geode_region_factory_s apache_geode_region_factory_t;
+
+struct apache_geode_region_s;
+typedef struct apache_geode_region_s apache_geode_region_t;
+
+APACHE_GEODE_C_EXPORT void apache_geode_DestroyRegionFactory(
+    apache_geode_region_factory_t* regionFactory);
+
+APACHE_GEODE_C_EXPORT void apache_geode_RegionFactory_SetPoolName(
+    apache_geode_region_factory_t* regionFactory, const char* poolName);
+
+APACHE_GEODE_C_EXPORT apache_geode_region_t*
+apache_geode_RegionFactory_CreateRegion(
+    apache_geode_region_factory_t* regionFactory, const char* regionName);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // APACHE_GEODE_C_REGION_FACTORY_H

--- a/c_bindings/include/geode/region/shortcut.h
+++ b/c_bindings/include/geode/region/shortcut.h
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef APACHE_GEODE_C_REGION_SHORTCUT_H
+#define APACHE_GEODE_C_REGION_SHORTCUT_H
+
+enum { PROXY, CACHING_PROXY, CACHING_PROXY_ENTRY_LRU, LOCAL, LOCAL_ENTRY_LRU };
+
+#endif

--- a/c_bindings/integration/CMakeLists.txt
+++ b/c_bindings/integration/CMakeLists.txt
@@ -4,40 +4,14 @@
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function(generate_export_file LIB_NAME)
-
-  if (MSVC)
-    set(EXPORT_HEADER_CUSTOM_CONTENT "
-  #define APACHE_GEODE_EXPLICIT_TEMPLATE_EXPORT APACHE_GEODE_EXPORT
-
-  #define APACHE_GEODE_EXTERN_TEMPLATE_EXPORT
-  ")
-  else()
-    set(EXPORT_HEADER_CUSTOM_CONTENT "
-  #define APACHE_GEODE_EXPLICIT_TEMPLATE_EXPORT
-
-  #define APACHE_GEODE_EXTERN_TEMPLATE_EXPORT APACHE_GEODE_EXPORT
-  ")
-  endif()
-
-  include(GenerateExportHeader)
-
-  generate_export_header(${PROJECT_NAME}
-    BASE_NAME APACHE_GEODE
-    EXPORT_FILE_NAME apache-geode_export.h
-    CUSTOM_CONTENT_FROM_VARIABLE EXPORT_HEADER_CUSTOM_CONTENT
-  )
-
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/apache-geode_export.h DESTINATION include/geode/internal)
-  
-endfunction()
-
+add_subdirectory(utilities)
+add_subdirectory(test)

--- a/c_bindings/integration/test/CAuthInitialize.cpp
+++ b/c_bindings/integration/test/CAuthInitialize.cpp
@@ -32,7 +32,7 @@
 #include "geode/region/factory.h"
 #include "geode/region/shortcut.h"
 
-auto credentialsRequested_ = 0;
+static auto credentialsRequested_ = 0;
 
 void simpleGetCredentials(apache_geode_properties_t* props) {
   apache_geode_AuthInitialize_AddProperty(props, "security-username", "root");

--- a/c_bindings/integration/test/CAuthInitialize.cpp
+++ b/c_bindings/integration/test/CAuthInitialize.cpp
@@ -64,7 +64,7 @@ TEST(CAuthInitializeTest, putGetWithBasicAuth) {
       .execute();
 
   auto client = apache_geode_ClientInitialize();
-  auto cache_factory = apache_geode_CreateCacheFactory(client);
+  auto cache_factory = apache_geode_CreateCacheFactory();
 
   apache_geode_CacheFactory_SetProperty(cache_factory,
                                         "statistic-sampling-enabled", "false");

--- a/c_bindings/integration/test/CAuthInitialize.cpp
+++ b/c_bindings/integration/test/CAuthInitialize.cpp
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <framework/Cluster.h>
+#include <framework/Framework.h>
+#include <framework/Gfsh.h>
+
+#include <gtest/gtest.h>
+
+#include "geode/auth_initialize.h"
+#include "geode/cache.h"
+#include "geode/cache/factory.h"
+#include "geode/client.h"
+#include "geode/pool.h"
+#include "geode/pool/factory.h"
+#include "geode/pool/manager.h"
+#include "geode/region.h"
+#include "geode/region/factory.h"
+#include "geode/region/shortcut.h"
+
+auto credentialsRequested_ = 0;
+
+void simpleGetCredentials(apache_geode_properties_t* props) {
+  apache_geode_AuthInitialize_AddProperty(props, "security-username", "root");
+  apache_geode_AuthInitialize_AddProperty(props, "security-password",
+                                          "root-password");
+  credentialsRequested_++;
+}
+
+void simpleClose() {}
+
+TEST(CAuthInitializeTest, putGetWithBasicAuth) {
+  Cluster cluster(
+      Name(std::string(::testing::UnitTest::GetInstance()
+                           ->current_test_info()
+                           ->test_suite_name()) +
+           "/" +
+           ::testing::UnitTest::GetInstance()->current_test_info()->name()),
+      Classpath{getFrameworkString(FrameworkVariable::JavaObjectJarPath)},
+      SecurityManager{"javaobject.SimpleSecurityManager"}, User{"root"},
+      Password{"root-password"}, LocatorCount{1}, ServerCount{1});
+
+  cluster.start();
+
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("PARTITION")
+      .execute();
+
+  auto client = apache_geode_ClientInitialize();
+  auto cache_factory = apache_geode_CreateCacheFactory(client);
+
+  apache_geode_CacheFactory_SetProperty(cache_factory,
+                                        "statistic-sampling-enabled", "false");
+  apache_geode_CacheFactory_SetAuthInitialize(
+      cache_factory, simpleGetCredentials, simpleClose);
+
+  auto cache = apache_geode_CacheFactory_CreateCache(cache_factory);
+
+  auto pool_manager = apache_geode_Cache_GetPoolManager(cache);
+  auto pool_factory = apache_geode_PoolManager_CreateFactory(pool_manager);
+
+  for (const auto& locator : cluster.getLocators()) {
+    apache_geode_PoolFactory_AddLocator(pool_factory,
+                                        locator.getAddress().address.c_str(),
+                                        locator.getAddress().port);
+  }
+
+  auto pool = apache_geode_PoolFactory_CreatePool(pool_factory, "default");
+
+  auto region_factory = apache_geode_Cache_CreateRegionFactory(cache, PROXY);
+
+  apache_geode_RegionFactory_SetPoolName(region_factory, "default");
+  auto region =
+      apache_geode_RegionFactory_CreateRegion(region_factory, "region");
+
+  apache_geode_Region_PutString(region, "foo", "bar");
+  apache_geode_Region_PutString(region, "baz", "qux");
+
+  auto foo_value = apache_geode_Region_GetString(region, "foo");
+  ASSERT_STREQ(foo_value, "bar");
+
+  auto baz_value = apache_geode_Region_GetString(region, "baz");
+  ASSERT_STREQ(baz_value, "qux");
+
+  ASSERT_GT(credentialsRequested_, 0);
+
+  apache_geode_DestroyRegion(region);
+  apache_geode_DestroyRegionFactory(region_factory);
+  apache_geode_DestroyPool(pool);
+  apache_geode_DestroyPoolFactory(pool_factory);
+  apache_geode_DestroyPoolManager(pool_manager);
+  apache_geode_DestroyCache(cache);
+
+  apache_geode_DestroyCacheFactory(cache_factory);
+  auto leaks = apache_geode_ClientUninitialize(client);
+  ASSERT_EQ(leaks, 0);
+}

--- a/c_bindings/integration/test/CCacheCreationTest.cpp
+++ b/c_bindings/integration/test/CCacheCreationTest.cpp
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <framework/Cluster.h>
+#include <framework/Framework.h>
+#include <framework/Gfsh.h>
+
+#include <gtest/gtest.h>
+
+#include "geode/cache.h"
+#include "geode/cache/factory.h"
+#include "geode/client.h"
+#include "geode/pool.h"
+#include "geode/pool/factory.h"
+#include "geode/pool/manager.h"
+#include "geode/region.h"
+#include "geode/region/factory.h"
+#include "geode/region/shortcut.h"
+
+/**
+ * Example test using single server and waiting for async put and update
+ * operations to synchronize using promises.
+ */
+TEST(CCacheCreationTest, setPdxIgnoreUnreadFieldsAndCreateCache) {
+  auto client = apache_geode_ClientInitialize();
+  auto cache_factory = apache_geode_CreateCacheFactory(client);
+
+  apache_geode_CacheFactory_SetProperty(cache_factory,
+                                        "statistic-sampling-enabled", "false");
+
+  apache_geode_CacheFactory_SetPdxIgnoreUnreadFields(cache_factory, true);
+  auto cache = apache_geode_CacheFactory_CreateCache(cache_factory);
+  ASSERT_TRUE(apache_geode_Cache_GetPdxIgnoreUnreadFields(cache));
+
+  apache_geode_CacheFactory_SetPdxIgnoreUnreadFields(cache_factory, false);
+  auto cache2 = apache_geode_CacheFactory_CreateCache(cache_factory);
+  ASSERT_FALSE(apache_geode_Cache_GetPdxIgnoreUnreadFields(cache2));
+
+  apache_geode_DestroyCache(cache);
+  apache_geode_DestroyCache(cache2);
+
+  apache_geode_DestroyCacheFactory(cache_factory);
+  auto leaks = apache_geode_ClientUninitialize(client);
+
+  ASSERT_EQ(leaks, 0);
+}

--- a/c_bindings/integration/test/CCacheCreationTest.cpp
+++ b/c_bindings/integration/test/CCacheCreationTest.cpp
@@ -37,7 +37,7 @@
  */
 TEST(CCacheCreationTest, setPdxIgnoreUnreadFieldsAndCreateCache) {
   auto client = apache_geode_ClientInitialize();
-  auto cache_factory = apache_geode_CreateCacheFactory(client);
+  auto cache_factory = apache_geode_CreateCacheFactory();
 
   apache_geode_CacheFactory_SetProperty(cache_factory,
                                         "statistic-sampling-enabled", "false");

--- a/c_bindings/integration/test/CMakeLists.txt
+++ b/c_bindings/integration/test/CMakeLists.txt
@@ -16,6 +16,7 @@
 project(apache-geode-c-integration-test)
 
 add_executable(${PROJECT_NAME}
+  CAuthInitialize.cpp
   CCacheCreationTest.cpp
   ExampleTest.cpp
 )

--- a/c_bindings/integration/test/CMakeLists.txt
+++ b/c_bindings/integration/test/CMakeLists.txt
@@ -16,6 +16,7 @@
 project(apache-geode-c-integration-test)
 
 add_executable(${PROJECT_NAME}
+  CCacheCreationTest.cpp
   ExampleTest.cpp
 )
 

--- a/c_bindings/integration/test/CMakeLists.txt
+++ b/c_bindings/integration/test/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(${PROJECT_NAME}
   ExampleTest.cpp
 )
 
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 
 target_compile_definitions(${PROJECT_NAME}
   PUBLIC
@@ -51,7 +51,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 if(WIN32)
-  foreach (_target apache-geode-c testobject)
+  foreach (_target apache-geode-c apache-geode testobject)
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "$<TARGET_FILE:${_target}>"
         "$<$<CONFIG:Debug>:$<TARGET_PDB_FILE:${_target}>>"
@@ -67,4 +67,4 @@ add_clangformat(${PROJECT_NAME})
 
 enable_testing()
 include(GoogleTest)
-gtest_discover_tests(${PROJECT_NAME})
+gtest_discover_tests(${PROJECT_NAME} DISCOVERY_TIMEOUT 60)

--- a/c_bindings/integration/test/CMakeLists.txt
+++ b/c_bindings/integration/test/CMakeLists.txt
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project(apache-geode-c-integration-test)
+
+add_executable(${PROJECT_NAME}
+  ExampleTest.cpp
+)
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
+target_compile_definitions(${PROJECT_NAME}
+  PUBLIC
+    GTEST_ELLIPSIS_NEEDS_POD_
+)
+
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+   ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+    apache-geode-c
+    apache-geode-c-integration-utilities
+    integration-framework
+    testobject
+    ACE::ACE
+    GTest::gtest
+    GTest::gtest_main
+    Boost::boost
+    Boost::system
+    Boost::log
+    Boost::filesystem
+    Boost::chrono
+    cryptoImpl
+  PRIVATE
+    _WarningsAsError
+    internal
+)
+
+add_dependencies(${PROJECT_NAME} cryptoImpl)
+
+if(WIN32)
+  foreach (_target apache-geode-c testobject cryptoImpl)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "$<TARGET_FILE:${_target}>"
+        "$<$<CONFIG:Debug>:$<TARGET_PDB_FILE:${_target}>>"
+        "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
+  endforeach()
+endif()
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+  FOLDER c_bindings/test/integration
+)
+
+add_clangformat(${PROJECT_NAME})
+
+enable_testing()
+include(GoogleTest)
+gtest_discover_tests(${PROJECT_NAME})

--- a/c_bindings/integration/test/CMakeLists.txt
+++ b/c_bindings/integration/test/CMakeLists.txt
@@ -45,16 +45,13 @@ target_link_libraries(${PROJECT_NAME}
     Boost::log
     Boost::filesystem
     Boost::chrono
-    cryptoImpl
   PRIVATE
     _WarningsAsError
     internal
 )
 
-add_dependencies(${PROJECT_NAME} cryptoImpl)
-
 if(WIN32)
-  foreach (_target apache-geode-c testobject cryptoImpl)
+  foreach (_target apache-geode-c testobject)
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "$<TARGET_FILE:${_target}>"
         "$<$<CONFIG:Debug>:$<TARGET_PDB_FILE:${_target}>>"

--- a/c_bindings/integration/test/ExampleTest.cpp
+++ b/c_bindings/integration/test/ExampleTest.cpp
@@ -48,7 +48,7 @@ TEST(ExampleTest, putGetAndUpdateWith1Server) {
       .execute();
 
   auto client = apache_geode_ClientInitialize();
-  auto cache_factory = apache_geode_CreateCacheFactory(client);
+  auto cache_factory = apache_geode_CreateCacheFactory();
 
   apache_geode_CacheFactory_SetProperty(cache_factory, "log-level", "none");
   apache_geode_CacheFactory_SetProperty(cache_factory,

--- a/c_bindings/integration/test/ExampleTest.cpp
+++ b/c_bindings/integration/test/ExampleTest.cpp
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <framework/Cluster.h>
+#include <framework/Framework.h>
+#include <framework/Gfsh.h>
+
+#include <gtest/gtest.h>
+
+#include "geode/cache.h"
+#include "geode/cache/factory.h"
+#include "geode/client.h"
+#include "geode/pool.h"
+#include "geode/pool/factory.h"
+#include "geode/pool/manager.h"
+#include "geode/region.h"
+#include "geode/region/factory.h"
+#include "geode/region/shortcut.h"
+
+/**
+ * Example test using single server and waiting for async put and update
+ * operations to synchronize using promises.
+ */
+TEST(ExampleTest, putGetAndUpdateWith1Server) {
+  Cluster cluster{LocatorCount{1}, ServerCount{1}};
+
+  cluster.start();
+
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("REPLICATE")
+      .execute();
+
+  auto client = apache_geode_ClientInitialize();
+  auto cache_factory = apache_geode_CreateCacheFactory(client);
+
+  apache_geode_CacheFactory_SetProperty(cache_factory, "log-level", "none");
+  apache_geode_CacheFactory_SetProperty(cache_factory,
+                                        "statistic-sampling-enabled", "false");
+
+  auto cache = apache_geode_CacheFactory_CreateCache(cache_factory);
+
+  auto pool_manager = apache_geode_Cache_GetPoolManager(cache);
+  auto pool_factory = apache_geode_PoolManager_CreateFactory(pool_manager);
+  apache_geode_PoolFactory_AddLocator(pool_factory, "localhost",
+                                      cluster.getLocatorPort());
+  auto pool = apache_geode_PoolFactory_CreatePool(pool_factory, "myPool");
+  auto region_factory = apache_geode_Cache_CreateRegionFactory(cache, PROXY);
+  apache_geode_RegionFactory_SetPoolName(region_factory, "myPool");
+  auto region =
+      apache_geode_RegionFactory_CreateRegion(region_factory, "region");
+
+  apache_geode_Region_PutString(region, "key", "value");
+
+  auto value = apache_geode_Region_GetString(region, "key");
+
+  ASSERT_STREQ(value, "value");
+
+  apache_geode_DestroyRegion(region);
+  apache_geode_DestroyRegionFactory(region_factory);
+  apache_geode_DestroyPool(pool);
+  apache_geode_DestroyPoolFactory(pool_factory);
+  apache_geode_DestroyPoolManager(pool_manager);
+  apache_geode_DestroyCache(cache);
+  apache_geode_DestroyCacheFactory(cache_factory);
+  auto leaks = apache_geode_ClientUninitialize(client);
+
+  ASSERT_EQ(leaks, 0);
+}

--- a/c_bindings/integration/utilities/CMakeLists.txt
+++ b/c_bindings/integration/utilities/CMakeLists.txt
@@ -21,3 +21,5 @@ target_link_libraries(${PROJECT_NAME}
   PUBLIC
     GTest::gtest
 )
+
+add_clangformat(apache-geode-c-integration-utilities)

--- a/c_bindings/integration/utilities/CMakeLists.txt
+++ b/c_bindings/integration/utilities/CMakeLists.txt
@@ -4,40 +4,20 @@
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function(generate_export_file LIB_NAME)
+project(apache-geode-c-integration-utilities)
 
-  if (MSVC)
-    set(EXPORT_HEADER_CUSTOM_CONTENT "
-  #define APACHE_GEODE_EXPLICIT_TEMPLATE_EXPORT APACHE_GEODE_EXPORT
+add_library(${PROJECT_NAME} OBJECT "internal/colored_printing.cpp")
 
-  #define APACHE_GEODE_EXTERN_TEMPLATE_EXPORT
-  ")
-  else()
-    set(EXPORT_HEADER_CUSTOM_CONTENT "
-  #define APACHE_GEODE_EXPLICIT_TEMPLATE_EXPORT
-
-  #define APACHE_GEODE_EXTERN_TEMPLATE_EXPORT APACHE_GEODE_EXPORT
-  ")
-  endif()
-
-  include(GenerateExportHeader)
-
-  generate_export_header(${PROJECT_NAME}
-    BASE_NAME APACHE_GEODE
-    EXPORT_FILE_NAME apache-geode_export.h
-    CUSTOM_CONTENT_FROM_VARIABLE EXPORT_HEADER_CUSTOM_CONTENT
-  )
-
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/apache-geode_export.h DESTINATION include/geode/internal)
-  
-endfunction()
-
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+    GTest::gtest
+)

--- a/c_bindings/integration/utilities/colored_printing.hpp
+++ b/c_bindings/integration/utilities/colored_printing.hpp
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "utilities/internal/colored_printing.hpp"
+
+namespace util {
+/* Include this header.
+
+   These instances will print that little colored box on the left column, just
+   like GoogleTest does, followed by your formatted text in the color specified.
+   The instances are extern'd to reduce object bloat and compile time. You can
+   find their definition and instantiation in the internal directory below.
+*/
+extern template void print_message<::testing::internal::COLOR_DEFAULT>(const char* fmt...);
+extern template void print_message<::testing::internal::COLOR_GREEN>(const char* fmt...);
+extern template void print_message<::testing::internal::COLOR_YELLOW>(const char* fmt...);
+extern template void print_message<::testing::internal::COLOR_RED>(const char* fmt...);
+}  // namespace util

--- a/c_bindings/integration/utilities/internal/colored_printing.cpp
+++ b/c_bindings/integration/utilities/internal/colored_printing.cpp
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "colored_printing.hpp"
+
+namespace util {
+/* This is explicit template instantiation. This translation unit will compile
+   these template instances here, and we can extern them everywhere they are
+   in use to reduce object bloat and compile time.
+ */
+template void print_message<::testing::internal::COLOR_DEFAULT>(const char* fmt...);
+template void print_message<::testing::internal::COLOR_GREEN>(const char* fmt...);
+template void print_message<::testing::internal::COLOR_YELLOW>(const char* fmt...);
+template void print_message<::testing::internal::COLOR_RED>(const char* fmt...);
+}  // namespace util

--- a/c_bindings/integration/utilities/internal/colored_printing.cpp
+++ b/c_bindings/integration/utilities/internal/colored_printing.cpp
@@ -21,8 +21,11 @@ namespace util {
    these template instances here, and we can extern them everywhere they are
    in use to reduce object bloat and compile time.
  */
-template void print_message<::testing::internal::COLOR_DEFAULT>(const char* fmt...);
-template void print_message<::testing::internal::COLOR_GREEN>(const char* fmt...);
-template void print_message<::testing::internal::COLOR_YELLOW>(const char* fmt...);
+template void print_message<::testing::internal::COLOR_DEFAULT>(
+    const char* fmt...);
+template void print_message<::testing::internal::COLOR_GREEN>(
+    const char* fmt...);
+template void print_message<::testing::internal::COLOR_YELLOW>(
+    const char* fmt...);
 template void print_message<::testing::internal::COLOR_RED>(const char* fmt...);
 }  // namespace util

--- a/c_bindings/integration/utilities/internal/colored_printing.hpp
+++ b/c_bindings/integration/utilities/internal/colored_printing.hpp
@@ -24,8 +24,10 @@
    extern template declarations of these templates to reduce object bloat and
    compile time.
 */
-namespace testing::internal {
-extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
+namespace testing {
+  namespace internal {
+    extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
+  }
 }  // namespace testing
 
 namespace util {

--- a/c_bindings/integration/utilities/internal/colored_printing.hpp
+++ b/c_bindings/integration/utilities/internal/colored_printing.hpp
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstdarg>
+
+#include <gtest/gtest.h>
+
+/* DO NOT INCLUDE THIS HEADER DIRECTLY.
+
+   Use the header of the same name in the directory above. That header contains
+   extern template declarations of these templates to reduce object bloat and
+   compile time.
+*/
+namespace testing::internal {
+extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
+}  // namespace testing
+
+namespace util {
+template <::testing::internal::GTestColor color>
+void print_message(const char* fmt...) {
+  va_list args;
+  va_start(args, fmt);
+
+  testing::internal::ColoredPrintf(
+    ::testing::Test::HasFatalFailure() ? testing::internal::COLOR_RED : testing::internal::COLOR_GREEN
+    , "[          ] ");
+
+  testing::internal::ColoredPrintf(color, va_arg(args, char*), args);
+}
+}  // namespace util

--- a/c_bindings/src/auth_initialize.cpp
+++ b/c_bindings/src/auth_initialize.cpp
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standard headers
+#include <memory>
+#include <string>
+
+// C++ client public headers
+#include <geode/Properties.hpp>
+
+// C++ client private headers
+#include "util/Log.hpp"
+
+// C client public headers
+#include "geode/auth_initialize.h"
+
+// C client private headers
+#include "auth_initialize.hpp"
+
+void apache_geode_AuthInitialize_AddProperty(
+    apache_geode_properties_t* properties, const char* key, const char* value) {
+  auto securityProperties =
+      reinterpret_cast<apache::geode::client::Properties*>(properties);
+  securityProperties->insert(key, value);
+  LOGDEBUG("AuthInitializeWrapper::%s: added (k, v) = (\"%s\", \"%s\")",
+           __FUNCTION__, key, value);
+}
+
+std::shared_ptr<apache::geode::client::Properties>
+AuthInitializeWrapper::getCredentials(
+    const std::shared_ptr<apache::geode::client::Properties>& securityprops,
+    const std::string& /*server*/) {
+  LOGDEBUG("AuthInitializeWrapper::%s(%p): entry", __FUNCTION__, this);
+
+  if (getCredentials_) {
+    LOGDEBUG("AuthInitializeWrapper::%s(%p): calling getCredentials()",
+             __FUNCTION__, this);
+    getCredentials_(
+        reinterpret_cast<apache_geode_properties_t*>(securityprops.get()));
+  }
+
+  LOGDEBUG("AuthInitializeWrapper::%s(%p): exit", __FUNCTION__, this);
+  return securityprops;
+}
+
+void AuthInitializeWrapper::close() {
+  LOGDEBUG("AuthInitializeWrapper::%s(%p): entry", __FUNCTION__, this);
+
+  if (close_) {
+    LOGDEBUG("AuthInitializeWrapper::%s(%p): calling close()", __FUNCTION__,
+             this);
+    close_();
+  }
+  LOGDEBUG("AuthInitializeWrapper::%s(%p): exit", __FUNCTION__, this);
+}
+
+AuthInitializeWrapper::AuthInitializeWrapper(
+    void (*getCredentials)(apache_geode_properties_t*), void (*close)())
+    : AuthInitialize(), getCredentials_(getCredentials), close_(close) {}

--- a/c_bindings/src/auth_initialize.hpp
+++ b/c_bindings/src/auth_initialize.hpp
@@ -23,8 +23,12 @@
 #include "geode/AuthInitialize.hpp"
 #include "geode/auth_initialize.h"
 
-namespace apache::geode::client {
+namespace apache {
+  namespace geode {
+    namespace client {
       class Properties;
+    }
+  }
 }
 
 class AuthInitializeWrapper : public apache::geode::client::AuthInitialize {

--- a/c_bindings/src/auth_initialize.hpp
+++ b/c_bindings/src/auth_initialize.hpp
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "geode/AuthInitialize.hpp"
+#include "geode/auth_initialize.h"
+
+namespace apache::geode::client {
+      class Properties;
+}
+
+class AuthInitializeWrapper : public apache::geode::client::AuthInitialize {
+  void (*getCredentials_)(apache_geode_properties_t*);
+  void (*close_)();
+
+ public:
+  std::shared_ptr<apache::geode::client::Properties> getCredentials(
+      const std::shared_ptr<apache::geode::client::Properties>& securityprops,
+      const std::string& /*server*/) override;
+
+  void close() override;
+
+  AuthInitializeWrapper(void (*getCredentials)(apache_geode_properties_t*),
+                        void (*close)());
+
+  ~AuthInitializeWrapper() override = default;
+};

--- a/c_bindings/src/cache.cpp
+++ b/c_bindings/src/cache.cpp
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standard headers
+#include <cstdint>
+
+// C++ client public headers
+#include "geode/RegionShortcut.hpp"
+
+// C++ client private headers
+#include "util/Log.hpp"
+
+// C client public headers
+#include "geode/cache.h"
+
+// C client private headers
+#include "cache.hpp"
+#include "pool/manager.hpp"
+#include "region/factory.hpp"
+#include "cache/factory.hpp"
+
+void apache_geode_DestroyCache(apache_geode_cache_t* cache) {
+  CacheWrapper* cacheWrapper = reinterpret_cast<CacheWrapper*>(cache);
+  LOGDEBUG("%s: destroying cache %p", __FUNCTION__, cache);
+  delete cacheWrapper;
+}
+
+bool apache_geode_Cache_GetPdxIgnoreUnreadFields(apache_geode_cache_t* cache) {
+  LOGDEBUG("%s: cache=%p", __FUNCTION__, cache);
+  CacheWrapper* cacheWrapper = reinterpret_cast<CacheWrapper*>(cache);
+  return cacheWrapper->getPdxIgnoreUnreadFields();
+}
+
+bool apache_geode_Cache_GetPdxReadSerialized(apache_geode_cache_t* cache) {
+  LOGDEBUG("%s: cache=%p", __FUNCTION__, cache);
+  CacheWrapper* cacheWrapper = reinterpret_cast<CacheWrapper*>(cache);
+  return cacheWrapper->getPdxReadSerialized();
+}
+
+apache_geode_pool_manager_t* apache_geode_Cache_GetPoolManager(
+    apache_geode_cache_t* cache) {
+  LOGDEBUG("%s: cache=%p", __FUNCTION__, cache);
+  CacheWrapper* cacheWrapper = reinterpret_cast<CacheWrapper*>(cache);
+  return reinterpret_cast<apache_geode_pool_manager_t*>(
+      cacheWrapper->getPoolManager());
+}
+
+apache_geode_region_factory_t* apache_geode_Cache_CreateRegionFactory(
+    apache_geode_cache_t* cache, std::int32_t regionType) {
+  LOGDEBUG("%s: cache=%p", __FUNCTION__, cache);
+  CacheWrapper* cacheWrapper = reinterpret_cast<CacheWrapper*>(cache);
+  apache::geode::client::RegionShortcut regionShortcut =
+      static_cast<apache::geode::client::RegionShortcut>(regionType);
+  return reinterpret_cast<apache_geode_region_factory_t*>(
+      cacheWrapper->createRegionFactory(regionShortcut));
+}
+
+const char* apache_geode_Cache_GetName(apache_geode_cache_t* cache) {
+  LOGDEBUG("%s: cache=%p", __FUNCTION__, cache);
+  CacheWrapper* cacheWrapper = reinterpret_cast<CacheWrapper*>(cache);
+  return cacheWrapper->getName();
+}
+
+void apache_geode_Cache_Close(apache_geode_cache_t* cache, bool keepalive) {
+  LOGDEBUG("%s: cache=%p", __FUNCTION__, cache);
+  CacheWrapper* cacheWrapper = reinterpret_cast<CacheWrapper*>(cache);
+  cacheWrapper->close(keepalive);
+}
+
+bool apache_geode_Cache_IsClosed(apache_geode_cache_t* cache) {
+  LOGDEBUG("%s: cache=%p", __FUNCTION__, cache);
+  CacheWrapper* cacheWrapper = reinterpret_cast<CacheWrapper*>(cache);
+  return cacheWrapper->isClosed();
+}
+
+CacheWrapper::CacheWrapper(CacheFactoryWrapper *cache_factory, apache::geode::client::Cache cache)
+    : ClientKeeper{cache_factory}, cache_(std::move(cache)) {
+      AddRecord(this, "CacheWrapper");
+    }
+    
+CacheWrapper::~CacheWrapper() {
+  RemoveRecord(this);
+}
+
+bool CacheWrapper::getPdxIgnoreUnreadFields() {
+  return cache_.getPdxIgnoreUnreadFields();
+}
+
+bool CacheWrapper::getPdxReadSerialized() {
+  return cache_.getPdxReadSerialized();
+}
+
+PoolManagerWrapper* CacheWrapper::getPoolManager() {
+  return new PoolManagerWrapper(this, cache_.getPoolManager());
+}
+
+RegionFactoryWrapper* CacheWrapper::createRegionFactory(
+    apache::geode::client::RegionShortcut regionShortcut) {
+  return new RegionFactoryWrapper(this, cache_.createRegionFactory(regionShortcut));
+}
+
+const char* CacheWrapper::getName() { return cache_.getName().c_str(); }
+
+void CacheWrapper::close(bool keepalive) { cache_.close(keepalive); }
+
+bool CacheWrapper::isClosed() { return cache_.isClosed(); }

--- a/c_bindings/src/cache.cpp
+++ b/c_bindings/src/cache.cpp
@@ -29,9 +29,9 @@
 
 // C client private headers
 #include "cache.hpp"
+#include "cache/factory.hpp"
 #include "pool/manager.hpp"
 #include "region/factory.hpp"
-#include "cache/factory.hpp"
 
 void apache_geode_DestroyCache(apache_geode_cache_t* cache) {
   CacheWrapper* cacheWrapper = reinterpret_cast<CacheWrapper*>(cache);
@@ -89,12 +89,10 @@ bool apache_geode_Cache_IsClosed(apache_geode_cache_t* cache) {
 
 CacheWrapper::CacheWrapper(apache::geode::client::Cache cache)
     : cache_(std::move(cache)) {
-      AddRecord(this, "CacheWrapper");
-    }
-    
-CacheWrapper::~CacheWrapper() {
-  RemoveRecord(this);
+  AddRecord(this, "CacheWrapper");
 }
+
+CacheWrapper::~CacheWrapper() { RemoveRecord(this); }
 
 bool CacheWrapper::getPdxIgnoreUnreadFields() {
   return cache_.getPdxIgnoreUnreadFields();
@@ -110,7 +108,8 @@ PoolManagerWrapper* CacheWrapper::getPoolManager() {
 
 RegionFactoryWrapper* CacheWrapper::createRegionFactory(
     apache::geode::client::RegionShortcut regionShortcut) {
-  return new RegionFactoryWrapper(this, cache_.createRegionFactory(regionShortcut));
+  return new RegionFactoryWrapper(this,
+                                  cache_.createRegionFactory(regionShortcut));
 }
 
 const char* CacheWrapper::getName() { return cache_.getName().c_str(); }

--- a/c_bindings/src/cache.cpp
+++ b/c_bindings/src/cache.cpp
@@ -87,8 +87,8 @@ bool apache_geode_Cache_IsClosed(apache_geode_cache_t* cache) {
   return cacheWrapper->isClosed();
 }
 
-CacheWrapper::CacheWrapper(CacheFactoryWrapper *cache_factory, apache::geode::client::Cache cache)
-    : ClientKeeper{cache_factory}, cache_(std::move(cache)) {
+CacheWrapper::CacheWrapper(apache::geode::client::Cache cache)
+    : cache_(std::move(cache)) {
       AddRecord(this, "CacheWrapper");
     }
     

--- a/c_bindings/src/cache.hpp
+++ b/c_bindings/src/cache.hpp
@@ -37,7 +37,7 @@ class CacheWrapper: public ClientKeeper {
   apache::geode::client::Cache cache_;
 
  public:
-  CacheWrapper(apache::geode::client::Cache);
+  explicit CacheWrapper(apache::geode::client::Cache);
   ~CacheWrapper();
 
   bool getPdxIgnoreUnreadFields();

--- a/c_bindings/src/cache.hpp
+++ b/c_bindings/src/cache.hpp
@@ -37,7 +37,7 @@ class CacheWrapper: public ClientKeeper {
   apache::geode::client::Cache cache_;
 
  public:
-  CacheWrapper(CacheFactoryWrapper *, apache::geode::client::Cache);
+  CacheWrapper(apache::geode::client::Cache);
   ~CacheWrapper();
 
   bool getPdxIgnoreUnreadFields();

--- a/c_bindings/src/cache.hpp
+++ b/c_bindings/src/cache.hpp
@@ -21,9 +21,13 @@
 #include "client.hpp"
 
 
-namespace apache::geode::client {
+namespace apache {
+  namespace geode {
+    namespace client {
 enum class RegionShortcut;
-}  // namespace apache
+    }
+  }
+}
 
 class PoolManagerWrapper;
 class RegionFactoryWrapper;

--- a/c_bindings/src/cache.hpp
+++ b/c_bindings/src/cache.hpp
@@ -24,7 +24,7 @@
 namespace apache {
   namespace geode {
     namespace client {
-enum class RegionShortcut;
+      enum class RegionShortcut;
     }
   }
 }

--- a/c_bindings/src/cache.hpp
+++ b/c_bindings/src/cache.hpp
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "geode/Cache.hpp"
+#include "client.hpp"
+
+
+namespace apache::geode::client {
+enum class RegionShortcut;
+}  // namespace apache
+
+class PoolManagerWrapper;
+class RegionFactoryWrapper;
+class CacheFactoryWrapper;
+
+class CacheWrapper: public ClientKeeper {
+  apache::geode::client::Cache cache_;
+
+ public:
+  CacheWrapper(CacheFactoryWrapper *, apache::geode::client::Cache);
+  ~CacheWrapper();
+
+  bool getPdxIgnoreUnreadFields();
+
+  bool getPdxReadSerialized();
+
+  PoolManagerWrapper* getPoolManager();
+
+  RegionFactoryWrapper* createRegionFactory(
+      apache::geode::client::RegionShortcut regionShortcut);
+
+  const char* getName();
+
+  void close(bool keepalive);
+
+  bool isClosed();
+};

--- a/c_bindings/src/cache/factory.cpp
+++ b/c_bindings/src/cache/factory.cpp
@@ -16,9 +16,9 @@
  */
 
 // Standard headers
+#include <iostream>
 #include <memory>
 #include <string>
-#include <iostream>
 
 // C++ client public headers
 #include "geode/CacheFactory.hpp"
@@ -43,9 +43,7 @@ CacheFactoryWrapper::CacheFactoryWrapper() {
   std::cout << __FUNCTION__ << " " << static_cast<void*>(this) << "\n";
 }
 
-CacheFactoryWrapper::~CacheFactoryWrapper() {
-  RemoveRecord(this);
-}
+CacheFactoryWrapper::~CacheFactoryWrapper() { RemoveRecord(this); }
 
 const char* CacheFactoryWrapper::getVersion() {
   return cacheFactory_.getVersion().c_str();
@@ -82,7 +80,8 @@ CacheWrapper* CacheFactoryWrapper::createCache() {
 
 apache_geode_cache_factory_t* apache_geode_CreateCacheFactory() {
   auto factory = new CacheFactoryWrapper();
-  std::cout << __FUNCTION__ << " factory: " << static_cast<void*>(factory) << "\n";
+  std::cout << __FUNCTION__ << " factory: " << static_cast<void*>(factory)
+            << "\n";
   LOGDEBUG("%s: factory=%p", __FUNCTION__, factory);
   return reinterpret_cast<apache_geode_cache_factory_t*>(factory);
 }
@@ -91,7 +90,8 @@ apache_geode_cache_t* apache_geode_CacheFactory_CreateCache(
     apache_geode_cache_factory_t* factory) {
   auto cacheFactory = reinterpret_cast<CacheFactoryWrapper*>(factory);
   CacheWrapper* cache = cacheFactory->createCache();
-  std::cout << __FUNCTION__ << " factory: " << static_cast<void*>(factory) << "cache: " << static_cast<void*>(cache) << "\n";
+  std::cout << __FUNCTION__ << " factory: " << static_cast<void*>(factory)
+            << "cache: " << static_cast<void*>(cache) << "\n";
   LOGDEBUG("%s: factory=%p, cache=%p", __FUNCTION__, factory, cache);
   return reinterpret_cast<apache_geode_cache_t*>(cache);
 }
@@ -112,10 +112,10 @@ const char* apache_geode_CacheFactory_GetProductDescription(
 
 void apache_geode_CacheFactory_SetPdxIgnoreUnreadFields(
     apache_geode_cache_factory_t* factory, bool pdxIgnoreUnreadFields) {
-  auto cacheFactory =
-      reinterpret_cast<CacheFactoryWrapper*>(factory);
+  auto cacheFactory = reinterpret_cast<CacheFactoryWrapper*>(factory);
   auto ignoreUnreadFields = pdxIgnoreUnreadFields ? "true" : "false";
-  std::cout << __FUNCTION__ << " factory: " << static_cast<void*>(factory) << "\n";
+  std::cout << __FUNCTION__ << " factory: " << static_cast<void*>(factory)
+            << "\n";
   LOGDEBUG("%s: factory=%p, ignoreUnreadFields=%s", __FUNCTION__, factory,
            ignoreUnreadFields);
   cacheFactory->setPdxIgnoreUnreadFields(pdxIgnoreUnreadFields);
@@ -148,6 +148,7 @@ void apache_geode_CacheFactory_SetProperty(
 }
 
 void apache_geode_DestroyCacheFactory(apache_geode_cache_factory_t* factory) {
-  std::cout << __FUNCTION__ << " factory: " << static_cast<void*>(factory) << "\n";
+  std::cout << __FUNCTION__ << " factory: " << static_cast<void*>(factory)
+            << "\n";
   delete reinterpret_cast<CacheFactoryWrapper*>(factory);
 }

--- a/c_bindings/src/cache/factory.cpp
+++ b/c_bindings/src/cache/factory.cpp
@@ -37,8 +37,7 @@
 #include "client.hpp"
 #include "factory.hpp"
 
-CacheFactoryWrapper::CacheFactoryWrapper(apache_geode_client_t* client)
-    : ClientKeeper{reinterpret_cast<ClientWrapper*>(client)} {
+CacheFactoryWrapper::CacheFactoryWrapper() {
   AddRecord(this, "CacheFactoryWrapper");
   cacheFactory_.set("log-level", "debug");
   std::cout << __FUNCTION__ << " " << static_cast<void*>(this) << "\n";
@@ -78,12 +77,11 @@ void CacheFactoryWrapper::setProperty(const std::string& key,
 
 CacheWrapper* CacheFactoryWrapper::createCache() {
   std::cout << __FUNCTION__ << " " << static_cast<void*>(this) << "\n";
-  return new CacheWrapper(this, cacheFactory_.create());
+  return new CacheWrapper(cacheFactory_.create());
 }
 
-apache_geode_cache_factory_t* apache_geode_CreateCacheFactory(
-    apache_geode_client_t* client) {
-  auto factory = new CacheFactoryWrapper(client);
+apache_geode_cache_factory_t* apache_geode_CreateCacheFactory() {
+  auto factory = new CacheFactoryWrapper();
   std::cout << __FUNCTION__ << " factory: " << static_cast<void*>(factory) << "\n";
   LOGDEBUG("%s: factory=%p", __FUNCTION__, factory);
   return reinterpret_cast<apache_geode_cache_factory_t*>(factory);

--- a/c_bindings/src/cache/factory.cpp
+++ b/c_bindings/src/cache/factory.cpp
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standard headers
+#include <memory>
+#include <string>
+
+// C++ client public headers
+#include "geode/CacheFactory.hpp"
+
+// C++ client private headers
+#include "util/Log.hpp"
+
+// C client public headers
+#include "geode/cache.h"
+#include "geode/cache/factory.h"
+#include "geode/client.h"
+
+// C client private headers
+#include "auth_initialize.hpp"
+#include "cache.hpp"
+#include "client.hpp"
+#include "factory.hpp"
+
+CacheFactoryWrapper::CacheFactoryWrapper(apache_geode_client_t* client)
+    : ClientKeeper{reinterpret_cast<ClientWrapper*>(client)} {
+  AddRecord(this, "CacheFactoryWrapper");
+}
+
+CacheFactoryWrapper::~CacheFactoryWrapper() {
+  RemoveRecord(this);
+}
+
+const char* CacheFactoryWrapper::getVersion() {
+  return cacheFactory_.getVersion().c_str();
+}
+
+const char* CacheFactoryWrapper::getProductDescription() {
+  return cacheFactory_.getProductDescription().c_str();
+}
+
+void CacheFactoryWrapper::setPdxIgnoreUnreadFields(bool pdxIgnoreUnreadFields) {
+  cacheFactory_.setPdxIgnoreUnreadFields(pdxIgnoreUnreadFields);
+}
+
+void CacheFactoryWrapper::setAuthInitialize(
+    void (*getCredentials)(apache_geode_properties_t*), void (*close)()) {
+  authInit_ = std::make_shared<AuthInitializeWrapper>(getCredentials, close);
+  cacheFactory_.setAuthInitialize(authInit_);
+}
+
+void CacheFactoryWrapper::setPdxReadSerialized(bool pdxReadSerialized) {
+  cacheFactory_.setPdxReadSerialized(pdxReadSerialized);
+}
+
+void CacheFactoryWrapper::setProperty(const std::string& key,
+                                      const std::string& value) {
+  cacheFactory_.set(key, value);
+}
+
+CacheWrapper* CacheFactoryWrapper::createCache() {
+  return new CacheWrapper(this, cacheFactory_.create());
+}
+
+apache_geode_cache_factory_t* apache_geode_CreateCacheFactory(
+    apache_geode_client_t* client) {
+  return reinterpret_cast<apache_geode_cache_factory_t*>(
+      new CacheFactoryWrapper(client));
+}
+apache_geode_cache_t* apache_geode_CacheFactory_CreateCache(
+    apache_geode_cache_factory_t* factory) {
+  auto cacheFactory = reinterpret_cast<CacheFactoryWrapper*>(factory);
+  CacheWrapper* cache = cacheFactory->createCache();
+  LOGDEBUG("%s: factory=%p, cache=%p", __FUNCTION__, factory, cache);
+  return reinterpret_cast<apache_geode_cache_t*>(cache);
+}
+
+const char* apache_geode_CacheFactory_GetVersion(
+    apache_geode_cache_factory_t* factory) {
+  LOGDEBUG("%s: factory=%p", __FUNCTION__, factory);
+  auto cacheFactory = reinterpret_cast<CacheFactoryWrapper*>(factory);
+  return cacheFactory->getVersion();
+}
+
+const char* apache_geode_CacheFactory_GetProductDescription(
+    apache_geode_cache_factory_t* factory) {
+  LOGDEBUG("%s: factory=%p", __FUNCTION__, factory);
+  auto cacheFactory = reinterpret_cast<CacheFactoryWrapper*>(factory);
+  return cacheFactory->getProductDescription();
+}
+
+void apache_geode_CacheFactory_SetPdxIgnoreUnreadFields(
+    apache_geode_cache_factory_t* factory, bool pdxIgnoreUnreadFields) {
+  auto cacheFactory =
+      reinterpret_cast<apache::geode::client::CacheFactory*>(factory);
+  auto ignoreUnreadFields = pdxIgnoreUnreadFields ? "true" : "false";
+  LOGDEBUG("%s: factory=%p, ignoreUnreadFields=%s", __FUNCTION__, factory,
+           ignoreUnreadFields);
+  cacheFactory->setPdxIgnoreUnreadFields(pdxIgnoreUnreadFields);
+}
+
+void apache_geode_CacheFactory_SetAuthInitialize(
+    apache_geode_cache_factory_t* factory,
+    void (*getCredentials)(apache_geode_properties_t*), void (*close)()) {
+  auto cacheFactory = reinterpret_cast<CacheFactoryWrapper*>(factory);
+  LOGDEBUG("%s: factory=%p, getCredentials=%p, close=%p", __FUNCTION__, factory,
+           getCredentials, close);
+  cacheFactory->setAuthInitialize(getCredentials, close);
+}
+
+void apache_geode_CacheFactory_SetPdxReadSerialized(
+    apache_geode_cache_factory_t* factory, bool pdxReadSerialized) {
+  auto cacheFactory = reinterpret_cast<CacheFactoryWrapper*>(factory);
+  auto readSerialized = pdxReadSerialized ? "true" : "false";
+  LOGDEBUG("%s: factory=%p, readSerialized=%s", __FUNCTION__, factory,
+           readSerialized);
+  cacheFactory->setPdxReadSerialized(pdxReadSerialized);
+}
+
+void apache_geode_CacheFactory_SetProperty(
+    apache_geode_cache_factory_t* factory, const char* key, const char* value) {
+  LOGDEBUG("%s: factory=%p, (k, v)=(%s, %s)", __FUNCTION__, factory,
+           std::string(key).c_str(), std::string(value).c_str());
+  auto cacheFactory = reinterpret_cast<CacheFactoryWrapper*>(factory);
+  cacheFactory->setProperty(key, value);
+}
+
+void apache_geode_DestroyCacheFactory(apache_geode_cache_factory_t* factory) {
+  delete reinterpret_cast<CacheFactoryWrapper*>(factory);
+}

--- a/c_bindings/src/cache/factory.hpp
+++ b/c_bindings/src/cache/factory.hpp
@@ -34,7 +34,7 @@ class CacheFactoryWrapper : public ClientKeeper {
   std::shared_ptr<AuthInitializeWrapper> authInit_;
 
  public:
-  CacheFactoryWrapper(apache_geode_client_t *client);
+  CacheFactoryWrapper();
 
   ~CacheFactoryWrapper();
 

--- a/c_bindings/src/cache/factory.hpp
+++ b/c_bindings/src/cache/factory.hpp
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standard headers
+#include <memory>
+#include <string>
+
+// C++ client public headers
+#include "geode/CacheFactory.hpp"
+
+// C client public headers
+#include "geode/client.h"
+
+// C client private headers
+#include "auth_initialize.hpp"
+#include "client.hpp"
+
+class CacheFactoryWrapper : public ClientKeeper {
+  apache::geode::client::CacheFactory cacheFactory_;
+  std::shared_ptr<AuthInitializeWrapper> authInit_;
+
+ public:
+  CacheFactoryWrapper(apache_geode_client_t *client);
+
+  ~CacheFactoryWrapper();
+
+  const char* getVersion();
+
+  const char* getProductDescription();
+
+  void setPdxIgnoreUnreadFields(bool pdxIgnoreUnreadFields);
+
+  void setAuthInitialize(void (*getCredentials)(apache_geode_properties_t*),
+                         void (*close)());
+
+  void setPdxReadSerialized(bool pdxReadSerialized);
+
+  void setProperty(const std::string& key, const std::string& value);
+
+  CacheWrapper* createCache();
+};

--- a/c_bindings/src/client.cpp
+++ b/c_bindings/src/client.cpp
@@ -16,9 +16,9 @@
  */
 
 // Standard headers
+#include <iostream>
 #include <string>
 #include <utility>
-#include <iostream>
 
 // C++ client public headers
 #include "geode/Exception.hpp"
@@ -33,12 +33,13 @@
 #include "client.hpp"
 
 std::shared_ptr<ClientWrapper>& PermaClient::instance() {
-    static auto client_ = std::make_shared<ClientWrapper>();
-    return client_;
+  static auto client_ = std::make_shared<ClientWrapper>();
+  return client_;
 }
 
 apache_geode_client_t* apache_geode_ClientInitialize() {
-  return reinterpret_cast<apache_geode_client_t*>(PermaClient::instance().get());
+  return reinterpret_cast<apache_geode_client_t*>(
+      PermaClient::instance().get());
 }
 
 int apache_geode_ClientUninitialize(apache_geode_client_t* client) {
@@ -50,20 +51,18 @@ int apache_geode_ClientUninitialize(apache_geode_client_t* client) {
   }
   return 0;
 }
-  
-void Client::AddRecord(void *value, const std::string &className) {
+
+void Client::AddRecord(void* value, const std::string& className) {
   do_AddRecord(value, className);
 }
 
-void Client::RemoveRecord(void *value) {
-  do_RemoveRecord(value);
-}
+void Client::RemoveRecord(void* value) { do_RemoveRecord(value); }
 
-void ClientKeeper::do_AddRecord(void *value, const std::string &className) {
+void ClientKeeper::do_AddRecord(void* value, const std::string& className) {
   PermaClient::instance()->AddRecord(value, className);
 }
 
-void ClientKeeper::do_RemoveRecord(void *value) {
+void ClientKeeper::do_RemoveRecord(void* value) {
   PermaClient::instance()->RemoveRecord(value);
 }
 
@@ -91,6 +90,4 @@ void ClientWrapper::do_AddRecord(void* value, const std::string& className) {
 
 void ClientWrapper::do_RemoveRecord(void* value) { registry_.erase(value); }
 
-ClientWrapper::~ClientWrapper() {
-  std::cout << "Geode client shut down...\n";
-}
+ClientWrapper::~ClientWrapper() { std::cout << "Geode client shut down...\n"; }

--- a/c_bindings/src/client.cpp
+++ b/c_bindings/src/client.cpp
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standard headers
+#include <string>
+#include <utility>
+
+// C++ client public headers
+#include "geode/Exception.hpp"
+
+// C++ client private headers
+#include "util/Log.hpp"
+
+// C client public headers
+#include "geode/client.h"
+
+// C client private headers
+#include "client.hpp"
+
+apache_geode_client_t* apache_geode_ClientInitialize() {
+  return reinterpret_cast<apache_geode_client_t*>(new ClientWrapper());
+}
+
+int apache_geode_ClientUninitialize(apache_geode_client_t* client) {
+  if(auto wrapper = reinterpret_cast<ClientWrapper*>(client)) {
+    const int result = wrapper->checkForLeaks();
+
+    delete wrapper;
+
+    return result;
+  }
+
+  return 0;
+}
+  
+void Client::AddRecord(void *value, const std::string &className) {
+  do_AddRecord(value, className);
+}
+
+void Client::RemoveRecord(void *value) {
+  do_RemoveRecord(value);
+}
+
+void ClientKeeper::do_AddRecord(void *value, const std::string &className) {
+  client->AddRecord(value, className);
+}
+
+void ClientKeeper::do_RemoveRecord(void *value) {
+  client->RemoveRecord(value);
+}
+
+ClientKeeper::ClientKeeper(Client *client):client{client} {}
+
+int ClientWrapper::checkForLeaks() {
+  int result = 0;
+  if (!registry_.empty()) {
+    for (auto recordPair : registry_) {
+      auto object = recordPair.first;
+      auto record = recordPair.second;
+
+      LOGERROR("Leaked object of type \"%s\" (pointer value %p), callstack %s",
+               record.className.c_str(), object,
+               record.allocationCallstack.c_str());
+      result = -1;
+    }
+  }
+  return result;
+}
+
+void ClientWrapper::do_AddRecord(void* value, const std::string& className) {
+  using apache::geode::client::Exception;
+
+  registry_.insert({value, {className, Exception("").getStackTrace()}});
+}
+
+void ClientWrapper::do_RemoveRecord(void* value) { registry_.erase(value); }

--- a/c_bindings/src/client.cpp
+++ b/c_bindings/src/client.cpp
@@ -32,13 +32,10 @@
 // C client private headers
 #include "client.hpp"
 
-class PermaClient {
- public:
-  static std::shared_ptr<ClientWrapper>& instance() {
+std::shared_ptr<ClientWrapper>& PermaClient::instance() {
     static auto client_ = std::make_shared<ClientWrapper>();
     return client_;
-  }
-};
+}
 
 apache_geode_client_t* apache_geode_ClientInitialize() {
   return reinterpret_cast<apache_geode_client_t*>(PermaClient::instance().get());
@@ -63,14 +60,12 @@ void Client::RemoveRecord(void *value) {
 }
 
 void ClientKeeper::do_AddRecord(void *value, const std::string &className) {
-  client->AddRecord(value, className);
+  PermaClient::instance()->AddRecord(value, className);
 }
 
 void ClientKeeper::do_RemoveRecord(void *value) {
-  client->RemoveRecord(value);
+  PermaClient::instance()->RemoveRecord(value);
 }
-
-ClientKeeper::ClientKeeper(Client *client):client{client} {}
 
 int ClientWrapper::checkForLeaks() {
   int result = 0;

--- a/c_bindings/src/client.hpp
+++ b/c_bindings/src/client.hpp
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <string>
+#include <memory>
 
 #include "geode/internal/geode_base.h"
 
@@ -38,13 +39,8 @@ class Client {
 // Anything that creates another wrapper derives from this.
 // Adding and removing from this defers to the parent retained within.
 class ClientKeeper : public Client {
-  Client *client;
-
   void do_AddRecord(void *, const std::string &) final override;
   void do_RemoveRecord(void *) final override;
-
- public:
-  ClientKeeper(Client *);
 };
 
 // This is the top level parent. Adding and removing from any client will
@@ -69,4 +65,9 @@ class ClientWrapper : public Client {
   int checkForLeaks();
 
   virtual ~ClientWrapper();
+};
+
+class PermaClient {
+ public:
+    static std::shared_ptr<ClientWrapper> &PermaClient::instance();
 };

--- a/c_bindings/src/client.hpp
+++ b/c_bindings/src/client.hpp
@@ -69,5 +69,5 @@ class ClientWrapper : public Client {
 
 class PermaClient {
  public:
-    static std::shared_ptr<ClientWrapper> &PermaClient::instance();
+    static std::shared_ptr<ClientWrapper> &instance();
 };

--- a/c_bindings/src/client.hpp
+++ b/c_bindings/src/client.hpp
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "geode/internal/geode_base.h"
+
+// All wrappers are passed their creator object for retention.
+// The parent objects implement this interface.
+class Client {
+  virtual void do_AddRecord(void *, const std::string &) = 0;
+  virtual void do_RemoveRecord(void *) = 0;
+
+ public:
+  // All wrappers call this in their constructors.
+  void AddRecord(void *, const std::string &);
+  // All wrappers call this in their destructors.
+  void RemoveRecord(void *);
+};
+
+// Anything that creates another wrapper derives from this.
+// Adding and removing from this defers to the parent retained within.
+class ClientKeeper : public Client {
+  Client *client;
+
+  void do_AddRecord(void *, const std::string &) final override;
+  void do_RemoveRecord(void *) final override;
+
+ public:
+  ClientKeeper(Client *);
+};
+
+// This is the top level parent. Adding and removing from any client will
+// ultimately add and remove from an instance of this. This is the client
+// object the user creates from the C interface. Because the wrappers form a
+// hierarchy, it's very important to destroy them in reverse order along that
+// hierarchy.
+class ClientWrapper : public Client {
+  struct ClientObjectRecord {
+    std::string className;
+    std::string allocationCallstack;
+  };
+
+  typedef std::map<void *, ClientObjectRecord> ClientObjectRegistry;
+
+  ClientObjectRegistry registry_;
+
+  void do_AddRecord(void *, const std::string &) final override;
+  void do_RemoveRecord(void *) final override;
+
+ public:
+  int checkForLeaks();
+};

--- a/c_bindings/src/client.hpp
+++ b/c_bindings/src/client.hpp
@@ -67,4 +67,6 @@ class ClientWrapper : public Client {
 
  public:
   int checkForLeaks();
+
+  virtual ~ClientWrapper();
 };

--- a/c_bindings/src/pool.cpp
+++ b/c_bindings/src/pool.cpp
@@ -33,11 +33,11 @@ void apache_geode_DestroyPool(apache_geode_pool_t* pool) {
   delete poolWrapper;
 }
 
-PoolWrapper::PoolWrapper(PoolFactoryWrapper &pool_factory, std::shared_ptr<apache::geode::client::Pool> pool)
-    : pool_(pool), pool_factory{pool_factory} {
-      pool_factory.AddRecord(this, "PoolWrapper");
-    }
+PoolWrapper::PoolWrapper(std::shared_ptr<apache::geode::client::Pool> pool)
+    : pool_(pool) {
+  AddRecord(this, "PoolWrapper");
+}
 
 PoolWrapper::~PoolWrapper() {
-  pool_factory.RemoveRecord(this);
+  RemoveRecord(this);
 }

--- a/c_bindings/src/pool.cpp
+++ b/c_bindings/src/pool.cpp
@@ -38,6 +38,4 @@ PoolWrapper::PoolWrapper(std::shared_ptr<apache::geode::client::Pool> pool)
   AddRecord(this, "PoolWrapper");
 }
 
-PoolWrapper::~PoolWrapper() {
-  RemoveRecord(this);
-}
+PoolWrapper::~PoolWrapper() { RemoveRecord(this); }

--- a/c_bindings/src/pool.cpp
+++ b/c_bindings/src/pool.cpp
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standard headers
+#include <memory>
+
+// C++ public headers
+#include "geode/Pool.hpp"
+
+// C client public headers
+#include "geode/pool.h"
+
+// C client private headers
+#include "pool.hpp"
+#include "pool/factory.hpp"
+
+void apache_geode_DestroyPool(apache_geode_pool_t* pool) {
+  PoolWrapper* poolWrapper = reinterpret_cast<PoolWrapper*>(pool);
+  delete poolWrapper;
+}
+
+PoolWrapper::PoolWrapper(PoolFactoryWrapper &pool_factory, std::shared_ptr<apache::geode::client::Pool> pool)
+    : pool_(pool), pool_factory{pool_factory} {
+      pool_factory.AddRecord(this, "PoolWrapper");
+    }
+
+PoolWrapper::~PoolWrapper() {
+  pool_factory.RemoveRecord(this);
+}

--- a/c_bindings/src/pool.hpp
+++ b/c_bindings/src/pool.hpp
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "geode/Pool.hpp"
+
+class PoolFactoryWrapper;
+class PoolWrapper {
+  std::shared_ptr<apache::geode::client::Pool> pool_;
+  PoolFactoryWrapper &pool_factory;
+
+ public:
+  PoolWrapper(PoolFactoryWrapper &pool_factory, std::shared_ptr<apache::geode::client::Pool> pool);
+  ~PoolWrapper();
+};

--- a/c_bindings/src/pool.hpp
+++ b/c_bindings/src/pool.hpp
@@ -27,6 +27,6 @@ class PoolWrapper : public ClientKeeper {
   std::shared_ptr<apache::geode::client::Pool> pool_;
 
  public:
-  PoolWrapper(std::shared_ptr<apache::geode::client::Pool> pool);
+  explicit PoolWrapper(std::shared_ptr<apache::geode::client::Pool> pool);
   ~PoolWrapper();
 };

--- a/c_bindings/src/pool.hpp
+++ b/c_bindings/src/pool.hpp
@@ -19,14 +19,14 @@
 
 #include <memory>
 
+#include "client.hpp"
 #include "geode/Pool.hpp"
 
 class PoolFactoryWrapper;
-class PoolWrapper {
+class PoolWrapper : public ClientKeeper {
   std::shared_ptr<apache::geode::client::Pool> pool_;
-  PoolFactoryWrapper &pool_factory;
 
  public:
-  PoolWrapper(PoolFactoryWrapper &pool_factory, std::shared_ptr<apache::geode::client::Pool> pool);
+  PoolWrapper(std::shared_ptr<apache::geode::client::Pool> pool);
   ~PoolWrapper();
 };

--- a/c_bindings/src/pool/factory.cpp
+++ b/c_bindings/src/pool/factory.cpp
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standard headers
+#include <cstdint>
+#include <string>
+
+// C client public headers
+#include "geode/pool/factory.h"
+
+// C client private headers
+#include "pool.hpp"
+#include "pool/factory.hpp"
+#include "pool/manager.hpp"
+
+apache_geode_pool_t* apache_geode_PoolFactory_CreatePool(
+    apache_geode_pool_factory_t* poolFactory, const char* name) {
+  PoolFactoryWrapper* poolFactoryWrapper =
+      reinterpret_cast<PoolFactoryWrapper*>(poolFactory);
+  return reinterpret_cast<apache_geode_pool_t*>(
+      poolFactoryWrapper->CreatePool(name));
+}
+
+void apache_geode_PoolFactory_AddLocator(
+    apache_geode_pool_factory_t* poolFactory, const char* hostname,
+    const std::uint16_t port) {
+  PoolFactoryWrapper* poolFactoryWrapper =
+      reinterpret_cast<PoolFactoryWrapper*>(poolFactory);
+  poolFactoryWrapper->AddLocator(hostname, port);
+}
+
+void apache_geode_DestroyPoolFactory(apache_geode_pool_factory_t* poolFactory) {
+  PoolFactoryWrapper* poolFactoryWrapper =
+      reinterpret_cast<PoolFactoryWrapper*>(poolFactory);
+  delete poolFactoryWrapper;
+}
+
+PoolFactoryWrapper::PoolFactoryWrapper(
+    PoolManagerWrapper* manager, apache::geode::client::PoolFactory poolFactory)
+    : ClientKeeper{manager}, poolFactory_(poolFactory) {
+  AddRecord(this, "PoolFactoryWrapper");
+}
+
+PoolFactoryWrapper::~PoolFactoryWrapper() { RemoveRecord(this); }
+
+PoolWrapper* PoolFactoryWrapper::CreatePool(const char* name) {
+  return new PoolWrapper(*this, poolFactory_.create(name));
+}
+
+void PoolFactoryWrapper::AddLocator(const std::string& hostname,
+                                    const std::uint16_t port) {
+  poolFactory_.addLocator(hostname, port);
+}

--- a/c_bindings/src/pool/factory.cpp
+++ b/c_bindings/src/pool/factory.cpp
@@ -49,7 +49,8 @@ void apache_geode_DestroyPoolFactory(apache_geode_pool_factory_t* poolFactory) {
   delete poolFactoryWrapper;
 }
 
-PoolFactoryWrapper::PoolFactoryWrapper(apache::geode::client::PoolFactory poolFactory)
+PoolFactoryWrapper::PoolFactoryWrapper(
+    apache::geode::client::PoolFactory poolFactory)
     : poolFactory_(poolFactory) {
   AddRecord(this, "PoolFactoryWrapper");
 }

--- a/c_bindings/src/pool/factory.cpp
+++ b/c_bindings/src/pool/factory.cpp
@@ -49,16 +49,15 @@ void apache_geode_DestroyPoolFactory(apache_geode_pool_factory_t* poolFactory) {
   delete poolFactoryWrapper;
 }
 
-PoolFactoryWrapper::PoolFactoryWrapper(
-    PoolManagerWrapper* manager, apache::geode::client::PoolFactory poolFactory)
-    : ClientKeeper{manager}, poolFactory_(poolFactory) {
+PoolFactoryWrapper::PoolFactoryWrapper(apache::geode::client::PoolFactory poolFactory)
+    : poolFactory_(poolFactory) {
   AddRecord(this, "PoolFactoryWrapper");
 }
 
 PoolFactoryWrapper::~PoolFactoryWrapper() { RemoveRecord(this); }
 
 PoolWrapper* PoolFactoryWrapper::CreatePool(const char* name) {
-  return new PoolWrapper(*this, poolFactory_.create(name));
+  return new PoolWrapper(poolFactory_.create(name));
 }
 
 void PoolFactoryWrapper::AddLocator(const std::string& hostname,

--- a/c_bindings/src/pool/factory.hpp
+++ b/c_bindings/src/pool/factory.hpp
@@ -30,7 +30,7 @@ class PoolFactoryWrapper: public ClientKeeper {
   apache::geode::client::PoolFactory poolFactory_;
 
  public:
-  PoolFactoryWrapper(PoolManagerWrapper *, apache::geode::client::PoolFactory poolFactory);
+  PoolFactoryWrapper(apache::geode::client::PoolFactory poolFactory);
   ~PoolFactoryWrapper();
 
   PoolWrapper* CreatePool(const char* name);

--- a/c_bindings/src/pool/factory.hpp
+++ b/c_bindings/src/pool/factory.hpp
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "geode/PoolFactory.hpp"
+#include "client.hpp"
+
+class PoolWrapper;
+class PoolManagerWrapper;
+
+class PoolFactoryWrapper: public ClientKeeper {
+  apache::geode::client::PoolFactory poolFactory_;
+
+ public:
+  PoolFactoryWrapper(PoolManagerWrapper *, apache::geode::client::PoolFactory poolFactory);
+  ~PoolFactoryWrapper();
+
+  PoolWrapper* CreatePool(const char* name);
+
+  void AddLocator(const std::string& hostname, std::uint16_t port);
+};

--- a/c_bindings/src/pool/factory.hpp
+++ b/c_bindings/src/pool/factory.hpp
@@ -30,7 +30,7 @@ class PoolFactoryWrapper: public ClientKeeper {
   apache::geode::client::PoolFactory poolFactory_;
 
  public:
-  PoolFactoryWrapper(apache::geode::client::PoolFactory poolFactory);
+  explicit PoolFactoryWrapper(apache::geode::client::PoolFactory poolFactory);
   ~PoolFactoryWrapper();
 
   PoolWrapper* CreatePool(const char* name);

--- a/c_bindings/src/pool/manager.cpp
+++ b/c_bindings/src/pool/manager.cpp
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// C client public headers
+#include "geode/pool/manager.h"
+
+// C client private headers
+#include "client.hpp"
+#include "pool/factory.hpp"
+#include "pool/manager.hpp"
+#include "cache.hpp"
+
+apache_geode_pool_factory_t* apache_geode_PoolManager_CreateFactory(
+    apache_geode_pool_manager_t* poolManager) {
+  PoolManagerWrapper* poolManagerWrapper =
+      reinterpret_cast<PoolManagerWrapper*>(poolManager);
+  return reinterpret_cast<apache_geode_pool_factory_t*>(
+      poolManagerWrapper->CreatePoolFactory());
+}
+
+void apache_geode_DestroyPoolManager(apache_geode_pool_manager_t* poolManager) {
+  PoolManagerWrapper* poolManagerWrapper =
+      reinterpret_cast<PoolManagerWrapper*>(poolManager);
+  delete poolManagerWrapper;
+}
+
+PoolManagerWrapper::PoolManagerWrapper(CacheWrapper *cache,
+    apache::geode::client::PoolManager& poolManager)
+    : ClientKeeper{cache}, poolManager_(poolManager) {
+      AddRecord(this, "PoolManagerWrapper");
+    }
+
+PoolManagerWrapper::~PoolManagerWrapper() {
+  RemoveRecord(this);
+}
+
+PoolFactoryWrapper* PoolManagerWrapper::CreatePoolFactory() {
+  return new PoolFactoryWrapper(this, poolManager_.createFactory());
+}

--- a/c_bindings/src/pool/manager.cpp
+++ b/c_bindings/src/pool/manager.cpp
@@ -19,10 +19,10 @@
 #include "geode/pool/manager.h"
 
 // C client private headers
+#include "cache.hpp"
 #include "client.hpp"
 #include "pool/factory.hpp"
 #include "pool/manager.hpp"
-#include "cache.hpp"
 
 apache_geode_pool_factory_t* apache_geode_PoolManager_CreateFactory(
     apache_geode_pool_manager_t* poolManager) {
@@ -38,15 +38,13 @@ void apache_geode_DestroyPoolManager(apache_geode_pool_manager_t* poolManager) {
   delete poolManagerWrapper;
 }
 
-PoolManagerWrapper::PoolManagerWrapper(CacheWrapper *cache,
-    apache::geode::client::PoolManager& poolManager)
+PoolManagerWrapper::PoolManagerWrapper(
+    CacheWrapper* cache, apache::geode::client::PoolManager& poolManager)
     : poolManager_(poolManager) {
-      AddRecord(this, "PoolManagerWrapper");
-    }
-
-PoolManagerWrapper::~PoolManagerWrapper() {
-  RemoveRecord(this);
+  AddRecord(this, "PoolManagerWrapper");
 }
+
+PoolManagerWrapper::~PoolManagerWrapper() { RemoveRecord(this); }
 
 PoolFactoryWrapper* PoolManagerWrapper::CreatePoolFactory() {
   return new PoolFactoryWrapper(poolManager_.createFactory());

--- a/c_bindings/src/pool/manager.cpp
+++ b/c_bindings/src/pool/manager.cpp
@@ -40,7 +40,7 @@ void apache_geode_DestroyPoolManager(apache_geode_pool_manager_t* poolManager) {
 
 PoolManagerWrapper::PoolManagerWrapper(CacheWrapper *cache,
     apache::geode::client::PoolManager& poolManager)
-    : ClientKeeper{cache}, poolManager_(poolManager) {
+    : poolManager_(poolManager) {
       AddRecord(this, "PoolManagerWrapper");
     }
 
@@ -49,5 +49,5 @@ PoolManagerWrapper::~PoolManagerWrapper() {
 }
 
 PoolFactoryWrapper* PoolManagerWrapper::CreatePoolFactory() {
-  return new PoolFactoryWrapper(this, poolManager_.createFactory());
+  return new PoolFactoryWrapper(poolManager_.createFactory());
 }

--- a/c_bindings/src/pool/manager.hpp
+++ b/c_bindings/src/pool/manager.hpp
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "geode/PoolManager.hpp"
+
+class PoolFactoryWrapper;
+class CacheWrapper;
+
+class PoolManagerWrapper: public ClientKeeper {
+  apache::geode::client::PoolManager& poolManager_;
+
+ public:
+  PoolManagerWrapper(CacheWrapper *cache, apache::geode::client::PoolManager& poolManager);
+  ~PoolManagerWrapper();
+
+  PoolFactoryWrapper* CreatePoolFactory();
+};

--- a/c_bindings/src/region.cpp
+++ b/c_bindings/src/region.cpp
@@ -36,12 +36,12 @@
 #include "region.hpp"
 #include "region/factory.hpp"
 
-RegionWrapper::RegionWrapper(RegionFactoryWrapper &region_factory, std::shared_ptr<apache::geode::client::Region> region)
-    : region_(region), region_factory{region_factory} {
-      region_factory.AddRecord(this, "RegionWrapper");
+RegionWrapper::RegionWrapper(std::shared_ptr<apache::geode::client::Region> region)
+    : region_(region) {
+      AddRecord(this, "RegionWrapper");
     }
 
-RegionWrapper::~RegionWrapper() { region_factory.RemoveRecord(this); }
+RegionWrapper::~RegionWrapper() { RemoveRecord(this); }
 
 void RegionWrapper::PutString(const std::string& key,
                               const std::string& value) {

--- a/c_bindings/src/region.cpp
+++ b/c_bindings/src/region.cpp
@@ -19,6 +19,10 @@
 #include <memory>
 #include <string>
 
+#ifdef _WIN32
+#include <objbase.h>
+#endif // _WIN32
+
 // C++ client public headers
 #include "geode/CacheableString.hpp"
 #include "geode/Region.hpp"

--- a/c_bindings/src/region.cpp
+++ b/c_bindings/src/region.cpp
@@ -21,7 +21,7 @@
 
 #ifdef _WIN32
 #include <objbase.h>
-#endif // _WIN32
+#endif  // _WIN32
 
 // C++ client public headers
 #include "geode/CacheableString.hpp"
@@ -36,10 +36,11 @@
 #include "region.hpp"
 #include "region/factory.hpp"
 
-RegionWrapper::RegionWrapper(std::shared_ptr<apache::geode::client::Region> region)
+RegionWrapper::RegionWrapper(
+    std::shared_ptr<apache::geode::client::Region> region)
     : region_(region) {
-      AddRecord(this, "RegionWrapper");
-    }
+  AddRecord(this, "RegionWrapper");
+}
 
 RegionWrapper::~RegionWrapper() { RemoveRecord(this); }
 
@@ -113,7 +114,8 @@ const char* apache_geode_Region_GetString(apache_geode_region_t* region,
 }
 
 void apache_geode_Region_GetByteArray(apache_geode_region_t* region,
-                                             const char* key, char** value, size_t* size) {
+                                      const char* key, char** value,
+                                      size_t* size) {
   RegionWrapper* regionWrapper = reinterpret_cast<RegionWrapper*>(region);
   return regionWrapper->GetByteArray(key, value, size);
 }

--- a/c_bindings/src/region.cpp
+++ b/c_bindings/src/region.cpp
@@ -71,16 +71,17 @@ void RegionWrapper::GetByteArray(const std::string& key, char** value,
 
   auto bytes =
       std::dynamic_pointer_cast<apache::geode::client::CacheableBytes>(val);
-  const int8_t* p = bytes->value().data();
   int valSize = val->objectSize();
 #if defined(_WIN32)
-  int8_t* byteArray = (int8_t*)CoTaskMemAlloc(valSize);
+  int8_t* byteArray = static_cast<int8_t*>(CoTaskMemAlloc(valSize));
 #else
-  int8_t* byteArray = (int8_t*)malloc(valSize);
+  int8_t* byteArray = static_cast<int8_t*>(malloc(valSize));
 #endif
-  memcpy(byteArray, bytes->value().data(), valSize);
-  *value = (char*)byteArray;
-  *size = valSize;
+  if (bytes) {
+    memcpy(byteArray, bytes->value().data(), valSize);
+    *value = (char*)byteArray;
+    *size = valSize;
+  }
 }
 
 void RegionWrapper::Remove(const std::string& key) { region_->remove(key); }

--- a/c_bindings/src/region.cpp
+++ b/c_bindings/src/region.cpp
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standard headers
+#include <memory>
+#include <string>
+
+// C++ client public headers
+#include "geode/CacheableString.hpp"
+#include "geode/Region.hpp"
+#include "geode/RegionShortcut.hpp"
+
+// C client public headers
+#include "geode/region.h"
+#include "geode/region/factory.h"
+
+// C client private headers
+#include "region.hpp"
+#include "region/factory.hpp"
+
+RegionWrapper::RegionWrapper(RegionFactoryWrapper &region_factory, std::shared_ptr<apache::geode::client::Region> region)
+    : region_(region), region_factory{region_factory} {
+      region_factory.AddRecord(this, "RegionWrapper");
+    }
+
+RegionWrapper::~RegionWrapper() { region_factory.RemoveRecord(this); }
+
+void RegionWrapper::PutString(const std::string& key,
+                              const std::string& value) {
+  region_->put(key, value);
+}
+
+void RegionWrapper::PutByteArray(const std::string& key, const char* value,
+                                 size_t size) {
+  std::vector<int8_t> val(value, value + size);
+  region_->put(key, apache::geode::client::CacheableBytes::create(val));
+}
+
+const char* RegionWrapper::GetString(const std::string& key) {
+  auto value = region_->get(key);
+  lastValue_ =
+      std::dynamic_pointer_cast<apache::geode::client::CacheableString>(value)
+          ->value();
+  return lastValue_.c_str();
+}
+
+void RegionWrapper::GetByteArray(const std::string& key, char** value,
+                                 size_t* size) {
+  std::shared_ptr<apache::geode::client::Serializable> val = region_->get(key);
+
+  if (val.get() == nullptr) return;
+
+  auto bytes =
+      std::dynamic_pointer_cast<apache::geode::client::CacheableBytes>(val);
+  const int8_t* p = bytes->value().data();
+  int valSize = val->objectSize();
+#if defined(_WIN32)
+  int8_t* byteArray = (int8_t*)CoTaskMemAlloc(valSize);
+#else
+  int8_t* byteArray = (int8_t*)malloc(valSize);
+#endif
+  memcpy(byteArray, bytes->value().data(), valSize);
+  *value = (char*)byteArray;
+  *size = valSize;
+}
+
+void RegionWrapper::Remove(const std::string& key) { region_->remove(key); }
+
+bool RegionWrapper::ContainsValueForKey(const std::string& key) {
+  return region_->containsValueForKey(key);
+}
+
+void apache_geode_DestroyRegion(apache_geode_region_t* region) {
+  RegionWrapper* regionWrapper = reinterpret_cast<RegionWrapper*>(region);
+  delete regionWrapper;
+}
+
+void apache_geode_Region_PutString(apache_geode_region_t* region,
+                                   const char* key, const char* value) {
+  RegionWrapper* regionWrapper = reinterpret_cast<RegionWrapper*>(region);
+  regionWrapper->PutString(key, value);
+}
+
+void apache_geode_Region_PutByteArray(apache_geode_region_t* region,
+                                      const char* key, const char* value,
+                                      size_t size) {
+  RegionWrapper* regionWrapper = reinterpret_cast<RegionWrapper*>(region);
+  regionWrapper->PutByteArray(key, value, size);
+}
+
+const char* apache_geode_Region_GetString(apache_geode_region_t* region,
+                                          const char* key) {
+  RegionWrapper* regionWrapper = reinterpret_cast<RegionWrapper*>(region);
+  return regionWrapper->GetString(key);
+}
+
+void apache_geode_Region_GetByteArray(apache_geode_region_t* region,
+                                             const char* key, char** value, size_t* size) {
+  RegionWrapper* regionWrapper = reinterpret_cast<RegionWrapper*>(region);
+  return regionWrapper->GetByteArray(key, value, size);
+}
+
+void apache_geode_Region_Remove(apache_geode_region_t* region,
+                                const char* key) {
+  RegionWrapper* regionWrapper = reinterpret_cast<RegionWrapper*>(region);
+  return regionWrapper->Remove(key);
+}
+
+bool apache_geode_Region_ContainsValueForKey(apache_geode_region_t* region,
+                                             const char* key) {
+  RegionWrapper* regionWrapper = reinterpret_cast<RegionWrapper*>(region);
+  return regionWrapper->ContainsValueForKey(key);
+}

--- a/c_bindings/src/region.cpp
+++ b/c_bindings/src/region.cpp
@@ -79,7 +79,7 @@ void RegionWrapper::GetByteArray(const std::string& key, char** value,
 #endif
   if (bytes) {
     memcpy(byteArray, bytes->value().data(), valSize);
-    *value = (char*)byteArray;
+    *value = reinterpret_cast<char*>(byteArray);
     *size = valSize;
   }
 }

--- a/c_bindings/src/region.hpp
+++ b/c_bindings/src/region.hpp
@@ -30,7 +30,7 @@ class RegionWrapper : public ClientKeeper {
   std::string lastValue_;
 
  public:
-  RegionWrapper(std::shared_ptr<apache::geode::client::Region> region);
+  explicit RegionWrapper(std::shared_ptr<apache::geode::client::Region> region);
   ~RegionWrapper();
 
   void PutString(const std::string& key, const std::string& value);

--- a/c_bindings/src/region.hpp
+++ b/c_bindings/src/region.hpp
@@ -20,17 +20,17 @@
 #include <string>
 #include <memory>
 
+#include "client.hpp"
 #include "geode/Region.hpp"
 
 class RegionFactoryWrapper;
 
-class RegionWrapper {
+class RegionWrapper : public ClientKeeper {
   std::shared_ptr<apache::geode::client::Region> region_;
   std::string lastValue_;
-  RegionFactoryWrapper &region_factory;
 
  public:
-  RegionWrapper(RegionFactoryWrapper &region_factory, std::shared_ptr<apache::geode::client::Region> region);
+  RegionWrapper(std::shared_ptr<apache::geode::client::Region> region);
   ~RegionWrapper();
 
   void PutString(const std::string& key, const std::string& value);

--- a/c_bindings/src/region.hpp
+++ b/c_bindings/src/region.hpp
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <memory>
+
+#include "geode/Region.hpp"
+
+class RegionFactoryWrapper;
+
+class RegionWrapper {
+  std::shared_ptr<apache::geode::client::Region> region_;
+  std::string lastValue_;
+  RegionFactoryWrapper &region_factory;
+
+ public:
+  RegionWrapper(RegionFactoryWrapper &region_factory, std::shared_ptr<apache::geode::client::Region> region);
+  ~RegionWrapper();
+
+  void PutString(const std::string& key, const std::string& value);
+
+  void PutByteArray(const std::string& key, const char* value, size_t size);
+
+  const char* GetString(const std::string& key);
+
+  void GetByteArray(const std::string& key, char** value, size_t* size);
+
+  void Remove(const std::string& key);
+
+  bool ContainsValueForKey(const std::string& key);
+};

--- a/c_bindings/src/region/factory.cpp
+++ b/c_bindings/src/region/factory.cpp
@@ -23,23 +23,21 @@
 #include "geode/RegionFactory.hpp"
 
 // C client public headers
-#include "geode/region/factory.h"
 #include "geode/region.h"
+#include "geode/region/factory.h"
 
 // C client private headers
+#include "cache.hpp"
 #include "region.hpp"
 #include "region/factory.hpp"
-#include "cache.hpp"
 
-RegionFactoryWrapper::RegionFactoryWrapper(CacheWrapper *cache,
-    apache::geode::client::RegionFactory regionFactory)
+RegionFactoryWrapper::RegionFactoryWrapper(
+    CacheWrapper* cache, apache::geode::client::RegionFactory regionFactory)
     : regionFactory_(std::move(regionFactory)) {
-      AddRecord(this, "RegionFactoryWrapper");
-    }
+  AddRecord(this, "RegionFactoryWrapper");
+}
 
-    RegionFactoryWrapper::~RegionFactoryWrapper() {
-      RemoveRecord(this);
-    }
+RegionFactoryWrapper::~RegionFactoryWrapper() { RemoveRecord(this); }
 
 void RegionFactoryWrapper::setPoolName(const std::string& poolName) {
   regionFactory_.setPoolName(poolName);

--- a/c_bindings/src/region/factory.cpp
+++ b/c_bindings/src/region/factory.cpp
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standard headers
+#include <string>
+#include <utility>
+
+// C++ client public headers
+#include "geode/RegionFactory.hpp"
+
+// C client public headers
+#include "geode/region/factory.h"
+#include "geode/region.h"
+
+// C client private headers
+#include "region.hpp"
+#include "region/factory.hpp"
+#include "cache.hpp"
+
+RegionFactoryWrapper::RegionFactoryWrapper(CacheWrapper *cache,
+    apache::geode::client::RegionFactory regionFactory)
+    : ClientKeeper{cache}, regionFactory_(std::move(regionFactory)) {
+      AddRecord(this, "RegionFactoryWrapper");
+    }
+
+    RegionFactoryWrapper::~RegionFactoryWrapper() {
+      RemoveRecord(this);
+    }
+
+void RegionFactoryWrapper::setPoolName(const std::string& poolName) {
+  regionFactory_.setPoolName(poolName);
+}
+
+RegionWrapper* RegionFactoryWrapper::createRegion(
+    const std::string& regionName) {
+  return new RegionWrapper(*this, regionFactory_.create(regionName));
+}
+
+void apache_geode_DestroyRegionFactory(
+    apache_geode_region_factory_t* regionFactory) {
+  delete reinterpret_cast<RegionFactoryWrapper*>(regionFactory);
+}
+
+void apache_geode_RegionFactory_SetPoolName(
+    apache_geode_region_factory_t* regionFactory, const char* poolName) {
+  RegionFactoryWrapper* regionFactoryWrapper =
+      reinterpret_cast<RegionFactoryWrapper*>(regionFactory);
+  regionFactoryWrapper->setPoolName(poolName);
+}
+apache_geode_region_t* apache_geode_RegionFactory_CreateRegion(
+    apache_geode_region_factory_t* regionFactory, const char* regionName) {
+  RegionFactoryWrapper* regionFactoryWrapper =
+      reinterpret_cast<RegionFactoryWrapper*>(regionFactory);
+  return reinterpret_cast<apache_geode_region_t*>(
+      regionFactoryWrapper->createRegion(regionName));
+}

--- a/c_bindings/src/region/factory.cpp
+++ b/c_bindings/src/region/factory.cpp
@@ -33,7 +33,7 @@
 
 RegionFactoryWrapper::RegionFactoryWrapper(CacheWrapper *cache,
     apache::geode::client::RegionFactory regionFactory)
-    : ClientKeeper{cache}, regionFactory_(std::move(regionFactory)) {
+    : regionFactory_(std::move(regionFactory)) {
       AddRecord(this, "RegionFactoryWrapper");
     }
 
@@ -47,7 +47,7 @@ void RegionFactoryWrapper::setPoolName(const std::string& poolName) {
 
 RegionWrapper* RegionFactoryWrapper::createRegion(
     const std::string& regionName) {
-  return new RegionWrapper(*this, regionFactory_.create(regionName));
+  return new RegionWrapper(regionFactory_.create(regionName));
 }
 
 void apache_geode_DestroyRegionFactory(

--- a/c_bindings/src/region/factory.hpp
+++ b/c_bindings/src/region/factory.hpp
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "geode/RegionFactory.hpp"
+#include "client.hpp"
+
+class RegionWrapper;
+class CacheWrapper;
+
+class RegionFactoryWrapper: public ClientKeeper {
+  apache::geode::client::RegionFactory regionFactory_;
+
+ public:
+  RegionFactoryWrapper(CacheWrapper *, apache::geode::client::RegionFactory regionFactory);
+  ~RegionFactoryWrapper();
+
+  void setPoolName(const std::string& poolName);
+
+  RegionWrapper* createRegion(const std::string& regionName);
+};

--- a/c_bindings/symbols
+++ b/c_bindings/symbols
@@ -1,1 +1,1 @@
-_apache_geode_*
+apache_geode_*

--- a/c_bindings/symbols
+++ b/c_bindings/symbols
@@ -1,1 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 apache_geode_*

--- a/c_bindings/symbols
+++ b/c_bindings/symbols
@@ -1,0 +1,1 @@
+_apache_geode_*

--- a/c_bindings/symbols.version
+++ b/c_bindings/symbols.version
@@ -1,0 +1,6 @@
+V0 {
+  global:
+    _apache_geode_*;
+  local:
+    *;
+};

--- a/c_bindings/symbols.version
+++ b/c_bindings/symbols.version
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 V0 {
   global:
     apache_geode_*;

--- a/c_bindings/symbols.version
+++ b/c_bindings/symbols.version
@@ -1,6 +1,6 @@
 V0 {
   global:
-    _apache_geode_*;
+    apache_geode_*;
   local:
     *;
 };

--- a/cppcache/include/geode/CacheableString.hpp
+++ b/cppcache/include/geode/CacheableString.hpp
@@ -54,7 +54,7 @@ class APACHE_GEODE_EXPORT CacheableString
       : m_str(std::move(value)), m_hashcode(0) {
     bool ascii = isAscii(m_str);
 
-    m_type = m_str.length() > std::numeric_limits<uint16_t>::max()
+    m_type = m_str.length() > (std::numeric_limits<uint16_t>::max)()
                  ? ascii ? DSCode::CacheableASCIIStringHuge
                          : DSCode::CacheableStringHuge
              : ascii ? DSCode::CacheableASCIIString

--- a/cppcache/include/geode/DataOutput.hpp
+++ b/cppcache/include/geode/DataOutput.hpp
@@ -274,7 +274,7 @@ class APACHE_GEODE_EXPORT DataOutput {
   inline void writeString(const std::basic_string<_CharT, _Tail...>& value) {
     // without scanning string, making worst case choices.
     // TODO constexp for each string type to jmutf8 length conversion
-    if (value.length() * 3 <= std::numeric_limits<uint16_t>::max()) {
+    if (value.length() * 3 <= (std::numeric_limits<uint16_t>::max)()) {
       write(static_cast<uint8_t>(DSCode::CacheableString));
       writeJavaModifiedUtf8(value);
     } else {
@@ -516,8 +516,8 @@ class APACHE_GEODE_EXPORT DataOutput {
   Pool* m_pool;
 
   inline void writeAscii(const std::string& value) {
-    uint16_t len = static_cast<uint16_t>(
-        std::min<size_t>(value.length(), std::numeric_limits<uint16_t>::max()));
+    uint16_t len = static_cast<uint16_t>(std::min<size_t>(
+        value.length(), (std::numeric_limits<uint16_t>::max)()));
     writeInt(len);
     for (size_t i = 0; i < len; i++) {
       // blindly assumes ascii so mask off only 7 bits
@@ -526,8 +526,8 @@ class APACHE_GEODE_EXPORT DataOutput {
   }
 
   inline void writeAsciiHuge(const std::string& value) {
-    uint32_t len = static_cast<uint32_t>(
-        std::min<size_t>(value.length(), std::numeric_limits<uint32_t>::max()));
+    uint32_t len = static_cast<uint32_t>(std::min<size_t>(
+        value.length(), (std::numeric_limits<uint32_t>::max)()));
     writeInt(static_cast<uint32_t>(len));
     for (size_t i = 0; i < len; i++) {
       // blindly assumes ascii so mask off only 7 bits
@@ -566,7 +566,7 @@ class APACHE_GEODE_EXPORT DataOutput {
     } else {
       auto encodedLen = static_cast<uint16_t>(
           std::min<size_t>(getJavaModifiedUtf8EncodedLength(data, len),
-                           std::numeric_limits<uint16_t>::max()));
+                           (std::numeric_limits<uint16_t>::max)()));
       writeInt(encodedLen);
       ensureCapacity(encodedLen);
       const auto end = m_buf + encodedLen;
@@ -606,7 +606,7 @@ class APACHE_GEODE_EXPORT DataOutput {
 
   inline void writeUtf16Huge(const char16_t* data, size_t length) {
     uint32_t len = static_cast<uint32_t>(
-        std::min<size_t>(length, std::numeric_limits<uint32_t>::max()));
+        std::min<size_t>(length, (std::numeric_limits<uint32_t>::max)()));
     writeInt(len);
     writeUtf16(data, length);
   }

--- a/cppcache/include/geode/PdxInstanceFactory.hpp
+++ b/cppcache/include/geode/PdxInstanceFactory.hpp
@@ -53,10 +53,6 @@ class APACHE_GEODE_EXPORT PdxInstanceFactory {
  public:
   PdxInstanceFactory() = delete;
   ~PdxInstanceFactory() noexcept = default;
-  PdxInstanceFactory(const PdxInstanceFactory& other) = default;
-  PdxInstanceFactory& operator=(const PdxInstanceFactory& other) = default;
-  PdxInstanceFactory(PdxInstanceFactory&& other) = default;
-  PdxInstanceFactory& operator=(PdxInstanceFactory&& other) = default;
 
  public:
   /**

--- a/cppcache/shared/CMakeLists.txt
+++ b/cppcache/shared/CMakeLists.txt
@@ -30,7 +30,7 @@ if (MSVC)
 endif()
 
 if (has_linker_exclude_libs)
-  target_link_options(apache-geode PRIVATE -Wl --exclude-libs ALL)
+  target_link_options(apache-geode PRIVATE -Wl,--exclude-libs,ALL)
 endif()
 
 generate_export_file( "apache-geode" )

--- a/cppcache/shared/CMakeLists.txt
+++ b/cppcache/shared/CMakeLists.txt
@@ -30,7 +30,7 @@ if (MSVC)
 endif()
 
 if (has_linker_exclude_libs)
-  target_link_options(apache-geode PRIVATE -Wl,--exclude-libs,ALL)
+  target_link_options(apache-geode PRIVATE -Wl --exclude-libs ALL)
 endif()
 
 generate_export_file( "apache-geode" )

--- a/cppcache/src/PoolManagerImpl.hpp
+++ b/cppcache/src/PoolManagerImpl.hpp
@@ -40,7 +40,6 @@ class PoolFactory;
 class PoolManagerImpl {
  public:
   explicit PoolManagerImpl(CacheImpl* cache) : m_cache(cache) {}
-  PoolManagerImpl(const PoolManagerImpl& copy) = default;
   ~PoolManagerImpl() = default;
 
   void removePool(const std::string& name);

--- a/cppcache/src/RegionAttributes.cpp
+++ b/cppcache/src/RegionAttributes.cpp
@@ -64,9 +64,8 @@ std::shared_ptr<CacheLoader> RegionAttributes::getCacheLoader() const {
     if (CacheXmlParser::managedCacheLoaderFn_ &&
         m_cacheLoaderFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheLoader.reset((
-          CacheXmlParser::managedCacheLoaderFn_)(m_cacheLoaderLibrary.c_str(),
-                                                 m_cacheLoaderFactory.c_str()));
+      m_cacheLoader.reset((CacheXmlParser::managedCacheLoaderFn_)(
+          m_cacheLoaderLibrary.c_str(), m_cacheLoaderFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheLoader*()>(
           m_cacheLoaderLibrary, m_cacheLoaderFactory);
@@ -81,9 +80,8 @@ std::shared_ptr<CacheWriter> RegionAttributes::getCacheWriter() const {
     if (CacheXmlParser::managedCacheWriterFn_ &&
         m_cacheWriterFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheWriter.reset((
-          CacheXmlParser::managedCacheWriterFn_)(m_cacheWriterLibrary.c_str(),
-                                                 m_cacheWriterFactory.c_str()));
+      m_cacheWriter.reset((CacheXmlParser::managedCacheWriterFn_)(
+          m_cacheWriterLibrary.c_str(), m_cacheWriterFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheWriter*()>(
           m_cacheWriterLibrary, m_cacheWriterFactory);
@@ -98,11 +96,8 @@ std::shared_ptr<CacheListener> RegionAttributes::getCacheListener() const {
     if (CacheXmlParser::managedCacheListenerFn_ &&
         m_cacheListenerFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheListener.reset(
-          (CacheXmlParser::managedCacheListenerFn_)(m_cacheListenerLibrary
-                                                        .c_str(),
-                                                    m_cacheListenerFactory
-                                                        .c_str()));
+      m_cacheListener.reset((CacheXmlParser::managedCacheListenerFn_)(
+          m_cacheListenerLibrary.c_str(), m_cacheListenerFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheListener*()>(
           m_cacheListenerLibrary, m_cacheListenerFactory);
@@ -119,10 +114,9 @@ std::shared_ptr<PartitionResolver> RegionAttributes::getPartitionResolver()
     if (CacheXmlParser::managedPartitionResolverFn_ &&
         m_partitionResolverFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_partitionResolver.reset((
-          CacheXmlParser::
-              managedPartitionResolverFn_)(m_partitionResolverLibrary.c_str(),
-                                           m_partitionResolverFactory.c_str()));
+      m_partitionResolver.reset((CacheXmlParser::managedPartitionResolverFn_)(
+          m_partitionResolverLibrary.c_str(),
+          m_partitionResolverFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<PartitionResolver*()>(
           m_partitionResolverLibrary, m_partitionResolverFactory);
@@ -138,11 +132,8 @@ std::shared_ptr<PersistenceManager> RegionAttributes::getPersistenceManager()
     if (CacheXmlParser::managedPersistenceManagerFn_ &&
         m_persistenceFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_persistenceManager.reset(
-          (CacheXmlParser::managedPersistenceManagerFn_)(m_persistenceLibrary
-                                                             .c_str(),
-                                                         m_persistenceFactory
-                                                             .c_str()));
+      m_persistenceManager.reset((CacheXmlParser::managedPersistenceManagerFn_)(
+          m_persistenceLibrary.c_str(), m_persistenceFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<PersistenceManager*()>(
           m_persistenceLibrary, m_persistenceFactory);

--- a/cppcache/src/RegionAttributes.cpp
+++ b/cppcache/src/RegionAttributes.cpp
@@ -64,8 +64,9 @@ std::shared_ptr<CacheLoader> RegionAttributes::getCacheLoader() const {
     if (CacheXmlParser::managedCacheLoaderFn_ &&
         m_cacheLoaderFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheLoader.reset((CacheXmlParser::managedCacheLoaderFn_)(
-          m_cacheLoaderLibrary.c_str(), m_cacheLoaderFactory.c_str()));
+      m_cacheLoader.reset((
+          CacheXmlParser::managedCacheLoaderFn_)(m_cacheLoaderLibrary.c_str(),
+                                                 m_cacheLoaderFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheLoader*()>(
           m_cacheLoaderLibrary, m_cacheLoaderFactory);
@@ -80,8 +81,9 @@ std::shared_ptr<CacheWriter> RegionAttributes::getCacheWriter() const {
     if (CacheXmlParser::managedCacheWriterFn_ &&
         m_cacheWriterFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheWriter.reset((CacheXmlParser::managedCacheWriterFn_)(
-          m_cacheWriterLibrary.c_str(), m_cacheWriterFactory.c_str()));
+      m_cacheWriter.reset((
+          CacheXmlParser::managedCacheWriterFn_)(m_cacheWriterLibrary.c_str(),
+                                                 m_cacheWriterFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheWriter*()>(
           m_cacheWriterLibrary, m_cacheWriterFactory);
@@ -96,8 +98,11 @@ std::shared_ptr<CacheListener> RegionAttributes::getCacheListener() const {
     if (CacheXmlParser::managedCacheListenerFn_ &&
         m_cacheListenerFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheListener.reset((CacheXmlParser::managedCacheListenerFn_)(
-          m_cacheListenerLibrary.c_str(), m_cacheListenerFactory.c_str()));
+      m_cacheListener.reset(
+          (CacheXmlParser::managedCacheListenerFn_)(m_cacheListenerLibrary
+                                                        .c_str(),
+                                                    m_cacheListenerFactory
+                                                        .c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheListener*()>(
           m_cacheListenerLibrary, m_cacheListenerFactory);
@@ -114,9 +119,10 @@ std::shared_ptr<PartitionResolver> RegionAttributes::getPartitionResolver()
     if (CacheXmlParser::managedPartitionResolverFn_ &&
         m_partitionResolverFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_partitionResolver.reset((CacheXmlParser::managedPartitionResolverFn_)(
-          m_partitionResolverLibrary.c_str(),
-          m_partitionResolverFactory.c_str()));
+      m_partitionResolver.reset((
+          CacheXmlParser::
+              managedPartitionResolverFn_)(m_partitionResolverLibrary.c_str(),
+                                           m_partitionResolverFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<PartitionResolver*()>(
           m_partitionResolverLibrary, m_partitionResolverFactory);
@@ -132,8 +138,11 @@ std::shared_ptr<PersistenceManager> RegionAttributes::getPersistenceManager()
     if (CacheXmlParser::managedPersistenceManagerFn_ &&
         m_persistenceFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_persistenceManager.reset((CacheXmlParser::managedPersistenceManagerFn_)(
-          m_persistenceLibrary.c_str(), m_persistenceFactory.c_str()));
+      m_persistenceManager.reset(
+          (CacheXmlParser::managedPersistenceManagerFn_)(m_persistenceLibrary
+                                                             .c_str(),
+                                                         m_persistenceFactory
+                                                             .c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<PersistenceManager*()>(
           m_persistenceLibrary, m_persistenceFactory);

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -1189,7 +1189,7 @@ TcrEndpoint* ThinClientPoolDM::getEndPoint(
 
 std::shared_ptr<TcrEndpoint> ThinClientPoolDM::getEndpoint(
     const std::string& endpointName) {
-  m_endpoints.make_lock();
+  const auto& ignored = m_endpoints.make_lock();
   const auto& find = m_endpoints.find(endpointName);
   if (find == m_endpoints.end()) {
     return {};

--- a/cppcache/static/CMakeLists.txt
+++ b/cppcache/static/CMakeLists.txt
@@ -52,7 +52,10 @@ if (MSVC)
   )
 endif()
 
-set_target_properties(apache-geode-static PROPERTIES INTERPROCEDURAL_OPTIMIZATION FALSE)
+set_target_properties(apache-geode-static PROPERTIES 
+  INTERPROCEDURAL_OPTIMIZATION FALSE
+  POSITION_INDEPENDENT_CODE ON
+)
 
 # BEGIN Visual Studio organization
 source_group("Header Files" REGULAR_EXPRESSION "\.(hpp|inl)$")


### PR DESCRIPTION
This is the initial work to create a C API for `geode-native`.  The goal of this work is _not_ to enable access to `geode-native` from the C language, though that will happen as a matter of course, but rather to enable access from all the other languages (.net core, Python, Go, etc.) from which access to a C API is simple and straightforward.

[RFC](https://cwiki.apache.org/confluence/display/GEODE/Add+C+Bindings+to+Native+Client+Library)