### PR TITLE
GEODE-9608: NetCore projects should be compiled with Warnings as Error

### DIFF
--- a/netcore/asp-netcore-session-sample/asp-netcore-session-sample.csproj
+++ b/netcore/asp-netcore-session-sample/asp-netcore-session-sample.csproj
@@ -3,11 +3,26 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
+	<Configurations>Debug;RelWithDebInfo</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\netcore-session\netcore-session.csproj" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<WarningsAsErrors />
+	<DebugType>pdbonly</DebugType>
+	<DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<WarningsAsErrors />
+	<Optimize>true</Optimize>
+	<DebugType>pdbonly</DebugType>
+	<DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
 
 </Project>

--- a/netcore/netcore-integration-test/netcore-integration-test.csproj
+++ b/netcore/netcore-integration-test/netcore-integration-test.csproj
@@ -1,32 +1,44 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+  <PropertyGroup>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
+      <IsPackable>false</IsPackable>
+      <Platforms>x64</Platforms>
+      <Configurations>Debug;RelWithDebInfo</Configurations>
+  </PropertyGroup>
 
-        <IsPackable>false</IsPackable>
+  <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="xunit" Version="2.4.1" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+  </ItemGroup>
 
-        <Platforms>x64</Platforms>
+  <ItemGroup>
+    <ProjectReference Include="..\netcore-lib\netcore-lib.csproj" />
+  </ItemGroup>
 
-        <Configurations>Debug;Release;RelWithDebInfo</Configurations>
-    </PropertyGroup>
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<WarningsAsErrors />
+	<DebugType>pdbonly</DebugType>
+	<DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\netcore-lib\netcore-lib.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <None Update="xunit.runner.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<WarningsAsErrors />
+	<Optimize>true</Optimize>
+	<DebugType>pdbonly</DebugType>
+	<DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
 
 </Project>

--- a/netcore/netcore-lib/netcore-lib.csproj
+++ b/netcore/netcore-lib/netcore-lib.csproj
@@ -5,7 +5,22 @@
         <RootNamespace>Apache.Geode.NetCore</RootNamespace>
         <AssemblyName>Apache.Geode.NetCore</AssemblyName>
         <Platforms>x64</Platforms>
-        <Configurations>Debug;Release;RelWithDebInfo</Configurations>
+        <Configurations>Debug;RelWithDebInfo</Configurations>
     </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+      <WarningsAsErrors />
+      <DebugType>pdbonly</DebugType>
+      <DebugSymbols>true</DebugSymbols>
+    </PropertyGroup>
+	
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">
+      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+      <WarningsAsErrors />
+      <Optimize>true</Optimize>
+      <DebugType>pdbonly</DebugType>
+      <DebugSymbols>true</DebugSymbols>
+    </PropertyGroup>	
 
 </Project>

--- a/netcore/netcore-session-integration-test/netcore-session-integration-test.csproj
+++ b/netcore/netcore-session-integration-test/netcore-session-integration-test.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
-
     <Platforms>x64</Platforms>
+	<Configurations>Debug;RelWithDebInfo</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,5 +18,20 @@
     <ProjectReference Include="..\netcore-session\netcore-session.csproj" />
     <ProjectReference Include="..\netcore-lib\netcore-lib.csproj" />
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<WarningsAsErrors />
+	<DebugType>pdbonly</DebugType>
+	<DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<WarningsAsErrors />
+	<Optimize>true</Optimize>
+	<DebugType>pdbonly</DebugType>
+	<DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
 
 </Project>

--- a/netcore/netcore-session/netcore-session.csproj
+++ b/netcore/netcore-session/netcore-session.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>x64</Platforms>
+	<Configurations>Debug;RelWithDebInfo</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,5 +14,20 @@
   <ItemGroup>
     <ProjectReference Include="..\netcore-lib\netcore-lib.csproj" />
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<WarningsAsErrors />
+	<DebugType>pdbonly</DebugType>
+	<DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<WarningsAsErrors />
+	<Optimize>true</Optimize>
+	<DebugType>pdbonly</DebugType>
+	<DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The NetCore projects should be compiled with Warnings as Errors to be consistent with other geode-native components. Also, some of the projects are missing RelWithDebInfo configuration.

Remove Release config, add Optimization and pdb