### PR TITLE
Ignore generated netcore/shared/Config.cs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 
 /tools/gnmsg/.idea/
 /tools/gnmsg/__pycache__/
+
+netcore/shared/Config.cs


### PR DESCRIPTION
Authored-by: M. Oleske <michael@oleske.engineer>

I finally got annoyed at my git status being dirty after running cmake ..

I don't like ignoring it, but I couldn't figure out where this file should go.  In the other cases where Config.cs.in is templated out, it is put into the build directory.  But I couldn't see any cs files in the build directory for the new dotnet work.  Let me know the cmakelists.txt should actually be updated instead of ignoring this file.