### PR TITLE
GEODE-10131: Remove set but unused variables

### DIFF
--- a/cppcache/src/ClientMetadata.cpp
+++ b/cppcache/src/ClientMetadata.cpp
@@ -50,10 +50,8 @@ ClientMetadata::ClientMetadata(
         "%zu ",
         totalNumBuckets, fpaSet->size());
     if (!fpaSet->empty()) {
-      int totalFPABuckets = 0;
       for (int i = 0; i < static_cast<int>(fpaSet->size()); i++) {
         std::vector<int> attList;
-        totalFPABuckets += fpaSet->at(i)->getNumBuckets();
         attList.push_back(fpaSet->at(i)->getNumBuckets());
         attList.push_back(fpaSet->at(i)->getStartingBucketID());
         m_fpaMap[fpaSet->at(i)->getPartitionName()] = attList;


### PR DESCRIPTION
- On AppleClang 13.1.6.13160021, the warning -Wunused-but-set-variable
  is appears as an error.  This allows compilation on AppleClang on
  MacOS 12.3

Authored-by: M. Oleske <michael@oleske.engineer>