### PR TITLE
GEODE-9576: Fix for single-hop function execution

### DIFF
--- a/cppcache/integration-test/resources/func_cacheserver1_pool_nonHA.xml
+++ b/cppcache/integration-test/resources/func_cacheserver1_pool_nonHA.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<cache 
+	xmlns="http://geode.apache.org/schema/cache" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd" version="1.0">
+	<!--cache-server host="cod" port="24680" /-->
+	<cache-server port="50507">
+	</cache-server>
+	<pdx read-serialized="true" />
+	<region name='partition_region'>
+		<region-attributes data-policy="partition">
+			<partition-attributes redundant-copies="0"/>
+		</region-attributes>
+	</region>
+	<function-service>
+		<function>
+			<class-name>javaobject.MultiGetAllFunctionNonHA</class-name>
+		</function>
+	</function-service>
+	<serialization-registration>
+		<instantiator id="5200">
+			<class-name>javaobject.InstantiatorTest</class-name>
+		</instantiator>
+	</serialization-registration>
+</cache>

--- a/cppcache/integration-test/resources/func_cacheserver2_pool_nonHA.xml
+++ b/cppcache/integration-test/resources/func_cacheserver2_pool_nonHA.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<cache 
+	xmlns="http://geode.apache.org/schema/cache" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd" version="1.0">
+	<cache-server port="50506">
+	</cache-server>
+	<pdx read-serialized="true" />
+	<region name='partition_region'>
+		<region-attributes data-policy="partition">
+			<partition-attributes redundant-copies="0"/>
+		</region-attributes>
+	</region>
+	<function-service>
+		<function>
+			<class-name>javaobject.MultiGetAllFunctionNonHA</class-name>
+		</function>
+	</function-service>
+	<serialization-registration>
+		<instantiator id="5200">
+			<class-name>javaobject.InstantiatorTest</class-name>
+		</instantiator>
+	</serialization-registration>
+</cache>

--- a/cppcache/integration-test/resources/func_cacheserver3_pool_nonHA.xml
+++ b/cppcache/integration-test/resources/func_cacheserver3_pool_nonHA.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<cache 
+	xmlns="http://geode.apache.org/schema/cache" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd" version="1.0">
+	<!--cache-server host="cod" port="24680" /-->
+	<cache-server port="50508">
+	</cache-server>
+	<pdx read-serialized="true" />
+	<region name='partition_region'>
+		<region-attributes data-policy="partition">
+			<partition-attributes redundant-copies="0"/>
+		</region-attributes>
+	</region>
+	<function-service>
+		<function>
+			<class-name>javaobject.MultiGetAllFunctionNonHA</class-name>
+		</function>
+	</function-service>
+	<serialization-registration>
+		<instantiator id="5200">
+			<class-name>javaobject.InstantiatorTest</class-name>
+		</instantiator>
+	</serialization-registration>
+</cache>

--- a/cppcache/src/ClientMetadataService.cpp
+++ b/cppcache/src/ClientMetadataService.cpp
@@ -569,7 +569,6 @@ std::shared_ptr<BucketServerLocation> ClientMetadataService::findNextServer(
 std::shared_ptr<ClientMetadataService::ServerToBucketsMap>
 ClientMetadataService::pruneNodes(
     const std::shared_ptr<ClientMetadata>& metadata, const BucketSet& buckets) {
-  BucketSet bucketSetWithoutServer;
   ServerToBucketsMap serverToBucketsMap;
 
   auto prunedServerToBucketsMap = std::make_shared<ServerToBucketsMap>();
@@ -578,12 +577,10 @@ ClientMetadataService::pruneNodes(
     const auto locations = metadata->adviseServerLocations(bucketId);
     if (locations.size() == 0) {
       LOGDEBUG(
-          "ClientMetadataService::pruneNodes Since no server location "
-          "available for bucketId = %d  putting it into "
-          "bucketSetWithoutServer ",
+          "ClientMetadataService::pruneNodes Use non single-hop path "
+          "since no server location is available for bucketId = %d",
           bucketId);
-      bucketSetWithoutServer.insert(bucketId);
-      continue;
+      return nullptr;
     }
 
     for (const auto& location : locations) {
@@ -662,11 +659,6 @@ ClientMetadataService::pruneNodes(
 
     prunedServerToBucketsMap->emplace(server, bucketSet2);
     serverToBucketsMap.erase(server);
-  }
-
-  const auto& itrRes2 = prunedServerToBucketsMap->begin();
-  for (const auto& itr : bucketSetWithoutServer) {
-    itrRes2->second->insert(itr);
   }
 
   return prunedServerToBucketsMap;

--- a/tests/javaobject/MultiGetAllFunctionNonHA.java
+++ b/tests/javaobject/MultiGetAllFunctionNonHA.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package javaobject;
+
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.Vector;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheClosedException;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.Declarable;
+import org.apache.geode.cache.execute.FunctionAdapter;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.execute.ResultSender;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.execute.RegionFunctionContext;
+import org.apache.geode.cache.partition.PartitionRegionHelper;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.cache.execute.InternalFunctionInvocationTargetException;
+
+public class MultiGetAllFunctionNonHA extends FunctionAdapter implements Declarable{
+
+  public void execute(FunctionContext context) {
+    RegionFunctionContext regionContext = (RegionFunctionContext) context;
+    final Region<String, String> region =
+        PartitionRegionHelper.getLocalDataForContext(regionContext);
+
+    Set<String> keys = region.keySet();
+    List<String> listKey = new ArrayList<>();
+    for (String key : keys) {
+      listKey.add(key);
+    }
+    context.getResultSender().lastResult(listKey);
+  }
+
+  public String getId() {
+    return "MultiGetAllFunctionNonHA";
+  }
+
+  public void init(Properties arg0) {
+
+  }
+
+  @Override
+  public boolean isHA() {
+    return false;
+  }
+}


### PR DESCRIPTION
Fault:
"InternalFunctionInvocationTargetException: Multiple target nodes
found for single hop operation" occurs on server when executing
function in a single hop manner for all buckets during the period when
client bucket metadata doesn't contains all buckets locations.

Fix:
The client will execute function in a non single-hop manner until it
recevies all buckets locations. This solution is aligned with java
client.