### PR TITLE
GEODE-10016: Add map of threadId to threadName

### DIFF
--- a/cppcache/src/ClientMetadataService.cpp
+++ b/cppcache/src/ClientMetadataService.cpp
@@ -66,7 +66,7 @@ void ClientMetadataService::stop() {
 }
 
 void ClientMetadataService::svc() {
-  DistributedSystemImpl::setThreadName(NC_CMDSvcThread);
+  DistributedSystemImpl::setThreadName(NC_CMDSvcThread, m_thread.get_id());
 
   LOGINFO("ClientMetadataService started for pool " + m_pool->getName());
 

--- a/cppcache/src/DistributedSystemImpl.cpp
+++ b/cppcache/src/DistributedSystemImpl.cpp
@@ -38,6 +38,10 @@
 #include "util/Log.hpp"
 #include "version.h"
 
+namespace {
+std::map<std::thread::id, std::string> m_threadNames;
+}
+
 namespace apache {
 namespace geode {
 namespace client {
@@ -143,10 +147,23 @@ void DistributedSystemImpl::unregisterCliCallback(int appdomainId) {
   }
 }
 
-void DistributedSystemImpl::setThreadName(const std::string& threadName) {
+std::string DistributedSystemImpl::getThreadName(std::thread::id id) {
+  std::string threadName = m_threadNames[id];
+  if (threadName == "") {
+    std::stringstream ss;
+    ss << id;
+    threadName = ss.str();
+  }
+  return threadName;
+}
+
+void DistributedSystemImpl::setThreadName(const std::string& threadName,
+                                          std::thread::id tid) {
   if (threadName.empty()) {
     throw IllegalArgumentException("Thread name is empty.");
   }
+
+  m_threadNames[tid] = threadName;
 
 #if defined(HAVE_pthread_setname_np)
 

--- a/cppcache/src/DistributedSystemImpl.hpp
+++ b/cppcache/src/DistributedSystemImpl.hpp
@@ -47,7 +47,8 @@ using CliCallbackMethod = std::function<void(Cache&)>;
  */
 class DistributedSystemImpl {
  public:
-  static void setThreadName(const std::string& threadName);
+  static void setThreadName(const std::string& threadName, std::thread::id tid);
+  static std::string getThreadName(std::thread::id id);
 
   /**
    * @brief destructor

--- a/cppcache/src/EvictionController.cpp
+++ b/cppcache/src/EvictionController.cpp
@@ -65,7 +65,7 @@ void EvictionController::stop() {
 
 void EvictionController::svc() {
   std::mutex mutex;
-  DistributedSystemImpl::setThreadName(NC_EC_Thread);
+  DistributedSystemImpl::setThreadName(NC_EC_Thread, thread_.get_id());
 
   while (running_) {
     {

--- a/cppcache/src/ExpiryTaskManager.cpp
+++ b/cppcache/src/ExpiryTaskManager.cpp
@@ -51,7 +51,7 @@ void ExpiryTaskManager::start() {
   auto start_future = start_promise.get_future();
   runner_ = std::thread{[this, &start_promise] {
     start_promise.set_value(true);
-    DistributedSystemImpl::setThreadName(NC_ETM_Thread);
+    DistributedSystemImpl::setThreadName(NC_ETM_Thread, runner_.get_id());
 
     LOGFINE("ExpiryTaskManager thread is running.");
     io_context_.run();

--- a/cppcache/src/Log.cpp
+++ b/cppcache/src/Log.cpp
@@ -38,6 +38,7 @@
 #include <geode/ExceptionTypes.hpp>
 #include <geode/util/LogLevel.hpp>
 
+#include "DistributedSystemImpl.hpp"
 #include "geodeBanner.hpp"
 #include "util/chrono/time_point.hpp"
 
@@ -381,8 +382,10 @@ std::string Log::formatLogLine(LogLevel level) {
   msg << "[" << Log::levelToChars(level) << " "
       << std::put_time(&tm_val, "%Y/%m/%d %H:%M:%S") << '.' << std::setfill('0')
       << std::setw(6) << microseconds.count() << ' '
-      << std::put_time(&tm_val, "%z  ") << g_hostName << ":"
-      << boost::this_process::get_id() << " " << std::this_thread::get_id()
+      << std::put_time(&tm_val, "%z  ") << g_hostName
+      << ":"
+      << boost::this_process::get_id() << " "
+      << DistributedSystemImpl::getThreadName(std::this_thread::get_id())
       << "] ";
 
   return msg.str();

--- a/cppcache/src/Task.hpp
+++ b/cppcache/src/Task.hpp
@@ -68,7 +68,7 @@ class Task {
   }
 
   inline void svc(void) {
-    DistributedSystemImpl::setThreadName(threadName_);
+    DistributedSystemImpl::setThreadName(threadName_, thread_.get_id());
 
     if (appDomainContext_) {
       appDomainContext_->run(

--- a/cppcache/src/ThreadPool.cpp
+++ b/cppcache/src/ThreadPool.cpp
@@ -16,6 +16,8 @@
  */
 #include "ThreadPool.hpp"
 
+#include <sstream>
+
 #include "DistributedSystemImpl.hpp"
 
 namespace apache {
@@ -29,7 +31,8 @@ ThreadPool::ThreadPool(size_t threadPoolSize)
   workers_.reserve(threadPoolSize);
 
   std::function<void()> executeWork = [this] {
-    DistributedSystemImpl::setThreadName(NC_Pool_Thread);
+    DistributedSystemImpl::setThreadName(NC_Pool_Thread,
+                                         std::this_thread::get_id());
     while (true) {
       std::unique_lock<decltype(queueMutex_)> lock(queueMutex_);
       queueCondition_.wait(lock,

--- a/cppcache/src/statistics/HostStatSampler.cpp
+++ b/cppcache/src/statistics/HostStatSampler.cpp
@@ -427,7 +427,8 @@ void HostStatSampler::checkDiskLimit() {
 }
 
 void HostStatSampler::svc(void) {
-  client::DistributedSystemImpl::setThreadName("NC HSS Thread");
+  client::DistributedSystemImpl::setThreadName("NC HSS Thread",
+                                               m_thread.get_id());
   try {
     // createArchiveFileName instead of getArchiveFileName here because
     // for the first time the sampler needs to add the pid to the filename

--- a/cppcache/src/statistics/PoolStatsSampler.cpp
+++ b/cppcache/src/statistics/PoolStatsSampler.cpp
@@ -47,7 +47,8 @@ PoolStatsSampler::PoolStatsSampler(milliseconds sampleRate, CacheImpl* cache,
           cache->getStatisticsManager().getStatisticsFactory()) {}
 
 void PoolStatsSampler::svc() {
-  client::DistributedSystemImpl::setThreadName(NC_PSS_Thread);
+  client::DistributedSystemImpl::setThreadName(NC_PSS_Thread,
+                                               m_thread.get_id());
   while (!m_stopRequested) {
     auto sampleStart = high_resolution_clock::now();
     putStatsInAdminRegion();


### PR DESCRIPTION
Since all internally created native client threads are named, we should print the threadName instead of threadId. This will be extremely helpful to understanding the flow of messages since there are many background threads in the native client.