### PR TITLE
GEODE-10040: Increase wait timeout for gfsh commands in the test framework

### DIFF
--- a/clicache/integration-test/CacheHelperN.cs
+++ b/clicache/integration-test/CacheHelperN.cs
@@ -316,7 +316,7 @@ namespace Apache.Geode.Client.UnitTests
     private const string JavaServerStopArgs = "stop server";
     private const string LocatorStartArgs = "start locator --max-heap=512m";
     private const string LocatorStopArgs = "stop locator";
-    private const int MaxWaitMillis = 60000;
+    private const int MaxWaitMillis = 60000*5;
 
     private static string m_testDir = null;
     private static Dictionary<int, string> m_runningJavaServers =


### PR DESCRIPTION
Occassionaly we see timeouts in the CI when running the legacy clicache tests. These appear to mostly be timeouts waiting for gfsh commands to complete.

The error message varies depending on what branch you're on:

- develop: "ExecuteGfsh: Timeout, killing 4604"
- 10.2.7: "Timed out waiting for Java cacheserver to stop"
