### PR TITLE
GEODE-9472: Relax the ratio of before and after threads.

### DIFF
--- a/clicache/integration-test2/GarbageCollectCache.cs
+++ b/clicache/integration-test2/GarbageCollectCache.cs
@@ -85,7 +85,7 @@ namespace Apache.Geode.Client.IntegrationTests
                     {
                         string error = "ncThreadsBefore = " + ncThreadsBefore.ToString() +
                             ", ncThreadsAfter = " + ncThreadsAfter.ToString();
-                        Assert.False(!(.5 < ratio && ratio < 2.0), error);
+                        Assert.True((.5 < ratio && ratio < 2.0), error);
                     }
                 }
             }

--- a/clicache/integration-test2/GarbageCollectCache.cs
+++ b/clicache/integration-test2/GarbageCollectCache.cs
@@ -83,10 +83,9 @@ namespace Apache.Geode.Client.IntegrationTests
                     // environment startup.
                     if (i > 5)
                     {
-                        //Assert.True(.8 < ratio && ratio < 1.3);
                         string error = "ncThreadsBefore = " + ncThreadsBefore.ToString() +
                             ", ncThreadsAfter = " + ncThreadsAfter.ToString();
-                        Assert.False(!(.8 < ratio && ratio < 1.3), error);
+                        Assert.False(!(.5 < ratio && ratio < 2.0), error);
                     }
                 }
             }


### PR DESCRIPTION
The heuristic was a bit too strict. With 25 iterations, there was no reason to have the range be so small.