### PR TITLE
GEODE-10030: Remove obsolete cross-reference in geode-native user docs

### DIFF
--- a/docs/geode-native-docs-cpp/configuring/sysprops.html.md.erb
+++ b/docs/geode-native-docs-cpp/configuring/sysprops.html.md.erb
@@ -212,7 +212,7 @@ When the chunk handler is not operative (enable-chunk-handler=false), each appli
 </tr>
 <tr class="even">
 <td>enable-time-statistics</td>
-<td>Enables time-based statistics for the distributed system and caching. For performance reasons, time-based statistics are disabled by default. See <a href="../system-statistics/chapter-overview.html#concept_3BE5237AF2D34371883453E6A9474A79">System Statistics</a>. </td>
+<td>Enables time-based statistics for the distributed system and caching. For performance reasons, time-based statistics are disabled by default./td>
 <td>false</td>
 </tr>
 </tbody>

--- a/docs/geode-native-docs-dotnet/configuring/sysprops.html.md.erb
+++ b/docs/geode-native-docs-dotnet/configuring/sysprops.html.md.erb
@@ -212,7 +212,7 @@ When the chunk handler is not operative (enable-chunk-handler=false), each appli
 </tr>
 <tr class="even">
 <td>enable-time-statistics</td>
-<td>Enables time-based statistics for the distributed system and caching. For performance reasons, time-based statistics are disabled by default. See <a href="../system-statistics/chapter-overview.html#concept_3BE5237AF2D34371883453E6A9474A79">System Statistics</a>. </td>
+<td>Enables time-based statistics for the distributed system and caching. For performance reasons, time-based statistics are disabled by default.</td>
 <td>false</td>
 </tr>
 </tbody>


### PR DESCRIPTION
Simple deletion of a cross-reference from two source files, one for the C++ user guide, one for the .NET user guide.