### PR TITLE
GEODE-10292: Bump to boost 1.79.0

### DIFF
--- a/cppcache/test/statistics/HostStatSamplerTest.cpp
+++ b/cppcache/test/statistics/HostStatSamplerTest.cpp
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 
 #include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
 #include <boost/process/environment.hpp>
 
 #include <gtest/gtest.h>

--- a/dependencies/boost/CMakeLists.txt
+++ b/dependencies/boost/CMakeLists.txt
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project(boost VERSION 1.76.0 LANGUAGES NONE)
+project(boost VERSION 1.79.0 LANGUAGES NONE)
 
-set(SHA256 7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca)
+set(SHA256 273f1be93238a068aba4f9735a4a2b003019af067b9c183ed227780b8f36062c)
 
 if (WIN32)
   set(BOOTSTRAP_COMMAND bootstrap.bat)


### PR DESCRIPTION
Initially complained that it did not know what `boost::filesystem::ofstream` before adding the header file