### PR TITLE
GEODE-9412: Fix up marshaling of (potential) Unicode strings

### DIFF
--- a/clicache/src/Cache.cpp
+++ b/clicache/src/Cache.cpp
@@ -26,6 +26,7 @@
 #include "PoolFactory.hpp"
 #include "Region.hpp"
 #include "RegionAttributes.hpp"
+#include "String.hpp"
 #include "QueryService.hpp"
 #include "CacheFactory.hpp"
 #include "impl/AuthenticatedView.hpp"
@@ -168,7 +169,7 @@ namespace Apache
 
           try
           {
-            return Client::Region<TKey, TValue>::Create(m_nativeptr->get()->getRegion(marshal_as<std::string>(path)));
+            return Client::Region<TKey, TValue>::Create(m_nativeptr->get()->getRegion(to_utf8(path)));
           }
           finally
           {
@@ -322,7 +323,7 @@ namespace Apache
       {
         try
         {
-          m_nativeptr->get()->initializeDeclarativeCache( marshal_as<std::string>(cacheXml));
+          m_nativeptr->get()->initializeDeclarativeCache(to_utf8(cacheXml));
         }
         finally
         {

--- a/clicache/src/CacheFactory.cpp
+++ b/clicache/src/CacheFactory.cpp
@@ -23,6 +23,7 @@
 #include "CacheFactory.hpp"
 #include "Cache.hpp"
 #include "DistributedSystem.hpp"
+#include "String.hpp"
 #include "SystemProperties.hpp"
 #include "impl/SafeConvert.hpp"
 #include "impl/PdxTypeRegistry.hpp"
@@ -136,7 +137,7 @@ namespace Apache
         _GF_MG_EXCEPTION_TRY2
           try
           {
-            m_nativeptr->get()->set(marshal_as<std::string>(name), marshal_as<std::string>(value));
+            m_nativeptr->get()->set(marshal_as<std::string>(name), to_utf8(value));
           }
           finally
           {

--- a/clicache/src/CqQuery.cpp
+++ b/clicache/src/CqQuery.cpp
@@ -24,6 +24,7 @@
 #include "CqStatistics.hpp"
 #include "ISelectResults.hpp"
 #include "ResultSet.hpp"
+#include "String.hpp"
 #include "StructSet.hpp"
 #include "ExceptionTypes.hpp"
 #include "TimeUtils.hpp"
@@ -89,7 +90,7 @@ namespace Apache
       {
         try
         {
-          return marshal_as<String^>(m_nativeptr->get()->getQueryString());
+          return to_String(m_nativeptr->get()->getQueryString());
         }
         finally
         {
@@ -102,7 +103,7 @@ namespace Apache
       {
         try
         {
-          return marshal_as<String^>(m_nativeptr->get()->getName());
+          return to_String(m_nativeptr->get()->getName());
         }
         finally
         {

--- a/clicache/src/DistributedSystem.cpp
+++ b/clicache/src/DistributedSystem.cpp
@@ -51,6 +51,7 @@
 #include "CacheableObjectXml.hpp"
 #include "CacheableBuiltins.hpp"
 #include "Log.hpp"
+#include "String.hpp"
 #include "Struct.hpp"
 #include "impl/SafeConvert.hpp"
 #include "impl/PdxType.hpp"
@@ -134,7 +135,7 @@ namespace Apache
         // TODO AppDomain should we be able to create a DS directly?
         _GF_MG_EXCEPTION_TRY2
 
-        auto nativeDistributedSystem = native::DistributedSystem::create(marshal_as<std::string>(name),
+        auto nativeDistributedSystem = native::DistributedSystem::create(to_utf8(name),
                                                            config->GetNative());
         nativeDistributedSystem.connect();
 

--- a/clicache/src/Execution.cpp
+++ b/clicache/src/Execution.cpp
@@ -24,6 +24,7 @@
 #include "impl/ManagedResultCollector.hpp"
 #include "ExceptionTypes.hpp"
 #include "impl/SafeConvert.hpp"
+#include "String.hpp"
 #include "TimeUtils.hpp"
 
 using namespace System;
@@ -108,7 +109,7 @@ namespace Apache
         _GF_MG_EXCEPTION_TRY2/* due to auto replace */
         try
         {
-          auto rc = m_nativeptr->get()->execute(marshal_as<std::string>(func), TimeUtils::TimeSpanToDurationCeil<std::chrono::milliseconds>(timeout));
+          auto rc = m_nativeptr->get()->execute(to_utf8(func), TimeUtils::TimeSpanToDurationCeil<std::chrono::milliseconds>(timeout));
           if (m_rc == nullptr)
             return gcnew ResultCollector<TResult>(rc);
           else

--- a/clicache/src/LocalRegion.cpp
+++ b/clicache/src/LocalRegion.cpp
@@ -26,6 +26,7 @@
 #include "CacheStatistics.hpp"
 #include "AttributesMutator.hpp"
 #include "RegionEntry.hpp"
+#include "String.hpp"
 #include "impl/AuthenticatedView.hpp"
 #include "impl/SafeConvert.hpp"
 #include "impl/CacheResolver.hpp"
@@ -588,7 +589,7 @@ namespace Apache
       {
         try
         {
-          return marshal_as<String^>( m_nativeptr->get()->getName( ) );
+          return to_String( m_nativeptr->get()->getName( ) );
         }
         finally
         {
@@ -601,7 +602,7 @@ namespace Apache
       {
         try
         {
-          return marshal_as<String^>( m_nativeptr->get()->getFullPath( ) );
+          return to_String( m_nativeptr->get()->getFullPath( ) );
         }
         finally
         {
@@ -688,7 +689,7 @@ namespace Apache
 
           try
           {
-            auto nativeptr = m_nativeptr->get()->getSubregion(marshal_as<std::string>(path));
+            auto nativeptr = m_nativeptr->get()->getSubregion(Apache::Geode::Client::to_utf8(path));
             auto region = Region<TKey, TValue>::Create(nativeptr);
             if (region == nullptr) {
               return nullptr;
@@ -713,7 +714,7 @@ namespace Apache
           {
             native::RegionAttributes regionAttributes;
             return Region<TKey, TValue>::Create(m_nativeptr->get()->createSubregion(
-              marshal_as<std::string>(subRegionName), regionAttributes))->GetLocalView();
+              Apache::Geode::Client::to_utf8(subRegionName), regionAttributes))->GetLocalView();
           }
           finally
           {

--- a/clicache/src/Properties.cpp
+++ b/clicache/src/Properties.cpp
@@ -22,6 +22,7 @@
 #include "end_native.hpp"
 
 #include "Properties.hpp"
+#include "String.hpp"
 #include "impl/ManagedVisitor.hpp"
 #include "impl/SafeConvert.hpp"
 #include "ExceptionTypes.hpp"
@@ -187,7 +188,7 @@ namespace Apache
 
           try
           {
-            m_nativeptr->get()->load( marshal_as<std::string>(fileName) );
+            m_nativeptr->get()->load( Apache::Geode::Client::to_utf8(fileName) );
           }
           finally
           {

--- a/clicache/src/Query.cpp
+++ b/clicache/src/Query.cpp
@@ -19,6 +19,7 @@
 #include "Query.hpp"
 #include "ISelectResults.hpp"
 #include "ResultSet.hpp"
+#include "String.hpp"
 #include "StructSet.hpp"
 #include "ExceptionTypes.hpp"
 #include "impl/SafeConvert.hpp"
@@ -112,7 +113,7 @@ namespace Apache
       {
         try
         {
-          return marshal_as<String^>(m_nativeptr->get()->getQueryString());
+          return to_String(m_nativeptr->get()->getQueryString());
         }
         finally
         {

--- a/clicache/src/QueryService.cpp
+++ b/clicache/src/QueryService.cpp
@@ -23,8 +23,9 @@
 #include "CqAttributes.hpp"
 #include "CqQuery.hpp"
 #include "CqServiceStatistics.hpp"
-#include "impl/ManagedString.hpp"
 #include "ExceptionTypes.hpp"
+#include "String.hpp"
+#include "impl/ManagedString.hpp"
 #include "impl/SafeConvert.hpp"
 
 using namespace System;
@@ -42,7 +43,7 @@ namespace Apache
         try
         {
           return Query<TResult>::Create(m_nativeptr->get()->newQuery(
-            marshal_as<std::string>(query)));
+            Apache::Geode::Client::to_utf8(query)));
         }
         catch (const apache::geode::client::Exception& ex)
         {
@@ -60,7 +61,7 @@ namespace Apache
           try
           {
             return CqQuery<TKey, TResult>::Create(m_nativeptr->get()->newCq(
-              marshal_as<std::string>(query), cqAttr->GetNative(), isDurable));
+              Apache::Geode::Client::to_utf8(query), cqAttr->GetNative(), isDurable));
           }
           catch (const apache::geode::client::Exception& ex)
           {
@@ -79,7 +80,7 @@ namespace Apache
         try
         {
           return CqQuery<TKey, TResult>::Create(m_nativeptr->get()->newCq(
-            marshal_as<std::string>(name), marshal_as<std::string>(query), cqAttr->GetNative(), isDurable));
+            Apache::Geode::Client::to_utf8(name), Apache::Geode::Client::to_utf8(query), cqAttr->GetNative(), isDurable));
         }
         catch (const apache::geode::client::Exception& ex)
         {
@@ -138,7 +139,7 @@ namespace Apache
         try
         {
           return CqQuery<TKey, TResult>::Create(m_nativeptr->get()->getCq(
-            marshal_as<std::string>(name)));
+            Apache::Geode::Client::to_utf8(name)));
         }
         catch (const apache::geode::client::Exception& ex)
         {
@@ -206,7 +207,7 @@ namespace Apache
           auto durableCqsList = gcnew System::Collections::Generic::List<String^>();
           for (const auto& d : *durableCqsArrayListPtr)
           {
-            durableCqsList->Add(marshal_as<String^>(std::dynamic_pointer_cast<apache::geode::client::CacheableString>(d)->value()));
+            durableCqsList->Add(to_String(std::dynamic_pointer_cast<apache::geode::client::CacheableString>(d)->value()));
           }
           return durableCqsList;
         }

--- a/clicache/src/Region.cpp
+++ b/clicache/src/Region.cpp
@@ -37,6 +37,7 @@
 #include "LocalRegion.hpp"
 #include "Pool.hpp"
 #include "PoolManager.hpp"
+#include "String.hpp"
 #include "SystemProperties.hpp"
 #include "impl/CacheResolver.hpp"
 #include "TimeUtils.hpp"
@@ -774,7 +775,7 @@ namespace Apache
       {
         try
         {
-          return marshal_as<String^>(m_nativeptr->get()->getName());
+          return to_String(m_nativeptr->get()->getName());
         }
         finally
         {
@@ -787,7 +788,7 @@ namespace Apache
       {
         try
         {
-          return marshal_as<String^>(m_nativeptr->get()->getFullPath());
+          return to_String(m_nativeptr->get()->getFullPath());
         }
         finally
         {
@@ -874,7 +875,7 @@ namespace Apache
 
           try
           {
-            auto subRegion = m_nativeptr->get()->getSubregion(marshal_as<std::string>(path));
+            auto subRegion = m_nativeptr->get()->getSubregion(Apache::Geode::Client::to_utf8(path));
             return Region::Create(subRegion);
           }
           finally
@@ -894,7 +895,7 @@ namespace Apache
           try
           {
             auto p_attrs = attributes->GetNative();
-            return Region::Create(m_nativeptr->get()->createSubregion(marshal_as<std::string>(subRegionName), *p_attrs));
+            return Region::Create(m_nativeptr->get()->createSubregion(Apache::Geode::Client::to_utf8(subRegionName), *p_attrs));
           }
           finally
           {
@@ -1249,7 +1250,7 @@ namespace Apache
         auto strarr = gcnew array<String^>(static_cast<int>(vc.size()));
         for (System::Int32 index = 0; index < strarr->Length; index++)
         {
-          strarr[index] = marshal_as<String^>(vc[index]->value());
+          strarr[index] = to_String(vc[index]->value());
           //collectionlist[ index ] = Serializable::GetManagedValue<TValue>(nativeptr);
         }
         auto collectionlist = (System::Collections::Generic::ICollection<String^>^)strarr;
@@ -1302,7 +1303,7 @@ namespace Apache
 
         try
         {
-          m_nativeptr->get()->registerRegex(marshal_as<std::string>(regex), isDurable,
+          m_nativeptr->get()->registerRegex(Apache::Geode::Client::to_utf8(regex), isDurable,
             getInitialValues, receiveValues);
         }
         finally
@@ -1320,7 +1321,7 @@ namespace Apache
 
         try
         {
-          m_nativeptr->get()->unregisterRegex(marshal_as<std::string>(regex));
+          m_nativeptr->get()->unregisterRegex(Apache::Geode::Client::to_utf8(regex));
         }
         finally
         {
@@ -1346,7 +1347,7 @@ namespace Apache
 
           try
           {
-            auto selectResults = m_nativeptr->get()->query(marshal_as<std::string>(predicate), TimeUtils::TimeSpanToDurationCeil<std::chrono::seconds>(timeout));
+            auto selectResults = m_nativeptr->get()->query(Apache::Geode::Client::to_utf8(predicate), TimeUtils::TimeSpanToDurationCeil<std::chrono::seconds>(timeout));
             if (auto resultptr = std::dynamic_pointer_cast<native::ResultSet>(selectResults))
             {
               return ResultSet<TResult>::Create(resultptr);
@@ -1378,7 +1379,7 @@ namespace Apache
 
           try
           {
-            return m_nativeptr->get()->existsValue(marshal_as<std::string>(predicate), TimeUtils::TimeSpanToDurationCeil<std::chrono::seconds>(timeout));
+            return m_nativeptr->get()->existsValue(Apache::Geode::Client::to_utf8(predicate), TimeUtils::TimeSpanToDurationCeil<std::chrono::seconds>(timeout));
           }
           finally
           {
@@ -1401,7 +1402,7 @@ namespace Apache
 
         try
         {
-          auto nativeptr = m_nativeptr->get()->selectValue(marshal_as<std::string>(predicate), TimeUtils::TimeSpanToDurationCeil<std::chrono::seconds>(timeout));
+          auto nativeptr = m_nativeptr->get()->selectValue(Apache::Geode::Client::to_utf8(predicate), TimeUtils::TimeSpanToDurationCeil<std::chrono::seconds>(timeout));
           return TypeRegistry::GetManagedValueGeneric<Object^>(nativeptr);
         }
         finally

--- a/clicache/src/Serializable.cpp
+++ b/clicache/src/Serializable.cpp
@@ -84,7 +84,7 @@ namespace Apache
       {
         try
         {
-          return marshal_as<String^>(m_nativeptr->get()->toString());
+          return to_String(m_nativeptr->get()->toString());
         }
         finally
         {

--- a/clicache/src/impl/AuthenticatedView.cpp
+++ b/clicache/src/impl/AuthenticatedView.cpp
@@ -29,6 +29,7 @@
 #include "../QueryService.hpp"
 #include "../FunctionService.hpp"
 #include "../Execution.hpp"
+#include "../String.hpp"
 #include "AuthenticatedView.hpp"
 #include "PdxInstanceFactoryImpl.hpp"
 
@@ -77,7 +78,7 @@ namespace Apache
 
           try
           {
-            auto nativeptr = m_nativeptr->get()->getRegion( marshal_as<std::string>(path) );
+            auto nativeptr = m_nativeptr->get()->getRegion(to_utf8(path) );
             return Client::Region<TKey, TValue>::Create( nativeptr );
           }
           finally

--- a/clicache/src/impl/ManagedCacheableKey.cpp
+++ b/clicache/src/impl/ManagedCacheableKey.cpp
@@ -26,6 +26,7 @@
 #include "../CacheableString.hpp"
 #include "../ExceptionTypes.hpp"
 #include "../Log.hpp"
+#include "../String.hpp"
 #include "CacheResolver.hpp"
 
 using namespace System;
@@ -100,7 +101,7 @@ namespace apache
       std::string ManagedCacheableKeyGeneric::toString() const
       {
         try {
-          return marshal_as<std::string>(m_managedptr->ToString());
+          return Apache::Geode::Client::to_utf8(m_managedptr->ToString());
         }
         catch (Apache::Geode::Client::GeodeException^ ex) {
           ex->ThrowNative();
@@ -158,7 +159,7 @@ namespace apache
       }
 
       std::string ManagedDataSerializablePrimitive::toString() const {
-        return marshal_as<std::string>(m_managedptr->ToString());
+        return Apache::Geode::Client::to_utf8(m_managedptr->ToString());
       }
 
       void ManagedDataSerializablePrimitive::toData(apache::geode::client::DataOutput& output) const {
@@ -216,7 +217,7 @@ namespace apache
       }
 
       std::string ManagedDataSerializableInternal::toString() const {
-        return marshal_as<std::string>(m_managedptr->ToString());
+        return Apache::Geode::Client::to_utf8(m_managedptr->ToString());
       }
 
       void ManagedDataSerializableInternal::toData(apache::geode::client::DataOutput& output) const {
@@ -250,7 +251,7 @@ namespace apache
       }
 
       std::string ManagedDataSerializableFixedId::toString() const {
-        return marshal_as<std::string>(m_managedptr->ToString());
+        return Apache::Geode::Client::to_utf8(m_managedptr->ToString());
       }
 
       void ManagedDataSerializableFixedId::toData(apache::geode::client::DataOutput& output) const {

--- a/clicache/src/impl/PdxManagedCacheableKey.cpp
+++ b/clicache/src/impl/PdxManagedCacheableKey.cpp
@@ -26,6 +26,7 @@
 #include "../DataOutput.hpp"
 #include "../CacheableString.hpp"
 #include "../ExceptionTypes.hpp"
+#include "../String.hpp"
 #include "CacheRegionHelper.hpp"
 #include "PdxHelper.hpp"
 #include "SafeConvert.hpp"
@@ -73,7 +74,7 @@ namespace apache
       {
         try
         {
-          return marshal_as<std::string>(m_managedptr->ToString());
+          return Apache::Geode::Client::to_utf8(m_managedptr->ToString());
         }
         catch (Apache::Geode::Client::GeodeException^ ex)
         {


### PR DESCRIPTION
...where applicable
- region names can be Unicode, cacheable keys/values, etc.  Most of the
  rest don't need this, because they're never Unicode.