### PR TITLE
GEODE-9741: Fix Release Build on Windows 2019

### DIFF
--- a/ci/lib/templates.lib.txt
+++ b/ci/lib/templates.lib.txt
@@ -203,6 +203,9 @@ git_rev=$(git rev-parse HEAD)
 popd
 version=$(cat version/number)
 builddate=$(date "+%Y-%m-%d")
+#@ if build.image_family == "build-windows-2019-vs-2019":
+  remote_shell 'c:/"Program Files (x86)\Microsoft Visual Studio"/2019/Community/VC/Auxiliary/Build/vcvarsall.bat x64 10.0.16299.0 -vcvars_ver=14.20'
+#@end
 remote_shell cmake -E make_directory build
 remote_shell cmake -E time cmake -E chdir build cmake ../source ${CMAKE_CONFIGURE_FLAGS} \
     -DCMAKE_BUILD_TYPE=${CMAKE_CONFIG} \

--- a/ci/lib/templates.lib.txt
+++ b/ci/lib/templates.lib.txt
@@ -194,7 +194,7 @@ set -ueo pipefail
 remote_download_directory build .
 (@- end @)
 
-(@ def build_bash_task(): -@)
+(@ def build_bash_task(use_vcvarsall): -@)
 set -ueo pipefail
 (@= remote_functions() @)
 pushd source
@@ -203,9 +203,9 @@ git_rev=$(git rev-parse HEAD)
 popd
 version=$(cat version/number)
 builddate=$(date "+%Y-%m-%d")
-#@ if build.image_family == "build-windows-2019-vs-2019":
-  remote_shell 'c:/"Program Files (x86)\Microsoft Visual Studio"/2019/Community/VC/Auxiliary/Build/vcvarsall.bat x64 10.0.16299.0 -vcvars_ver=14.20'
-#@end
+(@- if use_vcvarsall: @)
+remote_shell "c:/Program Files (x86)\Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvarsall.bat" x64 10.0.16299.0 -vcvars_ver=14.20
+(@ end -@)
 remote_shell cmake -E make_directory build
 remote_shell cmake -E time cmake -E chdir build cmake ../source ${CMAKE_CONFIGURE_FLAGS} \
     -DCMAKE_BUILD_TYPE=${CMAKE_CONFIG} \

--- a/ci/lib/templates.lib.yml
+++ b/ci/lib/templates.lib.yml
@@ -149,13 +149,13 @@ source:
 #@ end
 
 ---
-#@ def build_task(config, params={}):
+#@ def build_task(config, use_vcvarsall, params={}):
 #@ params = struct.decode(params)
 #@ params.update({"CMAKE_CONFIG": config})
 #@ return bash_task("build",
 #@   [{"name":"instance"},{"name":"version"},{"name":"source"}],
 #@   [{"name":"package"}],
-#@   build_bash_task(),
+#@   build_bash_task(use_vcvarsall),
 #@   params=params)
 #@ end
 
@@ -211,7 +211,11 @@ plan:
         steps:
           - #@ bash_task("upload-source", [{"name":"instance"},{"name":"source"}], [], upload_source_bash_task())
           - #@ bash_task("upload-geode", [{"name":"instance"},{"name":"geode-latest"}], [], upload_geode_bash_task())
-    - #@ build_task(config.config, build.params)
+    #@ if build.image_family == "build-windows-2019-vs-2019":
+    - #@ build_task(config.config, True, build.params)
+    #@ else:
+    - #@ build_task(config.config, False, build.params)
+    #@ end
     - #@ remote_task("cpp-unit-tests", config.config, ctest_bash_task("build/cppcache/test", parallel=8), "30m", build.params)
     - #@ remote_task("cpp-integration-tests", config.config, ctest_bash_task("build/cppcache/integration/test", parallel=4), "1h", build.params)
     - #@ remote_task("cpp-legacy-integration-tests", config.config, ctest_bash_task("build/cppcache/integration-test", timeout=500, parallel=4), "2h", build.params)


### PR DESCRIPTION
Building with the new tools (v142) on Windows caused the Release build to fail due to ACE not picking up the specified tools from the cmake configuration. This PR solves this problem by setting environment variables by calling vcvarsall.bat with the correct tools version  before configuring with cmake.

Note: Once geode-native is no longer dependent on ACE, the call to vcvarsall.bat can be removed.

