### PR TITLE
GEODE-10300: C++ native client: Allow locator responses greater than …

### DIFF
--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -502,7 +502,7 @@ class APACHE_GEODE_EXPORT DataInput {
 
   inline char readPdxChar() { return static_cast<char>(readInt16()); }
 
-  virtual inline void _checkBufferSize(size_t size, int32_t line) {
+  virtual void _checkBufferSize(size_t size, int32_t line) {
     if ((m_bufLength - (m_buf - m_bufHead)) < size) {
       throw OutOfRangeException(
           "DataInput: attempt to read beyond buffer at line " +

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -73,7 +73,7 @@ class APACHE_GEODE_EXPORT DataInput {
    */
   inline bool readBoolean() {
     _GEODE_CHECK_BUFFER_SIZE(1);
-    return *(m_buf++) == 1 ? true : false;
+    return *(buf_++) == 1 ? true : false;
   }
 
   /**
@@ -89,8 +89,8 @@ class APACHE_GEODE_EXPORT DataInput {
   inline void readBytesOnly(uint8_t* buffer, size_t len) {
     if (len > 0) {
       _GEODE_CHECK_BUFFER_SIZE(len);
-      std::memcpy(buffer, m_buf, len);
-      m_buf += len;
+      std::memcpy(buffer, buf_, len);
+      buf_ += len;
     }
   }
 
@@ -107,8 +107,8 @@ class APACHE_GEODE_EXPORT DataInput {
   inline void readBytesOnly(int8_t* buffer, size_t len) {
     if (len > 0) {
       _GEODE_CHECK_BUFFER_SIZE(len);
-      std::memcpy(buffer, m_buf, len);
-      m_buf += len;
+      std::memcpy(buffer, buf_, len);
+      buf_ += len;
     }
   }
 
@@ -129,8 +129,8 @@ class APACHE_GEODE_EXPORT DataInput {
     if (length > 0) {
       _GEODE_CHECK_BUFFER_SIZE(length);
       _GEODE_NEW(buffer, uint8_t[length]);
-      std::memcpy(buffer, m_buf, length);
-      m_buf += length;
+      std::memcpy(buffer, buf_, length);
+      buf_ += length;
     }
     *bytes = buffer;
   }
@@ -152,8 +152,8 @@ class APACHE_GEODE_EXPORT DataInput {
     if (length > 0) {
       _GEODE_CHECK_BUFFER_SIZE(length);
       _GEODE_NEW(buffer, int8_t[length]);
-      std::memcpy(buffer, m_buf, length);
-      m_buf += length;
+      std::memcpy(buffer, buf_, length);
+      buf_ += length;
     }
     *bytes = buffer;
   }
@@ -173,10 +173,10 @@ class APACHE_GEODE_EXPORT DataInput {
    */
   inline int32_t readInt32() {
     _GEODE_CHECK_BUFFER_SIZE(4);
-    int32_t tmp = *(m_buf++);
-    tmp = (tmp << 8) | *(m_buf++);
-    tmp = (tmp << 8) | *(m_buf++);
-    tmp = (tmp << 8) | *(m_buf++);
+    int32_t tmp = *(buf_++);
+    tmp = (tmp << 8) | *(buf_++);
+    tmp = (tmp << 8) | *(buf_++);
+    tmp = (tmp << 8) | *(buf_++);
     return tmp;
   }
 
@@ -186,14 +186,14 @@ class APACHE_GEODE_EXPORT DataInput {
   inline int64_t readInt64() {
     _GEODE_CHECK_BUFFER_SIZE(8);
     int64_t tmp;
-    tmp = *(m_buf++);
-    tmp = (tmp << 8) | *(m_buf++);
-    tmp = (tmp << 8) | *(m_buf++);
-    tmp = (tmp << 8) | *(m_buf++);
-    tmp = (tmp << 8) | *(m_buf++);
-    tmp = (tmp << 8) | *(m_buf++);
-    tmp = (tmp << 8) | *(m_buf++);
-    tmp = (tmp << 8) | *(m_buf++);
+    tmp = *(buf_++);
+    tmp = (tmp << 8) | *(buf_++);
+    tmp = (tmp << 8) | *(buf_++);
+    tmp = (tmp << 8) | *(buf_++);
+    tmp = (tmp << 8) | *(buf_++);
+    tmp = (tmp << 8) | *(buf_++);
+    tmp = (tmp << 8) | *(buf_++);
+    tmp = (tmp << 8) | *(buf_++);
     return tmp;
   }
 
@@ -396,33 +396,33 @@ class APACHE_GEODE_EXPORT DataInput {
    * as readonly and modification of contents using this internal pointer
    * has undefined behavior.
    */
-  inline const uint8_t* currentBufferPosition() const { return m_buf; }
+  inline const uint8_t* currentBufferPosition() const { return buf_; }
 
   /** get the number of bytes read in the buffer */
-  inline size_t getBytesRead() const { return m_buf - m_bufHead; }
+  inline size_t getBytesRead() const { return buf_ - bufHead_; }
 
   /** get the number of bytes remaining to be read in the buffer */
   inline size_t getBytesRemaining() const {
-    return (m_bufLength - getBytesRead());
+    return (bufLength_ - getBytesRead());
   }
 
   /** advance the cursor by given offset */
-  inline void advanceCursor(size_t offset) { m_buf += offset; }
+  inline void advanceCursor(size_t offset) { buf_ += offset; }
 
   /** rewind the cursor by given offset */
-  inline void rewindCursor(size_t offset) { m_buf -= offset; }
+  inline void rewindCursor(size_t offset) { buf_ -= offset; }
 
   /** reset the cursor to the start of buffer */
-  inline void reset() { m_buf = m_bufHead; }
+  inline void reset() { buf_ = bufHead_; }
 
   inline void setBuffer() {
-    m_buf = currentBufferPosition();
-    m_bufLength = getBytesRemaining();
+    buf_ = currentBufferPosition();
+    bufLength_ = getBytesRemaining();
   }
 
-  inline void resetPdx(size_t offset) { m_buf = m_bufHead + offset; }
+  inline void resetPdx(size_t offset) { buf_ = bufHead_ + offset; }
 
-  inline size_t getPdxBytes() const { return m_bufLength; }
+  inline size_t getPdxBytes() const { return bufLength_; }
 
   static uint8_t* getBufferCopy(const uint8_t* from, size_t length) {
     uint8_t* result;
@@ -432,7 +432,7 @@ class APACHE_GEODE_EXPORT DataInput {
     return result;
   }
 
-  inline void reset(size_t offset) { m_buf = m_bufHead + offset; }
+  inline void reset(size_t offset) { buf_ = bufHead_ + offset; }
 
   uint8_t* getBufferCopyFrom(const uint8_t* from, size_t length) {
     uint8_t* result;
@@ -452,11 +452,11 @@ class APACHE_GEODE_EXPORT DataInput {
   DataInput& operator=(DataInput&&) = default;
 
  protected:
-  const uint8_t* m_buf;
-  const uint8_t* m_bufHead;
-  size_t m_bufLength;
-  Pool* m_pool;
-  const CacheImpl* m_cache;
+  const uint8_t* buf_;
+  const uint8_t* bufHead_;
+  size_t bufLength_;
+  Pool* pool_;
+  const CacheImpl* cache_;
 
   /** constructor given a pre-allocated byte array with size */
   DataInput(const uint8_t* buffer, size_t len, const CacheImpl* cache,
@@ -503,20 +503,20 @@ class APACHE_GEODE_EXPORT DataInput {
   inline char readPdxChar() { return static_cast<char>(readInt16()); }
 
   virtual void _checkBufferSize(size_t size, int32_t line) {
-    if ((m_bufLength - (m_buf - m_bufHead)) < size) {
+    if ((bufLength_ - (buf_ - bufHead_)) < size) {
       throw OutOfRangeException(
           "DataInput: attempt to read beyond buffer at line " +
           std::to_string(line) + ": available buffer size " +
-          std::to_string(m_bufLength - (m_buf - m_bufHead)) +
+          std::to_string(bufLength_ - (buf_ - bufHead_)) +
           ", attempted read of size " + std::to_string(size));
     }
   }
 
-  inline int8_t readNoCheck() { return *(m_buf++); }
+  inline int8_t readNoCheck() { return *(buf_++); }
 
   inline int16_t readInt16NoCheck() {
-    int16_t tmp = *(m_buf++);
-    tmp = static_cast<int16_t>((tmp << 8) | *(m_buf++));
+    int16_t tmp = *(buf_++);
+    tmp = static_cast<int16_t>((tmp << 8) | *(buf_++));
     return tmp;
   }
 
@@ -605,7 +605,7 @@ class APACHE_GEODE_EXPORT DataInput {
     value.assign(reinterpret_cast<const wchar_t*>(tmp.data()), tmp.length());
   }
 
-  Pool* getPool() const { return m_pool; }
+  Pool* getPool() const { return pool_; }
 
   friend Cache;
   friend CacheImpl;

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -73,7 +73,7 @@ class APACHE_GEODE_EXPORT DataInput {
    */
   inline bool readBoolean() {
     _GEODE_CHECK_BUFFER_SIZE(1);
-    return *(buf_++) == 1 ? true : false;
+    return *(buffer_++) == 1 ? true : false;
   }
 
   /**
@@ -89,8 +89,8 @@ class APACHE_GEODE_EXPORT DataInput {
   inline void readBytesOnly(uint8_t* buffer, size_t len) {
     if (len > 0) {
       _GEODE_CHECK_BUFFER_SIZE(len);
-      std::memcpy(buffer, buf_, len);
-      buf_ += len;
+      std::memcpy(buffer, buffer_, len);
+      buffer_ += len;
     }
   }
 
@@ -107,8 +107,8 @@ class APACHE_GEODE_EXPORT DataInput {
   inline void readBytesOnly(int8_t* buffer, size_t len) {
     if (len > 0) {
       _GEODE_CHECK_BUFFER_SIZE(len);
-      std::memcpy(buffer, buf_, len);
-      buf_ += len;
+      std::memcpy(buffer, buffer_, len);
+      buffer_ += len;
     }
   }
 
@@ -129,8 +129,8 @@ class APACHE_GEODE_EXPORT DataInput {
     if (length > 0) {
       _GEODE_CHECK_BUFFER_SIZE(length);
       _GEODE_NEW(buffer, uint8_t[length]);
-      std::memcpy(buffer, buf_, length);
-      buf_ += length;
+      std::memcpy(buffer, buffer_, length);
+      buffer_ += length;
     }
     *bytes = buffer;
   }
@@ -152,8 +152,8 @@ class APACHE_GEODE_EXPORT DataInput {
     if (length > 0) {
       _GEODE_CHECK_BUFFER_SIZE(length);
       _GEODE_NEW(buffer, int8_t[length]);
-      std::memcpy(buffer, buf_, length);
-      buf_ += length;
+      std::memcpy(buffer, buffer_, length);
+      buffer_ += length;
     }
     *bytes = buffer;
   }
@@ -173,10 +173,10 @@ class APACHE_GEODE_EXPORT DataInput {
    */
   inline int32_t readInt32() {
     _GEODE_CHECK_BUFFER_SIZE(4);
-    int32_t tmp = *(buf_++);
-    tmp = (tmp << 8) | *(buf_++);
-    tmp = (tmp << 8) | *(buf_++);
-    tmp = (tmp << 8) | *(buf_++);
+    int32_t tmp = *(buffer_++);
+    tmp = (tmp << 8) | *(buffer_++);
+    tmp = (tmp << 8) | *(buffer_++);
+    tmp = (tmp << 8) | *(buffer_++);
     return tmp;
   }
 
@@ -186,14 +186,14 @@ class APACHE_GEODE_EXPORT DataInput {
   inline int64_t readInt64() {
     _GEODE_CHECK_BUFFER_SIZE(8);
     int64_t tmp;
-    tmp = *(buf_++);
-    tmp = (tmp << 8) | *(buf_++);
-    tmp = (tmp << 8) | *(buf_++);
-    tmp = (tmp << 8) | *(buf_++);
-    tmp = (tmp << 8) | *(buf_++);
-    tmp = (tmp << 8) | *(buf_++);
-    tmp = (tmp << 8) | *(buf_++);
-    tmp = (tmp << 8) | *(buf_++);
+    tmp = *(buffer_++);
+    tmp = (tmp << 8) | *(buffer_++);
+    tmp = (tmp << 8) | *(buffer_++);
+    tmp = (tmp << 8) | *(buffer_++);
+    tmp = (tmp << 8) | *(buffer_++);
+    tmp = (tmp << 8) | *(buffer_++);
+    tmp = (tmp << 8) | *(buffer_++);
+    tmp = (tmp << 8) | *(buffer_++);
     return tmp;
   }
 
@@ -396,33 +396,33 @@ class APACHE_GEODE_EXPORT DataInput {
    * as readonly and modification of contents using this internal pointer
    * has undefined behavior.
    */
-  inline const uint8_t* currentBufferPosition() const { return buf_; }
+  inline const uint8_t* currentBufferPosition() const { return buffer_; }
 
   /** get the number of bytes read in the buffer */
-  inline size_t getBytesRead() const { return buf_ - bufHead_; }
+  inline size_t getBytesRead() const { return buffer_ - bufferHead_; }
 
   /** get the number of bytes remaining to be read in the buffer */
   inline size_t getBytesRemaining() const {
-    return (bufLength_ - getBytesRead());
+    return (bufferLength_ - getBytesRead());
   }
 
   /** advance the cursor by given offset */
-  inline void advanceCursor(size_t offset) { buf_ += offset; }
+  inline void advanceCursor(size_t offset) { buffer_ += offset; }
 
   /** rewind the cursor by given offset */
-  inline void rewindCursor(size_t offset) { buf_ -= offset; }
+  inline void rewindCursor(size_t offset) { buffer_ -= offset; }
 
   /** reset the cursor to the start of buffer */
-  inline void reset() { buf_ = bufHead_; }
+  inline void reset() { buffer_ = bufferHead_; }
 
   inline void setBuffer() {
-    buf_ = currentBufferPosition();
-    bufLength_ = getBytesRemaining();
+    buffer_ = currentBufferPosition();
+    bufferLength_ = getBytesRemaining();
   }
 
-  inline void resetPdx(size_t offset) { buf_ = bufHead_ + offset; }
+  inline void resetPdx(size_t offset) { buffer_ = bufferHead_ + offset; }
 
-  inline size_t getPdxBytes() const { return bufLength_; }
+  inline size_t getPdxBytes() const { return bufferLength_; }
 
   static uint8_t* getBufferCopy(const uint8_t* from, size_t length) {
     uint8_t* result;
@@ -432,7 +432,7 @@ class APACHE_GEODE_EXPORT DataInput {
     return result;
   }
 
-  inline void reset(size_t offset) { buf_ = bufHead_ + offset; }
+  inline void reset(size_t offset) { buffer_ = bufferHead_ + offset; }
 
   uint8_t* getBufferCopyFrom(const uint8_t* from, size_t length) {
     uint8_t* result;
@@ -452,9 +452,9 @@ class APACHE_GEODE_EXPORT DataInput {
   DataInput& operator=(DataInput&&) = default;
 
  protected:
-  const uint8_t* buf_;
-  const uint8_t* bufHead_;
-  size_t bufLength_;
+  const uint8_t* buffer_;
+  const uint8_t* bufferHead_;
+  size_t bufferLength_;
   Pool* pool_;
   const CacheImpl* cache_;
 
@@ -503,20 +503,20 @@ class APACHE_GEODE_EXPORT DataInput {
   inline char readPdxChar() { return static_cast<char>(readInt16()); }
 
   virtual void _checkBufferSize(size_t size, int32_t line) {
-    if ((bufLength_ - (buf_ - bufHead_)) < size) {
+    if ((bufferLength_ - (buffer_ - bufferHead_)) < size) {
       throw OutOfRangeException(
           "DataInput: attempt to read beyond buffer at line " +
           std::to_string(line) + ": available buffer size " +
-          std::to_string(bufLength_ - (buf_ - bufHead_)) +
+          std::to_string(bufferLength_ - (buffer_ - bufferHead_)) +
           ", attempted read of size " + std::to_string(size));
     }
   }
 
-  inline int8_t readNoCheck() { return *(buf_++); }
+  inline int8_t readNoCheck() { return *(buffer_++); }
 
   inline int16_t readInt16NoCheck() {
-    int16_t tmp = *(buf_++);
-    tmp = static_cast<int16_t>((tmp << 8) | *(buf_++));
+    int16_t tmp = *(buffer_++);
+    tmp = static_cast<int16_t>((tmp << 8) | *(buffer_++));
     return tmp;
   }
 

--- a/cppcache/include/geode/DataInput.hpp
+++ b/cppcache/include/geode/DataInput.hpp
@@ -452,6 +452,12 @@ class APACHE_GEODE_EXPORT DataInput {
   DataInput& operator=(DataInput&&) = default;
 
  protected:
+  const uint8_t* m_buf;
+  const uint8_t* m_bufHead;
+  size_t m_bufLength;
+  Pool* m_pool;
+  const CacheImpl* m_cache;
+
   /** constructor given a pre-allocated byte array with size */
   DataInput(const uint8_t* buffer, size_t len, const CacheImpl* cache,
             Pool* pool);
@@ -459,12 +465,6 @@ class APACHE_GEODE_EXPORT DataInput {
   virtual const SerializationRegistry& getSerializationRegistry() const;
 
  private:
-  const uint8_t* m_buf;
-  const uint8_t* m_bufHead;
-  size_t m_bufLength;
-  Pool* m_pool;
-  const CacheImpl* m_cache;
-
   std::shared_ptr<Serializable> readObjectInternal(int8_t typeId = -1);
 
   template <typename mType>
@@ -502,7 +502,7 @@ class APACHE_GEODE_EXPORT DataInput {
 
   inline char readPdxChar() { return static_cast<char>(readInt16()); }
 
-  inline void _checkBufferSize(size_t size, int32_t line) {
+  virtual inline void _checkBufferSize(size_t size, int32_t line) {
     if ((m_bufLength - (m_buf - m_bufHead)) < size) {
       throw OutOfRangeException(
           "DataInput: attempt to read beyond buffer at line " +

--- a/cppcache/src/CacheXmlCreation.cpp
+++ b/cppcache/src/CacheXmlCreation.cpp
@@ -50,12 +50,12 @@ void CacheXmlCreation::create(Cache* cache) {
 }
 
 void CacheXmlCreation::setPdxIgnoreUnreadField(bool ignore) {
-  // m_cache->m_cacheImpl->setPdxIgnoreUnreadFields(ignore);
+  // cache_->m_cacheImpl->setPdxIgnoreUnreadFields(ignore);
   m_pdxIgnoreUnreadFields = ignore;
 }
 
 void CacheXmlCreation::setPdxReadSerialized(bool val) {
-  // m_cache->m_cacheImpl->setPdxIgnoreUnreadFields(ignore);
+  // cache_->m_cacheImpl->setPdxIgnoreUnreadFields(ignore);
   m_readPdxSerialized = val;
 }
 

--- a/cppcache/src/CacheXmlCreation.cpp
+++ b/cppcache/src/CacheXmlCreation.cpp
@@ -50,12 +50,12 @@ void CacheXmlCreation::create(Cache* cache) {
 }
 
 void CacheXmlCreation::setPdxIgnoreUnreadField(bool ignore) {
-  // cache_->m_cacheImpl->setPdxIgnoreUnreadFields(ignore);
+  // m_cache->m_cacheImpl->setPdxIgnoreUnreadFields(ignore);
   m_pdxIgnoreUnreadFields = ignore;
 }
 
 void CacheXmlCreation::setPdxReadSerialized(bool val) {
-  // cache_->m_cacheImpl->setPdxIgnoreUnreadFields(ignore);
+  // m_cache->m_cacheImpl->setPdxIgnoreUnreadFields(ignore);
   m_readPdxSerialized = val;
 }
 

--- a/cppcache/src/Connector.hpp
+++ b/cppcache/src/Connector.hpp
@@ -117,6 +117,11 @@ class Connector {
   virtual uint16_t getPort() = 0;
 
   /**
+   * Returns the remote endpoint for this connection in the form host:port
+   */
+  virtual std::string getRemoteEndpoint() = 0;
+
+  /**
    * Writes an array of a known size to the underlying output stream.
    *
    * @param   array A C-style stack array. Be weary of arrays that have been

--- a/cppcache/src/DataInput.cpp
+++ b/cppcache/src/DataInput.cpp
@@ -30,21 +30,21 @@ namespace client {
 
 DataInput::DataInput(const uint8_t* buffer, size_t len, const CacheImpl* cache,
                      Pool* pool)
-    : m_buf(buffer),
-      m_bufHead(buffer),
-      m_bufLength(len),
-      m_pool(pool),
-      m_cache(cache) {}
+    : buf_(buffer),
+      bufHead_(buffer),
+      bufLength_(len),
+      pool_(pool),
+      cache_(cache) {}
 
 std::shared_ptr<Serializable> DataInput::readObjectInternal(int8_t typeId) {
   return getSerializationRegistry().deserialize(*this, typeId);
 }
 
 const SerializationRegistry& DataInput::getSerializationRegistry() const {
-  return *m_cache->getSerializationRegistry();
+  return *cache_->getSerializationRegistry();
 }
 
-Cache* DataInput::getCache() const { return m_cache->getCache(); }
+Cache* DataInput::getCache() const { return cache_->getCache(); }
 
 template <class _Traits, class _Allocator>
 void DataInput::readJavaModifiedUtf8(
@@ -63,7 +63,7 @@ void DataInput::readJavaModifiedUtf8(
   uint16_t length = readInt16();
   _GEODE_CHECK_BUFFER_SIZE(length);
   value = internal::JavaModifiedUtf8::decode(
-      reinterpret_cast<const char*>(m_buf), length);
+      reinterpret_cast<const char*>(buf_), length);
   advanceCursor(length);
 }
 template APACHE_GEODE_EXPLICIT_TEMPLATE_EXPORT void

--- a/cppcache/src/DataInput.cpp
+++ b/cppcache/src/DataInput.cpp
@@ -30,9 +30,9 @@ namespace client {
 
 DataInput::DataInput(const uint8_t* buffer, size_t len, const CacheImpl* cache,
                      Pool* pool)
-    : buf_(buffer),
-      bufHead_(buffer),
-      bufLength_(len),
+    : buffer_(buffer),
+      bufferHead_(buffer),
+      bufferLength_(len),
       pool_(pool),
       cache_(cache) {}
 
@@ -63,7 +63,7 @@ void DataInput::readJavaModifiedUtf8(
   uint16_t length = readInt16();
   _GEODE_CHECK_BUFFER_SIZE(length);
   value = internal::JavaModifiedUtf8::decode(
-      reinterpret_cast<const char*>(buf_), length);
+      reinterpret_cast<const char*>(buffer_), length);
   advanceCursor(length);
 }
 template APACHE_GEODE_EXPLICIT_TEMPLATE_EXPORT void

--- a/cppcache/src/GetAllServersResponse.cpp
+++ b/cppcache/src/GetAllServersResponse.cpp
@@ -21,9 +21,9 @@ namespace geode {
 namespace client {
 
 void GetAllServersResponse::toData(DataOutput& output) const {
-  int32_t numServers = static_cast<int32_t>(servers_.size());
-  output.writeInt(numServers);
-  for (int32_t i = 0; i < numServers; i++) {
+  auto numServers = servers_.size();
+  output.writeInt(static_cast<int32_t>(numServers));
+  for (unsigned int i = 0; i < numServers; i++) {
     output.writeObject(servers_.at(i));
   }
 }

--- a/cppcache/src/GetAllServersResponse.cpp
+++ b/cppcache/src/GetAllServersResponse.cpp
@@ -21,10 +21,10 @@ namespace geode {
 namespace client {
 
 void GetAllServersResponse::toData(DataOutput& output) const {
-  int32_t numServers = static_cast<int32_t>(m_servers.size());
+  int32_t numServers = static_cast<int32_t>(servers_.size());
   output.writeInt(numServers);
   for (int32_t i = 0; i < numServers; i++) {
-    output.writeObject(m_servers.at(i));
+    output.writeObject(servers_.at(i));
   }
 }
 void GetAllServersResponse::fromData(DataInput& input) {
@@ -33,7 +33,7 @@ void GetAllServersResponse::fromData(DataInput& input) {
   for (int i = 0; i < numServers; i++) {
     std::shared_ptr<ServerLocation> sLoc = std::make_shared<ServerLocation>();
     sLoc->fromData(input);
-    m_servers.push_back(sLoc);
+    servers_.push_back(sLoc);
   }
 }
 

--- a/cppcache/src/GetAllServersResponse.hpp
+++ b/cppcache/src/GetAllServersResponse.hpp
@@ -35,8 +35,6 @@ namespace client {
 
 class GetAllServersResponse : public internal::DataSerializableFixedId_t<
                                   internal::DSFid::GetAllServersResponse> {
-  std::vector<std::shared_ptr<ServerLocation> > m_servers;
-
  public:
   static std::shared_ptr<Serializable> create() {
     return std::make_shared<GetAllServersResponse>();
@@ -44,19 +42,20 @@ class GetAllServersResponse : public internal::DataSerializableFixedId_t<
   GetAllServersResponse() : Serializable() {}
   explicit GetAllServersResponse(
       std::vector<std::shared_ptr<ServerLocation> > servers)
-      : Serializable() {
-    m_servers = servers;
-  }
+      : Serializable(), servers_(servers) {}
   void toData(DataOutput& output) const override;
   void fromData(DataInput& input) override;
 
   size_t objectSize() const override {
-    return sizeof(GetAllServersResponse) + m_servers.capacity();
+    return sizeof(GetAllServersResponse) + servers_.capacity();
   }
   std::vector<std::shared_ptr<ServerLocation> > getServers() {
-    return m_servers;
+    return servers_;
   }
   ~GetAllServersResponse() override = default;
+
+ private:
+  std::vector<std::shared_ptr<ServerLocation> > servers_;
 };
 
 }  // namespace client

--- a/cppcache/src/GetAllServersResponse.hpp
+++ b/cppcache/src/GetAllServersResponse.hpp
@@ -42,7 +42,8 @@ class GetAllServersResponse : public internal::DataSerializableFixedId_t<
     return std::make_shared<GetAllServersResponse>();
   }
   GetAllServersResponse() : Serializable() {}
-  GetAllServersResponse(std::vector<std::shared_ptr<ServerLocation> > servers)
+  explicit GetAllServersResponse(
+      std::vector<std::shared_ptr<ServerLocation> > servers)
       : Serializable() {
     m_servers = servers;
   }

--- a/cppcache/src/GetAllServersResponse.hpp
+++ b/cppcache/src/GetAllServersResponse.hpp
@@ -42,6 +42,10 @@ class GetAllServersResponse : public internal::DataSerializableFixedId_t<
     return std::make_shared<GetAllServersResponse>();
   }
   GetAllServersResponse() : Serializable() {}
+  GetAllServersResponse(std::vector<std::shared_ptr<ServerLocation> > servers)
+      : Serializable() {
+    m_servers = servers;
+  }
   void toData(DataOutput& output) const override;
   void fromData(DataInput& input) override;
 

--- a/cppcache/src/StreamDataInput.cpp
+++ b/cppcache/src/StreamDataInput.cpp
@@ -26,7 +26,7 @@ namespace apache {
 namespace geode {
 namespace client {
 
-const size_t kBufferSize = 3000;
+constexpr size_t kBufferSize = 3000;
 
 StreamDataInput::StreamDataInput(std::chrono::milliseconds timeout,
                                  std::unique_ptr<Connector> connector,
@@ -53,30 +53,30 @@ void StreamDataInput::readDataIfNotAvailable(size_t size) {
 
     LOGDEBUG(
         "received %d bytes from %s: %s, time spent: "
-        "%ld microsecs, time remaining before timeout: %ld microsecs",
+        "%ld millisecs, time remaining before timeout: %ld millisecs",
         receivedLength, connector_->getRemoteEndpoint().c_str(),
         Utils::convertBytesToString(reinterpret_cast<uint8_t*>(buff),
                                     receivedLength)
             .c_str(),
-        std::chrono::duration_cast<std::chrono::microseconds>(timeSpent)
+        std::chrono::duration_cast<std::chrono::milliseconds>(timeSpent)
             .count(),
-        std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
             remainingTimeBeforeTimeout_)
             .count());
 
-    if (remainingTimeBeforeTimeout_ <= std::chrono::microseconds ::zero()) {
+    if (remainingTimeBeforeTimeout_ <= std::chrono::milliseconds ::zero()) {
       throw(TimeoutException(std::string("Timeout when receiving from ")
                                  .append(connector_->getRemoteEndpoint())));
     }
 
-    auto newLength = bufLength_ + receivedLength;
+    auto newLength = bufferLength_ + receivedLength;
     auto currentPosition = getBytesRead();
     streamBuf_.resize(newLength);
-    memcpy(streamBuf_.data() + bufLength_, buff, receivedLength);
+    memcpy(streamBuf_.data() + bufferLength_, buff, receivedLength);
 
-    bufHead_ = streamBuf_.data();
-    buf_ = bufHead_ + currentPosition;
-    bufLength_ = newLength;
+    bufferHead_ = streamBuf_.data();
+    buffer_ = bufferHead_ + currentPosition;
+    bufferLength_ = newLength;
   }
 }
 

--- a/cppcache/src/StreamDataInput.cpp
+++ b/cppcache/src/StreamDataInput.cpp
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "StreamDataInput.hpp"
+
+#include <geode/DataInput.hpp>
+
+#include "Utils.hpp"
+#include "util/Log.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+const size_t BUFF_SIZE = 3000;
+
+StreamDataInput::StreamDataInput(std::chrono::milliseconds timeout,
+                                 std::unique_ptr<Connector> connector,
+                                 const CacheImpl* cache, Pool* pool)
+    : DataInput(nullptr, 0, cache, pool) {
+  m_remainingTimeBeforeTimeout = timeout;
+  m_connector = std::move(connector);
+  m_buf = nullptr;
+  m_bufHead = m_buf;
+  m_bufLength = 0;
+}
+
+StreamDataInput::~StreamDataInput() {
+  if (m_bufHead != nullptr) {
+    free(const_cast<uint8_t*>(m_bufHead));
+  }
+}
+
+void StreamDataInput::readDataIfNotAvailable(size_t size) {
+  char buff[BUFF_SIZE];
+  while ((m_bufLength - (m_buf - m_bufHead)) < size) {
+    const auto start = std::chrono::system_clock::now();
+
+    const auto receivedLength = m_connector->receive_nothrowiftimeout(
+        buff, BUFF_SIZE,
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            m_remainingTimeBeforeTimeout));
+
+    const auto timeSpent = std::chrono::system_clock::now() - start;
+
+    m_remainingTimeBeforeTimeout -=
+        std::chrono::duration_cast<decltype(m_remainingTimeBeforeTimeout)>(
+            timeSpent);
+
+    LOGDEBUG(
+        "received %d bytes from %s: %s, time spent: "
+        "%ld microsecs, time remaining before timeout: %ld microsecs",
+        receivedLength, m_connector->getRemoteEndpoint().c_str(),
+        Utils::convertBytesToString(reinterpret_cast<uint8_t*>(buff),
+                                    receivedLength)
+            .c_str(),
+        std::chrono::duration_cast<std::chrono::microseconds>(timeSpent)
+            .count(),
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            m_remainingTimeBeforeTimeout)
+            .count());
+
+    if (m_remainingTimeBeforeTimeout <= std::chrono::microseconds ::zero()) {
+      throw(TimeoutException(std::string("Timeout when receiving from ")
+                                 .append(m_connector->getRemoteEndpoint())));
+    }
+
+    size_t newLength = m_bufLength + receivedLength;
+    size_t currentPosition = m_buf - m_bufHead;
+    if ((m_bufHead) == nullptr) {
+      m_bufHead = static_cast<uint8_t*>(malloc(sizeof(uint8_t) * newLength));
+    } else {
+      m_bufHead = static_cast<uint8_t*>(
+          realloc(const_cast<uint8_t*>(m_bufHead), newLength));
+    }
+    memcpy(const_cast<uint8_t*>(m_bufHead + m_bufLength), buff, receivedLength);
+    m_buf = m_bufHead + currentPosition;
+    m_bufLength += receivedLength;
+  }
+}
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/StreamDataInput.cpp
+++ b/cppcache/src/StreamDataInput.cpp
@@ -41,9 +41,7 @@ void StreamDataInput::readDataIfNotAvailable(size_t size) {
     const auto start = std::chrono::system_clock::now();
 
     const auto receivedLength = connector_->receive_nothrowiftimeout(
-        buff, kBufferSize,
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            remainingTimeBeforeTimeout_));
+        buff, kBufferSize, remainingTimeBeforeTimeout_);
 
     const auto timeSpent = std::chrono::system_clock::now() - start;
 
@@ -60,9 +58,7 @@ void StreamDataInput::readDataIfNotAvailable(size_t size) {
             .c_str(),
         std::chrono::duration_cast<std::chrono::milliseconds>(timeSpent)
             .count(),
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            remainingTimeBeforeTimeout_)
-            .count());
+        remainingTimeBeforeTimeout_.count());
 
     if (remainingTimeBeforeTimeout_ <= std::chrono::milliseconds ::zero()) {
       throw(TimeoutException(std::string("Timeout when receiving from ")

--- a/cppcache/src/StreamDataInput.cpp
+++ b/cppcache/src/StreamDataInput.cpp
@@ -33,12 +33,7 @@ StreamDataInput::StreamDataInput(std::chrono::milliseconds timeout,
                                  const CacheImpl* cache, Pool* pool)
     : DataInput(nullptr, 0, cache, pool),
       connector_(std::move(connector)),
-      remainingTimeBeforeTimeout_(timeout),
-      streamBuf_(0) {
-  buf_ = nullptr;
-  bufHead_ = buf_;
-  bufLength_ = 0;
-}
+      remainingTimeBeforeTimeout_(timeout) {}
 
 void StreamDataInput::readDataIfNotAvailable(size_t size) {
   char buff[kBufferSize];
@@ -74,14 +69,14 @@ void StreamDataInput::readDataIfNotAvailable(size_t size) {
                                  .append(connector_->getRemoteEndpoint())));
     }
 
+    auto newLength = bufLength_ + receivedLength;
     auto currentPosition = getBytesRead();
-    streamBuf_.resize(bufLength_ + receivedLength);
-    streamBuf_.insert(streamBuf_.begin() + bufLength_, buff,
-                      buff + receivedLength);
+    streamBuf_.resize(newLength);
+    memcpy(streamBuf_.data() + bufLength_, buff, receivedLength);
 
     bufHead_ = streamBuf_.data();
     buf_ = bufHead_ + currentPosition;
-    bufLength_ += receivedLength;
+    bufLength_ = newLength;
   }
 }
 

--- a/cppcache/src/StreamDataInput.cpp
+++ b/cppcache/src/StreamDataInput.cpp
@@ -60,7 +60,7 @@ void StreamDataInput::readDataIfNotAvailable(size_t size) {
             .count(),
         remainingTimeBeforeTimeout_.count());
 
-    if (remainingTimeBeforeTimeout_ <= std::chrono::milliseconds ::zero()) {
+    if (remainingTimeBeforeTimeout_ <= std::chrono::milliseconds::zero()) {
       throw(TimeoutException(std::string("Timeout when receiving from ")
                                  .append(connector_->getRemoteEndpoint())));
     }

--- a/cppcache/src/StreamDataInput.cpp
+++ b/cppcache/src/StreamDataInput.cpp
@@ -26,7 +26,7 @@ namespace apache {
 namespace geode {
 namespace client {
 
-const size_t BUFF_SIZE = 3000;
+const size_t kBufferSize = 3000;
 
 StreamDataInput::StreamDataInput(std::chrono::milliseconds timeout,
                                  std::unique_ptr<Connector> connector,
@@ -46,12 +46,12 @@ StreamDataInput::~StreamDataInput() {
 }
 
 void StreamDataInput::readDataIfNotAvailable(size_t size) {
-  char buff[BUFF_SIZE];
+  char buff[kBufferSize];
   while ((m_bufLength - (m_buf - m_bufHead)) < size) {
     const auto start = std::chrono::system_clock::now();
 
     const auto receivedLength = m_connector->receive_nothrowiftimeout(
-        buff, BUFF_SIZE,
+        buff, kBufferSize,
         std::chrono::duration_cast<std::chrono::milliseconds>(
             m_remainingTimeBeforeTimeout));
 
@@ -79,8 +79,8 @@ void StreamDataInput::readDataIfNotAvailable(size_t size) {
                                  .append(m_connector->getRemoteEndpoint())));
     }
 
-    size_t newLength = m_bufLength + receivedLength;
-    size_t currentPosition = m_buf - m_bufHead;
+    auto newLength = m_bufLength + receivedLength;
+    auto currentPosition = m_buf - m_bufHead;
     if ((m_bufHead) == nullptr) {
       m_bufHead = static_cast<uint8_t*>(malloc(sizeof(uint8_t) * newLength));
     } else {

--- a/cppcache/src/StreamDataInput.hpp
+++ b/cppcache/src/StreamDataInput.hpp
@@ -33,8 +33,6 @@ namespace apache {
 namespace geode {
 namespace client {
 
-#include "geode/DataInput.hpp"
-
 class Connector;
 
 /**
@@ -49,10 +47,10 @@ class APACHE_GEODE_EXPORT StreamDataInput : public DataInput {
                   std::unique_ptr<Connector> connector, const CacheImpl* cache,
                   Pool* pool);
 
-  ~StreamDataInput();
+  ~StreamDataInput() override;
 
  protected:
-  inline void _checkBufferSize(size_t size, int32_t line) {
+  void _checkBufferSize(size_t size, int32_t line) override {
     readDataIfNotAvailable(size);
   }
 

--- a/cppcache/src/StreamDataInput.hpp
+++ b/cppcache/src/StreamDataInput.hpp
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_STREAMDATAINPUT_H_
+#define GEODE_STREAMDATAINPUT_H_
+
+#include <chrono>
+
+#include "Connector.hpp"
+#include "geode/DataInput.hpp"
+
+/**
+ * @file
+ */
+
+namespace apache {
+namespace geode {
+namespace client {
+
+#include "geode/DataInput.hpp"
+
+class Connector;
+
+/**
+ * Provide operations for reading primitive data values, byte arrays,
+ * strings, <code>Serializable</code> objects from a byte stream.
+ * The data is retrieved from a socket connection.
+ * This class is intentionally not thread safe.
+ */
+class APACHE_GEODE_EXPORT StreamDataInput : public DataInput {
+ public:
+  StreamDataInput(std::chrono::milliseconds timeout,
+                  std::unique_ptr<Connector> connector, const CacheImpl* cache,
+                  Pool* pool);
+
+  ~StreamDataInput();
+
+ protected:
+  inline void _checkBufferSize(size_t size, int32_t line) {
+    readDataIfNotAvailable(size);
+  }
+
+  void readDataIfNotAvailable(size_t size);
+
+ private:
+  std::unique_ptr<Connector> m_connector;
+  std::chrono::microseconds m_remainingTimeBeforeTimeout;
+};
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_STREAMDATAINPUT_H_

--- a/cppcache/src/StreamDataInput.hpp
+++ b/cppcache/src/StreamDataInput.hpp
@@ -51,7 +51,7 @@ class APACHE_GEODE_EXPORT StreamDataInput : public DataInput {
 
  private:
   std::unique_ptr<Connector> connector_;
-  std::chrono::microseconds remainingTimeBeforeTimeout_;
+  std::chrono::milliseconds remainingTimeBeforeTimeout_;
   std::vector<uint8_t> streamBuf_;
 };
 }  // namespace client

--- a/cppcache/src/StreamDataInput.hpp
+++ b/cppcache/src/StreamDataInput.hpp
@@ -42,8 +42,6 @@ class APACHE_GEODE_EXPORT StreamDataInput : public DataInput {
                   std::unique_ptr<Connector> connector, const CacheImpl* cache,
                   Pool* pool);
 
-  ~StreamDataInput() override;
-
  protected:
   void _checkBufferSize(size_t size, int32_t /* line */) override {
     readDataIfNotAvailable(size);
@@ -52,8 +50,9 @@ class APACHE_GEODE_EXPORT StreamDataInput : public DataInput {
   void readDataIfNotAvailable(size_t size);
 
  private:
-  std::unique_ptr<Connector> m_connector;
-  std::chrono::microseconds m_remainingTimeBeforeTimeout;
+  std::unique_ptr<Connector> connector_;
+  std::chrono::microseconds remainingTimeBeforeTimeout_;
+  std::vector<uint8_t> streamBuf_;
 };
 }  // namespace client
 }  // namespace geode

--- a/cppcache/src/StreamDataInput.hpp
+++ b/cppcache/src/StreamDataInput.hpp
@@ -25,10 +25,6 @@
 #include "Connector.hpp"
 #include "geode/DataInput.hpp"
 
-/**
- * @file
- */
-
 namespace apache {
 namespace geode {
 namespace client {
@@ -36,10 +32,9 @@ namespace client {
 class Connector;
 
 /**
- * Provide operations for reading primitive data values, byte arrays,
- * strings, <code>Serializable</code> objects from a byte stream.
- * The data is retrieved from a socket connection.
- * This class is intentionally not thread safe.
+ * Provides the same functionality as its parent class but
+ * data is retrieved, instead of from a passed buffer,
+ * from a socket connection.
  */
 class APACHE_GEODE_EXPORT StreamDataInput : public DataInput {
  public:
@@ -50,7 +45,7 @@ class APACHE_GEODE_EXPORT StreamDataInput : public DataInput {
   ~StreamDataInput() override;
 
  protected:
-  void _checkBufferSize(size_t size, int32_t line) override {
+  void _checkBufferSize(size_t size, int32_t /* line */) override {
     readDataIfNotAvailable(size);
   }
 

--- a/cppcache/src/TcpConn.cpp
+++ b/cppcache/src/TcpConn.cpp
@@ -17,7 +17,6 @@
 
 #include "TcpConn.hpp"
 
-#include <iomanip>
 #include <iostream>
 
 #include <boost/optional.hpp>
@@ -292,6 +291,11 @@ size_t TcpConn::send(const char *buff, const size_t len,
 
 //  Return the local port for this TCP connection.
 uint16_t TcpConn::getPort() { return socket_.local_endpoint().port(); }
+
+std::string TcpConn::getRemoteEndpoint() {
+  return socket_.remote_endpoint().address().to_string().append(":").append(
+      std::to_string(socket_.remote_endpoint().port()));
+}
 
 void TcpConn::connect(boost::asio::ip::tcp::resolver::results_type r,
                       std::chrono::microseconds timeout) {

--- a/cppcache/src/TcpConn.hpp
+++ b/cppcache/src/TcpConn.hpp
@@ -38,6 +38,8 @@ class TcpConn : public Connector {
 
   uint16_t getPort() override final;
 
+  std::string getRemoteEndpoint() override final;
+
  protected:
   boost::asio::io_context io_context_;
   boost::asio::ip::tcp::socket socket_;

--- a/cppcache/test/CMakeLists.txt
+++ b/cppcache/test/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(apache-geode_unittests
   QueueConnectionRequestTest.cpp
   RegionAttributesFactoryTest.cpp
   SerializableCreateTests.cpp
+  StreamDataInputTest.cpp
   StringPrefixPartitionResolverTest.cpp
   StructSetTest.cpp
   TcrConnectionTest.cpp

--- a/cppcache/test/StreamDataInputTest.cpp
+++ b/cppcache/test/StreamDataInputTest.cpp
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-matchers.h>
+
+#include <gtest/gtest.h>
+
+#include "CacheImpl.hpp"
+#include "Connector.hpp"
+#include "GetAllServersResponse.hpp"
+#include "ServerLocation.hpp"
+#include "StreamDataInput.hpp"
+#include "geode/DataOutput.hpp"
+#include "mock/ConnectorMock.hpp"
+
+namespace {
+
+using apache::geode::client::CacheImpl;
+using apache::geode::client::Connector;
+using apache::geode::client::ConnectorMock;
+using apache::geode::client::DataOutput;
+using apache::geode::client::GetAllServersResponse;
+using apache::geode::client::Serializable;
+using apache::geode::client::ServerLocation;
+using apache::geode::client::StreamDataInput;
+using apache::geode::client::TimeoutException;
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Eq;
+using ::testing::Return;
+using ::testing::SetArrayArgument;
+using ::testing::SizeIs;
+
+const size_t READ_BUFF_SIZE = 3000;
+const size_t STREAM_BUFF_SIZE = 10000;
+
+ACTION_P(WaitMs, milliseconds) {
+  std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
+  return 0;
+}
+
+TEST(StreamDataInputTest, ObjectSizeGreaterThanReadBufferSize) {
+  std::unique_ptr<ConnectorMock> connector =
+      std::unique_ptr<ConnectorMock>(new ConnectorMock());
+
+  unsigned int numServers = 100;
+  std::vector<std::shared_ptr<ServerLocation> > servers(numServers);
+
+  for (unsigned int i = 0; i < numServers; i++) {
+    servers[i] = std::make_shared<ServerLocation>(
+        std::string("this.is.a.quite.long.hostname.and.the.reason.is.that.it."
+                    "is.used.for.testing:") += std::to_string(2000 + i));
+  }
+
+  GetAllServersResponse getAllServersResponse(servers);
+
+  std::shared_ptr<CacheImpl> cache =
+      std::make_shared<CacheImpl>(nullptr, nullptr, false, false, nullptr);
+
+  DataOutput dataOutput = cache->createDataOutput();
+
+  getAllServersResponse.toData(dataOutput);
+
+  const uint8_t* buffer = dataOutput.getBuffer();
+  const size_t dataOutputBufferLength = dataOutput.getBufferLength();
+
+  // Gossip header
+  uint8_t streamBuffer[STREAM_BUFF_SIZE];
+  streamBuffer[0] = 1;
+  streamBuffer[1] = 0xd6;
+  memcpy(streamBuffer + 2, buffer, dataOutputBufferLength);
+
+  const size_t streamBufferLength = dataOutputBufferLength + 2;
+
+  auto timeout = std::chrono::milliseconds(1000);
+  EXPECT_CALL(*connector, getRemoteEndpoint())
+      .WillRepeatedly(Return("locator:9999"));
+
+  EXPECT_CALL(*connector, receive_nothrowiftimeout(_, _, _))
+      .WillOnce(DoAll(
+          SetArrayArgument<0>(streamBuffer, streamBuffer + READ_BUFF_SIZE),
+          Return(READ_BUFF_SIZE)))
+      .WillOnce(DoAll(SetArrayArgument<0>(streamBuffer + READ_BUFF_SIZE,
+                                          streamBuffer + 2 * READ_BUFF_SIZE),
+                      Return(READ_BUFF_SIZE)))
+      .WillOnce(DoAll(SetArrayArgument<0>(streamBuffer + 2 * READ_BUFF_SIZE,
+                                          &streamBuffer[streamBufferLength]),
+                      Return(streamBufferLength - (2 * READ_BUFF_SIZE))));
+
+  StreamDataInput streamDataInput(timeout, std::move(connector), cache.get(),
+                                  nullptr);
+
+  std::shared_ptr<Serializable> object = streamDataInput.readObject();
+
+  auto response = std::dynamic_pointer_cast<GetAllServersResponse>(object);
+
+  ASSERT_THAT(response->getServers(), SizeIs(servers.size()));
+  for (unsigned int i = 0; i < servers.size(); i++) {
+    ASSERT_THAT(response->getServers()[i]->getEpString(),
+                Eq(servers[i]->getEpString()));
+  }
+}
+
+TEST(StreamDataInputTest, TimeoutWhenReading) {
+  std::unique_ptr<ConnectorMock> connector =
+      std::unique_ptr<ConnectorMock>(new ConnectorMock());
+
+  std::shared_ptr<CacheImpl> cache =
+      std::make_shared<CacheImpl>(nullptr, nullptr, false, false, nullptr);
+
+  EXPECT_CALL(*connector, getRemoteEndpoint())
+      .WillRepeatedly(Return("locator:9999"));
+
+  EXPECT_CALL(*connector, receive_nothrowiftimeout(_, _, _))
+      .WillOnce(WaitMs(2));
+
+  auto timeout = std::chrono::milliseconds(1);
+  StreamDataInput streamDataInput(timeout, std::move(connector), cache.get(),
+                                  nullptr);
+
+  ASSERT_THROW(streamDataInput.readObject(), TimeoutException);
+}
+
+}  // namespace

--- a/cppcache/test/StreamDataInputTest.cpp
+++ b/cppcache/test/StreamDataInputTest.cpp
@@ -47,8 +47,8 @@ using ::testing::Return;
 using ::testing::SetArrayArgument;
 using ::testing::SizeIs;
 
-const size_t kReadBuffSize = 3000;
-const size_t kStreamBufferSize = 10000;
+constexpr size_t kReadBuffSize = 3000;
+constexpr size_t kStreamBufferSize = 10000;
 
 ACTION_P(WaitMs, milliseconds) {
   std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));

--- a/cppcache/test/mock/ConnectorMock.hpp
+++ b/cppcache/test/mock/ConnectorMock.hpp
@@ -28,9 +28,6 @@ namespace client {
 class ConnectorMock : public Connector {
  public:
   ConnectorMock(){
-  };
-
-  ConnectorMock(ConnectorMock const &mock) {
   }
 
   MOCK_METHOD3(receive, size_t(char *b, size_t len,

--- a/cppcache/test/mock/ConnectorMock.hpp
+++ b/cppcache/test/mock/ConnectorMock.hpp
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GEODE_CONNECTORMOCK_H_
+#define GEODE_CONNECTORMOCK_H_
+
+#include <gmock/gmock.h>
+
+#include "Connector.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+class ConnectorMock : public Connector {
+ public:
+  ConnectorMock(){
+  };
+
+  ConnectorMock(ConnectorMock const &mock) {
+  }
+
+  MOCK_METHOD3(receive, size_t(char *b, size_t len,
+                         std::chrono::milliseconds timeout));
+
+  MOCK_METHOD0(getPort, uint16_t());
+
+  MOCK_METHOD0(getRemoteEndpoint, std::string());
+
+  MOCK_METHOD3(send, size_t(const char *b, size_t len,
+                            std::chrono::milliseconds timeout));
+
+  MOCK_METHOD3(receive_nothrowiftimeout, size_t(
+      char *b, size_t len, std::chrono::milliseconds timeout));
+
+
+};
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_CONNECTORMOCK_H_


### PR DESCRIPTION
…3000 bytes

If a response message from the locator to the C++ native client
is longer than 3000 bytes the C++ native client will only
read the first 3000 bytes.