### PR TITLE
Add a fan-in job and print out the properties of the Geode build used for test

### DIFF
--- a/ci/lib/templates.lib.txt
+++ b/ci/lib/templates.lib.txt
@@ -251,6 +251,7 @@ geode_version=$(cat geode-latest/version)
 geode_name="apache-geode-${geode_version}"
 geode_artifact="${geode_name}.tgz"
 tar xvf geode-latest/${geode_artifact} --directory=geode --strip-components=1
+unzip -p geode/lib/geode-core-${geode_version}.jar org/apache/geode/internal/GemFireVersion.properties
 cp geode-latest/version geode/version
 (@- end @)
 

--- a/ci/release/pipeline.yml
+++ b/ci/release/pipeline.yml
@@ -17,6 +17,7 @@
 #@      "github_resource",
 #@      "gci_resource",
 #@      "registry_image_resource",
+#@      "bash_task",
 #@      "build_job_name",
 #@      "packer_job",
 #@      "packer_job_name",
@@ -27,6 +28,8 @@
 #@      "put_package",
 #@      "version_source_job",
 #@      "version_source_job_name")
+#@ load("templates.lib.txt",
+#@       "extract_geode_bash_task")
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
 
@@ -98,7 +101,7 @@ jobs:
               passed: [ version-source ]
 
   #@overlay/append
-  - name: github-pre-release
+  - name: native-passed
     plan:
       - in_parallel:
           fail_fast: true
@@ -127,6 +130,35 @@ jobs:
             - get: #@ package_resource_name(build, config, package)
               passed:
                 - #@ build_job_name(build, config)
+              trigger: true
+            #@ end
+            #@ end
+            #@ end
+            - do:
+              - get: task-image
+              - get: geode-latest
+              - #@ bash_task("extract-geode", [{"name":"geode-latest"}], [{"name":"geode"}], extract_geode_bash_task(), caches=[{"path":"geode"}])
+
+  #@overlay/append
+  - name: github-pre-release
+    plan:
+      - in_parallel:
+          fail_fast: true
+          steps:
+            - get: version
+              passed:
+                - native-passed
+              trigger: true
+            - get: source
+              passed:
+                - native-passed
+              trigger: true
+            #@ for build in data.values.builds:
+            #@ for config in data.values.configs:
+            #@ for package in build.packages:
+            - get: #@ package_resource_name(build, config, package)
+              passed:
+                - native-passed
               trigger: true
             #@ end
             #@ end
@@ -174,6 +206,8 @@ groups:
       - bump-minor-version
       #@overlay/append
       - github-pre-release
+      #@overlay/append
+      - native-passed
   #@overlay/match by="name"
   - name: version
     jobs:


### PR DESCRIPTION
* Provides an easy way to confirm the properties of the geode build used in the native-client tests
* Makes it easier to tell what build has passed all tests (since the current fan-in job has been paused since April)