### PR TITLE
GEODE-10400: Fix metadata completion detection

### DIFF
--- a/cppcache/src/ClientMetadataService.hpp
+++ b/cppcache/src/ClientMetadataService.hpp
@@ -179,7 +179,7 @@ class ClientMetadataService {
 
   std::shared_ptr<ClientMetadataService::ServerToBucketsMap>
   groupByServerToBuckets(const std::shared_ptr<ClientMetadata>& metadata,
-                         const BucketSet& bucketSet, bool optimizeForWrite);
+                         const BucketSet& bucketSet, bool primaryOnly);
 
   static std::shared_ptr<ClientMetadataService::ServerToBucketsMap> pruneNodes(
       const std::shared_ptr<ClientMetadata>& metadata,


### PR DESCRIPTION
 - Whenever execution server functions with isHA=false, hasResult=true
   and optimizeForWrite=true, if the metadata is incomplete a request of
   type EXECUTE_REGION_FUNCTION_SINGLE_HOP is sent with an invalid
   bucket set partition. This causes an
   InternalFunctionInvocationTargetException exception
 - In order to solve this issue, now, whenever calling
   groupByServerToBuckets, if there isn't a valid location for one of
   the buckets, it returns nullptr, triggering the fallback mechanism
   which would be sending EXECUTE_REGION_FUNCTION to one of the nodes
   instead.