### PR TITLE
GEODE-9487: Use locale-independent format specifier for timezone in

### DIFF
--- a/cppcache/src/Log.cpp
+++ b/cppcache/src/Log.cpp
@@ -380,7 +380,7 @@ std::string Log::formatLogLine(LogLevel level) {
   msg << "[" << Log::levelToChars(level) << " "
       << std::put_time(&tm_val, "%Y/%m/%d %H:%M:%S") << '.' << std::setfill('0')
       << std::setw(6) << microseconds.count() << ' '
-      << std::put_time(&tm_val, "%Z  ") << g_hostName << ":"
+      << std::put_time(&tm_val, "%z  ") << g_hostName << ":"
       << boost::this_process::get_id() << " " << std::this_thread::get_id()
       << "] ";
 


### PR DESCRIPTION
From the bug description:  "The native client logger was rewritten several months ago to use, among other things, `std::put_time` when formatting log strings, specifically using the "%Z" formatting for timezone. The documentation for this formatting says "writes locale-dependent time zone name or abbreviation, or no characters if the time zone information is not available," and indeed it does. We just received a log file from a customer machine in APJ region, i.e. locale is set to something like Traditional Chinese. These strings are dumped into the log file as is, in some unknown MBCS encoding, and contain invalid utf-8 start codes, throwing off our Python-based parsing tool."

The lower case `%z` format specifier just gives an offset from GMT, e.g. `-0700`, which might still be useful while also not dumping MBCS data into the logs, so that's what I went with.