### PR TITLE
GEODE-10227: Remove redundant sendRequestForChunkedResponse

### DIFF
--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -754,42 +754,36 @@ GfErrType TcrEndpoint::sendRequestConn(const TcrMessage& request,
   // TcrMessage * req = const_cast<TcrMessage *>(&request);
   LOGDEBUG("TcrEndpoint::sendRequestConn  = %p", m_baseDM);
   if (m_baseDM != nullptr) m_baseDM->beforeSendingRequest(request, conn);
-  if (((type == TcrMessage::EXECUTE_FUNCTION ||
-        type == TcrMessage::EXECUTE_REGION_FUNCTION) &&
-       (request.hasResult() & 2))) {
-    conn->sendRequestForChunkedResponse(request, request.getMsgLength(), reply,
-                                        request.getTimeout(),
-                                        reply.getTimeout());
-  } else if (type == TcrMessage::REGISTER_INTEREST_LIST ||
-             type == TcrMessage::REGISTER_INTEREST ||
-             type == TcrMessage::QUERY ||
-             type == TcrMessage::QUERY_WITH_PARAMETERS ||
-             type == TcrMessage::GET_ALL_70 ||
-             type == TcrMessage::GET_ALL_WITH_CALLBACK ||
-             type == TcrMessage::PUTALL ||
-             type == TcrMessage::PUT_ALL_WITH_CALLBACK ||
-             type == TcrMessage::REMOVE_ALL ||
-             ((type == TcrMessage::EXECUTE_FUNCTION ||
-               type == TcrMessage::EXECUTE_REGION_FUNCTION) &&
-              (request.hasResult() & 2)) ||
-             type ==
-                 TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP ||  // This is
-                                                                    // kept
-                                                                    // aside as
-                                                                    // server
-                                                                    // always
-                                                                    // sends
-                                                                    // chunked
-                                                                    // response.
-             type == TcrMessage::EXECUTECQ_MSG_TYPE ||
-             type == TcrMessage::STOPCQ_MSG_TYPE ||
-             type == TcrMessage::CLOSECQ_MSG_TYPE ||
-             type == TcrMessage::KEY_SET ||
-             type == TcrMessage::CLOSECLIENTCQS_MSG_TYPE ||
-             type == TcrMessage::GETCQSTATS_MSG_TYPE ||
-             type == TcrMessage::MONITORCQ_MSG_TYPE ||
-             type == TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE ||
-             type == TcrMessage::GETDURABLECQS_MSG_TYPE) {
+  if (type == TcrMessage::REGISTER_INTEREST_LIST ||
+    type == TcrMessage::REGISTER_INTEREST ||
+    type == TcrMessage::QUERY ||
+    type == TcrMessage::QUERY_WITH_PARAMETERS ||
+    type == TcrMessage::GET_ALL_70 ||
+    type == TcrMessage::GET_ALL_WITH_CALLBACK ||
+    type == TcrMessage::PUTALL ||
+    type == TcrMessage::PUT_ALL_WITH_CALLBACK ||
+    type == TcrMessage::REMOVE_ALL ||
+    ((type == TcrMessage::EXECUTE_FUNCTION ||
+      type == TcrMessage::EXECUTE_REGION_FUNCTION) &&
+     (request.hasResult() & 2)) ||
+    type ==
+        TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP ||  // This is
+                                                           // kept
+                                                           // aside as
+                                                           // server
+                                                           // always
+                                                           // sends
+                                                           // chunked
+                                                           // response.
+    type == TcrMessage::EXECUTECQ_MSG_TYPE ||
+    type == TcrMessage::STOPCQ_MSG_TYPE ||
+    type == TcrMessage::CLOSECQ_MSG_TYPE ||
+    type == TcrMessage::KEY_SET ||
+    type == TcrMessage::CLOSECLIENTCQS_MSG_TYPE ||
+    type == TcrMessage::GETCQSTATS_MSG_TYPE ||
+    type == TcrMessage::MONITORCQ_MSG_TYPE ||
+    type == TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE ||
+    type == TcrMessage::GETDURABLECQS_MSG_TYPE) {
     conn->sendRequestForChunkedResponse(request, request.getMsgLength(), reply,
                                         request.getTimeout(),
                                         reply.getTimeout());

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -755,35 +755,27 @@ GfErrType TcrEndpoint::sendRequestConn(const TcrMessage& request,
   LOGDEBUG("TcrEndpoint::sendRequestConn  = %p", m_baseDM);
   if (m_baseDM != nullptr) m_baseDM->beforeSendingRequest(request, conn);
   if (type == TcrMessage::REGISTER_INTEREST_LIST ||
-    type == TcrMessage::REGISTER_INTEREST ||
-    type == TcrMessage::QUERY ||
-    type == TcrMessage::QUERY_WITH_PARAMETERS ||
-    type == TcrMessage::GET_ALL_70 ||
-    type == TcrMessage::GET_ALL_WITH_CALLBACK ||
-    type == TcrMessage::PUTALL ||
-    type == TcrMessage::PUT_ALL_WITH_CALLBACK ||
-    type == TcrMessage::REMOVE_ALL ||
-    ((type == TcrMessage::EXECUTE_FUNCTION ||
-      type == TcrMessage::EXECUTE_REGION_FUNCTION) &&
-     (request.hasResult() & 2)) ||
-    type ==
-        TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP ||  // This is
-                                                           // kept
-                                                           // aside as
-                                                           // server
-                                                           // always
-                                                           // sends
-                                                           // chunked
-                                                           // response.
-    type == TcrMessage::EXECUTECQ_MSG_TYPE ||
-    type == TcrMessage::STOPCQ_MSG_TYPE ||
-    type == TcrMessage::CLOSECQ_MSG_TYPE ||
-    type == TcrMessage::KEY_SET ||
-    type == TcrMessage::CLOSECLIENTCQS_MSG_TYPE ||
-    type == TcrMessage::GETCQSTATS_MSG_TYPE ||
-    type == TcrMessage::MONITORCQ_MSG_TYPE ||
-    type == TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE ||
-    type == TcrMessage::GETDURABLECQS_MSG_TYPE) {
+      type == TcrMessage::REGISTER_INTEREST ||
+      type == TcrMessage::QUERY ||
+      type == TcrMessage::QUERY_WITH_PARAMETERS ||
+      type == TcrMessage::GET_ALL_70 ||
+      type == TcrMessage::GET_ALL_WITH_CALLBACK ||
+      type == TcrMessage::PUTALL ||
+      type == TcrMessage::PUT_ALL_WITH_CALLBACK ||
+      type == TcrMessage::REMOVE_ALL ||
+      ((type == TcrMessage::EXECUTE_FUNCTION ||
+        type == TcrMessage::EXECUTE_REGION_FUNCTION) &&
+       (request.hasResult() & 2)) ||
+      type == TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP ||
+      type == TcrMessage::EXECUTECQ_MSG_TYPE ||
+      type == TcrMessage::STOPCQ_MSG_TYPE ||
+      type == TcrMessage::CLOSECQ_MSG_TYPE ||
+      type == TcrMessage::KEY_SET ||
+      type == TcrMessage::CLOSECLIENTCQS_MSG_TYPE ||
+      type == TcrMessage::GETCQSTATS_MSG_TYPE ||
+      type == TcrMessage::MONITORCQ_MSG_TYPE ||
+      type == TcrMessage::EXECUTECQ_WITH_IR_MSG_TYPE ||
+      type == TcrMessage::GETDURABLECQS_MSG_TYPE) {
     conn->sendRequestForChunkedResponse(request, request.getMsgLength(), reply,
                                         request.getTimeout(),
                                         reply.getTimeout());

--- a/cppcache/src/TcrEndpoint.cpp
+++ b/cppcache/src/TcrEndpoint.cpp
@@ -755,12 +755,10 @@ GfErrType TcrEndpoint::sendRequestConn(const TcrMessage& request,
   LOGDEBUG("TcrEndpoint::sendRequestConn  = %p", m_baseDM);
   if (m_baseDM != nullptr) m_baseDM->beforeSendingRequest(request, conn);
   if (type == TcrMessage::REGISTER_INTEREST_LIST ||
-      type == TcrMessage::REGISTER_INTEREST ||
-      type == TcrMessage::QUERY ||
+      type == TcrMessage::REGISTER_INTEREST || type == TcrMessage::QUERY ||
       type == TcrMessage::QUERY_WITH_PARAMETERS ||
       type == TcrMessage::GET_ALL_70 ||
-      type == TcrMessage::GET_ALL_WITH_CALLBACK ||
-      type == TcrMessage::PUTALL ||
+      type == TcrMessage::GET_ALL_WITH_CALLBACK || type == TcrMessage::PUTALL ||
       type == TcrMessage::PUT_ALL_WITH_CALLBACK ||
       type == TcrMessage::REMOVE_ALL ||
       ((type == TcrMessage::EXECUTE_FUNCTION ||
@@ -769,8 +767,7 @@ GfErrType TcrEndpoint::sendRequestConn(const TcrMessage& request,
       type == TcrMessage::EXECUTE_REGION_FUNCTION_SINGLE_HOP ||
       type == TcrMessage::EXECUTECQ_MSG_TYPE ||
       type == TcrMessage::STOPCQ_MSG_TYPE ||
-      type == TcrMessage::CLOSECQ_MSG_TYPE ||
-      type == TcrMessage::KEY_SET ||
+      type == TcrMessage::CLOSECQ_MSG_TYPE || type == TcrMessage::KEY_SET ||
       type == TcrMessage::CLOSECLIENTCQS_MSG_TYPE ||
       type == TcrMessage::GETCQSTATS_MSG_TYPE ||
       type == TcrMessage::MONITORCQ_MSG_TYPE ||


### PR DESCRIPTION
TcrEndpoint::sendRequestConn contains redundant calls to TcrConnection::sendRequestForChunkedResponse which should be removed.