### PR TITLE
Fix buffer overflow gripes in RHEL-8 build

### DIFF
--- a/cppcache/integration-test/testExpiration.cpp
+++ b/cppcache/integration-test/testExpiration.cpp
@@ -59,7 +59,7 @@ void doNPuts(std::shared_ptr<Region> &rptr, int n) {
 
   for (int i = 0; i < n; i++) {
     auto keyStr = std::string("KeyA - ") + std::to_string(i + 1);
-    auto key = CacheableKey::create(keyStr.c_str());
+    auto key = CacheableKey::create(keyStr);
     LOGINFO("Putting key %s value %s in region %s", keyStr.c_str(),
             value->toString().c_str(), rptr->getFullPath().c_str());
     rptr->put(key, value);

--- a/cppcache/integration-test/testThinClientLRUExpiration.cpp
+++ b/cppcache/integration-test/testThinClientLRUExpiration.cpp
@@ -180,7 +180,7 @@ void doRgnOperations(const char *name, int n, int rgnOpt = 0) {
   ASSERT(rptr != nullptr, "Region not found.");
   for (int i = 0; i < n; i++) {
     auto keyStr = std::string("KeyA - ") + std::to_string(i + 1);
-    auto key = CacheableKey::create(keyStr.c_str());
+    auto key = CacheableKey::create(keyStr);
     switch (rgnOpt) {
       case 0:
         rptr->put(key, value);


### PR DESCRIPTION
- RHEL-8 CI images appear to have picked up a new compiler that's
  flagging some broken sprintf code in a couple of legacy tests.