### PR TITLE
GEODE-10396: Avoid endpoint closure upon exception

### DIFF
--- a/cppcache/src/ThinClientBaseDM.cpp
+++ b/cppcache/src/ThinClientBaseDM.cpp
@@ -137,8 +137,8 @@ GfErrType ThinClientBaseDM::handleEPError(TcrEndpoint* ep,
             (markServerDead || cacheClosedEx || nonFatalServerError(exceptStr));
         if (doFailover) {
           LOGFINE(
-              "ThinClientDistributionManager::sendRequestToEP: retrying for "
-              "server [" +
+              "ThinClientDistributionManager::sendRequestToEP: Server failure  "
+              "[" +
               ep->name() + "] exception: " + exceptStr);
           error = GF_NOTCON;
           if (markServerDead) {
@@ -185,12 +185,15 @@ bool ThinClientBaseDM::unrecoverableServerError(const std::string& exceptStr) {
  * This method is for exceptions when server should *not* be marked as dead.
  */
 bool ThinClientBaseDM::nonFatalServerError(const std::string& exceptStr) {
-  return (
-      (exceptStr.find("org.apache.geode.distributed.TimeoutException") !=
-       std::string::npos) ||
-      (exceptStr.find("org.apache.geode.ThreadInterruptedException") !=
-       std::string::npos) ||
-      (exceptStr.find("java.lang.IllegalStateException") != std::string::npos));
+  // Ignore exceptions when they are wrapped into a FunctionException
+  return exceptStr.find("org.apache.geode.cache.execute.FunctionException") ==
+             std::string::npos &&
+         ((exceptStr.find("org.apache.geode.distributed.TimeoutException") !=
+           std::string::npos) ||
+          (exceptStr.find("org.apache.geode.ThreadInterruptedException") !=
+           std::string::npos) ||
+          (exceptStr.find("java.lang.IllegalStateException") !=
+           std::string::npos));
 }
 
 void ThinClientBaseDM::failover() {}

--- a/tests/javaobject/ThrowingISEFunction.java
+++ b/tests/javaobject/ThrowingISEFunction.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package javaobject;
+
+import java.util.Properties;
+
+import org.apache.geode.cache.Declarable;
+import org.apache.geode.cache.execute.FunctionAdapter;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.execute.FunctionException;
+
+/**
+ * Function that puts the value from the argument at the key passed in through
+ * the filter.
+ */
+public class ThrowingISEFunction extends FunctionAdapter implements Declarable {
+
+  private static final String ID = "ThrowingISEFunction";
+
+  public void execute(FunctionContext context) {
+    throw new FunctionException("An error occurred", new IllegalStateException("Inner exception"));
+  }
+
+  public String getId() {
+    return ID;
+  }
+
+  public boolean hasResult() {
+    return true;
+  }
+
+  public void init(Properties p) {
+  }
+
+  public boolean optimizeForWrite() {
+    return true;
+  }
+  public boolean isHA() {
+    return false;
+  }
+}
+


### PR DESCRIPTION
 - Currently whenever a server function is executed on a region with no
   filter, if an IllegalStateException wrapped within a
   FunctionException is thrown inside the server fuction body, then
   the endpoint's connections are closed, given the client considers the
   endpoint is failing.
 - In order to solve this, now it's checked if the exception is wrapped
   into a FunctionException before triggering the endpoint disconnection
   mechanism.
 - A new IT has been added to verify the behavior.