### PR TITLE
Add license text to some doc sources

### DIFF
--- a/docs/geode-native-docs-cpp/getting-started/app-dev-walkthrough-cpp.html.md.erb
+++ b/docs/geode-native-docs-cpp/getting-started/app-dev-walkthrough-cpp.html.md.erb
@@ -2,6 +2,23 @@
 title:  C++ Application Development Walkthrough
 ---
 
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 This section describes how to set up a native client development environment using C++ and CMake.
 
 ## <a id="prerequisites_cpp"></a>Prerequisites

--- a/docs/geode-native-docs-cpp/getting-started/getting-started-nc-client.html.md.erb
+++ b/docs/geode-native-docs-cpp/getting-started/getting-started-nc-client.html.md.erb
@@ -2,6 +2,23 @@
 title: Getting Started with the Native Library
 ---
 
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 To use the <%=vars.product_name%> Native Library for developing <%=vars.product_name%> client applications:
 
 - Obtain a distribution of the Native library and install it on your development platform.

--- a/docs/geode-native-docs-dotnet/getting-started/app-dev-walkthrough-dotnet.html.md.erb
+++ b/docs/geode-native-docs-dotnet/getting-started/app-dev-walkthrough-dotnet.html.md.erb
@@ -2,6 +2,23 @@
 title:  .NET Application Development Walkthrough
 ---
 
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 This section describes how to set up a .NET native client development environment using C# and CMake.
 
 ## <a id="prerequisites_dotnet"></a>Prerequisites

--- a/docs/geode-native-docs-dotnet/getting-started/getting-started-nc-client.html.md.erb
+++ b/docs/geode-native-docs-dotnet/getting-started/getting-started-nc-client.html.md.erb
@@ -2,6 +2,23 @@
 title: Getting Started with the Native Library
 ---
 
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 To use the <%=vars.product_name%> Native Library for developing <%=vars.product_name%> client applications:
 
 - Obtain a distribution of the Native library and install it on your development platform.


### PR DESCRIPTION
Found four doc sources in the Getting Started section that were missing licenses.