### PR TITLE
GEODE-10404: Fix javaobject compilation for Java 11

### DIFF
--- a/cppcache/integration/test/PdxInstanceTest.cpp
+++ b/cppcache/integration/test/PdxInstanceTest.cpp
@@ -458,10 +458,10 @@ TEST(PdxInstanceTest, comparePdxInstanceWithStringWithJavaPdxInstance) {
         cache.createPdxInstanceFactory("PdxTests.MyTestClass", false);
 
     pdxInstanceFactory.writeString("asciiField", "value");
-    pdxInstanceFactory.writeString("utf8Field", u8"value€");
+    pdxInstanceFactory.writeString("utf8Field", u8"value\u20AC");
     pdxInstanceFactory.writeString("asciiHugeField", std::string(70000, 'x'));
     pdxInstanceFactory.writeString("utfHugeField",
-                                   std::string(70000, 'x') + u8"€");
+                                   std::string(70000, 'x') + u8"\u20AC");
     entry = pdxInstanceFactory.create();
   }
 

--- a/tests/javaobject/CMakeLists.txt
+++ b/tests/javaobject/CMakeLists.txt
@@ -21,6 +21,8 @@ find_package(Java REQUIRED)
 include(UseJava)
 include(CheckJavaClassExists)
 
+set(CMAKE_JAVA_COMPILE_FLAGS -encoding utf8)
+
 check_java_class_exists(org.apache.geode.security.AuthenticationExpiredException ${Geode_CLASSPATH} hasAuthenticationExpiredException)
 
 file(GLOB_RECURSE SOURCES "*.java")

--- a/tests/javaobject/ComparePdxInstanceFunction.java
+++ b/tests/javaobject/ComparePdxInstanceFunction.java
@@ -37,9 +37,9 @@ public class ComparePdxInstanceFunction implements Function {
 
     PdxInstanceFactory pdxInstanceFactory = context.getCache().createPdxInstanceFactory("PdxTests.MyTestClass");
     pdxInstanceFactory.writeString("asciiField", "value");
-    pdxInstanceFactory.writeString("utf8Field", "value€");
-    pdxInstanceFactory.writeString("asciiHugeField", longString);
-    pdxInstanceFactory.writeString("utfHugeField", longString + "€");
+    pdxInstanceFactory.writeString("utf8Field", "value\u20AC");
+    pdxInstanceFactory.writeString("asciiHugeField", longString );
+    pdxInstanceFactory.writeString("utfHugeField", longString + "\u20AC");
 
     PdxInstance expectedInstance = pdxInstanceFactory.create();
 


### PR DESCRIPTION
 - After merging #973, javaobject compilation was broken for Java 11.
   The build passed since packer images uses Java 8, but as docker build
   images uses Java 11, compilation is failing there.
 - Root cause of the compilation issue is the difference in UTF-8 string
   handling between Java 8 and Java 11.
 - So, the issue was fixed by using unicode hexcode codepoint
   characters, rather than the actual codepoint.