### PR TITLE
GEODE-10584: Bump Geode version to 2.0.2

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,7 +2,7 @@ extraction:
   cpp:
     configure:
       command:
-        - GEODE_VERSION=1.15.0
+        - GEODE_VERSION=2.0.2
         - mkdir _lgtm_build_dir
         - cd _lgtm_build_dir
         - wget -O apache-geode.tgz https://downloads.apache.org/geode/${GEODE_VERSION}/apache-geode-${GEODE_VERSION}.tgz

--- a/docker/centos-7/Dockerfile
+++ b/docker/centos-7/Dockerfile
@@ -51,7 +51,7 @@ RUN installer=$(mktemp) \
     && bash ${installer} --skip-license --prefix=/usr/local \
     && rm ${installer}
 
-ARG GEODE_VERSION=1.15.0
+ARG GEODE_VERSION=2.0.2
 ENV GEODE_HOME /apache-geode-${GEODE_VERSION}
 RUN curl -L -s "https://www.apache.org/dyn/closer.lua/geode/${GEODE_VERSION}/apache-geode-${GEODE_VERSION}.tgz?action=download" | tar -zxvf - --exclude javadoc
 

--- a/docker/centos-8/Dockerfile
+++ b/docker/centos-8/Dockerfile
@@ -53,7 +53,7 @@ RUN installer=$(mktemp) \
     && bash ${installer} --skip-license --prefix=/usr/local \
     && rm ${installer}
 
-ARG GEODE_VERSION=1.15.0
+ARG GEODE_VERSION=2.0.2
 ENV GEODE_HOME /apache-geode-${GEODE_VERSION}
 RUN curl -L -s "https://www.apache.org/dyn/closer.lua/geode/${GEODE_VERSION}/apache-geode-${GEODE_VERSION}.tgz?action=download" | tar -zxvf - --exclude javadoc
 

--- a/docker/rhel-7/Dockerfile
+++ b/docker/rhel-7/Dockerfile
@@ -54,7 +54,7 @@ RUN installer=$(mktemp) \
     && bash ${installer} --skip-license --prefix=/usr/local \
     && rm ${installer}
 
-ARG GEODE_VERSION=1.15.0
+ARG GEODE_VERSION=2.0.2
 ENV GEODE_HOME /apache-geode-${GEODE_VERSION}
 RUN curl -L -s "https://www.apache.org/dyn/closer.lua/geode/${GEODE_VERSION}/apache-geode-${GEODE_VERSION}.tgz?action=download" | tar -zxvf - --exclude javadoc
 

--- a/docker/rhel-8/Dockerfile
+++ b/docker/rhel-8/Dockerfile
@@ -54,7 +54,7 @@ RUN installer=$(mktemp) \
     && bash ${installer} --skip-license --prefix=/usr/local \
     && rm ${installer}
 
-ARG GEODE_VERSION=1.15.0
+ARG GEODE_VERSION=2.0.2
 ENV GEODE_HOME /apache-geode-${GEODE_VERSION}
 RUN curl -L -s "https://www.apache.org/dyn/closer.lua/geode/${GEODE_VERSION}/apache-geode-${GEODE_VERSION}.tgz?action=download" | tar -zxvf - --exclude javadoc
 

--- a/docker/ubuntu-16.04/Dockerfile
+++ b/docker/ubuntu-16.04/Dockerfile
@@ -66,7 +66,7 @@ RUN installer=$(mktemp) \
     && bash ${installer} --skip-license --prefix=/usr/local \
     && rm ${installer}
 
-ARG GEODE_VERSION=1.15.0
+ARG GEODE_VERSION=2.0.2
 ENV GEODE_HOME /apache-geode-${GEODE_VERSION}
 RUN curl -L -s "https://www.apache.org/dyn/closer.lua/geode/${GEODE_VERSION}/apache-geode-${GEODE_VERSION}.tgz?action=download" | tar -zxvf - --exclude javadoc
 

--- a/docker/ubuntu-18.04/Dockerfile
+++ b/docker/ubuntu-18.04/Dockerfile
@@ -66,7 +66,7 @@ RUN installer=$(mktemp) \
     && bash ${installer} --skip-license --prefix=/usr/local \
     && rm ${installer}
 
-ARG GEODE_VERSION=1.15.0
+ARG GEODE_VERSION=2.0.2
 ENV GEODE_HOME /apache-geode-${GEODE_VERSION}
 RUN curl -L -s "https://www.apache.org/dyn/closer.lua/geode/${GEODE_VERSION}/apache-geode-${GEODE_VERSION}.tgz?action=download" | tar -zxvf - --exclude javadoc
 

--- a/docker/ubuntu-20.04/Dockerfile
+++ b/docker/ubuntu-20.04/Dockerfile
@@ -64,7 +64,7 @@ RUN installer=$(mktemp) \
     && bash ${installer} --skip-license --prefix=/usr/local \
     && rm ${installer}
 
-ARG GEODE_VERSION=1.15.0
+ARG GEODE_VERSION=2.0.2
 ENV GEODE_HOME /apache-geode-${GEODE_VERSION}
 RUN curl -L -s "https://www.apache.org/dyn/closer.lua/geode/${GEODE_VERSION}/apache-geode-${GEODE_VERSION}.tgz?action=download" | tar -zxvf - --exclude javadoc
 

--- a/docker/windows/Dockerfile
+++ b/docker/windows/Dockerfile
@@ -39,7 +39,7 @@ RUN choco install `
 # Only for NUnit 2.6
 RUN choco install nunit.install --version 2.6.4 -confirm
 
-ARG GEODE_VERSION=1.15.0
+ARG GEODE_VERSION=2.0.2
 ENV GEODE_HOME C:\apache-geode-${GEODE_VERSION}
 RUN curl -L -s "https://www.apache.org/dyn/closer.lua/geode/%GEODE_VERSION%/apache-geode-%GEODE_VERSION%.tgz?action=download" | tar -zxvf - --exclude javadoc
 


### PR DESCRIPTION
Native client hardcodes Geode version to test with in several places. Update those variables to latest-and-greatest apache-geode 2.0.2