### PR TITLE
GEODE-10218: Allow server debug

### DIFF
--- a/clicache/integration-test2/Cluster.cs
+++ b/clicache/integration-test2/Cluster.cs
@@ -239,8 +239,13 @@ namespace Apache.Geode.Client.IntegrationTests
                     .withMaxHeap("256m")
                     .withJmxManagerPort(cluster_.jmxManagerPort)
                     .withJmxManagerStart(startJmxManager_)
-                    .withDebugAgent(useDebugAgent_, Address.address)
                     .withHttpServicePort(0);
+
+                if (useDebugAgent_)
+                {
+                    locator.withDebugAgent(Address.address);
+                }
+
                 if (cluster_.UseSSL)
                 {
                    locator
@@ -323,8 +328,13 @@ namespace Apache.Geode.Client.IntegrationTests
                     .withName(name_.Replace('/', '_'))
                     .withBindAddress(Address.address)
                     .withPort(Address.port)
-                    .withDebugAgent(useDebugAgent_, Address.address)
                     .withMaxHeap("1g");
+
+                if (useDebugAgent_)
+                {
+                    server.withDebugAgent(Address.address);
+                }
+
                 if (cluster_.UseSSL)
                 {
                     server

--- a/clicache/integration-test2/Cluster.cs
+++ b/clicache/integration-test2/Cluster.cs
@@ -72,7 +72,7 @@ namespace Apache.Geode.Client.IntegrationTests
 
             for (var i = 0; i < locatorCount_; i++)
             {
-                var locator = new Locator(this, new List<Locator>(),
+                var locator = new Locator(this, locators_,
                     name_ + "/locator/" + i.ToString(), i == 0, allowAttach_);
                 locators_.Add(locator);
                 if (locator.Start() != 0 ) {

--- a/clicache/integration-test2/Gfsh.cs
+++ b/clicache/integration-test2/Gfsh.cs
@@ -140,13 +140,13 @@ namespace Apache.Geode.Client.IntegrationTests
                     return this;
                 }
 
-                public Server withAllowAttach(bool allowAttach, string bindAddress)
+                public Server withDebugAgent(bool useDebugAgent, string bindAddress)
                 {
-                  if (allowAttach)
-                  {
-                    command_ += " --J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + bindAddress + ":" + Framework.FreeTcpPort();
-                  }
-                  return this;
+                    if (useDebugAgent)
+                    {
+                      command_ += " --J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + bindAddress + ":" + Framework.FreeTcpPort();
+                    }
+                    return this;
                 }
       }
 
@@ -197,9 +197,9 @@ namespace Apache.Geode.Client.IntegrationTests
                     return this;
                 }
 
-                public Locator withAllowAttach(bool allowAttach, string bindAddress)
+                public Locator withDebugAgent(bool useDebugAgent, string bindAddress)
                 {
-                  if (allowAttach) {
+                  if (useDebugAgent) {
                     command_ += " --J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + bindAddress + ":" + Framework.FreeTcpPort();
                   }
                   return this;

--- a/clicache/integration-test2/Gfsh.cs
+++ b/clicache/integration-test2/Gfsh.cs
@@ -139,7 +139,16 @@ namespace Apache.Geode.Client.IntegrationTests
                     command_ += " --J=-Dgemfire.ssl-enabled-components=" + components;
                     return this;
                 }
-            }
+
+                public Server withAllowAttach(bool allowAttach, string bindAddress)
+                {
+                  if (allowAttach)
+                  {
+                    command_ += " --J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + bindAddress + ":" + Framework.FreeTcpPort();
+                  }
+                  return this;
+                }
+      }
 
             public Server server()
             {
@@ -187,7 +196,15 @@ namespace Apache.Geode.Client.IntegrationTests
                     command_ += " --J=-Dgemfire.jmx-manager-start=" + (start ? "true" : "false");
                     return this;
                 }
-                
+
+                public Locator withAllowAttach(bool allowAttach, string bindAddress)
+                {
+                  if (allowAttach) {
+                    command_ += " --J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + bindAddress + ":" + Framework.FreeTcpPort();
+                  }
+                  return this;
+                }
+
                 public Locator withHttpServicePort(int httpServicePort)
                 {
                     command_ += " --http-service-port=" + httpServicePort;

--- a/clicache/integration-test2/Gfsh.cs
+++ b/clicache/integration-test2/Gfsh.cs
@@ -140,15 +140,12 @@ namespace Apache.Geode.Client.IntegrationTests
                     return this;
                 }
 
-                public Server withDebugAgent(bool useDebugAgent, string bindAddress)
+                public Server withDebugAgent(string bindAddress)
                 {
-                    if (useDebugAgent)
-                    {
-                      command_ += " --J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + bindAddress + ":" + Framework.FreeTcpPort();
-                    }
+                    command_ += " --J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + bindAddress + ":" + Framework.FreeTcpPort();
                     return this;
                 }
-      }
+            }
 
             public Server server()
             {
@@ -197,12 +194,10 @@ namespace Apache.Geode.Client.IntegrationTests
                     return this;
                 }
 
-                public Locator withDebugAgent(bool useDebugAgent, string bindAddress)
+                public Locator withDebugAgent(string bindAddress)
                 {
-                  if (useDebugAgent) {
                     command_ += " --J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + bindAddress + ":" + Framework.FreeTcpPort();
-                  }
-                  return this;
+                    return this;
                 }
 
                 public Locator withHttpServicePort(int httpServicePort)

--- a/clicache/integration-test2/GfshTest.cs
+++ b/clicache/integration-test2/GfshTest.cs
@@ -78,16 +78,19 @@ namespace Apache.Geode.Client.IntegrationTests
                 .withSslKeyStorePassword("password1")
                 .withSslTrustStore("some/path/truststore.jks")
                 .withSslTrustStorePassword("password2")
-                .withDebugAgent(true, "address");
+                .withDebugAgent("someAddress");
             s = locator.ToString();
             var withAttachPortRemoved = s.Substring(0, s.LastIndexOf(":", s.Length-1, 6));
+            var startLocatorCommandWithoutDebugAgentPort =
+                s.Substring(0, s.LastIndexOf(":", s.Length - 1, 6));
             Assert.Equal("start locator --name=name --dir=dir --bind-address=address --port=420 " +
-                "--J=-Dgemfire.jmx-manager-port=1111 --http-service-port=2222 --log-level=fine --max-heap=someHugeAmount " +
-                "--connect=false --J=-Dgemfire.ssl-enabled-components=locator,jmx " +
-                "--J=-Dgemfire.ssl-keystore=some/path/keystore.jks --J=-Dgemfire.ssl-keystore-password=password1 " +
-                "--J=-Dgemfire.ssl-truststore=some/path/truststore.jks --J=-Dgemfire.ssl-truststore-password=password2 " +
-                "--J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=address", withAttachPortRemoved);
-        }
+              "--J=-Dgemfire.jmx-manager-port=1111 --http-service-port=2222 --log-level=fine --max-heap=someHugeAmount " +
+              "--connect=false --J=-Dgemfire.ssl-enabled-components=locator,jmx " +
+              "--J=-Dgemfire.ssl-keystore=some/path/keystore.jks --J=-Dgemfire.ssl-keystore-password=password1 " +
+              "--J=-Dgemfire.ssl-truststore=some/path/truststore.jks --J=-Dgemfire.ssl-truststore-password=password2 " +
+              "--J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=someAddress",
+              startLocatorCommandWithoutDebugAgentPort);
+    }
 
         [Fact]
         public void StartServerStringsTest()
@@ -117,15 +120,25 @@ namespace Apache.Geode.Client.IntegrationTests
                 .withSslKeyStorePassword("password1")
                 .withSslTrustStore("some/path/truststore.jks")
                 .withSslTrustStorePassword("password2")
-                .withDebugAgent(true, "someAddress");
+                .withDebugAgent("someAddress");
             s = server.ToString();
-            var withAttachPortRemoved = s.Substring(0, s.LastIndexOf(":", s.Length-1, 6));
+            var startServerCommandWithoutDebugAgentPort =
+              s.Substring(0, s.LastIndexOf(":", s.Length-1, 6));
             Assert.Equal("start server --name=server " +
-                "--dir=someDir --bind-address=someAddress --server-port=1234 --locators=someLocator --log-level=debug " +
-                "--max-heap=1.21gigabytes --J=-Dgemfire.ssl-enabled-components=server,locator,jmx " +
-                "--J=-Dgemfire.ssl-keystore=some/path/keystore.jks --J=-Dgemfire.ssl-keystore-password=password1 " +
-                "--J=-Dgemfire.ssl-truststore=some/path/truststore.jks --J=-Dgemfire.ssl-truststore-password=password2 " +
-                "--J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=someAddress", withAttachPortRemoved);
+                "--dir=someDir " +
+                "--bind-address=someAddress " +
+                "--server-port=1234 " +
+                "--locators=someLocator " +
+                "--log-level=debug " +
+                "--max-heap=1.21gigabytes " +
+                "--J=-Dgemfire.ssl-enabled-components=server,locator,jmx " +
+                "--J=-Dgemfire.ssl-keystore=some/path/keystore.jks " +
+                "--J=-Dgemfire.ssl-keystore-password=password1 " +
+                "--J=-Dgemfire.ssl-truststore=some/path/truststore.jks " +
+                "--J=-Dgemfire.ssl-truststore-password=password2 " +
+                "--J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n," +
+                    "address=someAddress",
+                startServerCommandWithoutDebugAgentPort);
         }
 
         [Fact]

--- a/clicache/integration-test2/GfshTest.cs
+++ b/clicache/integration-test2/GfshTest.cs
@@ -78,7 +78,7 @@ namespace Apache.Geode.Client.IntegrationTests
                 .withSslKeyStorePassword("password1")
                 .withSslTrustStore("some/path/truststore.jks")
                 .withSslTrustStorePassword("password2")
-                .withAllowAttach(true, "address");
+                .withDebugAgent(true, "address");
             s = locator.ToString();
             var withAttachPortRemoved = s.Substring(0, s.LastIndexOf(":", s.Length-1, 6));
             Assert.Equal("start locator --name=name --dir=dir --bind-address=address --port=420 " +
@@ -117,7 +117,7 @@ namespace Apache.Geode.Client.IntegrationTests
                 .withSslKeyStorePassword("password1")
                 .withSslTrustStore("some/path/truststore.jks")
                 .withSslTrustStorePassword("password2")
-                .withAllowAttach(true, "someAddress");
+                .withDebugAgent(true, "someAddress");
             s = server.ToString();
             var withAttachPortRemoved = s.Substring(0, s.LastIndexOf(":", s.Length-1, 6));
             Assert.Equal("start server --name=server " +

--- a/clicache/integration-test2/GfshTest.cs
+++ b/clicache/integration-test2/GfshTest.cs
@@ -77,13 +77,16 @@ namespace Apache.Geode.Client.IntegrationTests
                 .withSslKeyStore("some/path/keystore.jks")
                 .withSslKeyStorePassword("password1")
                 .withSslTrustStore("some/path/truststore.jks")
-                .withSslTrustStorePassword("password2");
+                .withSslTrustStorePassword("password2")
+                .withAllowAttach(true, "address");
             s = locator.ToString();
+            var withAttachPortRemoved = s.Substring(0, s.LastIndexOf(":", s.Length-1, 6));
             Assert.Equal("start locator --name=name --dir=dir --bind-address=address --port=420 " +
                 "--J=-Dgemfire.jmx-manager-port=1111 --http-service-port=2222 --log-level=fine --max-heap=someHugeAmount " +
                 "--connect=false --J=-Dgemfire.ssl-enabled-components=locator,jmx " +
                 "--J=-Dgemfire.ssl-keystore=some/path/keystore.jks --J=-Dgemfire.ssl-keystore-password=password1 " +
-                "--J=-Dgemfire.ssl-truststore=some/path/truststore.jks --J=-Dgemfire.ssl-truststore-password=password2", s);
+                "--J=-Dgemfire.ssl-truststore=some/path/truststore.jks --J=-Dgemfire.ssl-truststore-password=password2 " +
+                "--J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=address", withAttachPortRemoved);
         }
 
         [Fact]
@@ -113,13 +116,16 @@ namespace Apache.Geode.Client.IntegrationTests
                 .withSslKeyStore("some/path/keystore.jks")
                 .withSslKeyStorePassword("password1")
                 .withSslTrustStore("some/path/truststore.jks")
-                .withSslTrustStorePassword("password2");
+                .withSslTrustStorePassword("password2")
+                .withAllowAttach(true, "someAddress");
             s = server.ToString();
+            var withAttachPortRemoved = s.Substring(0, s.LastIndexOf(":", s.Length-1, 6));
             Assert.Equal("start server --name=server " +
                 "--dir=someDir --bind-address=someAddress --server-port=1234 --locators=someLocator --log-level=debug " +
                 "--max-heap=1.21gigabytes --J=-Dgemfire.ssl-enabled-components=server,locator,jmx " +
                 "--J=-Dgemfire.ssl-keystore=some/path/keystore.jks --J=-Dgemfire.ssl-keystore-password=password1 " +
-                "--J=-Dgemfire.ssl-truststore=some/path/truststore.jks --J=-Dgemfire.ssl-truststore-password=password2", s);
+                "--J=-Dgemfire.ssl-truststore=some/path/truststore.jks --J=-Dgemfire.ssl-truststore-password=password2 " +
+                "--J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=someAddress", withAttachPortRemoved);
         }
 
         [Fact]

--- a/clicache/integration-test2/GfshTest.cs
+++ b/clicache/integration-test2/GfshTest.cs
@@ -80,7 +80,6 @@ namespace Apache.Geode.Client.IntegrationTests
                 .withSslTrustStorePassword("password2")
                 .withDebugAgent("someAddress");
             s = locator.ToString();
-            var withAttachPortRemoved = s.Substring(0, s.LastIndexOf(":", s.Length-1, 6));
             var startLocatorCommandWithoutDebugAgentPort =
                 s.Substring(0, s.LastIndexOf(":", s.Length - 1, 6));
             Assert.Equal("start locator --name=name --dir=dir --bind-address=address --port=420 " +

--- a/cppcache/integration/framework/Cluster.cpp
+++ b/cppcache/integration/framework/Cluster.cpp
@@ -93,23 +93,25 @@ void Locator::start(bool startJmxManager) {
                                     std::to_string(locatorAddress.port) + "]";
                  });
 
-  auto locator = cluster_.getGfsh()
-                     .start()
-                     .locator()
-                     .withLogLevel("INFO")
-                     .withDir(name_)
-                     .withName(safeName)
-                     .withBindAddress(locatorAddress_.address)
-                     .withPort(locatorAddress_.port)
-                     .withRemoteLocators(remoteLocators)
-                     .withDistributedSystemId(distributedSystemId_)
-                     .withMaxHeap("256m")
-                     .withJmxManagerPort(jmxManagerPort_)
-                     .withHttpServicePort(0)
-                     .withClasspath(cluster_.getClasspath())
-                     .withSecurityManager(cluster_.getSecurityManager())
-                     .withPreferIPv6(cluster_.getUseIPv6())
-                     .withJmxManagerStart(startJmxManager);
+  auto locator =
+      cluster_.getGfsh()
+          .start()
+          .locator()
+          .withLogLevel("INFO")
+          .withDir(name_)
+          .withName(safeName)
+          .withBindAddress(locatorAddress_.address)
+          .withPort(locatorAddress_.port)
+          .withRemoteLocators(remoteLocators)
+          .withDistributedSystemId(distributedSystemId_)
+          .withMaxHeap("256m")
+          .withJmxManagerPort(jmxManagerPort_)
+          .withHttpServicePort(0)
+          .withClasspath(cluster_.getClasspath())
+          .withSecurityManager(cluster_.getSecurityManager())
+          .withPreferIPv6(cluster_.getUseIPv6())
+          .withAllowAttach(cluster_.getAllowAttach(), locatorAddress_.address)
+          .withJmxManagerStart(startJmxManager);
 
   if (cluster_.useSsl()) {
     locator.withConnect(false)
@@ -207,7 +209,8 @@ void Server::start() {
           .withSecurityManager(cluster_.getSecurityManager())
           .withCacheXMLFile(getCacheXMLFile())
           .withConserveSockets(cluster_.getConserveSockets())
-          .withPreferIPv6(cluster_.getUseIPv6());
+          .withPreferIPv6(cluster_.getUseIPv6())
+          .withAllowAttach(cluster_.getAllowAttach(), serverAddress_.address);
 
   if (!cluster_.getUser().empty()) {
     server.withUser(cluster_.getUser()).withPassword(cluster_.getPassword());
@@ -276,6 +279,20 @@ Cluster::Cluster(InitialLocators initialLocators, InitialServers initialServers,
       initialServers_(initialServers.get()),
       jmxManagerPort_(Framework::getAvailablePort()),
       useIPv6_(useIpv6.get()) {
+  removeServerDirectory();
+}
+
+Cluster::Cluster(InitialLocators initialLocators, InitialServers initialServers,
+                 AllowAttach allowAttach)
+    : name_(std::string(::testing::UnitTest::GetInstance()
+                            ->current_test_info()
+                            ->test_suite_name()) +
+            "/" +
+            ::testing::UnitTest::GetInstance()->current_test_info()->name()),
+      initialLocators_(initialLocators.get()),
+      initialServers_(initialServers.get()),
+      jmxManagerPort_(Framework::getAvailablePort()),
+      allowAttach_(allowAttach.get()) {
   removeServerDirectory();
 }
 
@@ -424,6 +441,8 @@ std::string &Cluster::getPassword() { return password_; }
 std::vector<std::string> &Cluster::getCacheXMLFiles() { return cacheXMLFiles_; }
 
 bool Cluster::getUseIPv6() { return useIPv6_; }
+
+bool Cluster::getAllowAttach() { return allowAttach_; }
 
 bool Cluster::getConserveSockets() { return conserveSockets_; }
 

--- a/cppcache/integration/framework/Cluster.cpp
+++ b/cppcache/integration/framework/Cluster.cpp
@@ -110,7 +110,7 @@ void Locator::start(bool startJmxManager) {
           .withClasspath(cluster_.getClasspath())
           .withSecurityManager(cluster_.getSecurityManager())
           .withPreferIPv6(cluster_.getUseIPv6())
-          .withAllowAttach(cluster_.getAllowAttach(), locatorAddress_.address)
+          .withDebugAgent(cluster_.getUseDebugAgent(), locatorAddress_.address)
           .withJmxManagerStart(startJmxManager);
 
   if (cluster_.useSsl()) {
@@ -210,7 +210,7 @@ void Server::start() {
           .withCacheXMLFile(getCacheXMLFile())
           .withConserveSockets(cluster_.getConserveSockets())
           .withPreferIPv6(cluster_.getUseIPv6())
-          .withAllowAttach(cluster_.getAllowAttach(), serverAddress_.address);
+          .withDebugAgent(cluster_.getUseDebugAgent(), serverAddress_.address);
 
   if (!cluster_.getUser().empty()) {
     server.withUser(cluster_.getUser()).withPassword(cluster_.getPassword());
@@ -283,7 +283,7 @@ Cluster::Cluster(InitialLocators initialLocators, InitialServers initialServers,
 }
 
 Cluster::Cluster(InitialLocators initialLocators, InitialServers initialServers,
-                 AllowAttach allowAttach)
+                 UseDebugAgent useDebugAgent)
     : name_(std::string(::testing::UnitTest::GetInstance()
                             ->current_test_info()
                             ->test_suite_name()) +
@@ -292,7 +292,7 @@ Cluster::Cluster(InitialLocators initialLocators, InitialServers initialServers,
       initialLocators_(initialLocators.get()),
       initialServers_(initialServers.get()),
       jmxManagerPort_(Framework::getAvailablePort()),
-      allowAttach_(allowAttach.get()) {
+      useDebugAgent_(useDebugAgent.get()) {
   removeServerDirectory();
 }
 
@@ -442,7 +442,7 @@ std::vector<std::string> &Cluster::getCacheXMLFiles() { return cacheXMLFiles_; }
 
 bool Cluster::getUseIPv6() { return useIPv6_; }
 
-bool Cluster::getAllowAttach() { return allowAttach_; }
+bool Cluster::getUseDebugAgent() { return useDebugAgent_; }
 
 bool Cluster::getConserveSockets() { return conserveSockets_; }
 

--- a/cppcache/integration/framework/Cluster.h
+++ b/cppcache/integration/framework/Cluster.h
@@ -124,7 +124,7 @@ using Password = NamedType<std::string, struct PasswordParameter>;
 using CacheXMLFiles =
     NamedType<std::vector<std::string>, struct CacheXMLFilesParameter>;
 using UseIpv6 = NamedType<bool, struct UseIpv6Parameter>;
-using AllowAttach = NamedType<bool, struct AllowAttachParameter>;
+using UseDebugAgent = NamedType<bool, struct AllowAttachParameter>;
 using ConserveSockets = NamedType<bool, struct ConserveSocketsParameter>;
 using InitialLocators =
     NamedType<std::vector<LocatorAddress>, struct InitialLocatorsParameter>;
@@ -143,7 +143,7 @@ class Cluster {
           UseIpv6 useIpv6 = UseIpv6{false});
 
   Cluster(InitialLocators initialLocators, InitialServers initialServers,
-          AllowAttach allowAttach);
+          UseDebugAgent allowAttach);
 
   Cluster(InitialLocators initialLocators, InitialServers initialServers,
           RemoteLocators remoteLocators,
@@ -242,7 +242,7 @@ class Cluster {
 
   bool getUseIPv6();
 
-  bool getAllowAttach();
+  bool getUseDebugAgent();
 
   bool getConserveSockets();
 
@@ -280,7 +280,7 @@ class Cluster {
   std::string hostName_;
 
   bool useIPv6_ = false;
-  bool allowAttach_ = false;
+  bool useDebugAgent_ = false;
   bool conserveSockets_ = false;
 
   int16_t distributedSystemId_ = 0;

--- a/cppcache/integration/framework/Cluster.h
+++ b/cppcache/integration/framework/Cluster.h
@@ -124,7 +124,7 @@ using Password = NamedType<std::string, struct PasswordParameter>;
 using CacheXMLFiles =
     NamedType<std::vector<std::string>, struct CacheXMLFilesParameter>;
 using UseIpv6 = NamedType<bool, struct UseIpv6Parameter>;
-using UseDebugAgent = NamedType<bool, struct AllowAttachParameter>;
+using UseDebugAgent = NamedType<bool, struct UseDebugAgentParameter>;
 using ConserveSockets = NamedType<bool, struct ConserveSocketsParameter>;
 using InitialLocators =
     NamedType<std::vector<LocatorAddress>, struct InitialLocatorsParameter>;
@@ -143,7 +143,7 @@ class Cluster {
           UseIpv6 useIpv6 = UseIpv6{false});
 
   Cluster(InitialLocators initialLocators, InitialServers initialServers,
-          UseDebugAgent allowAttach);
+          UseDebugAgent useDebugAgent);
 
   Cluster(InitialLocators initialLocators, InitialServers initialServers,
           RemoteLocators remoteLocators,

--- a/cppcache/integration/framework/Cluster.h
+++ b/cppcache/integration/framework/Cluster.h
@@ -124,6 +124,7 @@ using Password = NamedType<std::string, struct PasswordParameter>;
 using CacheXMLFiles =
     NamedType<std::vector<std::string>, struct CacheXMLFilesParameter>;
 using UseIpv6 = NamedType<bool, struct UseIpv6Parameter>;
+using AllowAttach = NamedType<bool, struct AllowAttachParameter>;
 using ConserveSockets = NamedType<bool, struct ConserveSocketsParameter>;
 using InitialLocators =
     NamedType<std::vector<LocatorAddress>, struct InitialLocatorsParameter>;
@@ -140,6 +141,9 @@ class Cluster {
 
   Cluster(InitialLocators initialLocators, InitialServers initialServers,
           UseIpv6 useIpv6 = UseIpv6{false});
+
+  Cluster(InitialLocators initialLocators, InitialServers initialServers,
+          AllowAttach allowAttach);
 
   Cluster(InitialLocators initialLocators, InitialServers initialServers,
           RemoteLocators remoteLocators,
@@ -238,6 +242,8 @@ class Cluster {
 
   bool getUseIPv6();
 
+  bool getAllowAttach();
+
   bool getConserveSockets();
 
  private:
@@ -274,6 +280,7 @@ class Cluster {
   std::string hostName_;
 
   bool useIPv6_ = false;
+  bool allowAttach_ = false;
   bool conserveSockets_ = false;
 
   int16_t distributedSystemId_ = 0;

--- a/cppcache/integration/framework/Gfsh.cpp
+++ b/cppcache/integration/framework/Gfsh.cpp
@@ -85,7 +85,7 @@ Gfsh::Start::Locator &Gfsh::Start::Locator::withRemoteLocators(
   return *this;
 }
 
-Gfsh::Start::Locator &Gfsh::Start::Locator::withAllowAttach(
+Gfsh::Start::Locator &Gfsh::Start::Locator::withDebugAgent(
     bool allowAttach, const std::string &bindAddress) {
   if (allowAttach) {
     command_ +=
@@ -306,7 +306,7 @@ Gfsh::Start::Server &Gfsh::Start::Server::withPreferIPv6(bool useIPv6) {
   return *this;
 }
 
-Gfsh::Start::Server &Gfsh::Start::Server::withAllowAttach(
+Gfsh::Start::Server &Gfsh::Start::Server::withDebugAgent(
     bool allowAttach, const std::string &bindAddress) {
   if (allowAttach) {
     command_ +=

--- a/cppcache/integration/framework/Gfsh.cpp
+++ b/cppcache/integration/framework/Gfsh.cpp
@@ -20,6 +20,8 @@
 #include <iterator>
 #include <sstream>
 
+#include "Framework.h"
+
 Gfsh::Start Gfsh::start() { return Start{*this}; }
 
 Gfsh::Stop Gfsh::stop() { return Stop{*this}; }
@@ -79,6 +81,16 @@ Gfsh::Start::Locator &Gfsh::Start::Locator::withRemoteLocators(
               std::ostream_iterator<std::string>(command, ","));
     command << "'";
     command_ += command.str();
+  }
+  return *this;
+}
+
+Gfsh::Start::Locator &Gfsh::Start::Locator::withAllowAttach(
+    bool allowAttach, const std::string &bindAddress) {
+  if (allowAttach) {
+    command_ +=
+        " --J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" +
+        bindAddress + ":" + std::to_string(Framework::getAvailablePort());
   }
   return *this;
 }
@@ -294,6 +306,15 @@ Gfsh::Start::Server &Gfsh::Start::Server::withPreferIPv6(bool useIPv6) {
   return *this;
 }
 
+Gfsh::Start::Server &Gfsh::Start::Server::withAllowAttach(
+    bool allowAttach, const std::string &bindAddress) {
+  if (allowAttach) {
+    command_ +=
+        " --J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" +
+        bindAddress + ":" + std::to_string(Framework::getAvailablePort());
+  }
+  return *this;
+}
 Gfsh::Start::Server &Gfsh::Start::Server::withSslEnabledComponents(
     const std::string &components) {
   command_ += " --J=-Dgemfire.ssl-enabled-components=" + components;

--- a/cppcache/integration/framework/Gfsh.h
+++ b/cppcache/integration/framework/Gfsh.h
@@ -1,5 +1,4 @@
 /*
-/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/cppcache/integration/framework/Gfsh.h
+++ b/cppcache/integration/framework/Gfsh.h
@@ -1,4 +1,5 @@
 /*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -111,6 +112,9 @@ class Gfsh {
       Locator &withRemoteLocators(
           const std::vector<std::string> &remoteLocators);
 
+      Locator &withAllowAttach(const bool allowAttach,
+                               const std::string &bindAddress);
+
       Locator &withDistributedSystemId(const uint16_t &dsId);
 
       Locator &withJmxManagerPort(const uint16_t &jmxManagerPort);
@@ -179,6 +183,9 @@ class Gfsh {
       Server &withCacheXMLFile(const std::string file);
 
       Server &withPreferIPv6(bool useIPv6);
+
+      Server &withAllowAttach(const bool allowAttach,
+                              const std::string &bindAddress);
 
       Server &withSslEnabledComponents(const std::string &components);
 

--- a/cppcache/integration/framework/Gfsh.h
+++ b/cppcache/integration/framework/Gfsh.h
@@ -112,8 +112,8 @@ class Gfsh {
       Locator &withRemoteLocators(
           const std::vector<std::string> &remoteLocators);
 
-      Locator &withAllowAttach(const bool allowAttach,
-                               const std::string &bindAddress);
+      Locator &withDebugAgent(const bool allowAttach,
+                              const std::string &bindAddress);
 
       Locator &withDistributedSystemId(const uint16_t &dsId);
 
@@ -184,8 +184,8 @@ class Gfsh {
 
       Server &withPreferIPv6(bool useIPv6);
 
-      Server &withAllowAttach(const bool allowAttach,
-                              const std::string &bindAddress);
+      Server &withDebugAgent(const bool allowAttach,
+                             const std::string &bindAddress);
 
       Server &withSslEnabledComponents(const std::string &components);
 

--- a/cppcache/integration/test/AllowAttachTest.cpp
+++ b/cppcache/integration/test/AllowAttachTest.cpp
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <framework/Cluster.h>
+#include <framework/Framework.h>
+#include <framework/Gfsh.h>
+#include <hacks/range.h>
+
+#include <iostream>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+#include <geode/Cache.hpp>
+#include <geode/PoolManager.hpp>
+#include <geode/QueryService.hpp>
+#include <geode/RegionFactory.hpp>
+#include <geode/RegionShortcut.hpp>
+#include <geode/Struct.hpp>
+
+namespace {
+
+using apache::geode::client::Cache;
+using apache::geode::client::CacheableInt32;
+using apache::geode::client::CacheableString;
+using apache::geode::client::Region;
+using apache::geode::client::RegionShortcut;
+using apache::geode::client::Struct;
+
+std::shared_ptr<Region> setupRegion(Cache& cache) {
+  auto region = cache.createRegionFactory(RegionShortcut::PROXY)
+                    .setPoolName("default")
+                    .create("region");
+
+  return region;
+}
+
+/**
+ * Allow attaching to cluster
+ */
+TEST(AllowAttach, attachToLocatorAndServer) {
+  Cluster cluster{InitialLocators{{{"localhost", 0}}},
+                  InitialServers{{{"localhost", 0}}}, AllowAttach(true)};
+  cluster.start();
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("REPLICATE")
+      .execute();
+
+  auto cache = cluster.createCache();
+  auto region = setupRegion(cache);
+
+  std::unordered_map<int, std::string> values = {
+      {1, "one"}, {2, "two"}, {3, "three"}};
+
+  for (auto&& value : values) {
+    region->put(value.first, value.second);
+  }
+
+  auto&& queryResult =
+      cache.getQueryService()
+          ->newQuery("SELECT e.key, e.value FROM /region.entries e")
+          ->execute();
+  EXPECT_EQ(3, queryResult->size());
+
+  for (auto&& row : hacks::range(*queryResult)) {
+    auto rowStruct = std::dynamic_pointer_cast<Struct>(row);
+    ASSERT_NE(nullptr, rowStruct);
+    EXPECT_EQ(2, rowStruct->size());
+
+    auto key = -1;
+    for (auto&& column : *rowStruct) {
+      // Expect to read: key:int, value:string
+      if (auto cacheableInt32ColumnValue =
+              std::dynamic_pointer_cast<CacheableInt32>(column)) {
+        key = cacheableInt32ColumnValue->value();
+        EXPECT_NE(values.end(), values.find(key));
+      } else if (auto cacheableStringColumnValue =
+                     std::dynamic_pointer_cast<CacheableString>(column)) {
+        auto value = cacheableStringColumnValue->value();
+        EXPECT_EQ(values.find(key)->second, value);
+      } else {
+        FAIL() << "Column is not int or string.";
+      }
+    }
+  }
+}
+
+}  // namespace

--- a/cppcache/integration/test/AllowAttachTest.cpp
+++ b/cppcache/integration/test/AllowAttachTest.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<Region> setupRegion(Cache& cache) {
  */
 TEST(AllowAttach, attachToLocatorAndServer) {
   Cluster cluster{InitialLocators{{{"localhost", 0}}},
-                  InitialServers{{{"localhost", 0}}}, AllowAttach(true)};
+                  InitialServers{{{"localhost", 0}}}, UseDebugAgent(true)};
   cluster.start();
   cluster.getGfsh()
       .create()

--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 add_executable(cpp-integration-test
+  AllowAttachTest.cpp
   AuthInitializeTest.cpp
   BasicIPv6Test.cpp
   CacheWriterTest.cpp


### PR DESCRIPTION
To assist with protocol analysis it is very helpful to be able to step through the server code in the Intellij debugger while running native client test code. However, to be allowed to set breakpoints in the server code, the server must be started with the special flag below:

```
--J=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=127.0.0.1:FREEPORT
```
This ticket is to add support for the above flag in the native client test frameworks.