### PR TITLE
GEODE-10043: Solve TransactionCleaningTest failures

### DIFF
--- a/cppcache/integration/test/TransactionCleaningTest.cpp
+++ b/cppcache/integration/test/TransactionCleaningTest.cpp
@@ -65,6 +65,7 @@ std::shared_ptr<apache::geode::client::Region> setupRegion(
                         apache::geode::client::RegionShortcut::CACHING_PROXY)
                     .setPoolName("default")
                     .setCacheListener(listener)
+                    .setConcurrencyChecksEnabled(false)
                     .create("region");
   return region;
 }


### PR DESCRIPTION
 - From time to time this test was failing with the error "Concurrent
   modification in the cache". Thing is this test was not intended to
   check concurrent modifications.
 - In GEODE-9322 this test was modified to avoid a race-condition
   whenever restarting the server. To do so, it was needed to enable
   notification subscription and change the region shortcut to
   CACHE_PROXY. In doing so, concurrent checks are also enabled, and due
   to some strange race-condition this is occasionally leading to the exception.
 - Concurrency checks were disabled for the region to avoid the
   race-condition to happen at all