### PR TITLE
GEODE-9959: Add FQDN in log upon SSL missconfig

### DIFF
--- a/cppcache/src/ServerLocation.hpp
+++ b/cppcache/src/ServerLocation.hpp
@@ -82,6 +82,10 @@ class ServerLocation : public internal::DataSerializableInternal {
     return size;
   }
 
+  std::string toString() const override {
+    return m_serverName + ":" + std::to_string(m_port);
+  }
+
   void printInfo() {
     LOGDEBUG(" Got Host \"%s\", and port %d", getServerName().c_str(), m_port);
   }

--- a/cppcache/src/ThinClientLocatorHelper.cpp
+++ b/cppcache/src/ThinClientLocatorHelper.cpp
@@ -145,7 +145,8 @@ std::shared_ptr<Serializable> ThinClientLocatorHelper::sendRequest(
         reinterpret_cast<uint8_t*>(buff), receivedLength);
 
     if (di.read() == REPLY_SSL_ENABLED && !sys_prop.sslEnabled()) {
-      LOGERROR("SSL is enabled on locator, enable SSL in client as well");
+      LOGERROR("SSL is enabled on locator %s, enable SSL in client as well",
+               location.toString().c_str());
       throw AuthenticationRequiredException(
           "SSL is enabled on locator, enable SSL in client as well");
     }


### PR DESCRIPTION
 - Whenever there is an SSL missconfiguration while trying to reach a
   locator, an AuthenticationRequiredException is thrown and a log is
   written. Currently FQDN of the locator is not logged.
 - This commit adds the locator FQDN in order to further troubleshoot
   this kind of scenarios.
 - Also, in order to ease implementation, toString method was
   implemented for ServerLocation.