### PR TITLE
GEODE-10414: Implement Region::putIfAbsent method

### DIFF
--- a/cppcache/include/geode/Region.hpp
+++ b/cppcache/include/geode/Region.hpp
@@ -314,13 +314,13 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    * @throws RegionDestroyedException if the method is called on a destroyed
    *region
    **/
-  virtual std::shared_ptr<Cacheable> get(
+  virtual std::shared_ptr<Serializable> get(
       const std::shared_ptr<CacheableKey>& key,
       const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) = 0;
 
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
-  inline std::shared_ptr<Cacheable> get(
+  inline std::shared_ptr<Serializable> get(
       const KEYTYPE& key,
       const std::shared_ptr<Serializable>& callbackArg = nullptr) {
     return get(CacheableKey::create(key), callbackArg);
@@ -373,7 +373,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    */
   virtual void put(
       const std::shared_ptr<CacheableKey>& key,
-      const std::shared_ptr<Cacheable>& value,
+      const std::shared_ptr<Serializable>& value,
       const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) = 0;
 
   /** Convenience method allowing both key and value to be a const char* */
@@ -385,7 +385,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
 
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
-  inline void put(const KEYTYPE& key, const std::shared_ptr<Cacheable>& value,
+  inline void put(const KEYTYPE& key, const std::shared_ptr<Serializable>& value,
                   const std::shared_ptr<Serializable>& arg = nullptr) {
     put(CacheableKey::create(key), value, arg);
   }
@@ -397,6 +397,11 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
                   const std::shared_ptr<Serializable>& arg = nullptr) {
     put(key, Serializable::create(value), arg);
   }
+
+  virtual std::shared_ptr<Serializable> putIfAbsent(
+      const std::shared_ptr<CacheableKey>& key,
+      const std::shared_ptr<Serializable>& value,
+      const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) = 0;
 
   /**
    * Places a set of new values in this region with the specified keys
@@ -447,7 +452,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    */
   virtual void localPut(
       const std::shared_ptr<CacheableKey>& key,
-      const std::shared_ptr<Cacheable>& value,
+      const std::shared_ptr<Serializable>& value,
       const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) = 0;
 
   /** Convenience method allowing both key and value to be a const char* */
@@ -460,7 +465,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
   inline void localPut(const KEYTYPE& key,
-                       const std::shared_ptr<Cacheable>& value,
+                       const std::shared_ptr<Serializable>& value,
                        const std::shared_ptr<Serializable>& arg = nullptr) {
     localPut(CacheableKey::create(key), value, arg);
   }
@@ -521,7 +526,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    */
   virtual void create(
       const std::shared_ptr<CacheableKey>& key,
-      const std::shared_ptr<Cacheable>& value,
+      const std::shared_ptr<Serializable>& value,
       const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) = 0;
 
   /** Convenience method allowing both key and value to be a const char* */
@@ -534,7 +539,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
   inline void create(const KEYTYPE& key,
-                     const std::shared_ptr<Cacheable>& value,
+                     const std::shared_ptr<Serializable>& value,
                      const std::shared_ptr<Serializable>& arg = nullptr) {
     create(CacheableKey::create(key), value, arg);
   }
@@ -574,7 +579,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    */
   virtual void localCreate(
       const std::shared_ptr<CacheableKey>& key,
-      const std::shared_ptr<Cacheable>& value,
+      const std::shared_ptr<Serializable>& value,
       const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) = 0;
 
   /** Convenience method allowing both key and value to be a const char* */
@@ -587,7 +592,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
   inline void localCreate(const KEYTYPE& key,
-                          const std::shared_ptr<Cacheable>& value,
+                          const std::shared_ptr<Serializable>& value,
                           const std::shared_ptr<Serializable>& arg = nullptr) {
     localCreate(CacheableKey::create(key), value, arg);
   }
@@ -804,7 +809,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    */
   virtual bool remove(
       const std::shared_ptr<CacheableKey>& key,
-      const std::shared_ptr<Cacheable>& value,
+      const std::shared_ptr<Serializable>& value,
       const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) = 0;
 
   /** Convenience method allowing both key and value to be a const char* */
@@ -817,7 +822,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
   inline bool remove(const KEYTYPE& key,
-                     const std::shared_ptr<Cacheable>& value,
+                     const std::shared_ptr<Serializable>& value,
                      const std::shared_ptr<Serializable>& arg = nullptr) {
     return remove(CacheableKey::create(key), value, arg);
   }
@@ -926,7 +931,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    */
   virtual bool localRemove(
       const std::shared_ptr<CacheableKey>& key,
-      const std::shared_ptr<Cacheable>& value,
+      const std::shared_ptr<Serializable>& value,
       const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) = 0;
 
   /** Convenience method allowing both key and value to be a const char* */
@@ -940,7 +945,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
   inline bool localRemove(const KEYTYPE& key,
-                          const std::shared_ptr<Cacheable>& value,
+                          const std::shared_ptr<Serializable>& value,
                           const std::shared_ptr<Serializable>& arg = nullptr) {
     return localRemove(CacheableKey::create(key), value, arg);
   }
@@ -1027,7 +1032,7 @@ class APACHE_GEODE_EXPORT Region : public std::enable_shared_from_this<Region> {
    * Return all values in the local process for this region. No value is
    * included for entries that are invalidated.
    */
-  virtual std::vector<std::shared_ptr<Cacheable>> values() = 0;
+  virtual std::vector<std::shared_ptr<Serializable>> values() = 0;
 
   virtual std::vector<std::shared_ptr<RegionEntry>> entries(bool recursive) = 0;
 

--- a/cppcache/integration/test/CMakeLists.txt
+++ b/cppcache/integration/test/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(cpp-integration-test
   PositionKey.cpp
   PositionKey.hpp
   RegionGetAllTest.cpp
+  RegionPutTest.cpp
   RegionPutAllTest.cpp
   RegionPutGetAllTest.cpp
   RegisterKeysTest.cpp
@@ -69,6 +70,7 @@ add_executable(cpp-integration-test
   HARegionCacheListenerKeyValueTest.cpp
   LocalRegionCacheListenerTest.cpp
 )
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(cpp-integration-test
     PUBLIC

--- a/cppcache/integration/test/RegionPutTest.cpp
+++ b/cppcache/integration/test/RegionPutTest.cpp
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <random>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <geode/Cache.hpp>
+#include <geode/CacheTransactionManager.hpp>
+#include <geode/PoolManager.hpp>
+#include <geode/RegionFactory.hpp>
+#include <geode/RegionShortcut.hpp>
+
+#include "CacheRegionHelper.hpp"
+#include "framework/Cluster.h"
+#include "framework/Framework.h"
+#include "framework/Gfsh.h"
+
+namespace {
+
+using apache::geode::client::Cache;
+using apache::geode::client::Cacheable;
+using apache::geode::client::CacheableKey;
+using apache::geode::client::CacheableString;
+using apache::geode::client::CommitConflictException;
+using apache::geode::client::Pool;
+using apache::geode::client::Region;
+using apache::geode::client::RegionShortcut;
+
+using std::chrono::minutes;
+
+using ::testing::Eq;
+using ::testing::IsNull;
+using ::testing::NotNull;
+
+Cache createCache() {
+  using apache::geode::client::CacheFactory;
+
+  auto cache = CacheFactory()
+                   .set("log-level", "debug")
+                   .set("statistic-sampling-enabled", "false")
+                   .create();
+
+  return cache;
+}
+
+std::shared_ptr<Pool> createPool(Cluster& cluster, Cache& cache) {
+  auto poolFactory = cache.getPoolManager().createFactory();
+  cluster.applyLocators(poolFactory);
+  return poolFactory.create("default");
+}
+
+std::shared_ptr<Region> setupRegion(Cache& cache,
+                                    const std::shared_ptr<Pool>& pool) {
+  auto region = cache.createRegionFactory(RegionShortcut::PROXY)
+                    .setPoolName(pool->getName())
+                    .create("region");
+
+  return region;
+}
+
+std::shared_ptr<Region> setupCachingRegion(Cache& cache,
+                                           const std::shared_ptr<Pool>& pool) {
+  auto region = cache.createRegionFactory(RegionShortcut::CACHING_PROXY)
+                    .setPoolName(pool->getName())
+                    .create("region");
+
+  return region;
+}
+
+TEST(RegionPutTest, testPutIfAbsentNotExistingEntry) {
+  Cluster cluster{LocatorCount{1}, ServerCount{1}};
+
+  cluster.start();
+
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("REPLICATE")
+      .execute();
+
+  auto cache = createCache();
+  auto pool = createPool(cluster, cache);
+  auto region = setupRegion(cache, pool);
+  auto key = CacheableKey::create("key-1");
+  auto value = CacheableString::create("value");
+
+  EXPECT_THAT(region->putIfAbsent(key, value), IsNull());
+
+  auto retrieved = region->get(key);
+  EXPECT_THAT(retrieved, NotNull());
+
+  auto converted = std::dynamic_pointer_cast<CacheableString>(retrieved);
+  EXPECT_THAT(converted, NotNull());
+  EXPECT_THAT(converted->toString(), Eq(value->toString()));
+}
+
+TEST(RegionPutTest, testPutIfAbsentNotExistingEntryWithCaching) {
+  Cluster cluster{LocatorCount{1}, ServerCount{1}};
+
+  cluster.start();
+
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("REPLICATE")
+      .execute();
+
+  auto cache = createCache();
+  auto pool = createPool(cluster, cache);
+  auto region = setupCachingRegion(cache, pool);
+  auto key = CacheableKey::create("key-1");
+  auto value = CacheableString::create("value");
+
+  EXPECT_THAT(region->putIfAbsent(key, value), IsNull());
+
+  auto retrieved = region->get(key);
+  EXPECT_THAT(retrieved, NotNull());
+
+  auto converted = std::dynamic_pointer_cast<CacheableString>(retrieved);
+  EXPECT_THAT(converted, NotNull());
+  EXPECT_THAT(converted->toString(), Eq(value->toString()));
+
+  // Verify cached value matches expected
+  auto entry = region->getEntry(key);
+  EXPECT_THAT(entry, NotNull());
+
+  retrieved = entry->getValue();
+  EXPECT_THAT(converted, NotNull());
+
+  converted = std::dynamic_pointer_cast<CacheableString>(retrieved);
+  EXPECT_THAT(converted, NotNull());
+  EXPECT_THAT(converted->toString(), Eq(value->toString()));
+}
+
+TEST(RegionPutTest, testPutIfAbsentExistingEntry) {
+  Cluster cluster{LocatorCount{1}, ServerCount{1}};
+
+  cluster.start();
+
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("REPLICATE")
+      .execute();
+
+  auto cache = createCache();
+  auto pool = createPool(cluster, cache);
+  auto region = setupRegion(cache, pool);
+  auto key = CacheableKey::create("key-1");
+
+  EXPECT_NO_THROW(region->put(key, CacheableString::create("previous-value")));
+
+  auto value = std::dynamic_pointer_cast<CacheableString>(region->get(key));
+
+  auto previous =
+      region->putIfAbsent(key, CacheableString::create("new-value"));
+  EXPECT_THAT(previous, NotNull());
+
+  auto converted = std::dynamic_pointer_cast<CacheableString>(previous);
+  EXPECT_THAT(converted, NotNull());
+  EXPECT_THAT(converted->toString(), Eq(value->toString()));
+}
+
+TEST(RegionPutTest, testPutIfAbsentExistingEntryCaching) {
+  Cluster cluster{LocatorCount{1}, ServerCount{1}};
+
+  cluster.start();
+
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("REPLICATE")
+      .execute();
+
+  auto cache = createCache();
+  auto pool = createPool(cluster, cache);
+  auto region = setupCachingRegion(cache, pool);
+  auto key = CacheableKey::create("key-1");
+
+  EXPECT_NO_THROW(region->put(key, CacheableString::create("previous-value")));
+
+  auto value = std::dynamic_pointer_cast<CacheableString>(region->get(key));
+
+  auto previous =
+      region->putIfAbsent(key, CacheableString::create("new-value"));
+  EXPECT_THAT(previous, NotNull());
+
+  auto converted = std::dynamic_pointer_cast<CacheableString>(previous);
+  EXPECT_THAT(converted, NotNull());
+  EXPECT_THAT(converted->toString(), Eq(value->toString()));
+
+  // Verify cached value matches expected
+  auto entry = region->getEntry(key);
+  EXPECT_THAT(entry, NotNull());
+
+  auto retrieved = entry->getValue();
+  EXPECT_THAT(converted, NotNull());
+
+  converted = std::dynamic_pointer_cast<CacheableString>(retrieved);
+  EXPECT_THAT(converted, NotNull());
+  EXPECT_THAT(converted->toString(), Eq(value->toString()));
+}
+
+TEST(RegionPutTest, testPutIfAbsentWIthinTxAndOutOfTx) {
+  Cluster cluster{LocatorCount{1}, ServerCount{1}};
+
+  cluster.start();
+
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("REPLICATE")
+      .execute();
+
+  auto cache = createCache();
+  auto pool = createPool(cluster, cache);
+  auto region = setupRegion(cache, pool);
+  auto key = CacheableKey::create("key-1");
+  auto value = CacheableString::create("value");
+  auto txMgr = cache.getCacheTransactionManager();
+
+  txMgr->begin();
+  EXPECT_THAT(region->putIfAbsent(key, value), IsNull());
+
+  auto retrieved = region->get(key);
+  EXPECT_THAT(retrieved, NotNull());
+
+  auto converted = std::dynamic_pointer_cast<CacheableString>(retrieved);
+  EXPECT_THAT(converted, NotNull());
+  EXPECT_THAT(converted->toString(), Eq(value->toString()));
+  auto& txId = txMgr->suspend();
+
+  EXPECT_THAT(region->putIfAbsent(key, value), IsNull());
+
+  txMgr->resume(txId);
+  EXPECT_THROW(txMgr->commit(), CommitConflictException);
+}
+
+TEST(RegionPutTest, testPutIfAbsentExistingEntryTX) {
+  Cluster cluster{LocatorCount{1}, ServerCount{1}};
+
+  cluster.start();
+
+  cluster.getGfsh()
+      .create()
+      .region()
+      .withName("region")
+      .withType("REPLICATE")
+      .execute();
+
+  auto cache = createCache();
+  auto pool = createPool(cluster, cache);
+  auto region = setupRegion(cache, pool);
+  auto key = CacheableKey::create("key-1");
+  EXPECT_NO_THROW(region->put(key, CacheableString::create("previous-value")));
+
+  auto value = std::dynamic_pointer_cast<CacheableString>(region->get(key));
+
+  auto previous =
+      region->putIfAbsent(key, CacheableString::create("new-value"));
+  EXPECT_THAT(previous, NotNull());
+
+  auto converted = std::dynamic_pointer_cast<CacheableString>(previous);
+  EXPECT_THAT(converted, NotNull());
+  EXPECT_THAT(converted->toString(), Eq(value->toString()));
+}
+
+}  // namespace

--- a/cppcache/src/AdminRegion.cpp
+++ b/cppcache/src/AdminRegion.cpp
@@ -23,6 +23,7 @@
 
 #include "CacheImpl.hpp"
 #include "TcrConnectionManager.hpp"
+#include "TcrMessagePut.hpp"
 #include "ThinClientCacheDistributionManager.hpp"
 #include "ThinClientPoolDM.hpp"
 #include "ThinClientRegion.hpp"
@@ -76,8 +77,8 @@ GfErrType AdminRegion::putNoThrow(const std::shared_ptr<CacheableKey>& keyPtr,
 
   TcrMessagePut request(
       new DataOutput(m_connectionMgr->getCacheImpl()->createDataOutput()),
-      nullptr, keyPtr, valuePtr, nullptr, false, m_distMngr, true, false,
-      m_fullPath.c_str());
+      nullptr, keyPtr, valuePtr, nullptr, EventOperation::UPDATE, false,
+      m_distMngr, true, false, m_fullPath.c_str());
   request.setMetaRegion(true);
   TcrMessageReply reply(true, m_distMngr);
   reply.setMetaRegion(true);

--- a/cppcache/src/CacheEventFlags.cpp
+++ b/cppcache/src/CacheEventFlags.cpp
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CacheEventFlags.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+const CacheEventFlags CacheEventFlags::NORMAL(CacheEventFlags::GF_NORMAL);
+const CacheEventFlags CacheEventFlags::LOCAL(CacheEventFlags::GF_LOCAL);
+const CacheEventFlags CacheEventFlags::NOTIFICATION(
+    CacheEventFlags::GF_NOTIFICATION);
+const CacheEventFlags CacheEventFlags::NOTIFICATION_UPDATE(
+    CacheEventFlags::GF_NOTIFICATION_UPDATE);
+const CacheEventFlags CacheEventFlags::EVICTION(CacheEventFlags::GF_EVICTION);
+const CacheEventFlags CacheEventFlags::EXPIRATION(
+    CacheEventFlags::GF_EXPIRATION);
+const CacheEventFlags CacheEventFlags::CACHE_CLOSE(
+    CacheEventFlags::GF_CACHE_CLOSE);
+const CacheEventFlags CacheEventFlags::NOCACHEWRITER(
+    CacheEventFlags::GF_NOCACHEWRITER);
+const CacheEventFlags CacheEventFlags::NOCALLBACKS(
+    CacheEventFlags::GF_NOCALLBACKS);
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/CacheEventFlags.hpp
+++ b/cppcache/src/CacheEventFlags.hpp
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_CACHE_EVENT_FLAGS_H_
+#define GEODE_CACHE_EVENT_FLAGS_H_
+
+#include <cinttypes>
+
+namespace apache {
+namespace geode {
+namespace client {
+
+
+/**
+ * @class CacheEventFlags
+ *
+ * This class encapsulates the flags (e.g. notification, expiration, local)
+ * for cache events for various NoThrow methods.
+ *
+ *
+ */
+class CacheEventFlags {
+ public:
+  static const CacheEventFlags NORMAL;
+  static const CacheEventFlags LOCAL;
+  static const CacheEventFlags NOTIFICATION;
+  static const CacheEventFlags NOTIFICATION_UPDATE;
+  static const CacheEventFlags EVICTION;
+  static const CacheEventFlags EXPIRATION;
+  static const CacheEventFlags CACHE_CLOSE;
+  static const CacheEventFlags NOCACHEWRITER;
+  static const CacheEventFlags NOCALLBACKS;
+
+   CacheEventFlags(const CacheEventFlags& flags) = default;
+
+  CacheEventFlags() = delete;
+  CacheEventFlags& operator=(const CacheEventFlags&) = delete;
+
+  CacheEventFlags operator|(const CacheEventFlags& other) const {
+    return CacheEventFlags(flags_ | other.flags_);
+  }
+
+  uint32_t operator&(const CacheEventFlags& other) const {
+    return (flags_ & other.flags_);
+  }
+
+   bool operator==(const CacheEventFlags& other) const {
+    return (flags_ == other.flags_);
+  }
+
+   bool isNormal() const { return flags_ & GF_NORMAL; }
+
+   bool isLocal() const { return flags_ & GF_LOCAL; }
+
+   bool isNotification() const { return flags_ & GF_NOTIFICATION; }
+
+   bool isNotificationUpdate() const { return flags_ & GF_NOTIFICATION_UPDATE; }
+
+   bool isEviction() const { return flags_ & GF_EVICTION; }
+
+   bool isExpiration() const { return flags_ & GF_EXPIRATION; }
+
+   bool isCacheClose() const { return flags_ & GF_CACHE_CLOSE; }
+
+   bool isNoCacheWriter() const { return flags_ & GF_NOCACHEWRITER; }
+
+   bool isNoCallbacks() const { return flags_ & GF_NOCALLBACKS; }
+
+   bool isEvictOrExpire() const {
+     return flags_ & (GF_EVICTION | GF_EXPIRATION);
+   }
+
+   // special optimized method for CacheWriter invocation condition
+   bool invokeCacheWriter() const {
+    return (flags_ & (GF_NOTIFICATION | GF_EVICTION | GF_EXPIRATION |
+                        GF_NOCACHEWRITER | GF_NOCALLBACKS)) == 0;
+  }
+
+ protected:
+  enum : uint16_t {
+    GF_NORMAL = 0x01,
+    GF_LOCAL = 0x02,
+    GF_NOTIFICATION = 0x04,
+    GF_NOTIFICATION_UPDATE = 0x08,
+    GF_EVICTION = 0x10,
+    GF_EXPIRATION = 0x20,
+    GF_CACHE_CLOSE = 0x40,
+    GF_NOCACHEWRITER = 0x80,
+    GF_NOCALLBACKS = 0x100
+  };
+
+ protected:
+  explicit CacheEventFlags(int16_t flags) : flags_(flags) {}
+
+ protected:
+  uint16_t flags_;
+};
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_CACHE_EVENT_FLAGS_H_

--- a/cppcache/src/CreateAction.cpp
+++ b/cppcache/src/CreateAction.cpp
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CreateAction.hpp"
+
+#include "LocalRegion.hpp"
+#include "TSSTXStateWrapper.hpp"
+#include "Utils.hpp"
+#include "VersionTag.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+CreateAction::CreateAction(LocalRegion& region)
+    : region_{region}, txState_{TSSTXStateWrapper::get().getTXState()} {}
+
+void CreateAction::getCallbackOldValue(bool,
+                                       const std::shared_ptr<CacheableKey>&,
+                                       std::shared_ptr<MapEntryImpl>&,
+                                       std::shared_ptr<Serializable>&) const {}
+
+GfErrType CreateAction::remoteUpdate(const std::shared_ptr<CacheableKey>& key,
+                                     const std::shared_ptr<Serializable>& value,
+                                     const std::shared_ptr<Serializable>& cbArg,
+                                     std::shared_ptr<Serializable>&,
+                                     std::shared_ptr<VersionTag>& versionTag) {
+  return region_.remoteCreate(key, value, cbArg, versionTag);
+}
+
+GfErrType CreateAction::localUpdate(const std::shared_ptr<CacheableKey>& key,
+                                    const std::shared_ptr<Serializable>& value,
+                                    std::shared_ptr<Serializable>& oldValue,
+                                    bool cachingEnabled, const CacheEventFlags,
+                                    int updateCount,
+                                    std::shared_ptr<VersionTag> versionTag,
+                                    DataInput*, std::shared_ptr<EventId>,
+                                    bool) {
+  return region_.putLocal(name(), true, key, value, oldValue, cachingEnabled,
+                          updateCount, 0, versionTag);
+}
+
+GfErrType CreateAction::checkArgs(const std::shared_ptr<CacheableKey>& key,
+                                  const std::shared_ptr<Serializable>&,
+                                  DataInput*) {
+  if (!key) {
+    return GF_CACHE_ILLEGAL_ARGUMENT_EXCEPTION;
+  }
+
+  return GF_NOERR;
+}
+
+void CreateAction::logCacheWriterFailure(
+    const std::shared_ptr<CacheableKey>& key,
+    const std::shared_ptr<Serializable>&) {
+  LOGFINER("Cache writer vetoed create for key %s",
+           Utils::nullSafeToString(key).c_str());
+}
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/CreateAction.hpp
+++ b/cppcache/src/CreateAction.hpp
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_CREATE_ACTION_H_
+#define GEODE_CREATE_ACTION_H_
+
+#include <memory>
+
+#include "CacheEventFlags.hpp"
+#include "ErrType.hpp"
+#include "EventType.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+class CacheableKey;
+class DataInput;
+class EventId;
+class LocalRegion;
+class MapEntryImpl;
+class Serializable;
+class TXState;
+class VersionTag;
+
+// encapsulates actions that need to be taken for a create() operation
+class CreateAction {
+ public:
+  static const EntryEventType s_beforeEventType = BEFORE_CREATE;
+  static const EntryEventType s_afterEventType = AFTER_CREATE;
+  static const bool s_addIfAbsent = true;
+  static const bool s_failIfPresent = true;
+
+ public:
+  explicit CreateAction(LocalRegion& region);
+
+  void getCallbackOldValue(bool cachingEnabled,
+                           const std::shared_ptr<CacheableKey>& key,
+                           std::shared_ptr<MapEntryImpl>& entry,
+                           std::shared_ptr<Serializable>& oldValue) const;
+
+  GfErrType remoteUpdate(const std::shared_ptr<CacheableKey>& key,
+                         const std::shared_ptr<Serializable>& value,
+                         const std::shared_ptr<Serializable>& cbArg,
+                         std::shared_ptr<Serializable>& retValue,
+                         std::shared_ptr<VersionTag>& versionTag);
+
+  GfErrType localUpdate(const std::shared_ptr<CacheableKey>& key,
+                        const std::shared_ptr<Serializable>& value,
+                        std::shared_ptr<Serializable>& oldValue,
+                        bool cachingEnabled, const CacheEventFlags eventFlags,
+                        int updateCount, std::shared_ptr<VersionTag> versionTag,
+                        DataInput* delta = nullptr,
+                        std::shared_ptr<EventId> eventId = nullptr,
+                        bool afterRemote = false);
+
+  TXState* getTxState() const { return txState_; }
+
+ public:
+  static const char* name() { return "Region::create"; }
+
+  static GfErrType checkArgs(const std::shared_ptr<CacheableKey>& key,
+                             const std::shared_ptr<Serializable>& value,
+                             DataInput* delta);
+
+  static void logCacheWriterFailure(
+      const std::shared_ptr<CacheableKey>& key,
+      const std::shared_ptr<Serializable>& oldValue);
+
+ protected:
+  LocalRegion& region_;
+  TXState* txState_;
+};
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_CREATE_ACTION_H_

--- a/cppcache/src/DestroyAction.cpp
+++ b/cppcache/src/DestroyAction.cpp
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "DestroyAction.hpp"
+
+#include "CacheImpl.hpp"
+#include "LocalRegion.hpp"
+#include "TSSTXStateWrapper.hpp"
+#include "Utils.hpp"
+#include "VersionTag.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+DestroyAction::DestroyAction(LocalRegion& region)
+    : region_{region}, txState_{TSSTXStateWrapper::get().getTXState()} {}
+
+void DestroyAction::getCallbackOldValue(
+    bool cachingEnabled, const std::shared_ptr<CacheableKey>& key,
+    std::shared_ptr<MapEntryImpl>& entry,
+    std::shared_ptr<Cacheable>& oldValue) const {
+  if (cachingEnabled) {
+    region_.getEntryMap()->getEntry(key, entry, oldValue);
+  }
+}
+
+GfErrType DestroyAction::remoteUpdate(const std::shared_ptr<CacheableKey>& key,
+                                      const std::shared_ptr<Cacheable>&,
+                                      const std::shared_ptr<Cacheable>& cbArg,
+                                      std::shared_ptr<Cacheable>&,
+                                      std::shared_ptr<VersionTag>& versionTag) {
+  return region_.remoteDestroy(key, cbArg, versionTag);
+}
+
+GfErrType DestroyAction::localUpdate(
+    const std::shared_ptr<CacheableKey>& key, const std::shared_ptr<Cacheable>&,
+    std::shared_ptr<Cacheable>& oldValue, bool cachingEnabled,
+    const CacheEventFlags eventFlags, int updateCount,
+    std::shared_ptr<VersionTag> versionTag, DataInput*,
+    std::shared_ptr<EventId>, bool afterRemote) {
+  auto& cachePerfStats = region_.getCacheImpl()->getCachePerfStats();
+
+  if (cachingEnabled) {
+    std::shared_ptr<MapEntryImpl> entry;
+    //  for notification invoke the listener even if the key does
+    // not exist locally
+    GfErrType err;
+    LOGDEBUG("Region::destroy: region [%s] destroying key [%s]",
+             region_.getFullPath().c_str(),
+             Utils::nullSafeToString(key).c_str());
+    if ((err = region_.getEntryMap()->remove(key, oldValue, entry, updateCount,
+                                             versionTag, afterRemote)) !=
+        GF_NOERR) {
+      if (eventFlags.isNotification()) {
+        LOGDEBUG(
+            "Region::destroy: region [%s] destroy key [%s] for "
+            "notification having value [%s] failed with %d",
+            region_.getFullPath().c_str(), Utils::nullSafeToString(key).c_str(),
+            Utils::nullSafeToString(oldValue).c_str(), err);
+        err = GF_NOERR;
+      }
+
+      return err;
+    }
+
+    if (oldValue != nullptr) {
+      LOGDEBUG(
+          "Region::destroy: region [%s] destroyed key [%s] having "
+          "value [%s]",
+          region_.getFullPath().c_str(), Utils::nullSafeToString(key).c_str(),
+          Utils::nullSafeToString(oldValue).c_str());
+      // any cleanup required for the entry (e.g. removing from LRU list)
+      if (entry != nullptr) {
+        entry->cleanup(eventFlags);
+      }
+      // entry/region expiration
+      if (!eventFlags.isEvictOrExpire()) {
+        region_.updateAccessAndModifiedTime(true);
+      }
+      // update the stats
+      region_.getRegionStats()->setEntries(region_.getEntryMap()->size());
+      cachePerfStats.incEntries(-1);
+    }
+  }
+
+  // update the stats
+  region_.getRegionStats()->incDestroys();
+  cachePerfStats.incDestroys();
+  return GF_NOERR;
+}
+
+GfErrType DestroyAction::checkArgs(const std::shared_ptr<CacheableKey>& key,
+                                   const std::shared_ptr<Cacheable>&,
+                                   DataInput*) {
+  if (!key) {
+    return GF_CACHE_ILLEGAL_ARGUMENT_EXCEPTION;
+  }
+
+  return GF_NOERR;
+}
+
+void DestroyAction::logCacheWriterFailure(
+    const std::shared_ptr<CacheableKey>& key,
+    const std::shared_ptr<Cacheable>&) {
+  LOGFINER("Cache writer vetoed destroy for key %s",
+           Utils::nullSafeToString(key).c_str());
+}
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/DestroyAction.hpp
+++ b/cppcache/src/DestroyAction.hpp
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_DESTROY_ACTION_H_
+#define GEODE_DESTROY_ACTION_H_
+
+#include <memory>
+
+#include "CacheEventFlags.hpp"
+#include "ErrType.hpp"
+#include "EventType.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+class CacheableKey;
+class DataInput;
+class EventId;
+class LocalRegion;
+class MapEntryImpl;
+class Serializable;
+class TXState;
+class VersionTag;
+
+// encapsulates actions that need to be taken for a destroy() operation
+class DestroyAction {
+ public:
+  static const EntryEventType s_beforeEventType = BEFORE_DESTROY;
+  static const EntryEventType s_afterEventType = AFTER_DESTROY;
+  static const bool s_addIfAbsent = true;
+  static const bool s_failIfPresent = false;
+
+  explicit DestroyAction(LocalRegion& region);
+
+  void getCallbackOldValue(bool cachingEnabled,
+                           const std::shared_ptr<CacheableKey>& key,
+                           std::shared_ptr<MapEntryImpl>& entry,
+                           std::shared_ptr<Serializable>& oldValue) const;
+
+  GfErrType remoteUpdate(const std::shared_ptr<CacheableKey>& key,
+                         const std::shared_ptr<Serializable>& value,
+                         const std::shared_ptr<Serializable>& cbArg,
+                         std::shared_ptr<Serializable>& retValue,
+                         std::shared_ptr<VersionTag>& versionTag);
+
+  GfErrType localUpdate(const std::shared_ptr<CacheableKey>& key,
+                        const std::shared_ptr<Serializable>& value,
+                        std::shared_ptr<Serializable>& oldValue,
+                        bool cachingEnabled, const CacheEventFlags eventFlags,
+                        int updateCount, std::shared_ptr<VersionTag> versionTag,
+                        DataInput* delta = nullptr,
+                        std::shared_ptr<EventId> eventId = nullptr,
+                        bool afterRemote = false);
+
+  TXState* getTxState() const { return txState_; }
+
+ public:
+  static const char* name() { return "Region::destroy"; }
+
+  static GfErrType checkArgs(const std::shared_ptr<CacheableKey>& key,
+                             const std::shared_ptr<Serializable>& value,
+                             DataInput* delta);
+
+  static void logCacheWriterFailure(const std::shared_ptr<CacheableKey>& key,
+                                    const std::shared_ptr<Serializable>& oldValue);
+
+ protected:
+  LocalRegion& region_;
+  TXState* txState_;
+};
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_DESTROY_ACTION_H_

--- a/cppcache/src/EventOperation.hpp
+++ b/cppcache/src/EventOperation.hpp
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_EVENT_OPERATION_H_
+#define GEODE_EVENT_OPERATION_H_
+
+#include <atomic>
+#include <cinttypes>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "TcrMessage.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+enum class EventOperation {
+  MARKER = 0 /* 0 */,
+  CREATE /* 1 */,
+  PUTALL_CREATE /* 2 */,
+  GET /* 3 */,
+  GET_ENTRY /* 4 */,
+  CONTAINS_KEY /* 5 */,
+  CONTAINS_VALUE /* 6 */,
+  CONTAINS_VALUE_FOR_KEY /* 7 */,
+  FUNCTION_EXECUTION /* 8 */,
+  SEARCH_CREATE /* 9 */,
+  LOCAL_LOAD_CREATE /* 10 */,
+  NET_LOAD_CREATE /* 11 */,
+  UPDATE /* 12 */,
+  PUTALL_UPDATE /* 13 */,
+  SEARCH_UPDATE /* 14 */,
+  LOCAL_LOAD_UPDATE /* 15 */,
+  NET_LOAD_UPDATE /* 16 */,
+  INVALIDATE /* 17 */,
+  LOCAL_INVALIDATE /* 18 */,
+  DESTROY /* 19 */,
+  LOCAL_DESTROY /* 20 */,
+  EVICT_DESTROY /* 21 */,
+  REGION_LOAD_SNAPSHOT /* 22 */,
+  REGION_LOAD_DESTROY /* 23 */,
+  REGION_CREATE /* 24 */,
+  REGION_CLOSE /* 25 */,
+  REGION_DESTROY /* 26 */,
+  EXPIRE_DESTROY /* 27 */,
+  EXPIRE_LOCAL_DESTROY /* 28 */,
+  EXPIRE_INVALIDATE /* 29 */,
+  EXPIRE_LOCAL_INVALIDATE /* 30 */,
+  REGION_EXPIRE_DESTROY /* 31 */,
+  REGION_EXPIRE_LOCAL_DESTROY /* 32 */,
+  REGION_EXPIRE_INVALIDATE /* 33 */,
+  REGION_EXPIRE_LOCAL_INVALIDATE /* 34 */,
+  REGION_LOCAL_INVALIDATE /* 35 */,
+  REGION_INVALIDATE /* 36 */,
+  REGION_CLEAR /* 37 */,
+  REGION_LOCAL_CLEAR /* 38 */,
+  CACHE_CREATE /* 39 */,
+  CACHE_CLOSE /* 40 */,
+  FORCED_DISCONNECT /* 41 */,
+  REGION_REINITIALIZE /* 42 */,
+  CACHE_RECONNECT /* 43 */,
+  PUT_IF_ABSENT /* 44 */,
+  REPLACE /* 45 */,
+  REMOVE /* 46 */,
+  UPDATE_VERSION_STAMP /* 47 */,
+  REMOVEALL_DESTROY /* 48 */,
+  GET_FOR_REGISTER_INTEREST /* 49 */
+};
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_EVENT_OPERATION_H_

--- a/cppcache/src/InvalidateAction.cpp
+++ b/cppcache/src/InvalidateAction.cpp
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "InvalidateAction.hpp"
+
+#include "LocalRegion.hpp"
+#include "TSSTXStateWrapper.hpp"
+#include "Utils.hpp"
+#include "VersionTag.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+InvalidateAction::InvalidateAction(LocalRegion& region)
+    : region_{region}, txState_{TSSTXStateWrapper::get().getTXState()} {}
+
+void InvalidateAction::getCallbackOldValue(
+    bool cachingEnabled, const std::shared_ptr<CacheableKey>& key,
+    std::shared_ptr<MapEntryImpl>& entry,
+    std::shared_ptr<Serializable>& oldValue) const {
+  if (cachingEnabled) {
+    region_.getEntryMap()->getEntry(key, entry, oldValue);
+  }
+}
+
+GfErrType InvalidateAction::remoteUpdate(
+    const std::shared_ptr<CacheableKey>& key,
+    const std::shared_ptr<Serializable>&,
+    const std::shared_ptr<Serializable>& cbArg, std::shared_ptr<Serializable>&,
+    std::shared_ptr<VersionTag>& versionTag) {
+  // propagate the invalidate to remote server, if any
+  return region_.remoteInvalidate(key, cbArg, versionTag);
+}
+
+GfErrType InvalidateAction::localUpdate(
+    const std::shared_ptr<CacheableKey>& key,
+    const std::shared_ptr<Serializable>& value, std::shared_ptr<Serializable>&,
+    bool, const CacheEventFlags eventFlags, int,
+    std::shared_ptr<VersionTag> versionTag, DataInput*,
+    std::shared_ptr<EventId>, bool) {
+  return region_.invalidateLocal(name(), key, value, eventFlags, versionTag);
+}
+
+GfErrType InvalidateAction::checkArgs(const std::shared_ptr<CacheableKey>& key,
+                                      const std::shared_ptr<Serializable>&,
+                                      DataInput*) {
+  if (key == nullptr) {
+    return GF_CACHE_ILLEGAL_ARGUMENT_EXCEPTION;
+  }
+  return GF_NOERR;
+}
+
+void InvalidateAction::logCacheWriterFailure(
+    const std::shared_ptr<CacheableKey>& key,
+    const std::shared_ptr<Serializable>& oldValue) {
+  bool isUpdate = (oldValue != nullptr);
+  LOGFINER("Cache writer vetoed %s for key %s",
+           (isUpdate ? "update" : "invalidate"),
+           Utils::nullSafeToString(key).c_str());
+}
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/InvalidateAction.hpp
+++ b/cppcache/src/InvalidateAction.hpp
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_INVALIDATE_ACTION_H_
+#define GEODE_INVALIDATE_ACTION_H_
+
+#include <memory>
+
+#include "CacheEventFlags.hpp"
+#include "ErrType.hpp"
+#include "EventType.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+class CacheableKey;
+class DataInput;
+class EventId;
+class LocalRegion;
+class MapEntryImpl;
+class Serializable;
+class TXState;
+class VersionTag;
+
+// encapsulates actions that need to be taken for a invalidate() operation
+class InvalidateAction {
+ public:
+  static const EntryEventType s_beforeEventType = BEFORE_INVALIDATE;
+  static const EntryEventType s_afterEventType = AFTER_INVALIDATE;
+  static const bool s_addIfAbsent = true;
+  static const bool s_failIfPresent = false;
+
+ public:
+  explicit InvalidateAction(LocalRegion& region);
+
+  void getCallbackOldValue(bool cachingEnabled,
+                           const std::shared_ptr<CacheableKey>& key,
+                           std::shared_ptr<MapEntryImpl>& entry,
+                           std::shared_ptr<Serializable>& oldValue) const;
+
+  GfErrType remoteUpdate(const std::shared_ptr<CacheableKey>& key,
+                         const std::shared_ptr<Serializable>& value,
+                         const std::shared_ptr<Serializable>& cbArg,
+                         std::shared_ptr<Serializable>& retValue,
+                         std::shared_ptr<VersionTag>& versionTag);
+
+  GfErrType localUpdate(const std::shared_ptr<CacheableKey>& key,
+                        const std::shared_ptr<Serializable>& value,
+                        std::shared_ptr<Serializable>& oldValue,
+                        bool cachingEnabled, const CacheEventFlags eventFlags,
+                        int updateCount, std::shared_ptr<VersionTag> versionTag,
+                        DataInput* delta = nullptr,
+                        std::shared_ptr<EventId> eventId = nullptr,
+                        bool afterRemote = false);
+
+  TXState* getTxState() const { return txState_; }
+
+ public:
+  static const char* name() { return "Region::invalidate"; }
+
+  static GfErrType checkArgs(const std::shared_ptr<CacheableKey>& key,
+                             const std::shared_ptr<Serializable>& value,
+                             DataInput* delta = nullptr);
+
+  static void logCacheWriterFailure(const std::shared_ptr<CacheableKey>& key,
+                                    const std::shared_ptr<Serializable>& oldValue);
+
+ protected:
+  LocalRegion& region_;
+  TXState* txState_;
+};
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_INVALIDATE_ACTION_H_

--- a/cppcache/src/ProxyRegion.hpp
+++ b/cppcache/src/ProxyRegion.hpp
@@ -75,31 +75,31 @@ class ProxyRegion final : public Region {
     return m_realRegion->getStatistics();
   }
 
-  void invalidateRegion(const std::shared_ptr<Serializable>&) final {
+  void invalidateRegion(const std::shared_ptr<Cacheable>&) final {
     throw UnsupportedOperationException("Region.invalidateRegion()");
   }
 
-  void localInvalidateRegion(const std::shared_ptr<Serializable>&) final {
+  void localInvalidateRegion(const std::shared_ptr<Cacheable>&) final {
     throw UnsupportedOperationException("Region.localInvalidateRegion()");
   }
 
   void destroyRegion(
-      const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) final {
+      const std::shared_ptr<Cacheable>& aCallbackArgument = nullptr) final {
     GuardUserAttributes gua(m_authenticatedView);
     m_realRegion->destroyRegion(aCallbackArgument);
   }
 
   void clear(
-      const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) final {
+      const std::shared_ptr<Cacheable>& aCallbackArgument = nullptr) final {
     GuardUserAttributes gua(m_authenticatedView);
     m_realRegion->clear(aCallbackArgument);
   }
 
-  void localClear(const std::shared_ptr<Serializable>&) final {
+  void localClear(const std::shared_ptr<Cacheable>&) final {
     throw UnsupportedOperationException("localClear()");
   }
 
-  void localDestroyRegion(const std::shared_ptr<Serializable>&) final {
+  void localDestroyRegion(const std::shared_ptr<Cacheable>&) final {
     throw UnsupportedOperationException("Region.localDestroyRegion()");
   }
 
@@ -150,7 +150,7 @@ class ProxyRegion final : public Region {
 
   std::shared_ptr<Cacheable> get(
       const std::shared_ptr<CacheableKey>& key,
-      const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) final {
+      const std::shared_ptr<Cacheable>& aCallbackArgument = nullptr) final {
     GuardUserAttributes gua(m_authenticatedView);
     return m_realRegion->get(key, aCallbackArgument);
   }
@@ -159,14 +159,14 @@ class ProxyRegion final : public Region {
   template <class KEYTYPE>
   inline std::shared_ptr<Cacheable> get(
       const KEYTYPE& key,
-      const std::shared_ptr<Serializable>& callbackArg = nullptr) {
+      const std::shared_ptr<Cacheable>& callbackArg = nullptr) {
     return get(CacheableKey::create(key), callbackArg);
   }
 
   void put(
       const std::shared_ptr<CacheableKey>& key,
       const std::shared_ptr<Cacheable>& value,
-      const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) final {
+      const std::shared_ptr<Cacheable>& aCallbackArgument = nullptr) final {
     GuardUserAttributes gua(m_authenticatedView);
     return m_realRegion->put(key, value, aCallbackArgument);
   }
@@ -174,14 +174,14 @@ class ProxyRegion final : public Region {
   /** Convenience method allowing both key and value to be a const char* */
   template <class KEYTYPE, class VALUETYPE>
   inline void put(const KEYTYPE& key, const VALUETYPE& value,
-                  const std::shared_ptr<Serializable>& arg = nullptr) {
+                  const std::shared_ptr<Cacheable>& arg = nullptr) {
     put(CacheableKey::create(key), Serializable::create(value), arg);
   }
 
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
   inline void put(const KEYTYPE& key, const std::shared_ptr<Cacheable>& value,
-                  const std::shared_ptr<Serializable>& arg = nullptr) {
+                  const std::shared_ptr<Cacheable>& arg = nullptr) {
     put(CacheableKey::create(key), value, arg);
   }
 
@@ -189,28 +189,36 @@ class ProxyRegion final : public Region {
   template <class VALUETYPE>
   inline void put(const std::shared_ptr<CacheableKey>& key,
                   const VALUETYPE& value,
-                  const std::shared_ptr<Serializable>& arg = nullptr) {
+                  const std::shared_ptr<Cacheable>& arg = nullptr) {
     put(key, Serializable::create(value), arg);
+  }
+
+  std::shared_ptr<Cacheable> putIfAbsent(
+      const std::shared_ptr<CacheableKey>& key,
+      const std::shared_ptr<Cacheable>& value,
+      const std::shared_ptr<Cacheable>& cbArg = nullptr) final {
+    GuardUserAttributes gua(m_authenticatedView);
+    return m_realRegion->putIfAbsent(key, value, cbArg);
   }
 
   void putAll(
       const HashMapOfCacheable& map,
       std::chrono::milliseconds timeout = DEFAULT_RESPONSE_TIMEOUT,
-      const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) final {
+      const std::shared_ptr<Cacheable>& aCallbackArgument = nullptr) final {
     GuardUserAttributes gua(m_authenticatedView);
     return m_realRegion->putAll(map, timeout, aCallbackArgument);
   }
 
   void localPut(const std::shared_ptr<CacheableKey>&,
                 const std::shared_ptr<Cacheable>&,
-                const std::shared_ptr<Serializable>&) final {
+                const std::shared_ptr<Cacheable>&) final {
     throw UnsupportedOperationException("Region.localPut()");
   }
 
   /** Convenience method allowing both key and value to be a const char* */
   template <class KEYTYPE, class VALUETYPE>
   inline void localPut(const KEYTYPE& key, const VALUETYPE& value,
-                       const std::shared_ptr<Serializable>& arg = nullptr) {
+                       const std::shared_ptr<Cacheable>& arg = nullptr) {
     localPut(CacheableKey::create(key), Serializable::create(value), arg);
   }
 
@@ -218,7 +226,7 @@ class ProxyRegion final : public Region {
   template <class KEYTYPE>
   inline void localPut(const KEYTYPE& key,
                        const std::shared_ptr<Cacheable>& value,
-                       const std::shared_ptr<Serializable>& arg = nullptr) {
+                       const std::shared_ptr<Cacheable>& arg = nullptr) {
     localPut(CacheableKey::create(key), value, arg);
   }
 
@@ -226,14 +234,14 @@ class ProxyRegion final : public Region {
   template <class VALUETYPE>
   inline void localPut(const std::shared_ptr<CacheableKey>& key,
                        const VALUETYPE& value,
-                       const std::shared_ptr<Serializable>& arg = nullptr) {
+                       const std::shared_ptr<Cacheable>& arg = nullptr) {
     localPut(key, Serializable::create(value), arg);
   }
 
   void create(
       const std::shared_ptr<CacheableKey>& key,
       const std::shared_ptr<Cacheable>& value,
-      const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) final {
+      const std::shared_ptr<Cacheable>& aCallbackArgument = nullptr) final {
     GuardUserAttributes gua(m_authenticatedView);
     m_realRegion->create(key, value, aCallbackArgument);
   }
@@ -241,7 +249,7 @@ class ProxyRegion final : public Region {
   /** Convenience method allowing both key and value to be a const char* */
   template <class KEYTYPE, class VALUETYPE>
   inline void create(const KEYTYPE& key, const VALUETYPE& value,
-                     const std::shared_ptr<Serializable>& arg = nullptr) {
+                     const std::shared_ptr<Cacheable>& arg = nullptr) {
     create(CacheableKey::create(key), Serializable::create(value), arg);
   }
 
@@ -249,7 +257,7 @@ class ProxyRegion final : public Region {
   template <class KEYTYPE>
   inline void create(const KEYTYPE& key,
                      const std::shared_ptr<Cacheable>& value,
-                     const std::shared_ptr<Serializable>& arg = nullptr) {
+                     const std::shared_ptr<Cacheable>& arg = nullptr) {
     create(CacheableKey::create(key), value, arg);
   }
 
@@ -257,20 +265,20 @@ class ProxyRegion final : public Region {
   template <class VALUETYPE>
   inline void create(const std::shared_ptr<CacheableKey>& key,
                      const VALUETYPE& value,
-                     const std::shared_ptr<Serializable>& arg = nullptr) {
+                     const std::shared_ptr<Cacheable>& arg = nullptr) {
     create(key, Serializable::create(value), arg);
   }
 
   void localCreate(const std::shared_ptr<CacheableKey>&,
                    const std::shared_ptr<Cacheable>&,
-                   const std::shared_ptr<Serializable>&) final {
+                   const std::shared_ptr<Cacheable>&) final {
     throw UnsupportedOperationException("Region.localCreate()");
   }
 
   /** Convenience method allowing both key and value to be a const char* */
   template <class KEYTYPE, class VALUETYPE>
   inline void localCreate(const KEYTYPE& key, const VALUETYPE& value,
-                          const std::shared_ptr<Serializable>& arg = nullptr) {
+                          const std::shared_ptr<Cacheable>& arg = nullptr) {
     localCreate(CacheableKey::create(key), Serializable::create(value), arg);
   }
 
@@ -278,7 +286,7 @@ class ProxyRegion final : public Region {
   template <class KEYTYPE>
   inline void localCreate(const KEYTYPE& key,
                           const std::shared_ptr<Cacheable>& value,
-                          const std::shared_ptr<Serializable>& arg = nullptr) {
+                          const std::shared_ptr<Cacheable>& arg = nullptr) {
     localCreate(CacheableKey::create(key), value, arg);
   }
 
@@ -286,13 +294,13 @@ class ProxyRegion final : public Region {
   template <class VALUETYPE>
   inline void localCreate(const std::shared_ptr<CacheableKey>& key,
                           const VALUETYPE& value,
-                          const std::shared_ptr<Serializable>& arg = nullptr) {
+                          const std::shared_ptr<Cacheable>& arg = nullptr) {
     localCreate(key, Serializable::create(value), arg);
   }
 
   void invalidate(
       const std::shared_ptr<CacheableKey>& key,
-      const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) final {
+      const std::shared_ptr<Cacheable>& aCallbackArgument = nullptr) final {
     GuardUserAttributes gua(m_authenticatedView);
     m_realRegion->invalidate(key, aCallbackArgument);
   }
@@ -300,25 +308,25 @@ class ProxyRegion final : public Region {
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
   inline void invalidate(const KEYTYPE& key,
-                         const std::shared_ptr<Serializable>& arg = nullptr) {
+                         const std::shared_ptr<Cacheable>& arg = nullptr) {
     invalidate(CacheableKey::create(key), arg);
   }
 
   void localInvalidate(const std::shared_ptr<CacheableKey>&,
-                       const std::shared_ptr<Serializable>&) final {
+                       const std::shared_ptr<Cacheable>&) final {
     throw UnsupportedOperationException("Region.localInvalidate()");
   }
 
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
   inline void localInvalidate(
-      const KEYTYPE& key, const std::shared_ptr<Serializable>& arg = nullptr) {
+      const KEYTYPE& key, const std::shared_ptr<Cacheable>& arg = nullptr) {
     localInvalidate(CacheableKey::create(key), arg);
   }
 
   void destroy(
       const std::shared_ptr<CacheableKey>& key,
-      const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) final {
+      const std::shared_ptr<Cacheable>& aCallbackArgument = nullptr) final {
     GuardUserAttributes gua(m_authenticatedView);
     m_realRegion->destroy(key, aCallbackArgument);
   }
@@ -326,26 +334,26 @@ class ProxyRegion final : public Region {
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
   inline void destroy(const KEYTYPE& key,
-                      const std::shared_ptr<Serializable>& arg = nullptr) {
+                      const std::shared_ptr<Cacheable>& arg = nullptr) {
     destroy(CacheableKey::create(key), arg);
   }
 
   void localDestroy(const std::shared_ptr<CacheableKey>&,
-                    const std::shared_ptr<Serializable>&) final {
+                    const std::shared_ptr<Cacheable>&) final {
     throw UnsupportedOperationException("Region.localDestroy()");
   }
 
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
   inline void localDestroy(const KEYTYPE& key,
-                           const std::shared_ptr<Serializable>& arg = nullptr) {
+                           const std::shared_ptr<Cacheable>& arg = nullptr) {
     localDestroy(CacheableKey::create(key), arg);
   }
 
   bool remove(
       const std::shared_ptr<CacheableKey>& key,
       const std::shared_ptr<Cacheable>& value,
-      const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) final {
+      const std::shared_ptr<Cacheable>& aCallbackArgument = nullptr) final {
     GuardUserAttributes gua(m_authenticatedView);
     return m_realRegion->remove(key, value, aCallbackArgument);
   }
@@ -353,7 +361,7 @@ class ProxyRegion final : public Region {
   /** Convenience method allowing both key and value to be a const char* */
   template <class KEYTYPE, class VALUETYPE>
   inline bool remove(const KEYTYPE& key, const VALUETYPE& value,
-                     const std::shared_ptr<Serializable>& arg = nullptr) {
+                     const std::shared_ptr<Cacheable>& arg = nullptr) {
     return remove(CacheableKey::create(key), Serializable::create(value), arg);
   }
 
@@ -361,7 +369,7 @@ class ProxyRegion final : public Region {
   template <class KEYTYPE>
   inline bool remove(const KEYTYPE& key,
                      const std::shared_ptr<Cacheable>& value,
-                     const std::shared_ptr<Serializable>& arg = nullptr) {
+                     const std::shared_ptr<Cacheable>& arg = nullptr) {
     return remove(CacheableKey::create(key), value, arg);
   }
 
@@ -369,13 +377,13 @@ class ProxyRegion final : public Region {
   template <class VALUETYPE>
   inline bool remove(const std::shared_ptr<CacheableKey>& key,
                      const VALUETYPE& value,
-                     const std::shared_ptr<Serializable>& arg = nullptr) {
+                     const std::shared_ptr<Cacheable>& arg = nullptr) {
     return remove(key, Serializable::create(value), arg);
   }
 
   bool removeEx(
       const std::shared_ptr<CacheableKey>& key,
-      const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) final {
+      const std::shared_ptr<Cacheable>& aCallbackArgument = nullptr) final {
     GuardUserAttributes gua(m_authenticatedView);
     return m_realRegion->removeEx(key, aCallbackArgument);
   }
@@ -383,20 +391,20 @@ class ProxyRegion final : public Region {
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
   inline bool removeEx(const KEYTYPE& key,
-                       const std::shared_ptr<Serializable>& arg = nullptr) {
+                       const std::shared_ptr<Cacheable>& arg = nullptr) {
     return removeEx(CacheableKey::create(key), arg);
   }
 
   bool localRemove(const std::shared_ptr<CacheableKey>&,
                    const std::shared_ptr<Cacheable>&,
-                   const std::shared_ptr<Serializable>&) final {
+                   const std::shared_ptr<Cacheable>&) final {
     throw UnsupportedOperationException("Region.localRemove()");
   }
 
   /** Convenience method allowing both key and value to be a const char* */
   template <class KEYTYPE, class VALUETYPE>
   inline bool localRemove(const KEYTYPE& key, const VALUETYPE& value,
-                          const std::shared_ptr<Serializable>& arg = nullptr) {
+                          const std::shared_ptr<Cacheable>& arg = nullptr) {
     return localRemove(CacheableKey::create(key), Serializable::create(value),
                        arg);
   }
@@ -405,7 +413,7 @@ class ProxyRegion final : public Region {
   template <class KEYTYPE>
   inline bool localRemove(const KEYTYPE& key,
                           const std::shared_ptr<Cacheable>& value,
-                          const std::shared_ptr<Serializable>& arg = nullptr) {
+                          const std::shared_ptr<Cacheable>& arg = nullptr) {
     return localRemove(CacheableKey::create(key), value, arg);
   }
 
@@ -413,19 +421,19 @@ class ProxyRegion final : public Region {
   template <class VALUETYPE>
   inline bool localRemove(const std::shared_ptr<CacheableKey>& key,
                           const VALUETYPE& value,
-                          const std::shared_ptr<Serializable>& arg = nullptr) {
+                          const std::shared_ptr<Cacheable>& arg = nullptr) {
     return localRemove(key, Serializable::create(value), arg);
   }
 
   bool localRemoveEx(const std::shared_ptr<CacheableKey>&,
-                     const std::shared_ptr<Serializable>&) final {
+                     const std::shared_ptr<Cacheable>&) final {
     throw UnsupportedOperationException("Region.localRemoveEx()");
   }
 
   /** Convenience method allowing key to be a const char* */
   template <class KEYTYPE>
   inline bool localRemoveEx(
-      const KEYTYPE& key, const std::shared_ptr<Serializable>& arg = nullptr) {
+      const KEYTYPE& key, const std::shared_ptr<Cacheable>& arg = nullptr) {
     return localRemoveEx(CacheableKey::create(key), arg);
   }
 
@@ -526,7 +534,7 @@ class ProxyRegion final : public Region {
 
   HashMapOfCacheable getAll(
       const std::vector<std::shared_ptr<CacheableKey>>& keys,
-      const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) final {
+      const std::shared_ptr<Cacheable>& aCallbackArgument = nullptr) final {
     GuardUserAttributes gua(m_authenticatedView);
     return m_realRegion->getAll_internal(keys, aCallbackArgument, false);
   }
@@ -545,7 +553,7 @@ class ProxyRegion final : public Region {
     return m_realRegion->existsValue(predicate, timeout);
   }
 
-  std::shared_ptr<Serializable> selectValue(
+  std::shared_ptr<Cacheable> selectValue(
       const std::string& predicate, std::chrono::milliseconds timeout =
                                         DEFAULT_QUERY_RESPONSE_TIMEOUT) final {
     GuardUserAttributes gua(m_authenticatedView);
@@ -554,7 +562,7 @@ class ProxyRegion final : public Region {
 
   void removeAll(
       const std::vector<std::shared_ptr<CacheableKey>>& keys,
-      const std::shared_ptr<Serializable>& aCallbackArgument = nullptr) final {
+      const std::shared_ptr<Cacheable>& aCallbackArgument = nullptr) final {
     GuardUserAttributes gua(m_authenticatedView);
     m_realRegion->removeAll(keys, aCallbackArgument);
   }

--- a/cppcache/src/PutAction.cpp
+++ b/cppcache/src/PutAction.cpp
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PutAction.hpp"
+
+#include "LocalRegion.hpp"
+#include "TSSTXStateWrapper.hpp"
+#include "Utils.hpp"
+#include "VersionTag.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+PutAction::PutAction(LocalRegion& region)
+    : region_{region}, txState_{TSSTXStateWrapper::get().getTXState()} {}
+
+void PutAction::getCallbackOldValue(
+    bool cachingEnabled, const std::shared_ptr<CacheableKey>& key,
+    std::shared_ptr<MapEntryImpl>& entry,
+    std::shared_ptr<Serializable>& oldValue) const {
+  if (cachingEnabled) {
+    region_.getEntryMap()->getEntry(key, entry, oldValue);
+  }
+}
+
+GfErrType PutAction::remoteUpdate(const std::shared_ptr<CacheableKey>& key,
+                                  const std::shared_ptr<Serializable>& value,
+                                  const std::shared_ptr<Serializable>& cbArg,
+                                  std::shared_ptr<Serializable>& retVal,
+                                  std::shared_ptr<VersionTag>& versionTag) {
+  return region_.remotePut(key, value, cbArg, versionTag, retVal,
+                           EventOperation::UPDATE);
+}
+
+GfErrType PutAction::localUpdate(const std::shared_ptr<CacheableKey>& key,
+                                 const std::shared_ptr<Serializable>& value,
+                                 std::shared_ptr<Serializable>& oldValue,
+                                 bool cachingEnabled, const CacheEventFlags,
+                                 int updateCount,
+                                 std::shared_ptr<VersionTag> versionTag,
+                                 DataInput* delta,
+                                 std::shared_ptr<EventId> eventId, bool) {
+  return region_.putLocal(name(), false, key, value, oldValue, cachingEnabled,
+                          updateCount, 0, versionTag, delta, eventId);
+}
+
+void PutAction::logCacheWriterFailure(
+    const std::shared_ptr<CacheableKey>& key,
+    const std::shared_ptr<Serializable>& oldValue) {
+  bool isUpdate = (oldValue != nullptr);
+  LOGFINER("Cache writer vetoed %s for key %s",
+           (isUpdate ? "update" : "create"),
+           Utils::nullSafeToString(key).c_str());
+}
+
+GfErrType PutAction::checkArgs(const std::shared_ptr<CacheableKey>& key,
+                               const std::shared_ptr<Serializable>& value,
+                               DataInput* delta) {
+  if (key == nullptr || (value == nullptr && delta == nullptr)) {
+    return GF_CACHE_ILLEGAL_ARGUMENT_EXCEPTION;
+  }
+
+  return GF_NOERR;
+}
+
+PutActionTx::PutActionTx(LocalRegion& region) : PutAction{region} {}
+
+GfErrType PutActionTx::checkArgs(const std::shared_ptr<CacheableKey>& key,
+                                 const std::shared_ptr<Serializable>&,
+                                 DataInput*) {
+  if (key == nullptr) {
+    return GF_CACHE_ILLEGAL_ARGUMENT_EXCEPTION;
+  }
+
+  return GF_NOERR;
+}
+
+PutIfAbsentAction::PutIfAbsentAction(LocalRegion& region)
+    : PutAction{region}, absent_{true} {}
+
+GfErrType PutIfAbsentAction::remoteUpdate(
+    const std::shared_ptr<CacheableKey>& key,
+    const std::shared_ptr<Serializable>& value,
+    const std::shared_ptr<Serializable>& cbArg,
+    std::shared_ptr<Serializable>& retVal,
+    std::shared_ptr<VersionTag>& versionTag) {
+  auto err = region_.remotePut(key, value, cbArg, versionTag, retVal,
+                               EventOperation::PUT_IF_ABSENT);
+  if (err == GF_NOERR) {
+    absent_ = retVal == nullptr;
+  }
+
+  return err;
+}
+
+GfErrType PutIfAbsentAction::localUpdate(
+    const std::shared_ptr<CacheableKey>& key,
+    const std::shared_ptr<Serializable>& value,
+    std::shared_ptr<Serializable>& oldValue, bool cachingEnabled,
+    const CacheEventFlags flags, int updateCount,
+    std::shared_ptr<VersionTag> versionTag, DataInput* delta,
+    std::shared_ptr<EventId> eventId, bool afterRemote) {
+  if (!absent_) {
+    return GF_NOERR;
+  }
+
+  return PutAction::localUpdate(key, value, oldValue, cachingEnabled, flags,
+                                updateCount, versionTag, delta, eventId,
+                                afterRemote);
+}
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/PutAction.hpp
+++ b/cppcache/src/PutAction.hpp
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_PUT_ACTION_H_
+#define GEODE_PUT_ACTION_H_
+
+#include <memory>
+
+#include "CacheEventFlags.hpp"
+#include "ErrType.hpp"
+#include "EventType.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+class CacheableKey;
+class DataInput;
+class EventId;
+class LocalRegion;
+class MapEntryImpl;
+class Serializable;
+class TXState;
+class VersionTag;
+
+// encapsulates actions that need to be taken for a put() operation
+class PutAction {
+ public:
+  static const EntryEventType s_beforeEventType = BEFORE_UPDATE;
+  static const EntryEventType s_afterEventType = AFTER_UPDATE;
+  static const bool s_addIfAbsent = true;
+  static const bool s_failIfPresent = false;
+
+ public:
+  explicit PutAction(LocalRegion& region);
+
+  void getCallbackOldValue(bool cachingEnabled,
+                           const std::shared_ptr<CacheableKey>& key,
+                           std::shared_ptr<MapEntryImpl>& entry,
+                           std::shared_ptr<Serializable>& oldValue) const;
+
+  GfErrType remoteUpdate(const std::shared_ptr<CacheableKey>& key,
+                         const std::shared_ptr<Serializable>& value,
+                         const std::shared_ptr<Serializable>& cbArg,
+                         std::shared_ptr<Serializable>& retVal,
+                         std::shared_ptr<VersionTag>& versionTag);
+
+  GfErrType localUpdate(const std::shared_ptr<CacheableKey>& key,
+                        const std::shared_ptr<Serializable>& value,
+                        std::shared_ptr<Serializable>& oldValue,
+                        bool cachingEnabled, const CacheEventFlags eventFlags,
+                        int updateCount, std::shared_ptr<VersionTag> versionTag,
+                        DataInput* delta = nullptr,
+                        std::shared_ptr<EventId> eventId = nullptr,
+                        bool afterRemote = false);
+
+  TXState* getTxState() const { return txState_; }
+
+ public:
+  static const char* name() { return "Region::put"; }
+
+  static void logCacheWriterFailure(
+      const std::shared_ptr<CacheableKey>& key,
+      const std::shared_ptr<Serializable>& oldValue);
+
+  static GfErrType checkArgs(const std::shared_ptr<CacheableKey>& key,
+                             const std::shared_ptr<Serializable>& value,
+                             DataInput* delta = nullptr);
+
+ protected:
+  LocalRegion& region_;
+  TXState* txState_;
+};
+
+// encapsulates actions that need to be taken for a put() operation. This
+// implementation allows
+// null values in Put during transaction. See defect #743
+class PutActionTx : public PutAction {
+ public:
+  explicit PutActionTx(LocalRegion& region);
+  static GfErrType checkArgs(const std::shared_ptr<CacheableKey>& key,
+                             const std::shared_ptr<Serializable>& value,
+                             DataInput* delta = nullptr);
+};
+
+class PutIfAbsentAction : public PutAction {
+ public:
+  explicit PutIfAbsentAction(LocalRegion& region);
+
+  GfErrType localUpdate(const std::shared_ptr<CacheableKey>& key,
+                        const std::shared_ptr<Serializable>& value,
+                        std::shared_ptr<Serializable>& oldValue,
+                        bool cachingEnabled, const CacheEventFlags eventFlags,
+                        int updateCount, std::shared_ptr<VersionTag> versionTag,
+                        DataInput* delta = nullptr,
+                        std::shared_ptr<EventId> eventId = nullptr,
+                        bool afterRemote = false);
+
+  GfErrType remoteUpdate(const std::shared_ptr<CacheableKey>& key,
+                         const std::shared_ptr<Serializable>& value,
+                         const std::shared_ptr<Serializable>& cbArg,
+                         std::shared_ptr<Serializable>& retValue,
+                         std::shared_ptr<VersionTag>& versionTag);
+
+  static const char* name() { return "Region::putIfAbsent"; }
+
+ protected:
+  bool absent_;
+};
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_PUT_ACTION_H_

--- a/cppcache/src/RegionInternal.cpp
+++ b/cppcache/src/RegionInternal.cpp
@@ -25,23 +25,6 @@ namespace apache {
 namespace geode {
 namespace client {
 
-// Static initializers for CacheEventFlags
-const CacheEventFlags CacheEventFlags::NORMAL(CacheEventFlags::GF_NORMAL);
-const CacheEventFlags CacheEventFlags::LOCAL(CacheEventFlags::GF_LOCAL);
-const CacheEventFlags CacheEventFlags::NOTIFICATION(
-    CacheEventFlags::GF_NOTIFICATION);
-const CacheEventFlags CacheEventFlags::NOTIFICATION_UPDATE(
-    CacheEventFlags::GF_NOTIFICATION_UPDATE);
-const CacheEventFlags CacheEventFlags::EVICTION(CacheEventFlags::GF_EVICTION);
-const CacheEventFlags CacheEventFlags::EXPIRATION(
-    CacheEventFlags::GF_EXPIRATION);
-const CacheEventFlags CacheEventFlags::CACHE_CLOSE(
-    CacheEventFlags::GF_CACHE_CLOSE);
-const CacheEventFlags CacheEventFlags::NOCACHEWRITER(
-    CacheEventFlags::GF_NOCACHEWRITER);
-const CacheEventFlags CacheEventFlags::NOCALLBACKS(
-    CacheEventFlags::GF_NOCALLBACKS);
-
 RegionInternal::RegionInternal(CacheImpl* cacheImpl,
                                RegionAttributes attributes)
     : Region(cacheImpl), m_regionAttributes(attributes) {}

--- a/cppcache/src/RegionInternal.hpp
+++ b/cppcache/src/RegionInternal.hpp
@@ -26,6 +26,7 @@
 
 #include <geode/Region.hpp>
 
+#include "CacheEventFlags.hpp"
 #include "ErrType.hpp"
 #include "EventId.hpp"
 #include "HashMapOfException.hpp"
@@ -34,90 +35,6 @@
 namespace apache {
 namespace geode {
 namespace client {
-
-/**
- * @class CacheEventFlags RegionInternal.hpp
- *
- * This class encapsulates the flags (e.g. notification, expiration, local)
- * for cache events for various NoThrow methods.
- *
- *
- */
-class CacheEventFlags {
- private:
-  uint16_t m_flags;
-  static const uint16_t GF_NORMAL = 0x01;
-  static const uint16_t GF_LOCAL = 0x02;
-  static const uint16_t GF_NOTIFICATION = 0x04;
-  static const uint16_t GF_NOTIFICATION_UPDATE = 0x08;
-  static const uint16_t GF_EVICTION = 0x10;
-  static const uint16_t GF_EXPIRATION = 0x20;
-  static const uint16_t GF_CACHE_CLOSE = 0x40;
-  static const uint16_t GF_NOCACHEWRITER = 0x80;
-  static const uint16_t GF_NOCALLBACKS = 0x100;
-
-  inline explicit CacheEventFlags(const uint16_t flags) : m_flags(flags) {}
-
- public:
-  static const CacheEventFlags NORMAL;
-  static const CacheEventFlags LOCAL;
-  static const CacheEventFlags NOTIFICATION;
-  static const CacheEventFlags NOTIFICATION_UPDATE;
-  static const CacheEventFlags EVICTION;
-  static const CacheEventFlags EXPIRATION;
-  static const CacheEventFlags CACHE_CLOSE;
-  static const CacheEventFlags NOCACHEWRITER;
-  static const CacheEventFlags NOCALLBACKS;
-
-  inline CacheEventFlags(const CacheEventFlags& flags) = default;
-
-  CacheEventFlags() = delete;
-  CacheEventFlags& operator=(const CacheEventFlags&) = delete;
-
-  inline CacheEventFlags operator|(const CacheEventFlags& flags) const {
-    return CacheEventFlags(m_flags | flags.m_flags);
-  }
-
-  inline uint32_t operator&(const CacheEventFlags& flags) const {
-    return (m_flags & flags.m_flags);
-  }
-
-  inline bool operator==(const CacheEventFlags& flags) const {
-    return (m_flags == flags.m_flags);
-  }
-
-  inline bool isNormal() const { return (m_flags & GF_NORMAL) > 0; }
-
-  inline bool isLocal() const { return (m_flags & GF_LOCAL) > 0; }
-
-  inline bool isNotification() const { return (m_flags & GF_NOTIFICATION) > 0; }
-
-  inline bool isNotificationUpdate() const {
-    return (m_flags & GF_NOTIFICATION_UPDATE) > 0;
-  }
-
-  inline bool isEviction() const { return (m_flags & GF_EVICTION) > 0; }
-
-  inline bool isExpiration() const { return (m_flags & GF_EXPIRATION) > 0; }
-
-  inline bool isCacheClose() const { return (m_flags & GF_CACHE_CLOSE) > 0; }
-
-  inline bool isNoCacheWriter() const {
-    return (m_flags & GF_NOCACHEWRITER) > 0;
-  }
-
-  inline bool isNoCallbacks() const { return (m_flags & GF_NOCALLBACKS) > 0; }
-
-  inline bool isEvictOrExpire() const {
-    return (m_flags & (GF_EVICTION | GF_EXPIRATION)) > 0;
-  }
-
-  // special optimized method for CacheWriter invocation condition
-  inline bool invokeCacheWriter() const {
-    return ((m_flags & (GF_NOTIFICATION | GF_EVICTION | GF_EXPIRATION |
-                        GF_NOCACHEWRITER | GF_NOCALLBACKS)) == 0x0);
-  }
-};
 
 class TombstoneList;
 class VersionTag;
@@ -195,6 +112,14 @@ class RegionInternal : public Region {
       const CacheEventFlags eventFlags, std::shared_ptr<VersionTag> versionTag,
       DataInput* delta = nullptr,
       std::shared_ptr<EventId> eventId = nullptr) = 0;
+  virtual GfErrType putIfAbsentImpl(
+      const std::shared_ptr<CacheableKey>& key,
+      const std::shared_ptr<Cacheable>& value,
+      const std::shared_ptr<Serializable>& aCallbackArgument,
+      std::shared_ptr<Cacheable>& oldValue, int updateCount,
+      const CacheEventFlags eventFlags, std::shared_ptr<VersionTag> versionTag,
+      DataInput* delta = nullptr,
+      std::shared_ptr<EventId> eventId = nullptr) noexcept = 0;
   virtual GfErrType createNoThrow(
       const std::shared_ptr<CacheableKey>& key,
       const std::shared_ptr<Cacheable>& value,

--- a/cppcache/src/RemoveAction.cpp
+++ b/cppcache/src/RemoveAction.cpp
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RemoveAction.hpp"
+
+#include <geode/internal/DataSerializablePrimitive.hpp>
+
+#include "CacheImpl.hpp"
+#include "LocalRegion.hpp"
+#include "SerializableHelper.hpp"
+#include "TSSTXStateWrapper.hpp"
+#include "Utils.hpp"
+#include "VersionTag.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+using internal::DataSerializablePrimitive;
+
+RemoveAction::RemoveAction(LocalRegion& region, bool allowNull)
+    : region_(region),
+      response_(GF_ENOENT),
+      txState_{TSSTXStateWrapper::get().getTXState()},
+      allowNull_{allowNull} {}
+
+void RemoveAction::getCallbackOldValue(
+    bool cachingEnabled, const std::shared_ptr<CacheableKey>& key,
+    std::shared_ptr<MapEntryImpl>& entry,
+    std::shared_ptr<Cacheable>& oldValue) const {
+  if (cachingEnabled) {
+    region_.getEntryMap()->getEntry(key, entry, oldValue);
+  }
+}
+
+GfErrType RemoveAction::remoteUpdate(const std::shared_ptr<CacheableKey>& key,
+                                     const std::shared_ptr<Cacheable>& value,
+                                     const std::shared_ptr<Cacheable>& cbArg,
+                                     std::shared_ptr<Cacheable>&,
+                                     std::shared_ptr<VersionTag>& versionTag) {
+  // propagate the remove to remote server, if any
+  std::shared_ptr<Cacheable> oldValue;
+  GfErrType err = GF_NOERR;
+  if (!allowNull_ && region_.getAttributes().getCachingEnabled()) {
+    region_.getEntry(key, oldValue);
+    if (oldValue && value) {
+      if (!serializedEqualTo(oldValue, value)) {
+        err = GF_ENOENT;
+        return err;
+      }
+    } else if (!oldValue || CacheableToken::isInvalid(oldValue)) {
+      response_ = region_.remoteRemove(key, value, cbArg, versionTag);
+      return response_;
+    } else if (oldValue && !value) {
+      return GF_ENOENT;
+    }
+  }
+
+  if (allowNull_) {
+    response_ = region_.remoteRemoveEx(key, cbArg, versionTag);
+  } else {
+    response_ = region_.remoteRemove(key, value, cbArg, versionTag);
+  }
+
+  LOGDEBUG("RemoveAction::remoteUpdate server response: %d", response_);
+  return response_;
+}
+
+GfErrType RemoveAction::localUpdate(const std::shared_ptr<CacheableKey>& key,
+                                    const std::shared_ptr<Cacheable>& value,
+                                    std::shared_ptr<Cacheable>& oldValue,
+                                    bool cachingEnabled,
+                                    const CacheEventFlags eventFlags,
+                                    int updateCount,
+                                    std::shared_ptr<VersionTag> versionTag,
+                                    DataInput*, std::shared_ptr<EventId>,
+                                    bool afterRemote) {
+  std::shared_ptr<Cacheable> fetchedValue;
+  GfErrType err = GF_NOERR;
+  if (!allowNull_ && cachingEnabled) {
+    region_.getEntry(key, fetchedValue);
+    if (fetchedValue && value) {
+      if (!serializedEqualTo(fetchedValue, value)) {
+        return GF_ENOENT;
+      }
+    } else if (!value &&
+               (!CacheableToken::isInvalid(fetchedValue) || !fetchedValue)) {
+      err = (response_ == GF_NOERR && !fetchedValue) ? GF_NOERR : GF_ENOENT;
+      if (updateCount >= 0 &&
+          !region_.getAttributes().getConcurrencyChecksEnabled()) {
+        // This means server has deleted an entry & same entry has been
+        // destroyed locally
+        // So call removeTrackerForEntry to remove key that
+        // was added in the  map during addTrackerForEntry call.
+        region_.getEntryMap()->removeTrackerForEntry(key);
+      }
+
+      return err;
+    } else if (!fetchedValue && value && response_ != GF_NOERR) {
+      err = GF_ENOENT;
+      return err;
+    }
+  }
+
+  auto& cachePerfStats = region_.getCacheImpl()->getCachePerfStats();
+  if (cachingEnabled) {
+    //  for notification invoke the listener even if the key does
+    // not exist locally
+    LOGDEBUG("Region::remove: region [%s] removing key [%s]",
+             region_.getFullPath().c_str(),
+             Utils::nullSafeToString(key).c_str());
+
+    std::shared_ptr<MapEntryImpl> entry;
+    if ((err = region_.getEntryMap()->remove(key, oldValue, entry, updateCount,
+                                             versionTag, afterRemote)) !=
+        GF_NOERR) {
+      if (eventFlags.isNotification()) {
+        LOGDEBUG(
+            "Region::remove: region [%s] remove key [%s] for "
+            "notification having value [%s] failed with %d",
+            region_.getFullPath().c_str(), Utils::nullSafeToString(key).c_str(),
+            Utils::nullSafeToString(oldValue).c_str(), err);
+        err = GF_NOERR;
+      }
+
+      return err;
+    }
+
+    if (oldValue) {
+      LOGDEBUG(
+          "Region::remove: region [%s] removed key [%s] having "
+          "value [%s]",
+          region_.getFullPath().c_str(), Utils::nullSafeToString(key).c_str(),
+          Utils::nullSafeToString(oldValue).c_str());
+
+      // any cleanup required for the entry (e.g. removing from LRU list)
+      if (entry) {
+        entry->cleanup(eventFlags);
+      }
+
+      // entry/region expiration
+      if (!eventFlags.isEvictOrExpire()) {
+        region_.updateAccessAndModifiedTime(true);
+      }
+
+      // update the stats
+      region_.getRegionStats()->setEntries(region_.getEntryMap()->size());
+      cachePerfStats.incEntries(-1);
+    }
+  }
+  // update the stats
+  region_.getRegionStats()->incDestroys();
+  cachePerfStats.incDestroys();
+  return GF_NOERR;
+}
+
+bool RemoveAction::serializedEqualTo(const std::shared_ptr<Cacheable>& lhs,
+                                     const std::shared_ptr<Cacheable>& rhs) {
+  auto&& cache = *region_.getCacheImpl();
+
+  if (const auto primitive =
+          std::dynamic_pointer_cast<DataSerializablePrimitive>(lhs)) {
+    return SerializableHelper<DataSerializablePrimitive>{}.equalTo(
+        cache, primitive,
+        std::dynamic_pointer_cast<DataSerializablePrimitive>(rhs));
+  } else if (const auto dataSerializable =
+                 std::dynamic_pointer_cast<DataSerializable>(lhs)) {
+    return SerializableHelper<DataSerializable>{}.equalTo(
+        cache, dataSerializable,
+        std::dynamic_pointer_cast<DataSerializable>(rhs));
+  } else if (const auto pdxSerializable =
+                 std::dynamic_pointer_cast<PdxSerializable>(lhs)) {
+    return SerializableHelper<PdxSerializable>{}.equalTo(
+        cache, pdxSerializable,
+        std::dynamic_pointer_cast<PdxSerializable>(rhs));
+  } else if (const auto dataSerializableInternal =
+                 std::dynamic_pointer_cast<DataSerializableInternal>(lhs)) {
+    return SerializableHelper<DataSerializableInternal>{}.equalTo(
+        cache, dataSerializableInternal,
+        std::dynamic_pointer_cast<DataSerializableInternal>(rhs));
+  } else {
+    throw UnsupportedOperationException("Serialization type not implemented.");
+  }
+}
+
+GfErrType RemoveAction::checkArgs(const std::shared_ptr<CacheableKey>& key,
+                                  const std::shared_ptr<Cacheable>&,
+                                  DataInput*) {
+  if (!key) {
+    return GF_CACHE_ILLEGAL_ARGUMENT_EXCEPTION;
+  }
+
+  return GF_NOERR;
+}
+
+void RemoveAction::logCacheWriterFailure(
+    const std::shared_ptr<CacheableKey>& key,
+    const std::shared_ptr<Cacheable>&) {
+  LOGFINER("Cache writer vetoed remove for key %s",
+           Utils::nullSafeToString(key).c_str());
+}
+
+RemoveActionEx::RemoveActionEx(LocalRegion& region)
+    : RemoveAction(region, true) {}
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/RemoveAction.hpp
+++ b/cppcache/src/RemoveAction.hpp
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_REMOVE_ACTION_H_
+#define GEODE_REMOVE_ACTION_H_
+
+#include <memory>
+
+#include "CacheEventFlags.hpp"
+#include "ErrType.hpp"
+#include "EventType.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+class CacheableKey;
+class DataInput;
+class EventId;
+class LocalRegion;
+class MapEntryImpl;
+class Serializable;
+class TXState;
+class VersionTag;
+
+// encapsulates actions that need to be taken for a remove() operation
+class RemoveAction {
+ public:
+  static const EntryEventType s_beforeEventType = BEFORE_DESTROY;
+  static const EntryEventType s_afterEventType = AFTER_DESTROY;
+  static const bool s_addIfAbsent = true;
+  static const bool s_failIfPresent = false;
+
+ public:
+  explicit RemoveAction(LocalRegion& region, bool allowNull = false);
+
+  void getCallbackOldValue(bool cachingEnabled,
+                           const std::shared_ptr<CacheableKey>& key,
+                           std::shared_ptr<MapEntryImpl>& entry,
+                           std::shared_ptr<Serializable>& oldValue) const;
+
+  GfErrType remoteUpdate(const std::shared_ptr<CacheableKey>& key,
+                         const std::shared_ptr<Serializable>& newValue,
+                         const std::shared_ptr<Serializable>& aCallbackArgument,
+                         std::shared_ptr<Serializable>& retValue,
+                         std::shared_ptr<VersionTag>& versionTag);
+
+  GfErrType localUpdate(const std::shared_ptr<CacheableKey>& key,
+                        const std::shared_ptr<Serializable>& value,
+                        std::shared_ptr<Serializable>& oldValue,
+                        bool cachingEnabled, const CacheEventFlags eventFlags,
+                        int updateCount, std::shared_ptr<VersionTag> versionTag,
+                        DataInput* delta = nullptr,
+                        std::shared_ptr<EventId> eventId = nullptr,
+                        bool afterRemote = false);
+
+  TXState* getTxState() const { return txState_; }
+
+ public:
+  static const char* name() { return "Region::remove"; }
+
+  static GfErrType checkArgs(const std::shared_ptr<CacheableKey>& key,
+                             const std::shared_ptr<Serializable>& value,
+                             DataInput* delta);
+
+  static void logCacheWriterFailure(
+      const std::shared_ptr<CacheableKey>& key,
+      const std::shared_ptr<Serializable>& oldValue);
+
+ protected:
+  bool serializedEqualTo(const std::shared_ptr<Serializable>& lhs,
+                         const std::shared_ptr<Serializable>& rhs);
+
+ protected:
+  LocalRegion& region_;
+  GfErrType response_;
+  TXState* txState_;
+  bool allowNull_;
+};
+
+class RemoveActionEx : public RemoveAction {
+ public:
+  explicit RemoveActionEx(LocalRegion& region);
+};
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_REMOVE_ACTION_H_

--- a/cppcache/src/TcrMessage.hpp
+++ b/cppcache/src/TcrMessage.hpp
@@ -547,18 +547,6 @@ class TcrMessageInvalidate : public TcrMessage {
   ~TcrMessageInvalidate() override = default;
 };
 
-class TcrMessageDestroy : public TcrMessage {
- public:
-  TcrMessageDestroy(DataOutput* dataOutput, const Region* region,
-                    const std::shared_ptr<CacheableKey>& key,
-                    const std::shared_ptr<Cacheable>& value,
-                    bool isUserNullValue,
-                    const std::shared_ptr<Serializable>& aCallbackArgument,
-                    ThinClientBaseDM* connectionDM = nullptr);
-
-  ~TcrMessageDestroy() override = default;
-};
-
 class TcrMessageRegisterInterestList : public TcrMessage {
  public:
   TcrMessageRegisterInterestList(
@@ -580,19 +568,6 @@ class TcrMessageUnregisterInterestList : public TcrMessage {
       bool isDurable = false, ThinClientBaseDM* connectionDM = nullptr);
 
   ~TcrMessageUnregisterInterestList() override = default;
-};
-
-class TcrMessagePut : public TcrMessage {
- public:
-  TcrMessagePut(DataOutput* dataOutput, const Region* region,
-                const std::shared_ptr<CacheableKey>& key,
-                const std::shared_ptr<Cacheable>& value,
-                const std::shared_ptr<Serializable>& aCallbackArgument,
-                bool isDelta = false, ThinClientBaseDM* connectionDM = nullptr,
-                bool isMetaRegion = false, bool fullValueAfterDeltaFail = false,
-                const char* regionName = nullptr);
-
-  ~TcrMessagePut() override = default;
 };
 
 class TcrMessageCreateRegion : public TcrMessage {

--- a/cppcache/src/TcrMessageDestroy.cpp
+++ b/cppcache/src/TcrMessageDestroy.cpp
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TcrMessageDestroy.hpp"
+
+#include <geode/SystemProperties.hpp>
+
+#include "Connector.hpp"
+#include "EventOperation.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+TcrMessageDestroy::TcrMessageDestroy(DataOutput* dataOutput,
+                                     const Region* region,
+                                     const std::shared_ptr<CacheableKey>& key,
+                                     const std::shared_ptr<Cacheable>& value,
+                                     const std::shared_ptr<Serializable>& cbArg,
+                                     EventOperation operation,
+                                     ThinClientBaseDM* dm) {
+  if (!key) {
+    throw IllegalArgumentException(
+        "key passed to the constructor can't be nullptr");
+  }
+
+  m_request.reset(dataOutput);
+  m_msgType = TcrMessage::DESTROY;
+  m_tcdm = dm;
+  m_key = key;
+  m_regionName = (!region ? "INVALID_REGION_NAME" : region->getFullPath());
+  m_region = region;
+  m_timeout = DEFAULT_TIMEOUT;
+  uint32_t numOfParts = 5;
+  if (cbArg) {
+    ++numOfParts;
+  }
+
+  writeHeader(TcrMessage::DESTROY, numOfParts);
+  writeRegionPart(m_regionName);
+  writeObjectPart(key);
+  writeObjectPart(value);                          // expectedOldValue part
+  writeBytePart(static_cast<uint8_t>(operation));  // operation part
+  writeEventIdPart();
+
+  if (cbArg) {
+    writeObjectPart(cbArg);
+  }
+
+  writeMessageLength();
+}
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/TcrMessageDestroy.hpp
+++ b/cppcache/src/TcrMessageDestroy.hpp
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_TCR_MESSAGE_DESTROY_H_
+#define GEODE_TCR_MESSAGE_DESTROY_H_
+
+#include <cinttypes>
+#include <memory>
+
+#include "EventOperation.hpp"
+#include "TcrMessage.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+class TcrMessageDestroy : public TcrMessage {
+ public:
+  TcrMessageDestroy(DataOutput* dataOutput, const Region* region,
+                    const std::shared_ptr<CacheableKey>& key,
+                    const std::shared_ptr<Cacheable>& value,
+                    const std::shared_ptr<Serializable>& cbArg,
+                    EventOperation operation,
+                    ThinClientBaseDM* dm = nullptr);
+
+  ~TcrMessageDestroy() override = default;
+};
+
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_TCR_MESSAGE_DESTROY_H_

--- a/cppcache/src/TcrMessagePut.cpp
+++ b/cppcache/src/TcrMessagePut.cpp
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TcrMessagePut.hpp"
+
+#include <geode/SystemProperties.hpp>
+
+#include "Connector.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+TcrMessagePut::TcrMessagePut(DataOutput* dataOutput, const Region* region,
+                             const std::shared_ptr<CacheableKey>& key,
+                             const std::shared_ptr<Cacheable>& value,
+                             const std::shared_ptr<Serializable>& cbArg,
+                             EventOperation operation, bool isDelta,
+                             ThinClientBaseDM* connectionDM, bool isMetaRegion,
+                             bool fullValueAfterDeltaFail,
+                             const std::string& regionName) {
+  m_request.reset(dataOutput);
+  m_isMetaRegion = isMetaRegion;
+  m_msgType = TcrMessage::PUT;
+  m_tcdm = connectionDM;
+  m_key = key;
+  m_regionName = region != nullptr ? region->getFullPath() : regionName;
+  m_region = region;
+  m_timeout = DEFAULT_TIMEOUT;
+
+  // TODO check the number of parts in this constructor. doubt because in PUT
+  // value can be nullptr also.
+  uint32_t numOfParts = 5;
+  if (cbArg) {
+    ++numOfParts;
+  }
+
+  numOfParts++;
+
+  if (key == nullptr) {
+    throw IllegalArgumentException(
+        "key passed to the constructor can't be nullptr");
+  }
+
+  numOfParts++;
+  writeHeader(m_msgType, numOfParts);
+  writeRegionPart(m_regionName);
+  writeBytePart(static_cast<int8_t>(operation));
+
+  // Flags are not used for now
+  writeIntPart(0);
+  writeObjectPart(key);
+  writeObjectPart(CacheableBoolean::create(isDelta));
+  writeObjectPart(value, isDelta);
+  writeEventIdPart(0, fullValueAfterDeltaFail);
+  if (cbArg) {
+    writeObjectPart(cbArg);
+  }
+
+  writeMessageLength();
+}
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache

--- a/cppcache/src/TcrMessagePut.hpp
+++ b/cppcache/src/TcrMessagePut.hpp
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GEODE_TCR_MESSAGE_PUT_H_
+#define GEODE_TCR_MESSAGE_PUT_H_
+
+#include <cinttypes>
+#include <memory>
+
+#include "EventOperation.hpp"
+#include "TcrMessage.hpp"
+
+namespace apache {
+namespace geode {
+namespace client {
+
+class TcrMessagePut : public TcrMessage {
+ public:
+  TcrMessagePut(DataOutput* dataOutput, const Region* region,
+                const std::shared_ptr<CacheableKey>& key,
+                const std::shared_ptr<Cacheable>& value,
+                const std::shared_ptr<Serializable>& cbArg,
+                EventOperation operation, bool isDelta = false,
+                ThinClientBaseDM* connectionDM = nullptr,
+                bool isMetaRegion = false, bool fullValueAfterDeltaFail = false,
+                const std::string& regionName = std::string{});
+
+  ~TcrMessagePut() override = default;
+};
+
+}  // namespace client
+}  // namespace geode
+}  // namespace apache
+
+#endif  // GEODE_TCR_MESSAGE_PUT_H_

--- a/cppcache/test/TcrMessageTest.cpp
+++ b/cppcache/test/TcrMessageTest.cpp
@@ -36,8 +36,8 @@ using apache::geode::client::CacheableKey;
 using apache::geode::client::CacheableString;
 using apache::geode::client::CacheableVector;
 using apache::geode::client::CqState;
-using apache::geode::client::EventOperation;
 using apache::geode::client::DataOutput;
+using apache::geode::client::EventOperation;
 using apache::geode::client::InterestResultPolicy;
 using apache::geode::client::Region;
 using apache::geode::client::Serializable;
@@ -354,14 +354,9 @@ TEST_F(TcrMessageTest, testCreate) {
   using apache::geode::client::TcrMessagePut;
 
   TcrMessagePut message(
-      new DataOutputUnderTest(), nullptr,
-      CacheableString::create("mykey"), CacheableString::create("myvalue"),
-      nullptr,
-      EventOperation::CREATE,
-      false, nullptr,
-      false,
-      false,
-      "myRegionName");
+      new DataOutputUnderTest(), nullptr, CacheableString::create("mykey"),
+      CacheableString::create("myvalue"), nullptr, EventOperation::CREATE,
+      false, nullptr, false, false, "myRegionName");
 
   EXPECT_EQ(TcrMessage::PUT, message.getMessageType());
 


### PR DESCRIPTION
- Moved PUT actions from LocalRegion into its own modules.
- Added PutIfAbsent action.
- Added the necessary scaffolding for put requests to return a value.
- Moved TcrMessagePut implementation into its own file. Now this message
  type accepts an operation as input.
- Moved TcrMessageDestroy implementation into its own file. Now this
  message accepts an operation as input.
- Also, updated TcrMessageDestroy operation format so it uses a byte
  part instead of an object.
- Added putIfAbsent method to the Region interface and its
  implementations both for LocalRegion and ThinClientRegion.
- Modified LocalRegion and ThinClientRegion to comply with the above
  code changes.
- Modified PUT's old value parsing to handle null pointer.
- Also replaced Cacheable type by Serializable in some places in order
  in order to take advantage of fast-forward definition.