### PR TITLE
Fix Ubuntu images in CI

### DIFF
--- a/packer/ubuntu/update.sh
+++ b/packer/ubuntu/update.sh
@@ -18,4 +18,4 @@
 set -x -e -o pipefail
 
 export DEBIAN_FRONTEND=noninteractive
-apt-update && apt-get -y autoremove && apt remove -y unattended-upgrades
+apt update && apt-get -y autoremove && apt remove -y unattended-upgrades


### PR DESCRIPTION
Something in the `apt -yq full-upgrade` command started breaking Ubuntu 20.04 instances a couple of weeks ago.  The symptom is, after the upgrade, if you create an instance of the machine you can't connect via SSH.  This is broken both in CI and when creating instances from the Google console.  We've also seen this intermittently with Ubuntu 18.04 images.  Abandoning the upgrade fixes things.