### PR TITLE
GEODE-10291: Compile on ubuntu jammy (gcc/g++ 11.2.0)

### DIFF
--- a/cppcache/integration/test/PdxTypeRegistryTest.cpp
+++ b/cppcache/integration/test/PdxTypeRegistryTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <thread>
 
 #include <gtest/gtest.h>
 

--- a/cppcache/test/ConnectionQueueTest.cpp
+++ b/cppcache/test/ConnectionQueueTest.cpp
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 
 #include <future>
+#include <thread>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Initially failed to compile because it could not find `sleep_for` (was undefined)