### PR TITLE
GEODE-10017: Fix servers restart within new ITs

### DIFF
--- a/cppcache/integration/framework/Cluster.h
+++ b/cppcache/integration/framework/Cluster.h
@@ -100,7 +100,17 @@ class Server {
 
   void stop();
 
+  void wait();
+
   const ServerAddress &getAddress() const;
+
+  boost::process::pid_t getPid() const {
+    return pid_;
+  }
+
+ protected:
+  std::string getPidFilePath() const;
+  boost::process::pid_t getPidFromFile() const;
 
  private:
   Cluster &cluster_;
@@ -108,7 +118,8 @@ class Server {
 
   ServerAddress serverAddress_;
 
-  bool started_ = false;
+  bool started_{false};
+  boost::process::pid_t pid_;
 
   std::string name_;
   std::string xmlFile_;

--- a/cppcache/integration/test/FunctionExecutionTest.cpp
+++ b/cppcache/integration/test/FunctionExecutionTest.cpp
@@ -324,7 +324,9 @@ TEST(FunctionExecutionTest, testThatFunctionExecutionThrowsExceptionNonHA) {
       .withType("PARTITION")
       .execute();
 
-  cluster.getServers()[2].stop();
+  auto &targetServer = cluster.getServers()[2];
+  targetServer.stop();
+  targetServer.wait();
 
   auto cache = CacheFactory().create();
   auto poolFactory = cache.getPoolManager().createFactory();
@@ -340,7 +342,7 @@ TEST(FunctionExecutionTest, testThatFunctionExecutionThrowsExceptionNonHA) {
 
   populateRegionReturnFilter(region, 1000);
   //  Start the the server
-  cluster.getServers()[2].start();
+  targetServer.start();
 
   // Do the rebalance, so that primary buckets
   // are transferred to the newly added server
@@ -382,7 +384,9 @@ TEST(FunctionExecutionTest,
       .withType("PARTITION")
       .execute();
 
-  cluster.getServers()[2].stop();
+  auto &targetServer = cluster.getServers()[2];
+  targetServer.stop();
+  targetServer.wait();
 
   auto cache = CacheFactory().create();
   auto poolFactory = cache.getPoolManager().createFactory();
@@ -399,7 +403,7 @@ TEST(FunctionExecutionTest,
   auto filter = populateRegionReturnFilter(region, 1000);
 
   //  Start the the server
-  cluster.getServers()[2].start();
+  targetServer.start();
 
   // Do the rebalance, so that primary buckets
   // are transferred to the newly added server

--- a/cppcache/integration/test/HARegionCacheListenerARLTest.cpp
+++ b/cppcache/integration/test/HARegionCacheListenerARLTest.cpp
@@ -106,8 +106,10 @@ class HARegionCacheListenerARLTest : public ::testing::Test {
      * processed this event. But there is an exception: the state is reset if
      * the endpoint disconnects.
      */
-    cluster_->getServers()[0].stop();
-    cluster_->getServers()[0].start();
+    auto &targetServer = cluster_->getServers()[0];
+    targetServer.stop();
+    targetServer.wait();
+    targetServer.start();
   }
 
   void create_the_test_region() {

--- a/cppcache/integration/test/PartitionRegionOpsTest.cpp
+++ b/cppcache/integration/test/PartitionRegionOpsTest.cpp
@@ -187,11 +187,13 @@ int putget(bool useSingleHop) {
   auto numOpsRequiringHop = putEntries(cache, region, ENTRIES);
   numOpsRequiringHop += getEntries(cache, region, ENTRIES);
 
-  cluster.getServers()[1].stop();
+  auto& targetServer = cluster.getServers()[1];
+  targetServer.stop();
+  targetServer.wait();
 
   numOpsRequiringHop += getEntries(cache, region, ENTRIES);
 
-  cluster.getServers()[1].start();
+  targetServer.start();
 
   numOpsRequiringHop += getEntries(cache, region, ENTRIES);
   return numOpsRequiringHop;
@@ -218,11 +220,13 @@ int putAllgetAll(bool useSingleHop) {
   auto numOpsRequiringHop = putAllEntries(cache, region, ENTRIES);
   numOpsRequiringHop += getAllEntries(cache, region, ENTRIES);
 
-  cluster.getServers()[1].stop();
+  auto& targetServer = cluster.getServers()[1];
+  targetServer.stop();
+  targetServer.wait();
 
   numOpsRequiringHop += getAllEntries(cache, region, ENTRIES);
 
-  cluster.getServers()[1].start();
+  targetServer.start();
 
   numOpsRequiringHop += getAllEntries(cache, region, ENTRIES);
   return numOpsRequiringHop;

--- a/cppcache/integration/test/PdxInstanceTest.cpp
+++ b/cppcache/integration/test/PdxInstanceTest.cpp
@@ -395,9 +395,8 @@ TEST(PdxInstanceTest, testInstancePutAfterRestart) {
     cv_status.wait(lock, [&status] { return !status; });
   }
 
-  std::this_thread::sleep_for(std::chrono::seconds{30});
-
   for (auto& server : cluster.getServers()) {
+    server.wait();
     server.start();
   }
 

--- a/cppcache/integration/test/PdxTypeRegistryTest.cpp
+++ b/cppcache/integration/test/PdxTypeRegistryTest.cpp
@@ -131,8 +131,11 @@ TEST(PdxTypeRegistryTest, cleanupOnClusterRestart) {
 
   // Shutdown and wait for some time
   gfsh.shutdown().execute();
+  for (auto& server : cluster.getServers()) {
+    server.wait();
+  }
+
   listener->waitDisconnected();
-  std::this_thread::sleep_for(std::chrono::seconds{15});
 
   for (auto& server : cluster.getServers()) {
     server.start();

--- a/cppcache/integration/test/RegisterKeysTest.cpp
+++ b/cppcache/integration/test/RegisterKeysTest.cpp
@@ -37,6 +37,8 @@
 #include "mock/CacheListenerMock.hpp"
 #include "util/concurrent/binary_semaphore.hpp"
 
+namespace bp = boost::process;
+
 namespace {
 
 using apache::geode::client::binary_semaphore;
@@ -280,6 +282,7 @@ TEST(RegisterKeysTest, RegisterAnyAndClusterRestart) {
   shut_sem.release();
 
   for (auto& server : cluster.getServers()) {
+    server.wait();
     server.start();
   }
 
@@ -353,6 +356,7 @@ TEST(RegisterKeysTest, RegisterRegexAndClusterRestart) {
   shut_sem.release();
 
   for (auto& server : cluster.getServers()) {
+    server.wait();
     server.start();
   }
 
@@ -435,6 +439,7 @@ TEST(RegisterKeysTest, RegisterKeySetAndClusterRestart) {
   shut_sem.release();
 
   for (auto& server : cluster.getServers()) {
+    server.wait();
     server.start();
   }
 
@@ -519,6 +524,7 @@ TEST(RegisterKeysTest, RegisterKeySetAndDestroyClusterRestart) {
   shut_sem.release();
 
   for (auto& server : cluster.getServers()) {
+    server.wait();
     server.start();
   }
 

--- a/cppcache/integration/test/TransactionCleaningTest.cpp
+++ b/cppcache/integration/test/TransactionCleaningTest.cpp
@@ -97,7 +97,9 @@ TEST(TransactionCleaningTest, txWithStoppedServer) {
   region->put("one", "one");
   cache.getCacheTransactionManager()->commit();
 
-  cluster.getServers()[0].stop();
+  auto& targetServer = cluster.getServers()[0];
+  targetServer.stop();
+  targetServer.wait();
   shut_sem.acquire();
   shut_sem.release();
 
@@ -106,7 +108,7 @@ TEST(TransactionCleaningTest, txWithStoppedServer) {
 
   cache.getCacheTransactionManager()->rollback();
 
-  cluster.getServers()[0].start();
+  targetServer.start();
   live_sem.acquire();
   live_sem.release();
 


### PR DESCRIPTION
 - Due to a rare race-condition described on the Jira case, it could
   happen that some test cases that needed to restart a/some server(s)
   could end up getting stuck.
 - This change introduces a mechanism to verify the server process has
   been actually stopped.
 - Also, removed sleeps on some TCs which were put in place as a WA.
 - Modified all of the new IT TCs that were restarting servers in order
   to use the above mentioned mechanism, so the race-condition is
   avoided.