### PR TITLE
Support "rolled" log files in gnmsg

### DIFF
--- a/tools/gnmsg/client_message_decoder.py
+++ b/tools/gnmsg/client_message_decoder.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 import re
 import struct
+import sys
 
 from dateutil import parser
 
@@ -242,7 +243,8 @@ class ClientMessageDecoder(DecoderBase):
                     self.request_requires_security_footer(str(send_trace["Type"]))
                 ):
                     print(
-                        "ERROR: Security flag is set, but no footer was added for this message!"
+                        "ERROR: Security flag is set, but no footer was added for this message!",
+                        file=sys.stderr,
                     )
 
                 parse_client_message(send_trace, message_bytes)

--- a/tools/gnmsg/command_line.py
+++ b/tools/gnmsg/command_line.py
@@ -41,6 +41,11 @@ def parse_command_line():
         "--thread_id", metavar="T", nargs="?", help="Show only messages on this thread"
     )
 
+    parser.add_argument(
+        "--rolled",
+        action="store_true",
+        help="(optionally) treat file as first in a sequence of rolled log files, and scan all sequential files.",
+    )
     args = parser.parse_args()
 
     if args.file is None:
@@ -48,4 +53,4 @@ def parse_command_line():
         parser.print_help()
         sys.exit(1)
 
-    return (args.file, args.handshake, args.messages, args.thread_id)
+    return (args.file, args.handshake, args.messages, args.thread_id, args.rolled)

--- a/tools/gnmsg/server_message_decoder.py
+++ b/tools/gnmsg/server_message_decoder.py
@@ -393,9 +393,11 @@ class ServerMessageDecoder(DecoderBase):
             if tid in self.chunk_decoders_.keys():
                 self.chunk_decoders_[tid].add_chunk(parts[3])
                 if self.chunk_decoders_[tid].is_complete_message():
-                    self.output_queue_.put(
-                        {"message": self.chunk_decoders_[tid].get_decoded_message(parts[0])}
+                    receive_trace = self.chunk_decoders_[tid].get_decoded_message(
+                        parts[0]
                     )
+                    receive_trace["tid"] = str(tid)
+                    self.output_queue_.put({"message": receive_trace})
                     self.chunk_decoders_[tid].reset()
         else:
             return
@@ -418,9 +420,7 @@ class ServerMessageDecoder(DecoderBase):
                 self.headers_[tid] = last_header
 
                 self.connection_states_[tid] = self.STATE_WAITING_FOR_MESSAGE_BODY_
-        elif (
-            self.connection_states_[tid] == self.STATE_WAITING_FOR_MESSAGE_BODY_
-        ):
+        elif self.connection_states_[tid] == self.STATE_WAITING_FOR_MESSAGE_BODY_:
             if message_body:
                 receive_trace = self.headers_[tid]
                 self.headers_[tid] = None


### PR DESCRIPTION
- With new parameter --rolled, gnmsg will expect file of the form
  <basename>-<number>.<ext>, and will scan the same directory for files of
  the same form with incrementing numbers until it runs out.  It will
  then attempt to open <basename>.<ext>, which should be the last file
  geode-native was logging to at the time of app exit.  Output will be a
  single consecutive JSON array of message structures, handy for
  post-processing.
- single file behavior remains the same as before