### PR TITLE
GEODE-9896: Bump sqlite to 3.37.2

### DIFF
--- a/dependencies/sqlite/CMakeLists.txt
+++ b/dependencies/sqlite/CMakeLists.txt
@@ -13,15 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project( sqlite VERSION 3360000 LANGUAGES NONE )
+project( sqlite VERSION 3370200 LANGUAGES NONE )
 
-set( SHA256 999826fe4c871f18919fdb8ed7ec9dd8217180854dd1fe21eea96aed36186729 )
+set( SHA256 cb25df0fb90b77be6660f6ace641bbea88f3d0441110d394ce418f35f7561bb0 )
 
 
 set( EXTERN ${PROJECT_NAME}-extern )
 include(ExternalProject)
 ExternalProject_Add( ${EXTERN}
-  URL "https://www.sqlite.org/2021/sqlite-amalgamation-${PROJECT_VERSION}.zip"
+  URL "https://www.sqlite.org/2022/sqlite-amalgamation-${PROJECT_VERSION}.zip"
   URL_HASH SHA256=${SHA256}
   UPDATE_COMMAND ""
   CMAKE_ARGS


### PR DESCRIPTION
Authored-by: M. Oleske <michael@oleske.engineer>

Seemed rude not to bump the other dependencies after doing ACE, so here is another one
May also conflict with #899

maybe some day I'll look into dependabot so this type of bumping can be automated