### PR TITLE
GEODE-9960: Remove strong name signing support for .net assemblies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,16 +283,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   # Enables multiprocess compiles
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 
-  # Enables strong name signing
-  set(STRONG_NAME_KEY "" CACHE FILEPATH "Strong Name Key File")
-  if(EXISTS "${STRONG_NAME_KEY}")
-    set(SHARED_LINKER_FLAGS_STRONG_KEY "/keyfile:${STRONG_NAME_KEY}")
-    execute_process(COMMAND sn -p ${STRONG_NAME_KEY} ${CMAKE_CURRENT_BINARY_DIR}/public.snk)
-    execute_process(COMMAND sn -tp ${CMAKE_CURRENT_BINARY_DIR}/public.snk OUTPUT_VARIABLE STRONG_NAME_PUBLIC_KEY)
-    string(REPLACE "\n" "" STRONG_NAME_PUBLIC_KEY ${STRONG_NAME_PUBLIC_KEY})
-    string(REGEX REPLACE ".*sha1\\):([a-f0-9]+).*" "\\1" STRONG_NAME_PUBLIC_KEY ${STRONG_NAME_PUBLIC_KEY})
-  endif()
-
   find_program(NUGET nuget)
   add_custom_target(nuget-restore 
     COMMAND ${NUGET} restore ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.sln

--- a/clicache/acceptance-test/CMakeLists.txt
+++ b/clicache/acceptance-test/CMakeLists.txt
@@ -62,11 +62,4 @@ set_target_properties( ${PROJECT_NAME} PROPERTIES
   FOLDER cli/test/acceptance
 )
 
-if(NOT "${STRONG_NAME_KEY}" STREQUAL "")
-  set_target_properties( ${PROJECT_NAME} PROPERTIES
-    VS_GLOBAL_SignAssembly "true"
-    VS_GLOBAL_AssemblyOriginatorKeyFile ${STRONG_NAME_KEY}
-  )
-endif()
-
 add_dependencies(${PROJECT_NAME} nuget-restore)

--- a/clicache/integration-test/CMakeLists.txt
+++ b/clicache/integration-test/CMakeLists.txt
@@ -68,13 +68,6 @@ set_target_properties(Apache.Geode.Client.UnitTests PROPERTIES
   FOLDER cli/test/integration
 )
 
-if(NOT "${STRONG_NAME_KEY}" STREQUAL "")
-  set_target_properties(Apache.Geode.Client.UnitTests PROPERTIES
-    VS_GLOBAL_SignAssembly "true"
-    VS_GLOBAL_AssemblyOriginatorKeyFile ${STRONG_NAME_KEY}
-  )
-endif()
-
 add_dependencies(Apache.Geode.Client.UnitTests FwkClient SqLiteImpl)
 add_dependencies(Apache.Geode.Client.UnitTests nuget-restore)
 

--- a/clicache/integration-test2/CMakeLists.txt
+++ b/clicache/integration-test2/CMakeLists.txt
@@ -85,13 +85,6 @@ set_target_properties(Apache.Geode.IntegrationTests2 PROPERTIES
   FOLDER cli/test/integration
 )
 
-if(NOT "${STRONG_NAME_KEY}" STREQUAL "")
-  set_target_properties( Apache.Geode.IntegrationTests2 PROPERTIES
-    VS_GLOBAL_SignAssembly "true"
-    VS_GLOBAL_AssemblyOriginatorKeyFile ${STRONG_NAME_KEY}
-  )
-endif()
-
 add_dependencies(Apache.Geode.IntegrationTests2 nuget-restore)
 
 enable_testing()

--- a/clicache/src/CMakeLists.txt
+++ b/clicache/src/CMakeLists.txt
@@ -16,9 +16,6 @@
 cmake_minimum_required(VERSION 3.12)
 project(Apache.Geode CXX)
 
-if(NOT "${STRONG_NAME_PUBLIC_KEY}" STREQUAL "")
-  set(STRONG_NAME_PUBLIC_KEY_ATTRIBUTE ", PublicKey=${STRONG_NAME_PUBLIC_KEY}")
-endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/impl/AssemblyInfo.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/impl/AssemblyInfo.cpp)
 list(APPEND CONFIGURE_IN_FILES ${CMAKE_CURRENT_SOURCE_DIR}/impl/AssemblyInfo.cpp.in)
 list(APPEND CONFIGURE_OUT_FILES ${CMAKE_CURRENT_BINARY_DIR}/impl/AssemblyInfo.cpp)
@@ -364,9 +361,6 @@ target_link_options(Apache.Geode
 )
 
 string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${SHARED_LINKER_FLAGS_STRONG_KEY}")
-
 
 include(PrecompiledHeader)
 add_precompiled_header(Apache.Geode-object geode_includes.hpp FORCEINCLUDE)

--- a/clicache/src/impl/AssemblyInfo.cpp.in
+++ b/clicache/src/impl/AssemblyInfo.cpp.in
@@ -42,3 +42,6 @@ using namespace System::Security::Permissions;
 
 [assembly:SecurityPermission(SecurityAction::RequestMinimum, UnmanagedCode = true)];
 
+[assembly:InternalsVisibleToAttribute("Apache.Geode.Client.UnitTests")];
+[assembly:InternalsVisibleToAttribute("cli-unit-tests")];
+

--- a/clicache/src/impl/AssemblyInfo.cpp.in
+++ b/clicache/src/impl/AssemblyInfo.cpp.in
@@ -42,5 +42,3 @@ using namespace System::Security::Permissions;
 
 [assembly:SecurityPermission(SecurityAction::RequestMinimum, UnmanagedCode = true)];
 
-[assembly:InternalsVisibleToAttribute("Apache.Geode.Client.UnitTests@STRONG_NAME_PUBLIC_KEY_ATTRIBUTE@")];
-[assembly:InternalsVisibleToAttribute("cli-unit-tests@STRONG_NAME_PUBLIC_KEY_ATTRIBUTE@")];

--- a/clicache/test2/CMakeLists.txt
+++ b/clicache/test2/CMakeLists.txt
@@ -53,13 +53,6 @@ set_target_properties(Apache.Geode.Tests2 PROPERTIES
   FOLDER cli/test/unit
 )
 
-if(NOT "${STRONG_NAME_KEY}" STREQUAL "")
-  set_target_properties(Apache.Geode.Tests2 PROPERTIES
-    VS_GLOBAL_SignAssembly "true"
-    VS_GLOBAL_AssemblyOriginatorKeyFile ${STRONG_NAME_KEY}
-  )
-endif()
-
 add_dependencies(Apache.Geode.Tests2 nuget-restore)
 
 enable_testing()

--- a/templates/security/csharp/CMakeLists.txt
+++ b/templates/security/csharp/CMakeLists.txt
@@ -34,9 +34,3 @@ set_target_properties(Apache.Geode.Templates.Cache.Security PROPERTIES
   FOLDER cli/test/integration
 )
 
-if(NOT "${STRONG_NAME_KEY}" STREQUAL "")
-  set_target_properties(Apache.Geode.Templates.Cache.Security PROPERTIES
-    VS_GLOBAL_SignAssembly "true"
-    VS_GLOBAL_AssemblyOriginatorKeyFile ${STRONG_NAME_KEY}
-  )
-endif()

--- a/tests/cli/DUnitFramework/CMakeLists.txt
+++ b/tests/cli/DUnitFramework/CMakeLists.txt
@@ -51,11 +51,4 @@ set_target_properties(DUnitFramework PROPERTIES
   FOLDER cli/test/integration
 )
 
-if(NOT "${STRONG_NAME_KEY}" STREQUAL "")
-  set_target_properties(DUnitFramework PROPERTIES
-    VS_GLOBAL_SignAssembly "true"
-    VS_GLOBAL_AssemblyOriginatorKeyFile ${STRONG_NAME_KEY}
-  )
-endif()
-
 add_dependencies(DUnitFramework nuget-restore)

--- a/tests/cli/FwkClient/CMakeLists.txt
+++ b/tests/cli/FwkClient/CMakeLists.txt
@@ -36,9 +36,3 @@ set_target_properties(FwkClient PROPERTIES
   FOLDER cli/test/integration
 )
 
-if(NOT "${STRONG_NAME_KEY}" STREQUAL "")
-  set_target_properties(FwkClient PROPERTIES
-    VS_GLOBAL_SignAssembly "true"
-    VS_GLOBAL_AssemblyOriginatorKeyFile ${STRONG_NAME_KEY}
-  )
-endif()

--- a/tests/cli/FwkLauncher/FwkLauncher.csproj.txt
+++ b/tests/cli/FwkLauncher/FwkLauncher.csproj.txt
@@ -30,7 +30,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Apache.Geode.Client.FwkLauncher</RootNamespace>
     <AssemblyName>FwkLauncher</AssemblyName>
-    <SignAssembly>${STRONG_NAME_KEY_ENABLED}</SignAssembly>
     <AssemblyOriginatorKeyFile>${STRONG_NAME_KEY}</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>${DOTNET_TARGET_FRAMEWORK_VERSION}</TargetFrameworkVersion>
     <FileUpgradeFlags>

--- a/tests/cli/FwkLauncher/FwkLauncher.csproj.txt
+++ b/tests/cli/FwkLauncher/FwkLauncher.csproj.txt
@@ -30,7 +30,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Apache.Geode.Client.FwkLauncher</RootNamespace>
     <AssemblyName>FwkLauncher</AssemblyName>
-    <AssemblyOriginatorKeyFile>${STRONG_NAME_KEY}</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>${DOTNET_TARGET_FRAMEWORK_VERSION}</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/tests/cli/FwkUtil/FwkUtil.csproj.txt
+++ b/tests/cli/FwkUtil/FwkUtil.csproj.txt
@@ -30,8 +30,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Apache.Geode.Client.FwkLib</RootNamespace>
     <AssemblyName>FwkUtil</AssemblyName>
-    <SignAssembly>${STRONG_NAME_KEY_ENABLED}</SignAssembly>
-    <AssemblyOriginatorKeyFile>${STRONG_NAME_KEY}</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>${DOTNET_TARGET_FRAMEWORK_VERSION}</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/tests/cli/NewTestObject/CMakeLists.txt
+++ b/tests/cli/NewTestObject/CMakeLists.txt
@@ -53,9 +53,3 @@ set_target_properties(NewTestObject PROPERTIES
   FOLDER cli/test/integration
 )
 
-if(NOT "${STRONG_NAME_KEY}" STREQUAL "")
-  set_target_properties(NewTestObject PROPERTIES
-    VS_GLOBAL_SignAssembly "true"
-    VS_GLOBAL_AssemblyOriginatorKeyFile ${STRONG_NAME_KEY}
-  )
-endif()

--- a/tests/cli/PdxClassLibrary/CMakeLists.txt
+++ b/tests/cli/PdxClassLibrary/CMakeLists.txt
@@ -41,9 +41,3 @@ set_target_properties( PdxClassLibrary PROPERTIES
   FOLDER cli/test/integration
 )
 
-if(NOT "${STRONG_NAME_KEY}" STREQUAL "")
-  set_target_properties( PdxClassLibrary PROPERTIES
-    VS_GLOBAL_SignAssembly "true"
-    VS_GLOBAL_AssemblyOriginatorKeyFile ${STRONG_NAME_KEY}
-  )
-endif()

--- a/tests/cli/PdxVersion1Lib/CMakeLists.txt
+++ b/tests/cli/PdxVersion1Lib/CMakeLists.txt
@@ -34,9 +34,3 @@ set_target_properties(PdxVersion1Lib PROPERTIES
   FOLDER cli/test/integration
 )
 
-if(NOT "${STRONG_NAME_KEY}" STREQUAL "")
-  set_target_properties(PdxVersion1Lib PROPERTIES
-    VS_GLOBAL_SignAssembly "true"
-    VS_GLOBAL_AssemblyOriginatorKeyFile ${STRONG_NAME_KEY}
-  )
-endif()

--- a/tests/cli/PdxVersion2Lib/CMakeLists.txt
+++ b/tests/cli/PdxVersion2Lib/CMakeLists.txt
@@ -34,9 +34,3 @@ set_target_properties(PdxVersion2Lib PROPERTIES
   FOLDER cli/test/integration
 )
 
-if(NOT "${STRONG_NAME_KEY}" STREQUAL "")
-  set_target_properties(PdxVersion2Lib PROPERTIES
-    VS_GLOBAL_SignAssembly "true"
-    VS_GLOBAL_AssemblyOriginatorKeyFile ${STRONG_NAME_KEY}
-  )
-endif()

--- a/tests/cli/QueryHelper/CMakeLists.txt
+++ b/tests/cli/QueryHelper/CMakeLists.txt
@@ -55,7 +55,6 @@ target_link_libraries(QueryWrapper
 add_dependencies(QueryWrapper Apache.Geode)
 
 string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${SHARED_LINKER_FLAGS_STRONG_KEY}")
 
 # For Visual Studio organization
 set_target_properties(QueryWrapper PROPERTIES FOLDER cli/test/integration)

--- a/tests/cli/SecurityUtil/CMakeLists.txt
+++ b/tests/cli/SecurityUtil/CMakeLists.txt
@@ -40,9 +40,3 @@ set_target_properties(SecurityUtil PROPERTIES
   FOLDER cli/test/integration
 )
 
-if(NOT "${STRONG_NAME_KEY}" STREQUAL "")
-  set_target_properties(SecurityUtil PROPERTIES
-    VS_GLOBAL_SignAssembly "true"
-    VS_GLOBAL_AssemblyOriginatorKeyFile ${STRONG_NAME_KEY}
-  )
-endif()


### PR DESCRIPTION
- This has caused problems with build pipelines, and is no longer used by .net runtimes