### PR TITLE
 GEODE-10012: Avoid non-HA function retries

### DIFF
--- a/cppcache/src/FunctionAttributes.hpp
+++ b/cppcache/src/FunctionAttributes.hpp
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_FUNCTIONATTRIBUTES_H_
+#define GEODE_FUNCTIONATTRIBUTES_H_
+
+#include <cstdint>
+
+namespace apache {
+namespace geode {
+namespace client {
+
+class FunctionAttributes {
+ public:
+  enum : uint8_t {
+    IS_HA = 1,
+    HAS_RESULT = 2,
+    OPTIMIZE_FOR_WRITE = 4,
+    RETRY = 8,
+    VALID = 128U,
+  };
+
+ public:
+  FunctionAttributes() : flags_{0} {}
+  FunctionAttributes(bool isHA, bool hasResult, bool optimizeForWrite)
+      : flags_{
+            static_cast<uint8_t>(static_cast<uint8_t>(isHA) |
+                                 (static_cast<uint8_t>(hasResult) << 1) |
+                                 (static_cast<uint8_t>(optimizeForWrite) << 2) |
+                                 static_cast<uint8_t>(VALID))} {}
+
+  explicit operator bool() const {
+    return (flags_ & VALID) != 0;
+  }
+
+  bool isHA() const
+  {
+    return (flags_ & IS_HA) != 0;
+  }
+
+  bool hasResult() const
+  {
+    return (flags_ & HAS_RESULT) != 0;
+  }
+
+  bool isOptimizedForWrite() const
+  {
+    return (flags_ & OPTIMIZE_FOR_WRITE) != 0;
+  }
+
+  bool isRetry() const {
+    return (flags_ & RETRY) != 0;
+  }
+
+  FunctionAttributes& markRetry() {
+      flags_ |= RETRY;
+      return *this;
+  }
+
+  uint8_t getFlags() const {
+    return flags_ & ~VALID;
+  }
+
+ protected:
+  uint8_t flags_;
+};  // class FunctionAttributes
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_FUNCTIONATTRIBUTES_H_

--- a/cppcache/src/FunctionExecution.cpp
+++ b/cppcache/src/FunctionExecution.cpp
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "FunctionExecution.hpp"
+
+#include <geode/ResultCollector.hpp>
+
+#include "CacheImpl.hpp"
+#include "TcrConnectionManager.hpp"
+#include "TcrMessage.hpp"
+#include "ThinClientPoolDM.hpp"
+#include "ThinClientRegion.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+void FunctionExecution::setParameters(
+    const std::string& funcName, FunctionAttributes funcAttrs,
+    std::chrono::milliseconds timeout, std::shared_ptr<Cacheable> args,
+    TcrEndpoint* ep, ThinClientPoolDM* poolDM,
+    std::shared_ptr<std::recursive_mutex> resultCollectorMutex,
+    std::shared_ptr<ResultCollector> resultCollector,
+    std::shared_ptr<UserAttributes> userAttr) {
+  exceptionMsg_.clear();
+  resultCollectorMutex_ = std::move(resultCollectorMutex);
+  resultCollector_ = resultCollector;
+  error_ = GF_NOTCON;
+  funcName_ = funcName;
+  funcAttrs_ = funcAttrs;
+  timeout_ = timeout;
+  args_ = args;
+  endpoint_ = ep;
+  pool_ = poolDM;
+  userAttrs_ = userAttr;
+}
+
+GfErrType FunctionExecution::execute() {
+  GuardUserAttributes gua;
+
+  if (userAttrs_) {
+    gua.setAuthenticatedView(userAttrs_->getAuthenticatedView());
+  }
+
+  TcrMessageExecuteFunction request(
+      new DataOutput(
+          pool_->getConnectionManager().getCacheImpl()->createDataOutput()),
+      funcName_, args_, funcAttrs_, pool_, timeout_);
+  TcrMessageReply reply(true, pool_);
+
+  auto resultProcessor = std::unique_ptr<ChunkedFunctionExecutionResponse>(
+      new ChunkedFunctionExecutionResponse(reply, funcAttrs_.hasResult(),
+                                           resultCollector_,
+                                           resultCollectorMutex_));
+
+  reply.setChunkedResultHandler(resultProcessor.get());
+  reply.setTimeout(timeout_);
+  reply.setDM(pool_);
+
+  LOGDEBUG(
+      "ThinClientPoolDM::sendRequestToAllServer sendRequest on endpoint[%s]!",
+      endpoint_->name().c_str());
+
+  error_ = pool_->sendRequestToEP(request, reply, endpoint_);
+  error_ = pool_->handleEPError(endpoint_, reply, error_);
+  if (error_ != GF_NOERR) {
+    if (error_ == GF_NOTCON) {
+      return GF_NOERR;  // if server is unavailable its not an error for
+      // functionexec OnServers() case
+    }
+    LOGDEBUG("FunctionExecution::execute failed on endpoint[%s]!. Error = %d ",
+             endpoint_->name().c_str(), error_);
+    if (reply.getMessageType() == TcrMessage::EXCEPTION) {
+      exceptionMsg_ = reply.getException();
+    }
+
+    return error_;
+  } else if (reply.getMessageType() == TcrMessage::EXCEPTION ||
+             reply.getMessageType() == TcrMessage::EXECUTE_FUNCTION_ERROR) {
+    error_ = ThinClientRegion::handleServerException("Execute",
+                                                     reply.getException());
+    exceptionMsg_ = reply.getException();
+  }
+
+  return error_;
+}
+
+OnRegionFunctionExecution::OnRegionFunctionExecution(
+    std::string funcName, const Region* region, std::shared_ptr<Cacheable> args,
+    std::shared_ptr<CacheableHashSet> routingObj, FunctionAttributes funcAttrs,
+    std::chrono::milliseconds timeout, ThinClientPoolDM* poolDM,
+    const std::shared_ptr<std::recursive_mutex>& collectorMutex,
+    std::shared_ptr<ResultCollector> collector,
+    std::shared_ptr<UserAttributes> userAttrs, bool isBGThread,
+    const std::shared_ptr<BucketServerLocation>& serverLocation,
+    bool allBuckets)
+    : serverLocation_{serverLocation},
+      backgroundThread_{isBGThread},
+      pool_{poolDM},
+      funcName_{funcName},
+      funcAttrs_{funcAttrs},
+      timeout_{timeout},
+      args_{args},
+      routingObj_{routingObj},
+      resultCollector_{std::move(collector)},
+      resultCollectorMutex_{collectorMutex},
+      userAttrs_{userAttrs},
+      region_{region},
+      allBuckets_{allBuckets} {
+  request_ = new TcrMessageExecuteRegionFunctionSingleHop(
+      new DataOutput(
+          pool_->getConnectionManager().getCacheImpl()->createDataOutput()),
+      funcName_, region_, args_, routingObj_, funcAttrs, nullptr, allBuckets_,
+      timeout, pool_);
+  reply_ = new TcrMessageReply(true, pool_);
+  chunkedResponse_ = new ChunkedFunctionExecutionResponse(
+      *reply_, funcAttrs.hasResult(), resultCollector_, resultCollectorMutex_);
+  reply_->setChunkedResultHandler(chunkedResponse_);
+  reply_->setTimeout(timeout);
+  reply_->setDM(pool_);
+}
+
+OnRegionFunctionExecution::~OnRegionFunctionExecution() noexcept {
+  delete request_;
+  delete reply_;
+}
+
+std::shared_ptr<CacheableHashSet> OnRegionFunctionExecution::getFailedNode()
+    const {
+  return reply_->getFailedNode();
+}
+
+GfErrType OnRegionFunctionExecution::execute() {
+  GuardUserAttributes gua;
+
+  if (userAttrs_) {
+    gua.setAuthenticatedView(userAttrs_->getAuthenticatedView());
+  }
+
+  // Function failover logic is not handled in the network layer. That's why
+  // attemptFailover should be always be false when calling sendSyncRequest
+  return pool_->sendSyncRequest(*request_, *reply_, false, backgroundThread_,
+                                serverLocation_);
+}
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/FunctionExecution.hpp
+++ b/cppcache/src/FunctionExecution.hpp
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_FUNCTIONEXECUTION_H_
+#define GEODE_FUNCTIONEXECUTION_H_
+
+#include <memory>
+#include <string>
+
+#include <geode/Serializable.hpp>
+
+#include "ErrType.hpp"
+#include "FunctionAttributes.hpp"
+#include "ThreadPool.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+class BucketServerLocation;
+class CacheableHashSet;
+class CacheableString;
+class ChunkedFunctionExecutionResponse;
+class Region;
+class ResultCollector;
+class TcrChunkedResult;
+class TcrEndpoint;
+class TcrMessage;
+class TcrMessageReply;
+class ThinClientPoolDM;
+class UserAttributes;
+
+class FunctionExecution : public PooledWork<GfErrType> {
+ public:
+  FunctionExecution() : pool_{nullptr}, endpoint_{nullptr}, error_{GF_NOERR} {}
+
+  ~FunctionExecution() noexcept override = default;
+
+  const std::string& getException() { return exceptionMsg_; }
+
+  void setParameters(const std::string& funcName, FunctionAttributes funcAttrs,
+                     std::chrono::milliseconds timeout,
+                     std::shared_ptr<Cacheable> args, TcrEndpoint* ep,
+                     ThinClientPoolDM* poolDM,
+                     std::shared_ptr<std::recursive_mutex> resultCollectorMutex,
+                     std::shared_ptr<ResultCollector> resultCollector,
+                     std::shared_ptr<UserAttributes> userAttr);
+
+  GfErrType execute(void) override;
+
+ protected:
+  ThinClientPoolDM* pool_;
+  TcrEndpoint* endpoint_;
+  std::string funcName_;
+  FunctionAttributes funcAttrs_;
+  std::chrono::milliseconds timeout_;
+  std::shared_ptr<Cacheable> args_;
+  GfErrType error_;
+  std::shared_ptr<ResultCollector> resultCollector_;
+  std::shared_ptr<std::recursive_mutex> resultCollectorMutex_;
+  std::string exceptionMsg_;
+  std::shared_ptr<UserAttributes> userAttrs_;
+};
+
+class OnRegionFunctionExecution : public PooledWork<GfErrType> {
+ public:
+  OnRegionFunctionExecution(
+      std::string funcName, const Region* region,
+      std::shared_ptr<Cacheable> args,
+      std::shared_ptr<CacheableHashSet> routingObj,
+      FunctionAttributes funcAttrs, std::chrono::milliseconds timeout,
+      ThinClientPoolDM* poolDM,
+      const std::shared_ptr<std::recursive_mutex>& collectorMutex,
+      std::shared_ptr<ResultCollector> collector,
+      std::shared_ptr<UserAttributes> userAttrs, bool isBGThread,
+      const std::shared_ptr<BucketServerLocation>& serverLocation,
+      bool allBuckets);
+
+  ~OnRegionFunctionExecution() noexcept override;
+
+  TcrMessage* getReply() { return reinterpret_cast<TcrMessage*>(reply_); }
+
+  std::shared_ptr<CacheableHashSet> getFailedNode() const;
+
+  ChunkedFunctionExecutionResponse* getResultCollector() {
+    return reinterpret_cast<ChunkedFunctionExecutionResponse*>(
+        resultCollector_.get());
+  }
+
+  GfErrType execute() override;
+
+ protected:
+  std::shared_ptr<BucketServerLocation> serverLocation_;
+  TcrMessage* request_;
+  TcrMessageReply* reply_;
+  bool backgroundThread_;
+  ThinClientPoolDM* pool_;
+  std::string funcName_;
+  FunctionAttributes funcAttrs_;
+  std::chrono::milliseconds timeout_;
+  std::shared_ptr<Cacheable> args_;
+  std::shared_ptr<CacheableHashSet> routingObj_;
+  std::shared_ptr<ResultCollector> resultCollector_;
+  TcrChunkedResult* chunkedResponse_;
+  std::shared_ptr<std::recursive_mutex> resultCollectorMutex_;
+  std::shared_ptr<UserAttributes> userAttrs_;
+  const Region* region_;
+  bool allBuckets_;
+};  // class FunctionAttributes
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_FUNCTIONEXECUTION_H_

--- a/cppcache/src/RegionAttributes.cpp
+++ b/cppcache/src/RegionAttributes.cpp
@@ -64,9 +64,8 @@ std::shared_ptr<CacheLoader> RegionAttributes::getCacheLoader() const {
     if (CacheXmlParser::managedCacheLoaderFn_ &&
         m_cacheLoaderFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheLoader.reset((
-          CacheXmlParser::managedCacheLoaderFn_)(m_cacheLoaderLibrary.c_str(),
-                                                 m_cacheLoaderFactory.c_str()));
+      m_cacheLoader.reset((CacheXmlParser::managedCacheLoaderFn_)(
+          m_cacheLoaderLibrary.c_str(), m_cacheLoaderFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheLoader*()>(
           m_cacheLoaderLibrary, m_cacheLoaderFactory);
@@ -81,9 +80,8 @@ std::shared_ptr<CacheWriter> RegionAttributes::getCacheWriter() const {
     if (CacheXmlParser::managedCacheWriterFn_ &&
         m_cacheWriterFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheWriter.reset((
-          CacheXmlParser::managedCacheWriterFn_)(m_cacheWriterLibrary.c_str(),
-                                                 m_cacheWriterFactory.c_str()));
+      m_cacheWriter.reset((CacheXmlParser::managedCacheWriterFn_)(
+          m_cacheWriterLibrary.c_str(), m_cacheWriterFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheWriter*()>(
           m_cacheWriterLibrary, m_cacheWriterFactory);
@@ -98,11 +96,8 @@ std::shared_ptr<CacheListener> RegionAttributes::getCacheListener() const {
     if (CacheXmlParser::managedCacheListenerFn_ &&
         m_cacheListenerFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheListener.reset(
-          (CacheXmlParser::managedCacheListenerFn_)(m_cacheListenerLibrary
-                                                        .c_str(),
-                                                    m_cacheListenerFactory
-                                                        .c_str()));
+      m_cacheListener.reset((CacheXmlParser::managedCacheListenerFn_)(
+          m_cacheListenerLibrary.c_str(), m_cacheListenerFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheListener*()>(
           m_cacheListenerLibrary, m_cacheListenerFactory);
@@ -119,10 +114,9 @@ std::shared_ptr<PartitionResolver> RegionAttributes::getPartitionResolver()
     if (CacheXmlParser::managedPartitionResolverFn_ &&
         m_partitionResolverFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_partitionResolver.reset((
-          CacheXmlParser::
-              managedPartitionResolverFn_)(m_partitionResolverLibrary.c_str(),
-                                           m_partitionResolverFactory.c_str()));
+      m_partitionResolver.reset((CacheXmlParser::managedPartitionResolverFn_)(
+          m_partitionResolverLibrary.c_str(),
+          m_partitionResolverFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<PartitionResolver*()>(
           m_partitionResolverLibrary, m_partitionResolverFactory);
@@ -138,11 +132,8 @@ std::shared_ptr<PersistenceManager> RegionAttributes::getPersistenceManager()
     if (CacheXmlParser::managedPersistenceManagerFn_ &&
         m_persistenceFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_persistenceManager.reset(
-          (CacheXmlParser::managedPersistenceManagerFn_)(m_persistenceLibrary
-                                                             .c_str(),
-                                                         m_persistenceFactory
-                                                             .c_str()));
+      m_persistenceManager.reset((CacheXmlParser::managedPersistenceManagerFn_)(
+          m_persistenceLibrary.c_str(), m_persistenceFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<PersistenceManager*()>(
           m_persistenceLibrary, m_persistenceFactory);

--- a/cppcache/src/RegionAttributes.cpp
+++ b/cppcache/src/RegionAttributes.cpp
@@ -64,8 +64,9 @@ std::shared_ptr<CacheLoader> RegionAttributes::getCacheLoader() const {
     if (CacheXmlParser::managedCacheLoaderFn_ &&
         m_cacheLoaderFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheLoader.reset((CacheXmlParser::managedCacheLoaderFn_)(
-          m_cacheLoaderLibrary.c_str(), m_cacheLoaderFactory.c_str()));
+      m_cacheLoader.reset((
+          CacheXmlParser::managedCacheLoaderFn_)(m_cacheLoaderLibrary.c_str(),
+                                                 m_cacheLoaderFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheLoader*()>(
           m_cacheLoaderLibrary, m_cacheLoaderFactory);
@@ -80,8 +81,9 @@ std::shared_ptr<CacheWriter> RegionAttributes::getCacheWriter() const {
     if (CacheXmlParser::managedCacheWriterFn_ &&
         m_cacheWriterFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheWriter.reset((CacheXmlParser::managedCacheWriterFn_)(
-          m_cacheWriterLibrary.c_str(), m_cacheWriterFactory.c_str()));
+      m_cacheWriter.reset((
+          CacheXmlParser::managedCacheWriterFn_)(m_cacheWriterLibrary.c_str(),
+                                                 m_cacheWriterFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheWriter*()>(
           m_cacheWriterLibrary, m_cacheWriterFactory);
@@ -96,8 +98,11 @@ std::shared_ptr<CacheListener> RegionAttributes::getCacheListener() const {
     if (CacheXmlParser::managedCacheListenerFn_ &&
         m_cacheListenerFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_cacheListener.reset((CacheXmlParser::managedCacheListenerFn_)(
-          m_cacheListenerLibrary.c_str(), m_cacheListenerFactory.c_str()));
+      m_cacheListener.reset(
+          (CacheXmlParser::managedCacheListenerFn_)(m_cacheListenerLibrary
+                                                        .c_str(),
+                                                    m_cacheListenerFactory
+                                                        .c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<CacheListener*()>(
           m_cacheListenerLibrary, m_cacheListenerFactory);
@@ -114,9 +119,10 @@ std::shared_ptr<PartitionResolver> RegionAttributes::getPartitionResolver()
     if (CacheXmlParser::managedPartitionResolverFn_ &&
         m_partitionResolverFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_partitionResolver.reset((CacheXmlParser::managedPartitionResolverFn_)(
-          m_partitionResolverLibrary.c_str(),
-          m_partitionResolverFactory.c_str()));
+      m_partitionResolver.reset((
+          CacheXmlParser::
+              managedPartitionResolverFn_)(m_partitionResolverLibrary.c_str(),
+                                           m_partitionResolverFactory.c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<PartitionResolver*()>(
           m_partitionResolverLibrary, m_partitionResolverFactory);
@@ -132,8 +138,11 @@ std::shared_ptr<PersistenceManager> RegionAttributes::getPersistenceManager()
     if (CacheXmlParser::managedPersistenceManagerFn_ &&
         m_persistenceFactory.find('.') != std::string::npos) {
       // this is a managed library
-      m_persistenceManager.reset((CacheXmlParser::managedPersistenceManagerFn_)(
-          m_persistenceLibrary.c_str(), m_persistenceFactory.c_str()));
+      m_persistenceManager.reset(
+          (CacheXmlParser::managedPersistenceManagerFn_)(m_persistenceLibrary
+                                                             .c_str(),
+                                                         m_persistenceFactory
+                                                             .c_str()));
     } else {
       auto funcptr = Utils::getFactoryFunction<PersistenceManager*()>(
           m_persistenceLibrary, m_persistenceFactory);

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -754,9 +754,9 @@ GfErrType TcrEndpoint::sendRequestConn(const TcrMessage& request,
   // TcrMessage * req = const_cast<TcrMessage *>(&request);
   LOGDEBUG("TcrEndpoint::sendRequestConn  = %p", m_baseDM);
   if (m_baseDM != nullptr) m_baseDM->beforeSendingRequest(request, conn);
-  if (((type == TcrMessage::EXECUTE_FUNCTION ||
-        type == TcrMessage::EXECUTE_REGION_FUNCTION) &&
-       (request.hasResult() & 2))) {
+  if ((type == TcrMessage::EXECUTE_FUNCTION ||
+       type == TcrMessage::EXECUTE_REGION_FUNCTION) &&
+      request.hasResult()) {
     conn->sendRequestForChunkedResponse(request, request.getMsgLength(), reply,
                                         request.getTimeout(),
                                         reply.getTimeout());
@@ -771,7 +771,7 @@ GfErrType TcrEndpoint::sendRequestConn(const TcrMessage& request,
              type == TcrMessage::REMOVE_ALL ||
              ((type == TcrMessage::EXECUTE_FUNCTION ||
                type == TcrMessage::EXECUTE_REGION_FUNCTION) &&
-              (request.hasResult() & 2)) ||
+              request.hasResult()) ||
              type ==
                  TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP ||  // This is
                                                                     // kept

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -38,6 +38,7 @@
 #include <geode/internal/geode_globals.hpp>
 
 #include "EventIdMap.hpp"
+#include "FunctionAttributes.hpp"
 #include "InterestResultPolicy.hpp"
 #include "util/concurrent/binary_semaphore.hpp"
 
@@ -267,7 +268,7 @@ class TcrMessage {
   int8_t getMetaDataVersion() const;
   uint32_t getEntryNotFound() const;
   int8_t getserverGroupVersion() const;
-  std::shared_ptr<std::vector<int8_t>> getFunctionAttributes();
+  FunctionAttributes getFunctionAttributes() const;
 
   // set the DM for chunked response messages
   void setDM(ThinClientBaseDM* dm);
@@ -321,7 +322,7 @@ class TcrMessage {
 
   void setVersionTag(std::shared_ptr<VersionTag> versionTag);
   std::shared_ptr<VersionTag> getVersionTag() const;
-  uint8_t hasResult() const;
+  bool hasResult() const;
   std::shared_ptr<CacheableHashMap> getTombstoneVersions() const;
   std::shared_ptr<CacheableHashSet> getTombstoneKeys() const;
 
@@ -402,7 +403,7 @@ class TcrMessage {
   std::unique_ptr<DataInput> m_delta;
   int8_t* m_deltaBytes;
   std::vector<std::shared_ptr<FixedPartitionAttributesImpl>>* m_fpaSet;
-  std::shared_ptr<std::vector<int8_t>> m_functionAttributes;
+  FunctionAttributes m_functionAttributes;
   std::shared_ptr<CacheableBytes> m_connectionIDBytes;
   std::shared_ptr<Properties> m_creds;
   std::shared_ptr<CacheableKey> m_key;
@@ -444,7 +445,7 @@ class TcrMessage {
   int8_t m_serverGroupVersion;
   bool m_boolValue;
   bool m_isCallBackArguement;
-  uint8_t m_hasResult;
+  bool m_hasResult;
 
   friend class TcrMessageHelper;
 };
@@ -715,7 +716,7 @@ class TcrMessageExecuteRegionFunction : public TcrMessage {
   TcrMessageExecuteRegionFunction(
       DataOutput* dataOutput, const std::string& funcName, const Region* region,
       const std::shared_ptr<Cacheable>& args,
-      std::shared_ptr<CacheableVector> routingObj, uint8_t getResult,
+      std::shared_ptr<CacheableVector> routingObj, FunctionAttributes funcAttrs,
       std::shared_ptr<CacheableHashSet> failedNodes,
       std::chrono::milliseconds timeout,
       ThinClientBaseDM* connectionDM = nullptr, int8_t reExecute = 0);
@@ -728,7 +729,8 @@ class TcrMessageExecuteRegionFunctionSingleHop : public TcrMessage {
   TcrMessageExecuteRegionFunctionSingleHop(
       DataOutput* dataOutput, const std::string& funcName, const Region* region,
       const std::shared_ptr<Cacheable>& args,
-      std::shared_ptr<CacheableHashSet> routingObj, uint8_t getResult,
+      std::shared_ptr<CacheableHashSet> routingObj,
+      FunctionAttributes funcAttrs,
       std::shared_ptr<CacheableHashSet> failedNodes, bool allBuckets,
       std::chrono::milliseconds timeout, ThinClientBaseDM* connectionDM);
 
@@ -874,7 +876,8 @@ class TcrMessageExecuteFunction : public TcrMessage {
  public:
   TcrMessageExecuteFunction(DataOutput* dataOutput, const std::string& funcName,
                             const std::shared_ptr<Cacheable>& args,
-                            uint8_t getResult, ThinClientBaseDM* connectionDM,
+                            FunctionAttributes funcAttrs,
+                            ThinClientBaseDM* connectionDM,
                             std::chrono::milliseconds timeout);
 
   ~TcrMessageExecuteFunction() override = default;

--- a/cppcache/src/ThinClientPoolDM.cpp
+++ b/cppcache/src/ThinClientPoolDM.cpp
@@ -28,6 +28,8 @@
 #include "CacheImpl.hpp"
 #include "DistributedSystemImpl.hpp"
 #include "ExecutionImpl.hpp"
+#include "FunctionAttributes.hpp"
+#include "FunctionExecution.hpp"
 #include "FunctionExpiryTask.hpp"
 #include "TcrConnectionManager.hpp"
 #include "TcrEndpoint.hpp"
@@ -637,9 +639,9 @@ void ThinClientPoolDM::addConnection(TcrConnection* conn) {
 }
 
 GfErrType ThinClientPoolDM::sendRequestToAllServers(
-    const char* func, uint8_t getResult, std::chrono::milliseconds timeout,
-    std::shared_ptr<Cacheable> args, std::shared_ptr<ResultCollector>& rs,
-    std::shared_ptr<CacheableString>& exceptionPtr) {
+    const std::string& funcName, FunctionAttributes funcAttrs,
+    std::chrono::milliseconds timeout, std::shared_ptr<Cacheable> args,
+    std::shared_ptr<ResultCollector> rc, std::string& exceptionMsg) {
   getStats().setCurClientOps(++m_clientOps);
 
   auto resultCollectorLock = std::make_shared<std::recursive_mutex>();
@@ -668,8 +670,8 @@ GfErrType ThinClientPoolDM::sendRequestToAllServers(
           cs->value().c_str());
     }
     auto funcExe = std::make_shared<FunctionExecution>();
-    funcExe->setParameters(func, getResult, timeout, args, ep.get(), this,
-                           resultCollectorLock, &rs, userAttr);
+    funcExe->setParameters(funcName, funcAttrs, timeout, args, ep.get(), this,
+                           resultCollectorLock, rc, userAttr);
     fePtrList.push_back(funcExe);
     threadPool.perform(funcExe);
   }
@@ -678,7 +680,7 @@ GfErrType ThinClientPoolDM::sendRequestToAllServers(
   for (auto& funcExe : fePtrList) {
     auto err = funcExe->getResult();
     if (err != GF_NOERR) {
-      if (funcExe->getException() == nullptr) {
+      if (funcExe->getException().empty()) {
         if (err == GF_TIMEOUT) {
           getStats().incTimeoutClientOps();
         } else {
@@ -688,7 +690,7 @@ GfErrType ThinClientPoolDM::sendRequestToAllServers(
           err = GF_NOTCON;
         }
       } else {
-        exceptionPtr = funcExe->getException();
+        exceptionMsg = funcExe->getException();
       }
     }
 
@@ -709,8 +711,8 @@ GfErrType ThinClientPoolDM::sendRequestToAllServers(
     }
   }
 
-  if (static_cast<uint8_t>(getResult & 2) == static_cast<uint8_t>(2)) {
-    rs->endResults();
+  if (funcAttrs.hasResult()) {
+    rc->endResults();
   }
 
   getStats().setCurClientOps(--m_clientOps);
@@ -2408,89 +2410,6 @@ std::shared_ptr<TcrEndpoint> ThinClientPoolDM::createEP(
       endpointName, m_connManager.getCacheImpl(),
       m_connManager.failover_semaphore_, m_connManager.cleanup_semaphore_,
       m_connManager.redundancy_semaphore_, this);
-}
-
-GfErrType FunctionExecution::execute() {
-  GuardUserAttributes gua;
-
-  if (m_userAttr) {
-    gua.setAuthenticatedView(m_userAttr->getAuthenticatedView());
-  }
-
-  std::string funcName(m_func);
-  TcrMessageExecuteFunction request(
-      new DataOutput(
-          m_poolDM->getConnectionManager().getCacheImpl()->createDataOutput()),
-      funcName, m_args, m_getResult, m_poolDM, m_timeout);
-  TcrMessageReply reply(true, m_poolDM);
-  auto resultProcessor = std::unique_ptr<ChunkedFunctionExecutionResponse>(
-      new ChunkedFunctionExecutionResponse(reply, (m_getResult & 2) == 2, *m_rc,
-                                           m_resultCollectorLock));
-  reply.setChunkedResultHandler(resultProcessor.get());
-  reply.setTimeout(m_timeout);
-  reply.setDM(m_poolDM);
-
-  LOGDEBUG(
-      "ThinClientPoolDM::sendRequestToAllServer sendRequest on endpoint[%s]!",
-      m_ep->name().c_str());
-
-  m_error = m_poolDM->sendRequestToEP(request, reply, m_ep);
-  m_error = m_poolDM->handleEPError(m_ep, reply, m_error);
-  if (m_error != GF_NOERR) {
-    if (m_error == GF_NOTCON) {
-      return GF_NOERR;  // if server is unavailable its not an error for
-      // functionexec OnServers() case
-    }
-    LOGDEBUG("FunctionExecution::execute failed on endpoint[%s]!. Error = %d ",
-             m_ep->name().c_str(), m_error);
-    if (reply.getMessageType() == TcrMessage::EXCEPTION) {
-      exceptionPtr = CacheableString::create(reply.getException());
-    }
-
-    return m_error;
-  } else if (reply.getMessageType() == TcrMessage::EXCEPTION ||
-             reply.getMessageType() == TcrMessage::EXECUTE_FUNCTION_ERROR) {
-    m_error = ThinClientRegion::handleServerException("Execute",
-                                                      reply.getException());
-    exceptionPtr = CacheableString::create(reply.getException());
-  }
-
-  return m_error;
-}
-
-OnRegionFunctionExecution::OnRegionFunctionExecution(
-    std::string func, const Region* region, std::shared_ptr<Cacheable> args,
-    std::shared_ptr<CacheableHashSet> routingObj, uint8_t getResult,
-    std::chrono::milliseconds timeout, ThinClientPoolDM* poolDM,
-    const std::shared_ptr<std::recursive_mutex>& rCL,
-    std::shared_ptr<ResultCollector> rs,
-    std::shared_ptr<UserAttributes> userAttr, bool isBGThread,
-    const std::shared_ptr<BucketServerLocation>& serverLocation,
-    bool allBuckets)
-    : m_serverLocation(serverLocation),
-      m_isBGThread(isBGThread),
-      m_poolDM(poolDM),
-      m_func(func),
-      m_getResult(getResult),
-      m_timeout(timeout),
-      m_args(args),
-      m_routingObj(routingObj),
-      m_rc(rs),
-      m_resultCollectorLock(rCL),
-      m_userAttr(userAttr),
-      m_region(region),
-      m_allBuckets(allBuckets) {
-  m_request = new TcrMessageExecuteRegionFunctionSingleHop(
-      new DataOutput(
-          m_poolDM->getConnectionManager().getCacheImpl()->createDataOutput()),
-      m_func, m_region, m_args, m_routingObj, m_getResult, nullptr,
-      m_allBuckets, timeout, m_poolDM);
-  m_reply = new TcrMessageReply(true, m_poolDM);
-  m_resultCollector = new ChunkedFunctionExecutionResponse(
-      *m_reply, (m_getResult & 2) == 2, m_rc, m_resultCollectorLock);
-  m_reply->setChunkedResultHandler(m_resultCollector);
-  m_reply->setTimeout(m_timeout);
-  m_reply->setDM(m_poolDM);
 }
 
 }  // namespace client

--- a/cppcache/test/TcrMessageTest.cpp
+++ b/cppcache/test/TcrMessageTest.cpp
@@ -24,6 +24,7 @@
 #include <geode/CqState.hpp>
 
 #include "ByteArrayFixture.hpp"
+#include "FunctionAttributes.hpp"
 #include "SerializationRegistry.hpp"
 
 namespace {
@@ -35,6 +36,7 @@ using apache::geode::client::CacheableString;
 using apache::geode::client::CacheableVector;
 using apache::geode::client::CqState;
 using apache::geode::client::DataOutput;
+using apache::geode::client::FunctionAttributes;
 using apache::geode::client::InterestResultPolicy;
 using apache::geode::client::Region;
 using apache::geode::client::Serializable;
@@ -730,9 +732,10 @@ TEST_F(TcrMessageTest, testConstructorExecuteRegionFunctionSingleHop) {
 
   std::shared_ptr<Cacheable> myPtr(CacheableString::createDeserializable());
 
+  FunctionAttributes funcAttrs{false, true, false};
   TcrMessageExecuteRegionFunctionSingleHop message(
-      new DataOutputUnderTest(), "myFuncName", region, myPtr, myHashCachePtr, 2,
-      myHashCachePtr,
+      new DataOutputUnderTest(), "myFuncName", region, myPtr, myHashCachePtr,
+      funcAttrs, myHashCachePtr,
       false,  // allBuckets
       std::chrono::milliseconds{1}, static_cast<ThinClientBaseDM *>(nullptr));
 
@@ -759,9 +762,10 @@ TEST_F(TcrMessageTest, testConstructorExecuteRegionFunction) {
       CacheableString::createDeserializable());
   auto myVectPtr = CacheableVector::create();
 
+  FunctionAttributes funcAttrs{false, true, false};
   TcrMessageExecuteRegionFunction testMessage(
       new DataOutputUnderTest(), "ExecuteRegion", region, myCacheablePtr,
-      myVectPtr, 2, myHashCachePtr, std::chrono::milliseconds{10},
+      myVectPtr, funcAttrs, myHashCachePtr, std::chrono::milliseconds{10},
       static_cast<ThinClientBaseDM *>(nullptr), 10);
 
   EXPECT_EQ(TcrMessage::EXECUTE_REGION_FUNCTION, testMessage.getMessageType());
@@ -784,8 +788,9 @@ TEST_F(TcrMessageTest, DISABLED_testConstructorExecuteFunction) {
   std::shared_ptr<Cacheable> myCacheablePtr(
       CacheableString::createDeserializable());
 
+  FunctionAttributes funcAttrs{true, false, false};
   TcrMessageExecuteFunction testMessage(
-      new DataOutputUnderTest(), "ExecuteFunction", myCacheablePtr, 1,
+      new DataOutputUnderTest(), "ExecuteFunction", myCacheablePtr, funcAttrs,
       static_cast<ThinClientBaseDM *>(nullptr), std::chrono::milliseconds{10});
 
   EXPECT_EQ(TcrMessage::EXECUTE_FUNCTION, testMessage.getMessageType());

--- a/tests/javaobject/MultiGetAllFunctionTimeoutNonHA.java
+++ b/tests/javaobject/MultiGetAllFunctionTimeoutNonHA.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package javaobject;
+
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.Vector;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.execute.ResultSender;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.execute.RegionFunctionContext;
+import org.apache.geode.cache.partition.PartitionRegionHelper;
+
+public class MultiGetAllFunctionTimeoutNonHA implements Function {
+
+  @Override
+  public void execute(FunctionContext context) {
+    if(context.isPossibleDuplicate()) {
+        throw new IllegalStateException("This function should never be re-executed as isHA=false");
+    }
+
+    RegionFunctionContext regionContext = (RegionFunctionContext) context;
+    final Region<String, String> region =
+        PartitionRegionHelper.getLocalDataForContext(regionContext);
+
+    Set<String> keys = region.keySet();
+    if (keys.isEmpty()) {
+      context.getResultSender().lastResult(null);
+    }
+
+    int counter = 1;
+    for (String key : keys) {
+      if (counter == keys.size()) {
+        context.getResultSender().lastResult(key);
+      } else {
+        context.getResultSender().sendResult(key);
+      }
+      if(++counter == 2) {
+          try {
+            Thread.sleep(30000);
+          } catch (InterruptedException e) {
+            // ignore
+          }
+      }
+    }
+  }
+
+  @Override
+  public String getId() {
+    return "MultiGetAllFunctionTimeoutNonHA";
+  }
+
+  @Override
+  public boolean isHA() {
+    return false;
+  }
+}


### PR DESCRIPTION
 - Currently, in the native client, if you configure retryAttemps to be >0 for your pool, non-HA function executions are retried. 
    This happens as retries are coded at the network layer.
 - Geode documentation states that retries should happen for functions
   which isHA=true and in the function execution logic. And this is how
   it works in the Java client API.
 - If a function is retried at the network layer, it could happen that due to bucket
   partition it could end up in a InternalFunctionInvocationTargetException
 - So, this commit changes the behavior, so non-HA functions are not
   retried.
 - Also, FunctionAttributes were introduced in order to improve code
   readability.
 - Moved function execution classes to a file of its own, in order to
   improve readability and modularity.
 - Solved a bug in which there could not exist 2 functions with the same
   name, defined on different clusters and with different function
   attributes.
 - Implemented several new ITs to test that non-HA function executions are not
   retried by the API.
 - These are the cases being tested:
    * Function execution with PR enabled:
      - A timeout is forced from the server-side, so the server closes
        the connection towards the client.
      - A timeout is forced in the client.
    * Function execution with PR disabled.


Co-authored-by: Jakov Varenina <jakov.varenina@est.tech>
