### PR TITLE
Revert "GEODE-9501: Works with toolset Microsoft v142 (#841)"

### DIFF
--- a/ci/base/base.yml
+++ b/ci/base/base.yml
@@ -61,7 +61,7 @@ builds:
     with_dot_net: #@ True
     #@yaml/map-key-override
     params:
-      CMAKE_CONFIGURE_FLAGS: ""
+      CMAKE_CONFIGURE_FLAGS: "-A x64 -Tv141,version=14.16,host=x64 -DCMAKE_SYSTEM_VERSION=10.0.16299.0"
       CMAKE_BUILD_FLAGS: "/m"
       CPACK_GENERATORS: "ZIP"
 
@@ -72,7 +72,7 @@ builds:
     with_dot_net: #@ True
     #@yaml/map-key-override
     params:
-      CMAKE_CONFIGURE_FLAGS: ""
+      CMAKE_CONFIGURE_FLAGS: "-A x64 -Tv141,version=14.16,host=x64 -DCMAKE_SYSTEM_VERSION=10.0.16299.0"
       CMAKE_BUILD_FLAGS: "/m"
       CPACK_GENERATORS: "ZIP"
 

--- a/dependencies/ACE/CMakeLists.txt
+++ b/dependencies/ACE/CMakeLists.txt
@@ -79,6 +79,7 @@ if (${WIN32})
   set ( _CONFIGURE_COMMAND ${MPC} -static ${MPC_FLAGS}
                            -name_modifier "*_${MPC_TYPE}_static"
                            -value_template MultiProcessorCompilation=true
+                           -value_template WindowsTargetPlatformVersion=${CMAKE_SYSTEM_VERSION}
                            -value_template staticflags+=__ACE_INLINE__
                            -value_template staticflags+=ACE_BUILD_DLL
                            -value_template staticflags+=ACE_AS_STATIC_LIBS
@@ -88,6 +89,7 @@ if (${WIN32})
   )
   set ( _INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/lib <INSTALL_DIR>/lib
                  COMMAND ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/ace <INSTALL_DIR>/include/ace
+                 COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/ace/Static_$<$<CONFIG:Debug>:Debug>$<$<NOT:$<CONFIG:Debug>>:Release>/ace_${MPC_TYPE}_static/AMD64/ACE_${MPC_TYPE}_static.pdb <INSTALL_DIR>/lib
   )
 
   set(CMAKE_STATIC_LIBRARY_SUFFIX s$<${MSVC}:$<$<CONFIG:Debug>:d>>.lib)


### PR DESCRIPTION
This reverts commit 95c6b5ee53f9c8b7525fd34885cd9f3284d579d4.  Windows builds are breaking, and it looks like we should really be fixing the SDK version at a certain point and only updating intentionally, rather than by virtue of picking up whatever's the latest from Microsoft.