### PR TITLE
GEODE-9921: Rename .NET to .NET Framework

### DIFF
--- a/docs/geode-native-book-dotnet/config.yml
+++ b/docs/geode-native-book-dotnet/config.yml
@@ -35,11 +35,11 @@ template_variables:
   dotnetapiref_version: dotnetapiref
   #
   product_language: dotnet
-  client_name: Geode Native Client for .NET
+  client_name: Geode Native Client for .NET Framework
   min_java_update: 121
   support_url: http://geode.apache.org/community
   product_url: http://geode.apache.org
-  book_title: Apache Geode Native .NET Documentation
+  book_title: Apache Geode Native .NET Framework Documentation
   book_header_img: /images/Apache_Geode_logo_symbol_white.png
   support_link: <a href="http://geode.apache.org/community" target="_blank">Community</a>
   support_call_to_action: <a href="http://geode.apache.org/community" target="_blank">Need Help?</a>
@@ -47,7 +47,7 @@ template_variables:
   product_link: <div class="header-item"><a href="http://geode.apache.org">Back to Product Page</a></div>
   domain_name: apache.org
   book_title_short: Geode Native .NET Docs
-  local_header_title: Apache Geode Native .NET
+  local_header_title: Apache Geode Native .NET Framework
   local_header_img: /images/Apache_Geode_logo_symbol.png
   serverman: https://geode.apache.org/docs/guide/latest
   geodeman: https://geode.apache.org/docs/guide/latest

--- a/docs/geode-native-docs-dotnet/about-client-users-guide.html.md.erb
+++ b/docs/geode-native-docs-dotnet/about-client-users-guide.html.md.erb
@@ -21,12 +21,12 @@ This documentation describes the Apache Geode Native Client version <%=vars.prod
 Source files are available from the [Apache Geode-Native Github repository](https://github.com/apache/geode-native) 
 and instructions on how to build this documentation are available in the project README file found at that location.
 
-The Apache Geode Native Client is a library that provides access for C++ and Microsoft<sup>®</sup> .NET™ clients to an Apache Geode cluster.
+The Apache Geode Native Client is a library that provides access for C++ and Microsoft<sup>®</sup> .NET™ Framework clients to an Apache Geode cluster.
 
 See the API docs for API details:
 
   - [C++ API docs](/<%=vars.cppapiref_version%>/hierarchy.html)
-  - [.NET API docs](/<%=vars.dotnetapiref_version%>/hierarchy.html)
+  - [.NET Framework API docs](/<%=vars.dotnetapiref_version%>/hierarchy.html)
 
 See the [_<%=vars.product_name_long%> User Guide_](<%=vars.serverman%>/about_<%=vars.product_name.downcase%>.html) for information regarding the server.
 

--- a/docs/geode-native-docs-dotnet/client-cache-ref.html.md.erb
+++ b/docs/geode-native-docs-dotnet/client-cache-ref.html.md.erb
@@ -40,8 +40,8 @@ When you run your application, the native client runtime library reads and appli
 specified in the XML file.
 
 The declarative XML file is used to externalize the configuration of the client cache.
-The contents of the XML file correspond to APIs found in the`apache::geode::client` package for C++ applications,
-and the `Apache::Geode::Client` package for .NET applications.
+The contents of the XML file correspond to APIs found in the `apache::geode::client` package for C++ applications,
+and the `Apache::Geode::Client` package for .NET Framework applications.
 
 Elements are defined in the Client Cache XSD file, named `cpp-cache-1.0.xsd`, which you can find in
 your native client distribution in the `xsds` directory, and online at

--- a/docs/geode-native-docs-dotnet/configuring/config-client-cache.html.md.erb
+++ b/docs/geode-native-docs-dotnet/configuring/config-client-cache.html.md.erb
@@ -32,5 +32,5 @@ Regions are created from `Cache` instances. Regions provide the entry points to 
 instances of `Region` and `RegionEntry`.
 
 For more information specific to your client programming language, see the
-[.NET Client API](<%=vars.dotnetapiref%>/hierarchy.html).
+[.NET Framework Client API](<%=vars.dotnetapiref%>/hierarchy.html).
 

--- a/docs/geode-native-docs-dotnet/configuring/sysprops.html.md.erb
+++ b/docs/geode-native-docs-dotnet/configuring/sysprops.html.md.erb
@@ -20,7 +20,7 @@ limitations under the License.
 -->
 
 A variety of system properties can be specified when a client connects to a distributed system, either programmatically or in a `geode.properties` file.
-See `Apache::Geode::Client::SystemProperties` in the [.NET API docs](<%=vars.dotnetapiref%>/hierarchy.html).
+See `Apache::Geode::Client::SystemProperties` in the [.NET Framework API documentation](<%=vars.dotnetapiref%>/hierarchy.html).
 
 The following settings can be configured:
 

--- a/docs/geode-native-docs-dotnet/continuous-queries.html.md.erb
+++ b/docs/geode-native-docs-dotnet/continuous-queries.html.md.erb
@@ -19,7 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-The C++ and .NET clients can initiate queries that run on the <%=vars.product_name%> cache server
+The C++ and .NET Framework clients can initiate queries that run on the <%=vars.product_name%> cache server
 and notify the client when the query results have changed.  For details on the server-side setup for
 continuous queries, see [How Continuous Querying Works](<%=vars.serverman%>/developing/continuous_querying/how_continuous_querying_works.html) 
 in the *<%=vars.product_name%> User Guide*.
@@ -70,7 +70,7 @@ The essential steps to create and execute a continuous query are:
 1.  Iterate through the returned objects.
 1.  When finished, close down the continuous query.
 
-### <a id="DotNetCQExample"></a>.NET Continuous Query Example
+### <a id="DotNetCQExample"></a>.NET Framework Continuous Query Example
 
 These C# code excerpts are from the `examples\dotnet\continuousquery` example included in your client
 distribution. See the example for full context.

--- a/docs/geode-native-docs-dotnet/function-execution.html.md.erb
+++ b/docs/geode-native-docs-dotnet/function-execution.html.md.erb
@@ -97,13 +97,13 @@ The client:
 - invokes the object's execute method to invoke the server-side function
 
 If the client expects results, it must create a result object.
-The .NET example uses a built-in result collector (`IResultCollector.GetResults()`) to retrieve the function results.
+The .NET Framework example uses a built-in result collector (`IResultCollector.GetResults()`) to retrieve the function results.
 
-### <a id="nc-fe-dotnet_example"></a>.NET Example
-This section contains code snippets showing highlights of the .NET function execution example. They are not intended for cut-and-paste execution.
+### <a id="nc-fe-dotnet_example"></a>.NET Framework Example
+This section contains code snippets showing highlights of the .NET Framework function execution example. They are not intended for cut-and-paste execution.
 For the complete source, see the example source directory.
 
-The .NET example creates a cache, then uses it to create a connection pool.
+The .NET Framework example creates a cache, then uses it to create a connection pool.
 
 ```csharp
    var cacheFactory = new CacheFactory()

--- a/docs/geode-native-docs-dotnet/getting-started/app-dev-walkthrough-dotnet.html.md.erb
+++ b/docs/geode-native-docs-dotnet/getting-started/app-dev-walkthrough-dotnet.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  .NET Application Development Walkthrough
+title:  .NET Framework Application Development Walkthrough
 ---
 
 
@@ -20,7 +20,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-This section describes how to set up a .NET native client development environment using C# and CMake.
+This section describes how to set up a .NET Framework native client development environment using C# and CMake.
 
 ## <a id="prerequisites_dotnet"></a>Prerequisites
 This walkthrough assumes that certain components are in place:
@@ -33,9 +33,9 @@ This walkthrough assumes that certain components are in place:
 
 - **Geode**: Install and configure Geode. See the [_Geode User's Guide_](http://geode.apache.org/docs/) for instructions and system requirements.
 
-- **Visual Studio 2015** or higher and **.NET 4.5.2**.
+- **Visual Studio 2015** or higher and **.NET Framework 4.5.2**.
 
-To develop a Native Client application using .NET and CMake:
+To develop a Native Client application using .NET Framework and CMake:
 
   - Create a project directory structure
   - Populate the project directories with C# source code
@@ -104,7 +104,7 @@ should contain the following CMake instructions:
 Combined, the above elements comprise the following CMakeLists.txt:
 
 ```
-# CMakeLists.txt for .NET Native Client App
+# CMakeLists.txt for .NET Framework Native Client App
 cmake_minimum_required(VERSION 3.10)
 
 project(MyProject LANGUAGES CSharp)
@@ -139,7 +139,7 @@ set_target_properties(MyProject PROPERTIES
     $ cmake ..
     ```
 
-This creates a Visual Studio solution for your .NET application. For example, `MyProject.sln`.
+This creates a Visual Studio solution for your .NET Framework application. For example, `MyProject.sln`.
 
 ## <a id="building_and_running_dotnet"></a>Building and Running the App
 

--- a/docs/geode-native-docs-dotnet/getting-started/getting-started-nc-client.html.md.erb
+++ b/docs/geode-native-docs-dotnet/getting-started/getting-started-nc-client.html.md.erb
@@ -57,7 +57,7 @@ To connect to a server, your application must follow these steps:
 
 Once the connection pool and the shared region are in place, your client application is ready to share data with the server.
 
-**Server Connection: .NET Example**
+**Server Connection: .NET Framework Example**
 
 Create a cache and set its characteristics:
 
@@ -91,7 +91,7 @@ for more details.
 
 ### <a id="app_dev_walkthroughs"></a>Application Development Walkthrough
 
-The [.NET App Development Walkthrough](app-dev-walkthrough-dotnet.html) describes how to set up a native client development environment using CMake.
+The [.NET Framework App Development Walkthrough](app-dev-walkthrough-dotnet.html) describes how to set up a native client development environment using CMake.
 
 ## <a id="programming_examples"></a>Programming Examples
 

--- a/docs/geode-native-docs-dotnet/getting-started/put-get-example.html.md.erb
+++ b/docs/geode-native-docs-dotnet/getting-started/put-get-example.html.md.erb
@@ -19,9 +19,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-The native client release contains an example written for .NET showing how a client application
-can establish a connection to a cluster and then use that connection to perform basic operations on a remote server. 
-The example is located in `../examples/dotnet/putgetremove`. 
+The native client release contains an example written for .NET Framework showing how a client
+application can establish a connection to a cluster and then use that connection to perform basic
+operations on a remote server. The example is located in `../examples/dotnet/putgetremove`. 
 
 The example performs a sequence of operations, displaying simple log entries as they run.
 
@@ -40,10 +40,11 @@ The example performs a sequence of operations, displaying simple log entries as 
 
 ## <a id="put-get-remove-example-code"></a>Put/Get/Remove Example Code
 
-This section contains code snippets showing highlights of the .NET put/get/remove example. They are not intended for cut-and-paste execution.
+This section contains code snippets showing highlights of the .NET Framework put/get/remove
+example. They are not intended for cut-and-paste execution.
 For the complete source, see the example source directory.
 
-The .NET example creates a cache, then uses it to create a connection pool and a region object (of class `IRegion`).
+The .NET Framework example creates a cache, then uses it to create a connection pool and a region object (of class `IRegion`).
 
 ```csharp
   var cache = new CacheFactory()

--- a/docs/geode-native-docs-dotnet/preserving-data/config-durable-reconnect.html.md.erb
+++ b/docs/geode-native-docs-dotnet/preserving-data/config-durable-reconnect.html.md.erb
@@ -21,7 +21,7 @@ limitations under the License.
 
 You can configure a durable client to obtain an approximate count of pending events upon durable client reconnection. Based on the returned number, you can determine whether to proceed and receive the pending events or to close the cache.
 
-Use the `getPendingEventCount` (C++ API) and the `PendingEventCount` (.NET API) property to detect whether the previously registered subscription queue is available upon durable client reconnection and the count of pending events in the queue. Based on the returned results, you can then decide whether to receive the remaining events or close the cache if the number is too large.
+Use the `getPendingEventCount` (C++ API) and the `PendingEventCount` (.NET Framework API) property to detect whether the previously registered subscription queue is available upon durable client reconnection and the count of pending events in the queue. Based on the returned results, you can then decide whether to receive the remaining events or close the cache if the number is too large.
 
 For example, consider this code fragment for a client with only the default pool created:
 

--- a/docs/geode-native-docs-dotnet/preserving-data/using-queue-conflation.html.md.erb
+++ b/docs/geode-native-docs-dotnet/preserving-data/using-queue-conflation.html.md.erb
@@ -23,7 +23,7 @@ Conflation of entry update messages can reduce the number of update messages a c
 
 Conflation is enabled for a cache server region, so all clients receiving updates for a particular region benefit from the conflation. To enable conflation, set the cache server’s `enable-subscription-conflation` region attribute to `true`. This region attribute is `false` by default.
 
-The queue managment code conflates entry updates as part of the enqueue operation. If the previous enqueued item for that key is also an `update` operation, the queue management code removes that previously enqueued update, leaving only the latest update to be sent when event distribution occurs. For high availability, conflation also occurs for any secondary queues.
+The queue management code conflates entry updates as part of the enqueue operation. If the previous enqueued item for that key is also an `update` operation, the queue management code removes that previously enqueued update, leaving only the latest update to be sent when event distribution occurs. For high availability, conflation also occurs for any secondary queues.
 
 Only entry `update` messages in a cache server region with `distributed-no-ack` scope are conflated. Region operations and entry operations other than updates are not conflated.
 

--- a/docs/geode-native-docs-dotnet/regions/regions.html.md.erb
+++ b/docs/geode-native-docs-dotnet/regions/regions.html.md.erb
@@ -42,7 +42,7 @@ To create a region:
 1. Use the cache to instantiate a `RegionFactory` and use it to create a region, specifying any desired attributes
 and an association with the connection pool.
 
-### .NET C# Region Creation Example
+### .NET Framework C# Region Creation Example
 
 This example illustrates how to create two regions with different characteristics using C#:
 

--- a/docs/geode-native-docs-dotnet/regions/registering-interest-for-entries.html.md.erb
+++ b/docs/geode-native-docs-dotnet/regions/registering-interest-for-entries.html.md.erb
@@ -28,7 +28,7 @@ You can register interest for specific entry keys or for all keys. Regular expre
 
 ## <a id="registering-interest-for-entries__section_C9A3D7F193B24ACD83B2D67813E596A0" class="no-quick-link"></a>Client API for Registering Interest
 
-You register client interest through the .NET API. The .NET API provides the `RegisterKeys`, `RegisterAllKeys`, and `RegisterRegex` methods, with corresponding unregistration accomplished using the `UnregisterKeys`, `UnregisterAllKeys`, and `UnregisterRegex` methods.
+You register client interest through the .NET Framework API. The .NET Framework API provides the `RegisterKeys`, `RegisterAllKeys`, and `RegisterRegex` methods, with corresponding unregistration accomplished using the `UnregisterKeys`, `UnregisterAllKeys`, and `UnregisterRegex` methods.
 
 The `RegisterKeys`, `RegisterRegex` and `RegisterAllKeys` methods have the option to populate the cache with the registration results from the server. The `RegisterRegex` and `RegisterAllKeys` methods can also optionally return the current list of keys registered on the server.
 

--- a/docs/geode-native-docs-dotnet/remote-queries.html.md.erb
+++ b/docs/geode-native-docs-dotnet/remote-queries.html.md.erb
@@ -76,7 +76,7 @@ The essential steps to create and execute a query are:
    remotely evaluates the query string and returns the results to the client.
 1.  Iterate through the returned objects.
 
-### <a id="DotNetQueryExample"></a>.NET Query Example
+### <a id="DotNetQueryExample"></a>.NET Framework Query Example
 
 These C# code excerpts are from the `examples\dotnet\remotequery` example included in your client
 distribution. See the example for full context.

--- a/docs/geode-native-docs-dotnet/security/authentication.html.md.erb
+++ b/docs/geode-native-docs-dotnet/security/authentication.html.md.erb
@@ -25,7 +25,7 @@ For details on the server's role in authentication and what it expects from the 
 In your application, authentication credentials must be set when creating the cache. In practice,
 this means setting the authentication credentials when you create the CacheFactory.
 
-### .NET Authentication Example
+### .NET Framework Authentication Example
 
 In this C# authentication example, the `CacheFactory` creation process sets the authentication callback:
 

--- a/docs/geode-native-docs-dotnet/serialization/data-serialization.html.md.erb
+++ b/docs/geode-native-docs-dotnet/serialization/data-serialization.html.md.erb
@@ -20,15 +20,16 @@ limitations under the License.
 -->
 
 Data in your client application's <%=vars.product_name%> cache must be serializable to be shared
-with <%=vars.product_name%> servers and other <%=vars.product_name%> clients.  Built-in .NET types
-are serialized automatically into the cache and can be retrieved by Java servers and other
-<%=vars.product_name%> clients.
+with <%=vars.product_name%> servers and other <%=vars.product_name%> clients. Built-in .NET
+Framework types are serialized automatically into the cache and can be retrieved by Java servers
+and other <%=vars.product_name%> clients.
 
-For domain objects that are not simple types, <%=vars.product_name%> provides multiple serialization options
-for storage and transmittal between processes, of which [**<%=vars.product_name%> Portable Data eXchange (PDX) serialization**](dotnet-serialization/dotnet-pdx-serialization.html) offers
-the best combination of versatility and ease-of-use for most applications.
+For domain objects that are not simple types, <%=vars.product_name%> provides multiple
+serialization options for storage and transmittal between processes, of which
+[**<%=vars.product_name%> Portable Data eXchange (PDX) serialization**](dotnet-serialization/dotnet-pdx-serialization.html) offers the best combination of
+versatility and ease-of-use for most applications.
 
-Many .NET clients can take advantage of **PDX reflection-based autoserialization**.
+Many .NET Framework clients can take advantage of **PDX reflection-based autoserialization**.
 
 To learn more about other serialization options, see the [Data Serialization section in the
 _<%=vars.product_name_long%> User

--- a/docs/geode-native-docs-dotnet/serialization/dotnet-serialization/dotnet-pdx-autoserializer.html.md.erb
+++ b/docs/geode-native-docs-dotnet/serialization/dotnet-serialization/dotnet-pdx-autoserializer.html.md.erb
@@ -17,8 +17,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-It's extremely easy for .NET applications to store and retrieve data from Geode. All that's required
-is a single line of code to set the `PdxSerializer` to the .NET client's `ReflectionBasedAutoSerializer`:
+It's extremely easy for .NET Framework applications to store and retrieve data from Geode. All
+that's required is a single line of code to set the `PdxSerializer` to the .NET Framework client's
+`ReflectionBasedAutoSerializer`:
 
 ```csharp
 cache.TypeRegistry.PdxSerializer = new ReflectionBasedAutoSerializer();
@@ -34,30 +35,31 @@ the region.
 region.Put(key, value);
 ```
     
-The .NET client's `ReflectionBasedAutoSerializer` supports the full list of .NET primitives and other common
-built-in types.
+The .NET Framework client's `ReflectionBasedAutoSerializer` supports the full list of .NET
+Framework primitives and other common built-in types.
 
 Types without a no-arg constructor are not supported by the `ReflectionBasedAutoSerializer`. This
 includes all user defined structs. `System.Data.Datatable` is an example of a system class that is not
 supported due to lack of a no-arg constructor.
 
-## <a id="auto-ser-java-interop"></a>Java Interoperability with .NET Specific Types
+## <a id="auto-ser-java-interop"></a>Java Interoperability with .NET Framework Specific Types
 
 Java does not have unsigned data types or exact equivalents of `Guid` and `Decimal`. Care should be
-taken when passing these types between .NET and Java applications using the .NET
-`ReflectionBasedAutoSerializer`. For example, if storing `UInt16` data (that is, 16-bit unsigned values),
-be aware that values greater than `UInt16.MaxValue/2 - 1` will show up as negative numbers in
-Java. Using that data in a Java application may have unexpected behavior. If you expect to exceed
+taken when passing these types between .NET Framework and Java applications using the .NET
+Framework `ReflectionBasedAutoSerializer`. For example, if storing `UInt16` data (that is, 16-bit
+unsigned values), be aware that values greater than `UInt16.MaxValue/2 - 1` will show up as
+negative numbers in Java.
+Using that data in a Java application may have unexpected behavior. If you expect to exceed
 half the range for the given type (`Byte.MaxValue/2`, `UInt16.MaxValue/2`, `UInt32.MaxValue/2`, or
 `UInt64.MaxValue/2`) you should use the next larger type. This obviously breaks down for
-`UInt64`, which has no next larger type. However, if your range exceeds `UIn64.MaxValue/2`, you likely
-have a much more complex set of issues to deal with, such as heavy paging due to such a large data
-set.
+`UInt64`, which has no next larger type. However, if your range exceeds `UIn64.MaxValue/2`, you
+likely have a much more complex set of issues to deal with, such as heavy paging due to such a
+large data set.
 
-## <a id="auto-ser-remote-queries"></a>Remote Queries of .NET Only Types
+## <a id="auto-ser-remote-queries"></a>Remote Queries of .NET Framework Only Types
 
-At this time the .NET Client does not support queries against user classes that have been stored on
-the server using the `ReflectionBasedAutoSerializer`.
+At this time the .NET Framework Client does not support queries against user classes that have been
+stored on the server using the `ReflectionBasedAutoSerializer`.
 
 When you register the reflection-based serializer, <%=vars.product_name%> uses it to serialize all
 objects that do not implement `IPdxSerializable`. You can customize the
@@ -87,7 +89,7 @@ For example:
 [PdxIdentityField] private int id;
 ```
 
-To exclude a field from serialization, add the .NET attribute `NonSerialized` to the field.
+To exclude a field from serialization, add the .NET Framework attribute `NonSerialized` to the field.
 
 For example:
 
@@ -97,7 +99,7 @@ For example:
 
 For each domain class <%=vars.product_name%> serializes using the autoserializer, all fields are
 considered for serialization except those defined as `static`, `literal` or `readonly` and those you
-explicitly exclude using the .NET `NonSerialized` attribute.
+explicitly exclude using the .NET Framework `NonSerialized` attribute.
 
 This example code demonstrates how to extend the autoserializer to customize serialization.
 

--- a/docs/geode-native-docs-dotnet/serialization/dotnet-serialization/dotnet-pdx-serialization.html.md.erb
+++ b/docs/geode-native-docs-dotnet/serialization/dotnet-serialization/dotnet-pdx-serialization.html.md.erb
@@ -19,7 +19,7 @@ limitations under the License.
 
 <%=vars.product_name%>'s Portable Data eXchange (PDX) is a cross-language data format that can reduce the cost of distributing and serializing your objects.
 
-<%=vars.product_name%> .NET PDX serialization:
+<%=vars.product_name%> .NET Framework PDX serialization:
 
 - Is <a href="#pdx-ser-portability">interoperable with other languages by <%=vars.product_name%></a> -- no need to program a Java-side implementation
 
@@ -30,9 +30,11 @@ limitations under the License.
 
 - <a href="#pdx-ser-delta-prop">Works with <%=vars.product_name%> delta propagation</a>
 
-The simplest option is to use [automatic serialization](dotnet-pdx-autoserializer.html) by registering the <%=vars.product_name%> .NET
-PDX reflection-based autoserializer in your application. When you have an autoserializer,
-<%=vars.product_name%> uses it for all domain objects that are not separately treated under the IPDXSerializable interface.
+The simplest option is to use [automatic serialization](dotnet-pdx-autoserializer.html) by
+registering the <%=vars.product_name%> .NET Framework PDX reflection-based autoserializer in your
+application. When you have an autoserializer,
+<%=vars.product_name%> uses it for all domain objects that are not separately treated under the
+IPDXSerializable interface.
 
 For greater control, you can specify individual treatment for domain objects using the `IPdxSerializable` interface.
 Objects derived from the `IPdxSerializable` interface are not subject to autoserialization.
@@ -43,21 +45,23 @@ When you create an `IPdxSerializable` object, <%=vars.product_name%> stores the 
 information in a central registry. The information is passed between peers, between clients and
 servers, and between distributed systems.
 
-This offers a notable advantage to the .NET client, which shares data with Java cache
-servers. When using PDX serialization, clients automatically pass registry information to servers when they store an
-`IPdxSerializable` object. Clients can run queries and functions against the data in the servers
-without the servers needing to know anything about the stored objects. One client can store data on
-the server to be retrieved by another client, with the server never needing to know the object
-type. This means you can code your .NET clients to manage data using Java servers without having to
-create Java implementations of your .NET domain objects.
+This offers a notable advantage to the .NET Framework client, which shares data with Java cache
+servers. When using PDX serialization, clients automatically pass registry information to servers
+when they store an `IPdxSerializable` object. Clients can run queries and functions against the
+data in the servers without the servers needing to know anything about the stored objects. One
+client can store data on the server to be retrieved by another client, with the server never
+needing to know the object type. This means you can code your .NET Framework clients to manage data
+using Java servers without having to create Java implementations of your .NET Framework domain
+objects.
 
 ## <a id="pdx-ser-reduced-deserialization"></a>Reduced Deserialization of Serialized Objects
 
 The access methods for `IPdxSerializable` objects allow you to examine specific fields of your
 domain object without deserializing the entire object. This can reduce 
-deserialization costs significantly. Client .NET apps can run queries and execute functions against
-the objects in the server caches without deserializing the entire object on the server side. The
-query engine automatically recognizes PDX objects and uses only the fields it needs.
+deserialization costs significantly. Client .NET Framework apps can run queries and execute
+functions against the objects in the server caches without deserializing the entire object on the
+server side. The query engine automatically recognizes PDX objects and uses only the fields it
+needs.
 
 Clients can execute Java functions on server data that only access parts of the domain objects by using `PdxInstance.`
 

--- a/docs/geode-native-docs-dotnet/serialization/dotnet-serialization/pdx-serializable-examples.html.md.erb
+++ b/docs/geode-native-docs-dotnet/serialization/dotnet-serialization/pdx-serializable-examples.html.md.erb
@@ -19,8 +19,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-The native client release contain an example showing how a client application
-can register for serialization of domain objects using the .NET IPdxSerializable interface.
+The native client release contain an example showing how a client application can register for
+serialization of domain objects using the .NET Framework IPdxSerializable interface.
 
 The example is located in `examples\dotnet\pdxserializable`.
 
@@ -48,12 +48,12 @@ The example performs a sequence of operations, displaying simple log entries as 
 
 
 <a id="pdsxbl_dotnet_example"></a>
-## .NET Example
+## .NET Framework Example
 
-This section contains code snippets showing highlights of the .NET PdxSerializable example. They are not intended for cut-and-paste execution.
+This section contains code snippets showing highlights of the .NET Framework PdxSerializable example. They are not intended for cut-and-paste execution.
 For the complete source, see the example source directory.
 
-The .NET example defines a PdxSerializable class called `Order` that inherits from the `IPdxSerializable` interface.
+The .NET Framework example defines a PdxSerializable class called `Order` that inherits from the `IPdxSerializable` interface.
 An `Order` object contains three fields:
 
 - an integer `order_id`
@@ -102,7 +102,7 @@ From Order.cs:
     }
 ```
 
-The .NET example mainline creates a cache, then uses it to register the PdxSerializable class that was created in Orders.cs:
+The .NET Framework example mainline creates a cache, then uses it to register the PdxSerializable class that was created in Orders.cs:
 
 ```csharp
 var cache = new CacheFactory()

--- a/docs/geode-native-docs-dotnet/serialization/dotnet-serialization/serialize-using-ipdxserializable.html.md.erb
+++ b/docs/geode-native-docs-dotnet/serialization/dotnet-serialization/serialize-using-ipdxserializable.html.md.erb
@@ -38,7 +38,7 @@ Use this procedure to program your domain object for PDX serialization using the
     If you also use PDX serialization in Java for the object, serialize the object in the same way for each language. Serialize the same fields in the same order and mark the same identify fields.
 
 3.  Program the `IPdxSerializable ToData` function to serialize your object as required by your application.
-    1.  Write your domain class's standard .NET data fields using the `IPdxWriter` write methods. <%=vars.product_name%> automatically provides `IPdxWriter` to the `ToData` function for `IPdxSerializable` objects.
+    1.  Write your domain class's standard .NET Framework data fields using the `IPdxWriter` write methods. <%=vars.product_name%> automatically provides `IPdxWriter` to the `ToData` function for `IPdxSerializable` objects.
     2.  Call the `ToData MarkIdentifyField` function for each field <%=vars.product_name%> should use to identify your object. This is used to compare objects for operations like `DISTINCT` queries. The `MarkIdentifyField` call must come after the associated field write methods.
 
         Example:

--- a/docs/geode-native-docs-dotnet/transactions.html.md.erb
+++ b/docs/geode-native-docs-dotnet/transactions.html.md.erb
@@ -29,7 +29,7 @@ For complete information about how transactions are conducted on the <%=vars.pro
 The API for distributed transactions has the familiar relational database methods, `Begin`,
 `Commit`, and `Rollback`. There are also APIs available to suspend and resume transactions.
 
-The .NET classes for executing transactions are:
+The .NET Framework classes for executing transactions are:
 
 -   `Apache.Geode.Client.CacheTransactionManager`
 -   `Apache.Geode.Client.TransactionId`
@@ -80,12 +80,12 @@ treated as unsuccessful. The transaction is retried until it succeeds.
   - In case the transaction repeatedly fails, the retry loop uses a counter to set a limit of 5 retries.
 
 
-### <a id="dotnet-example"></a>.NET Example
+### <a id="dotnet-example"></a>.NET Framework Example
 
-This section contains code snippets showing highlights of the .NET transaction example. They are not intended for cut-and-paste execution.
+This section contains code snippets showing highlights of the .NET Framework transaction example. They are not intended for cut-and-paste execution.
 For the complete source, see the example source directory.
 
-The .NET example creates a cache, then uses it to create a connection pool.
+The .NET Framework example creates a cache, then uses it to create a connection pool.
 
 ```csharp
   var cache = new CacheFactory()


### PR DESCRIPTION
GEODE-9921: Update references of ".NET" to ".NET Framework" to clarify that we are not referring to .NET Core.