### PR TITLE
GEODE-8891: Move static regex in ThinClientRegion

### DIFF
--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -49,8 +49,14 @@ namespace apache {
 namespace geode {
 namespace client {
 
-static const std::regex PREDICATE_IS_FULL_QUERY_REGEX(
-    "^\\s*(?:select|import)\\b", std::regex::icase);
+class IsFullQueryRegex {
+ public:
+  static const std::regex& instance() {
+    static const std::regex predicateIsFullQueryRegex(
+        "^\\s*(?:select|import)\\b", std::regex::icase);
+    return predicateIsFullQueryRegex;
+  }
+};
 
 void setThreadLocalExceptionMessage(std::string exMsg);
 
@@ -589,7 +595,7 @@ std::shared_ptr<SelectResults> ThinClientRegion::query(
   }
 
   std::string squery;
-  if (std::regex_search(predicate, PREDICATE_IS_FULL_QUERY_REGEX)) {
+  if (std::regex_search(predicate, IsFullQueryRegex::instance())) {
     squery = predicate;
   } else {
     squery = "select distinct * from ";

--- a/cppcache/src/ThinClientRegion.cpp
+++ b/cppcache/src/ThinClientRegion.cpp
@@ -49,15 +49,6 @@ namespace apache {
 namespace geode {
 namespace client {
 
-class IsFullQueryRegex {
- public:
-  static const std::regex& instance() {
-    static const std::regex predicateIsFullQueryRegex(
-        "^\\s*(?:select|import)\\b", std::regex::icase);
-    return predicateIsFullQueryRegex;
-  }
-};
-
 void setThreadLocalExceptionMessage(std::string exMsg);
 
 class PutAllWork : public PooledWork<GfErrType> {
@@ -594,8 +585,11 @@ std::shared_ptr<SelectResults> ThinClientRegion::query(
     throw IllegalArgumentException("Region query predicate string is empty");
   }
 
+  static const std::regex isFullQueryRegex("^\\s*(?:select|import)\\b",
+                                           std::regex::icase);
+
   std::string squery;
-  if (std::regex_search(predicate, IsFullQueryRegex::instance())) {
+  if (std::regex_search(predicate, isFullQueryRegex)) {
     squery = predicate;
   } else {
     squery = "select distinct * from ";


### PR DESCRIPTION
- Latest compiler/runtime on RHEL-8 causes an order-of-initialization
  bug for this static regex, and will core dump at app startup for
  optimized builds.
- Changing to local static ensures regex variable isn't initialized
  until the first time we use it, long after all static initializers are
  called.