### PR TITLE
GEODE-10082: Fixes mixing of DSCode and DSFid enums.

### DIFF
--- a/cppcache/include/geode/CacheableEnum.hpp
+++ b/cppcache/include/geode/CacheableEnum.hpp
@@ -93,7 +93,7 @@ class APACHE_GEODE_EXPORT CacheableEnum
     return size;
   }
 
-  virtual DSCode getDsCode() const override { return DSCode::CacheableEnum; }
+  virtual DSCode getDsCode() const override { return DSCode::PDX_ENUM; }
 
   /**
    * Display this object as c string.

--- a/cppcache/include/geode/internal/DSCode.hpp
+++ b/cppcache/include/geode/internal/DSCode.hpp
@@ -35,6 +35,9 @@ enum class DSCode : int32_t {
                  // TcrMessage and  C# DistributedM.cpp
   BooleanArray = 26,
   CharArray = 27,
+  CacheableUserData = 39,
+  CacheableUserData2 = 38,
+  CacheableUserData4 = 37,
   NullObj = 41,
   CacheableString = 42,
   Class = 43,
@@ -71,15 +74,8 @@ enum class DSCode : int32_t {
   CacheableASCIIString = 87,
   CacheableASCIIStringHuge = 88,
   CacheableStringHuge = 89,
-  InternalDistributedMember = 92,
-  CacheableEnum = 94,
-  ClientProxyMembershipId = 38,
-  CacheableUserData = 39,
-  CacheableUserData2 = 38,
-  CacheableUserData4 = 37,
   PDX = 93,
-  PDX_ENUM = 94,
-  InterestResultPolicy = 37,
+  PDX_ENUM = 94
 };
 
 }  // namespace internal

--- a/cppcache/include/geode/internal/DSFixedId.hpp
+++ b/cppcache/include/geode/internal/DSFixedId.hpp
@@ -43,6 +43,8 @@ enum class DSFid : int32_t {
   CacheableUndefined = 31,
   Struct = 32,
   EventId = 36,
+  InterestResultPolicy = 37,
+  ClientProxyMembershipId = 38,
   InternalDistributedMember = 92,
   TXCommitMessage = 110,
   DiskVersionTag = 2131,

--- a/cppcache/src/CacheableEnum.cpp
+++ b/cppcache/src/CacheableEnum.cpp
@@ -31,7 +31,7 @@ void CacheableEnum::toData(apache::geode::client::DataOutput& output) const {
   int enumVal = PdxHelper::getEnumValue(
       m_enumClassName.c_str(), m_enumName.c_str(), m_ordinal,
       CacheRegionHelper::getCacheImpl(output.getCache())->getPdxTypeRegistry());
-  output.write(static_cast<int8_t>(DSCode::CacheableEnum));
+  output.write(static_cast<int8_t>(DSCode::PDX_ENUM));
   output.write(int8_t(enumVal >> 24));
   output.writeArrayLen(enumVal & 0xFFFFFF);
 }

--- a/cppcache/src/ClientProxyMembershipID.cpp
+++ b/cppcache/src/ClientProxyMembershipID.cpp
@@ -113,7 +113,7 @@ void ClientProxyMembershipID::initObjectVars(
 
   vmViewId_ = vmViewId;
   m_memID.write(static_cast<int8_t>(DSCode::FixedIDByte));
-  m_memID.write(static_cast<int8_t>(DSCode::InternalDistributedMember));
+  m_memID.write(static_cast<int8_t>(DSFid::InternalDistributedMember));
   m_memID.writeBytes(hostAddr_.data(), static_cast<int32_t>(hostAddr_.size()));
   m_memID.writeInt(static_cast<int32_t>(synch_counter));
   m_memID.writeString(hostname);

--- a/cppcache/src/PdxInstanceImpl.cpp
+++ b/cppcache/src/PdxInstanceImpl.cpp
@@ -494,9 +494,9 @@ bool PdxInstanceImpl::deepArrayEquals(std::shared_ptr<Cacheable> obj,
       case DSCode::PdxType:
       case DSCode::BooleanArray:
       case DSCode::CharArray:
-      case DSCode::CacheableUserData4:
-      case DSCode::ClientProxyMembershipId:
       case DSCode::CacheableUserData:
+      case DSCode::CacheableUserData2:
+      case DSCode::CacheableUserData4:
       case DSCode::NullObj:
       case DSCode::Class:
       case DSCode::JavaSerializable:
@@ -521,9 +521,8 @@ bool PdxInstanceImpl::deepArrayEquals(std::shared_ptr<Cacheable> obj,
       case DSCode::CacheableTimeUnit:
       case DSCode::CacheableIdentityHashMap:
       case DSCode::CacheableStack:
-      case DSCode::InternalDistributedMember:
       case DSCode::PDX:
-      case DSCode::CacheableEnum:
+      case DSCode::PDX_ENUM:
       case DSCode::CacheableString:
       case DSCode::CacheableNullString:
       case DSCode::CacheableASCIIString:
@@ -704,12 +703,11 @@ int PdxInstanceImpl::deepArrayHashCode(std::shared_ptr<Cacheable> obj) {
       case DSCode::CacheableASCIIString:
       case DSCode::CacheableASCIIStringHuge:
       case DSCode::CacheableStringHuge:
-      case DSCode::InternalDistributedMember:
-      case DSCode::CacheableEnum:
-      case DSCode::ClientProxyMembershipId:
       case DSCode::CacheableUserData:
+      case DSCode::CacheableUserData2:
       case DSCode::CacheableUserData4:
       case DSCode::PDX:
+      case DSCode::PDX_ENUM:
         break;
     }
   }

--- a/cppcache/src/QueueConnectionRequest.cpp
+++ b/cppcache/src/QueueConnectionRequest.cpp
@@ -27,7 +27,7 @@ namespace client {
 void QueueConnectionRequest::toData(DataOutput& output) const {
   output.writeString(m_serverGp);
   output.write(static_cast<int8_t>(DSCode::FixedIDByte));
-  output.write(static_cast<int8_t>(DSCode::ClientProxyMembershipId));
+  output.write(static_cast<int8_t>(DSFid::ClientProxyMembershipId));
   const auto& dsMemberId = m_membershipID.getDSMemberId();
   output.writeBytes(reinterpret_cast<const uint8_t*>(dsMemberId.c_str()),
                     static_cast<int32_t>(dsMemberId.size()));

--- a/cppcache/src/SerializationRegistry.cpp
+++ b/cppcache/src/SerializationRegistry.cpp
@@ -303,7 +303,7 @@ std::shared_ptr<Serializable> SerializationRegistry::deserialize(
     case DSCode::PDX: {
       return pdxTypeHandler_->deserialize(input);
     }
-    case DSCode::CacheableEnum: {
+    case DSCode::PDX_ENUM: {
       auto enumObject = CacheableEnum::create(" ", " ", 0);
       enumObject->fromData(input);
       return std::move(enumObject);
@@ -362,7 +362,6 @@ std::shared_ptr<Serializable> SerializationRegistry::deserialize(
     case DSCode::CacheableASCIIString:
     case DSCode::CacheableASCIIStringHuge:
     case DSCode::CacheableStringHuge:
-    case DSCode::InternalDistributedMember:
       break;
   }
 
@@ -441,12 +440,11 @@ SerializationRegistry::deserializeDataSerializableFixedId(DataInput& input,
     case DSCode::CacheableASCIIString:
     case DSCode::CacheableASCIIStringHuge:
     case DSCode::CacheableStringHuge:
-    case DSCode::InternalDistributedMember:
-    case DSCode::CacheableEnum:
-    case DSCode::ClientProxyMembershipId:
     case DSCode::CacheableUserData:
+    case DSCode::CacheableUserData2:
     case DSCode::CacheableUserData4:
     case DSCode::PDX:
+    case DSCode::PDX_ENUM:
       throw IllegalStateException("Invalid fixed ID");
   }
 
@@ -823,8 +821,7 @@ void DataSerializableHandler::serialize(
     case DSCode::CacheableASCIIString:
     case DSCode::CacheableASCIIStringHuge:
     case DSCode::CacheableStringHuge:
-    case DSCode::InternalDistributedMember:
-    case DSCode::CacheableEnum:
+    case DSCode::PDX_ENUM:
     case DSCode::PDX:
       IllegalStateException("Invalid DS Code.");
   }
@@ -899,8 +896,7 @@ std::shared_ptr<DataSerializable> DataSerializableHandler::deserialize(
     case DSCode::CacheableASCIIString:
     case DSCode::CacheableASCIIStringHuge:
     case DSCode::CacheableStringHuge:
-    case DSCode::InternalDistributedMember:
-    case DSCode::CacheableEnum:
+    case DSCode::PDX_ENUM:
     case DSCode::PDX:
       break;
   }

--- a/cppcache/src/TXCommitMessage.cpp
+++ b/cppcache/src/TXCommitMessage.cpp
@@ -73,10 +73,10 @@ void TXCommitMessage::fromData(DataInput& input) {
     m_regions.push_back(rc);
   }
 
-  const auto fixedId = static_cast<const DSCode>(input.read());
-  if (fixedId == DSCode::FixedIDByte) {
-    const auto dscode = static_cast<const DSCode>(input.read());
-    if (dscode == DSCode::ClientProxyMembershipId) {
+  const auto dsCode = static_cast<const DSCode>(input.read());
+  if (dsCode == DSCode::FixedIDByte) {
+    const auto fixedId = static_cast<const DSFid>(input.read());
+    if (fixedId == DSFid::ClientProxyMembershipId) {
       ClientProxyMembershipID memId1;
 
       input.advanceCursor(input.readArrayLength());
@@ -84,18 +84,16 @@ void TXCommitMessage::fromData(DataInput& input) {
       input.readInt32();
     } else {
       LOGERROR("TXCommitMessage::fromData Unexpected type id: %" PRId8
-               "while "
-               "desirializing commit response",
-               dscode);
+               "while deserializing commit response",
+               fixedId);
       GfErrTypeThrowException(
           "TXCommitMessage::fromData Unable to handle commit response",
           GF_CACHE_ILLEGAL_STATE_EXCEPTION);
     }
-  } else if (fixedId != DSCode::NullObj) {
+  } else if (dsCode != DSCode::NullObj) {
     LOGERROR("TXCommitMessage::fromData Unexpected type id: %" PRId8
-             "while desirializing "
-             "commit response",
-             fixedId);
+             "while deserializing commit response",
+             dsCode);
     GfErrTypeThrowException(
         "TXCommitMessage::fromData Unable to handle commit response",
         GF_CACHE_ILLEGAL_STATE_EXCEPTION);

--- a/cppcache/src/TcrConnection.cpp
+++ b/cppcache/src/TcrConnection.cpp
@@ -192,7 +192,7 @@ bool TcrConnection::initTcrConnection(
   handShakeMsg.write(static_cast<int8_t>(DSCode::FixedIDByte));
   // Writing byte for ClientProxyMembershipID class id=38 as registered on the
   // java server.
-  handShakeMsg.write(static_cast<int8_t>(DSCode::ClientProxyMembershipId));
+  handShakeMsg.write(static_cast<int8_t>(DSFid::ClientProxyMembershipId));
   if (endpointObj->getPoolHADM()) {
     ClientProxyMembershipID* memId =
         endpointObj->getPoolHADM()->getMembershipId();
@@ -1122,12 +1122,11 @@ std::shared_ptr<CacheableString> TcrConnection::readHandshakeString(
     case DSCode::CacheableStack:
     case DSCode::CacheableASCIIStringHuge:
     case DSCode::CacheableStringHuge:
-    case DSCode::InternalDistributedMember:
-    case DSCode::CacheableEnum:
-    case DSCode::ClientProxyMembershipId:
     case DSCode::CacheableUserData:
+    case DSCode::CacheableUserData2:
     case DSCode::CacheableUserData4:
-    case DSCode::PDX: {
+    case DSCode::PDX:
+    case DSCode::PDX_ENUM: {
       m_conn.reset();
       throwException(
           GeodeIOException("TcrConnection::TcrConnection: "

--- a/cppcache/src/TcrMessage.cpp
+++ b/cppcache/src/TcrMessage.cpp
@@ -320,7 +320,7 @@ void TcrMessage::writeInterestResultPolicyPart(InterestResultPolicy policy) {
   m_request->writeInt(static_cast<int32_t>(3));  // size
   m_request->write(static_cast<int8_t>(1));      // isObject
   m_request->write(static_cast<int8_t>(DSCode::FixedIDByte));
-  m_request->write(static_cast<int8_t>(DSCode::InterestResultPolicy));
+  m_request->write(static_cast<int8_t>(DSFid::InterestResultPolicy));
   m_request->write(static_cast<int8_t>(policy));
 }
 
@@ -3103,8 +3103,8 @@ std::shared_ptr<DSMemberForVersionStamp> TcrMessage::readDSMember(
     apache::geode::client::DataInput& input) {
   uint8_t typeidLen = input.read();
   if (typeidLen == 1) {
-    auto typeidofMember = static_cast<DSCode>(input.read());
-    if (typeidofMember != DSCode::InternalDistributedMember) {
+    auto typeidofMember = static_cast<DSFid>(input.read());
+    if (typeidofMember != DSFid::InternalDistributedMember) {
       throw Exception(
           "Reading DSMember. Expecting type id 92 for "
           "InternalDistributedMember. ");
@@ -3115,8 +3115,8 @@ std::shared_ptr<DSMemberForVersionStamp> TcrMessage::readDSMember(
     memId->fromData(input);
     return std::shared_ptr<DSMemberForVersionStamp>(memId);
   } else if (typeidLen == 2) {
-    auto typeidofMember = input.readInt16();
-    if (typeidofMember != static_cast<int16_t>(DSFid::DiskStoreId)) {
+    auto typeidofMember = static_cast<DSFid>(input.readInt16());
+    if (typeidofMember != DSFid::DiskStoreId) {
       throw Exception(
           "Reading DSMember. Expecting type id 2133 for DiskStoreId. ");
     }


### PR DESCRIPTION
Moves InterestResultPolicy and ClientProxyMembershipId to DSFid.

Replaces eroneous CacheableEnum with PDX_ENUM.