### PR TITLE
GEODE-9848: Eliminate duplicate REGISTER_INTEREST message

### DIFF
--- a/cppcache/src/ThinClientRedundancyManager.cpp
+++ b/cppcache/src/ThinClientRedundancyManager.cpp
@@ -887,7 +887,11 @@ GfErrType ThinClientRedundancyManager::sendSyncRequestRegisterInterest(
     TcrEndpoint* primaryEndpoint = nullptr;
 
     if (!m_redundantEndpoints.empty()) {
-      for (auto&& redundantEndpoint : m_redundantEndpoints) {
+      primaryEndpoint = m_redundantEndpoints[0];
+      for (auto& redundantEndpoint : m_redundantEndpoints) {
+        if (redundantEndpoint == primaryEndpoint) {
+          continue;
+        }
         redundantEndpoint->setDM(request.getDM());
         opErr = theHADM->sendSyncRequestRegisterInterestEP(
             request, reply, false, redundantEndpoint);
@@ -895,7 +899,6 @@ GfErrType ThinClientRedundancyManager::sendSyncRequestRegisterInterest(
           err = opErr;
         }
       }
-      primaryEndpoint = m_redundantEndpoints[0];
     }
 
     if ((request.getMessageType() == TcrMessage::REGISTER_INTEREST_LIST ||


### PR DESCRIPTION
- first endpoint in m_redundantEndpoints was originally supposed to
be left out of the for loop.  This broke during a refactor roughly three years ago, moving from old-school iterator to a ranged for loop.