### PR TITLE
GEODE-10085: Don't start JmxManager if already running

### DIFF
--- a/clicache/integration-test2/Cluster.cs
+++ b/clicache/integration-test2/Cluster.cs
@@ -70,8 +70,9 @@ namespace Apache.Geode.Client.IntegrationTests
 
             for (var i = 0; i < locatorCount_; i++)
             {
+                var startJmxManager = (i == 0);
                 var locator = new Locator(this, new List<Locator>(),
-                    name_ + "/locator/" + i.ToString());
+                    name_ + "/locator/" + i.ToString(), startJmxManager);
                 locators_.Add(locator);
                 success = (locator.Start() == 0);
             }
@@ -165,12 +166,14 @@ namespace Apache.Geode.Client.IntegrationTests
         private string name_;
         private List<Locator> locators_;
         private bool started_;
+        private bool startJmxManager_;
 
-        public Locator(Cluster cluster, List<Locator> locators, string name)
+        public Locator(Cluster cluster, List<Locator> locators, string name, bool startJmxManager)
         {
             cluster_ = cluster;
             locators_ = locators;
             name_ = name;
+            startJmxManager_ = startJmxManager;
             var address = new Address();
             address.address = "localhost";
             address.port = Framework.FreeTcpPort();
@@ -193,7 +196,7 @@ namespace Apache.Geode.Client.IntegrationTests
                     .withPort(Address.port)
                     .withMaxHeap("256m")
                     .withJmxManagerPort(cluster_.jmxManagerPort)
-                    .withJmxManagerStart(true)
+                    .withJmxManagerStart(startJmxManager_)
                     .withHttpServicePort(0);
                 if (cluster_.UseSSL)
                 {

--- a/clicache/integration-test2/Cluster.cs
+++ b/clicache/integration-test2/Cluster.cs
@@ -70,11 +70,13 @@ namespace Apache.Geode.Client.IntegrationTests
 
             for (var i = 0; i < locatorCount_; i++)
             {
-                var startJmxManager = (i == 0);
                 var locator = new Locator(this, new List<Locator>(),
-                    name_ + "/locator/" + i.ToString(), startJmxManager);
+                    name_ + "/locator/" + i.ToString(), i == 0);
                 locators_.Add(locator);
-                success = (locator.Start() == 0);
+                if (locator.Start() != 0 ) {
+                    success = false;
+                    break;
+                }
             }
             return success;
         }
@@ -91,6 +93,7 @@ namespace Apache.Geode.Client.IntegrationTests
                 if (localResult != 0)
                 {
                     success = false;
+                    break;
                 }
             }
             return success;

--- a/cppcache/integration/framework/Cluster.h
+++ b/cppcache/integration/framework/Cluster.h
@@ -56,7 +56,7 @@ class Locator {
 
   const LocatorAddress &getAddress() const;
 
-  void start();
+  void start(bool startJmxManager);
 
   void stop();
 


### PR DESCRIPTION
This adds support for multiple locators in the new .NET test framework.